### PR TITLE
feat: show relationship status in account detail

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Relationship.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Relationship.kt
@@ -1,0 +1,21 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Relationship(
+    @SerialName("blocking") val blocking: Boolean = false,
+    @SerialName("domain_blocking") val domainBlocking: Boolean = false,
+    @SerialName("endorsed") val endorsed: Boolean = false,
+    @SerialName("followed_by") val followedBy: Boolean = false,
+    @SerialName("following") val following: Boolean = false,
+    @SerialName("id") val id: String,
+    @SerialName("muting") val muting: Boolean = false,
+    @SerialName("muting_notifications") val mutingNotifications: Boolean = false,
+    @SerialName("note") val note: String? = null,
+    @SerialName("notifying") val notifying: Boolean = false,
+    @SerialName("requested") val requested: Boolean = false,
+    @SerialName("requested_by") val requestedBy: Boolean = false,
+    @SerialName("showing_reblogs") val showingReblogs: Boolean = false,
+)

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/AccountService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/AccountService.kt
@@ -1,6 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.core.api.service
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Account
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Relationship
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Status
 import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.Path
@@ -27,4 +28,9 @@ interface AccountService {
     suspend fun lookup(
         @Query("acct") acct: String,
     ): Account
+
+    @GET("accounts/relationships")
+    suspend fun getRelationships(
+        @Query("id") id: String,
+    ): List<Relationship>
 }

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NotificationStatus.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NotificationStatus.kt
@@ -1,0 +1,16 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.data
+
+sealed interface NotificationStatus {
+    data object Enabled : NotificationStatus
+
+    data object Disabled : NotificationStatus
+
+    data object Undetermined : NotificationStatus
+}
+
+fun RelationshipModel.toNotificationStatus(): NotificationStatus =
+    when {
+        mutingNotifications -> NotificationStatus.Disabled
+        notifying -> NotificationStatus.Enabled
+        else -> NotificationStatus.Undetermined
+    }

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/RelationshipModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/RelationshipModel.kt
@@ -1,0 +1,14 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.data
+
+data class RelationshipModel(
+    val id: String,
+    val following: Boolean = false,
+    val notifying: Boolean = false,
+    val followedBy: Boolean = false,
+    val blocking: Boolean = false,
+    val muting: Boolean = false,
+    val mutingNotifications: Boolean = false,
+    val requested: Boolean = false,
+    val requestedBy: Boolean = false,
+    val note: String? = null,
+)

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/RelationshipStatus.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/RelationshipStatus.kt
@@ -1,0 +1,25 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.data
+
+sealed interface RelationshipStatus {
+    data object MutualFollow : RelationshipStatus
+
+    data object Following : RelationshipStatus
+
+    data object FollowsYou : RelationshipStatus
+
+    data object RequestedToOther : RelationshipStatus
+
+    data object RequestedToYou : RelationshipStatus
+
+    data object Undetermined : RelationshipStatus
+}
+
+fun RelationshipModel.toStatus(): RelationshipStatus =
+    when {
+        following && followedBy -> RelationshipStatus.MutualFollow
+        following -> RelationshipStatus.Following
+        followedBy -> RelationshipStatus.FollowsYou
+        requested -> RelationshipStatus.RequestedToOther
+        requestedBy -> RelationshipStatus.RequestedToYou
+        else -> RelationshipStatus.Undetermined
+    }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/AccountRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/AccountRepository.kt
@@ -1,9 +1,12 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.AccountModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.RelationshipModel
 
 interface AccountRepository {
     suspend fun getById(id: String): AccountModel?
 
     suspend fun getByHandle(handle: String): AccountModel?
+
+    suspend fun getRelationship(id: String): RelationshipModel?
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultAccountRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultAccountRepository.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.AccountModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.RelationshipModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
@@ -20,6 +21,16 @@ internal class DefaultAccountRepository(
         runCatching {
             withContext(Dispatchers.IO) {
                 provider.accounts.lookup(handle).toModel()
+            }
+        }.getOrNull()
+
+    override suspend fun getRelationship(id: String): RelationshipModel? =
+        runCatching {
+            withContext(Dispatchers.IO) {
+                provider.accounts
+                    .getRelationships(id)
+                    .firstOrNull()
+                    ?.toModel()
             }
         }.getOrNull()
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/Mappings.kt
@@ -10,6 +10,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.dto.MediaType.IMAGE
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.MediaType.UNKNOWN
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.MediaType.VIDEO
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Notification
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Relationship
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Status
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.StatusContext
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Tag
@@ -19,6 +20,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.FieldModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationType
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.RelationshipModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TagModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineContextModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
@@ -154,3 +156,17 @@ internal fun Notification.toModel() =
         account = account?.toModel(),
         entry = status?.toModel(),
 )
+
+internal fun Relationship.toModel() =
+    RelationshipModel(
+        id = id,
+        following = following,
+        notifying = notifying,
+        followedBy = followedBy,
+        blocking = blocking,
+        muting = muting,
+        mutingNotifications = mutingNotifications,
+        requested = requested,
+        requestedBy = requestedBy,
+        note = note,
+    )

--- a/feature/accountdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/accountdetail/AccountDetailMviModel.kt
+++ b/feature/accountdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/accountdetail/AccountDetailMviModel.kt
@@ -4,6 +4,8 @@ import cafe.adriel.voyager.core.model.ScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.AccountSection
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.AccountModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationStatus
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.RelationshipStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 
 interface AccountDetailMviModel :
@@ -20,6 +22,8 @@ interface AccountDetailMviModel :
     }
 
     data class State(
+        val relationshipStatus: RelationshipStatus = RelationshipStatus.Undetermined,
+        val notificationStatus: NotificationStatus = NotificationStatus.Undetermined,
         val refreshing: Boolean = false,
         val loading: Boolean = false,
         val initial: Boolean = true,

--- a/feature/accountdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/accountdetail/AccountDetailScreen.kt
+++ b/feature/accountdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/accountdetail/AccountDetailScreen.kt
@@ -122,6 +122,8 @@ class AccountDetailScreen(
                             item {
                                 AccountHeader(
                                     account = uiState.account,
+                                    relationshipStatus = uiState.relationshipStatus,
+                                    notificationStatus = uiState.notificationStatus,
                                     onOpenUrl = { url ->
                                         urlManager.open(url)
                                     },

--- a/feature/accountdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/accountdetail/AccountDetailViewModel.kt
+++ b/feature/accountdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/accountdetail/AccountDetailViewModel.kt
@@ -3,6 +3,10 @@ package com.livefast.eattrash.feature.accountdetail
 import cafe.adriel.voyager.core.model.screenModelScope
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.AccountSection
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationStatus
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.RelationshipStatus
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toNotificationStatus
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationSpecification
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.AccountRepository
@@ -47,8 +51,15 @@ class AccountDetailViewModel(
 
     private suspend fun loadUser() {
         val account = accountRepository.getById(id)
+        val relationship = accountRepository.getRelationship(id)
         updateState {
-            it.copy(account = account)
+            it.copy(
+                account = account,
+                relationshipStatus =
+                    relationship?.toStatus() ?: RelationshipStatus.Undetermined,
+                notificationStatus =
+                    relationship?.toNotificationStatus() ?: NotificationStatus.Undetermined,
+            )
         }
     }
 


### PR DESCRIPTION
This PR adds the following/follower and notification status in the header of the account detail screen.