### PR TITLE
refactor: use v2 api where possible, fix getRelationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ The app is under ongoing development, here is a list of the features that are be
 - [x] see following recommendations
 - [x] view all the posts containing a given hashtag
 - [x] view followers and following of a given user
-- [ ] media visualization
 - [ ] follow/unfollow an account
+- [ ] post actions (re-share, favorite, bookmark)
+- [ ] media visualization
 - [ ] enable/disable notifications for an account
 - [ ] edit one's own profile
 - [ ] create a post/reply

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/DefaultServiceProvider.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/DefaultServiceProvider.kt
@@ -24,7 +24,6 @@ internal class DefaultServiceProvider(
     private val factory: HttpClientEngine = provideHttpClientEngine(),
 ) : ServiceProvider {
     companion object {
-        private const val VERSION = "v1"
         private const val ENABLE_LOGGING = false
         private const val REAM_NAME = "Friendica"
     }
@@ -38,7 +37,7 @@ internal class DefaultServiceProvider(
     override lateinit var notifications: NotificationService
     override lateinit var trends: TrendsService
 
-    private val baseUrl: String get() = "https://$currentNode/api/$VERSION/"
+    private val baseUrl: String get() = "https://$currentNode/api/"
 
     override fun changeNode(value: String) {
         if (currentNode != value) {

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/NotificationService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/NotificationService.kt
@@ -6,7 +6,7 @@ import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.Query
 
 interface NotificationService {
-    @GET("notifications")
+    @GET("v1/notifications")
     suspend fun get(
         @Query("types") types: List<NotificationType>,
         @Query("max_id") maxId: String? = null,

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/StatusService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/StatusService.kt
@@ -6,12 +6,12 @@ import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.Path
 
 interface StatusService {
-    @GET("statuses/{id}")
+    @GET("v1/statuses/{id}")
     suspend fun get(
         @Path("id") id: String,
     ): Status
 
-    @GET("statuses/{id}/context")
+    @GET("v1/statuses/{id}/context")
     suspend fun getContext(
         @Path("id") id: String,
     ): StatusContext

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/TimelineService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/TimelineService.kt
@@ -6,7 +6,7 @@ import de.jensklingenberg.ktorfit.http.Path
 import de.jensklingenberg.ktorfit.http.Query
 
 interface TimelineService {
-    @GET("timelines/public")
+    @GET("v1/timelines/public")
     suspend fun getPublic(
         @Query("max_id") maxId: String? = null,
         @Query("min_id") minId: String? = null,
@@ -14,14 +14,14 @@ interface TimelineService {
         @Query("local") local: Boolean = false,
     ): List<Status>
 
-    @GET("timelines/home")
+    @GET("v1/timelines/home")
     suspend fun getHome(
         @Query("max_id") maxId: String? = null,
         @Query("min_id") minId: String? = null,
         @Query("limit") limit: Int = 20,
     ): List<Status>
 
-    @GET("timelines/tag/{hashtag}")
+    @GET("v1/timelines/tag/{hashtag}")
     suspend fun getHashtag(
         @Path("hashtag") hashtag: String,
         @Query("max_id") maxId: String? = null,

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/TrendsService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/TrendsService.kt
@@ -7,19 +7,19 @@ import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.Query
 
 interface TrendsService {
-    @GET("trends/tags")
+    @GET("v1/trends/tags")
     suspend fun getHashtags(
         @Query("offset") offset: Int,
         @Query("limit") limit: Int = 20,
     ): List<Tag>
 
-    @GET("trends/statuses")
+    @GET("v1/trends/statuses")
     suspend fun getStatuses(
         @Query("offset") offset: Int,
         @Query("limit") limit: Int = 20,
     ): List<Status>
 
-    @GET("trends/links")
+    @GET("v1/trends/links")
     suspend fun getLinks(
         @Query("offset") offset: Int,
         @Query("limit") limit: Int = 20,

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/UserService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/UserService.kt
@@ -9,12 +9,12 @@ import de.jensklingenberg.ktorfit.http.Path
 import de.jensklingenberg.ktorfit.http.Query
 
 interface UserService {
-    @GET("accounts/{id}")
+    @GET("v1/accounts/{id}")
     suspend fun getById(
         @Path("id") id: String,
     ): Account
 
-    @GET("accounts/{id}/statuses")
+    @GET("v1/accounts/{id}/statuses")
     suspend fun getStatuses(
         @Path("id") id: String,
         @Query("max_id") maxId: String? = null,
@@ -26,23 +26,22 @@ interface UserService {
         @Query("limit") limit: Int = 20,
     ): List<Status>
 
-    @GET("accounts/lookup")
+    @GET("v1/accounts/lookup")
     suspend fun lookup(
         @Query("acct") acct: String,
     ): Account
 
-    @GET("accounts/relationships")
+    @GET("v1/accounts/relationships")
     suspend fun getRelationships(
         @Query("id[]") id: List<String>,
     ): List<Relationship>
 
-    // TODO: the v1 API is deprecated
-    @GET("suggestions")
+    @GET("v2/suggestions")
     suspend fun getSuggestions(
         @Query("limit") limit: Int,
     ): List<Suggestion>
 
-    @GET("accounts/{id}/followers")
+    @GET("v1/accounts/{id}/followers")
     suspend fun getFollowers(
         @Path("id") id: String,
         @Query("max_id") maxId: String? = null,
@@ -50,7 +49,7 @@ interface UserService {
         @Query("limit") limit: Int = 20,
     ): List<Account>
 
-    @GET("accounts/{id}/following")
+    @GET("v1/accounts/{id}/following")
     suspend fun getFollowing(
         @Path("id") id: String,
         @Query("max_id") maxId: String? = null,

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/UserService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/UserService.kt
@@ -33,7 +33,7 @@ interface UserService {
 
     @GET("accounts/relationships")
     suspend fun getRelationships(
-        @Query("id") id: String,
+        @Query("id[]") id: List<String>,
     ): List<Relationship>
 
     // TODO: the v1 API is deprecated

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultNotificationsPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultNotificationsPaginationManager.kt
@@ -54,15 +54,15 @@ internal class DefaultNotificationsPaginationManager(
     }
 
     private suspend fun List<NotificationModel>.determineRelationshipStatus(): List<NotificationModel> =
-        map {
-            val accountId = it.user?.id
-            if (accountId == null) {
-                it
-            } else {
-                val relationship = userRepository.getRelationship(accountId)
-                it.copy(
+        run {
+            val userIds = mapNotNull { notification -> notification.user?.id }
+            val relationships = userRepository.getRelationships(userIds)
+            map { notification ->
+                val relationship =
+                    relationships.firstOrNull { rel -> rel.id == notification.user?.id }
+                notification.copy(
                     user =
-                        it.user?.copy(
+                        notification.user?.copy(
                             relationshipStatus = relationship?.toStatus(),
                             notificationStatus = relationship?.toNotificationStatus(),
                         ),

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/NotificationsPaginationSpecification.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/NotificationsPaginationSpecification.kt
@@ -12,6 +12,6 @@ sealed interface NotificationsPaginationSpecification {
                 NotificationType.Entry,
                 NotificationType.Update,
             ),
-        val withRelationshipStatus: Boolean = false,
+        val withRelationshipStatus: Boolean = true,
     ) : NotificationsPaginationSpecification
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepository.kt
@@ -24,15 +24,14 @@ internal class DefaultUserRepository(
             }
         }.getOrNull()
 
-    override suspend fun getRelationship(id: String): RelationshipModel? =
+    override suspend fun getRelationships(ids: List<String>): List<RelationshipModel> =
         runCatching {
             withContext(Dispatchers.IO) {
                 provider.users
-                    .getRelationships(id)
-                    .firstOrNull()
-                    ?.toModel()
+                    .getRelationships(ids)
+                    .map { it.toModel() }
             }
-        }.getOrNull()
+        }.getOrElse { emptyList() }
 
     override suspend fun getSuggestions(): List<UserModel> =
         runCatching {

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/UserRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/UserRepository.kt
@@ -8,7 +8,7 @@ interface UserRepository {
 
     suspend fun getByHandle(handle: String): UserModel?
 
-    suspend fun getRelationship(id: String): RelationshipModel?
+    suspend fun getRelationships(ids: List<String>): List<RelationshipModel>
 
     suspend fun getSuggestions(): List<UserModel>
 

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/UserDetailViewModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/UserDetailViewModel.kt
@@ -53,7 +53,7 @@ class UserDetailViewModel(
 
     private suspend fun loadUser() {
         val account = userRepository.getById(id)
-        val relationship = userRepository.getRelationship(id)
+        val relationship = userRepository.getRelationships(listOf(id)).firstOrNull()
         updateState {
             it.copy(
                 user =


### PR DESCRIPTION
This PR contains some refactor of API calls:
- the `/accounts/relationships` was migrated to pass multiple user ID at once, to improve performance;
- the version number has been coded into service path, to make it easier for different versions to coexist (this allowed to migrate GET `/suggestions` to v2).