### PR TITLE
chore: remove follow requests from drawer

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentFooter.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentFooter.kt
@@ -8,9 +8,9 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Message
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.BookmarkBorder
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.Repeat
-import androidx.compose.material.icons.filled.Star
-import androidx.compose.material.icons.filled.StarBorder
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -50,8 +50,8 @@ fun ContentFooter(
             onClick = onReblog,
         )
         FooterItem(
-            icon = Icons.Default.StarBorder,
-            toggledIcon = Icons.Default.Star,
+            icon = Icons.Default.FavoriteBorder,
+            toggledIcon = Icons.Default.Favorite,
             value = favoriteCount.takeIf { it > 0 },
             toggled = favorite,
             onClick = onFavorite,

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -100,5 +100,4 @@ internal open class DefaultStrings : Strings {
     override val bookmarksTitle = "Bookmarks"
     override val favoritesTitle = "Favorites"
     override val followedHashtagsTitle = "Followed hashtags"
-    override val followRequestsTitle = "Follow requests"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -101,5 +101,4 @@ internal val ItStrings =
         override val bookmarksTitle = "Segnalibri"
         override val favoritesTitle = "Preferiti"
         override val followedHashtagsTitle = "Hashtag che segui"
-        override val followRequestsTitle = "Richieste di seguirti"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -106,7 +106,6 @@ interface Strings {
     val bookmarksTitle: String
     val favoritesTitle: String
     val followedHashtagsTitle: String
-    val followRequestsTitle: String
 }
 
 object Locales {

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerContent.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerContent.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.filled.PersonAddAlt
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Tag
 import androidx.compose.material3.HorizontalDivider
@@ -83,10 +82,6 @@ class DrawerContent : Screen {
                     onSelected = {
                         handleOpen { detailOpener.openFollowedHashtags() }
                     },
-                )
-                DrawerShortcut(
-                    title = LocalStrings.current.followRequestsTitle,
-                    icon = Icons.Default.PersonAddAlt,
                 )
             }
 

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationItem.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationItem.kt
@@ -11,12 +11,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChatBubble
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Loop
 import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.material.icons.filled.Poll
 import androidx.compose.material.icons.filled.PostAdd
 import androidx.compose.material.icons.filled.QuestionMark
-import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -135,7 +135,7 @@ private fun NotificationType.toReadableName(): String =
 private fun NotificationType.toIcon(): ImageVector =
     when (this) {
         NotificationType.Entry -> Icons.Default.PostAdd
-        NotificationType.Favorite -> Icons.Default.Star
+        NotificationType.Favorite -> Icons.Default.Favorite
         NotificationType.Follow -> Icons.Default.PersonAdd
         NotificationType.FollowRequest -> Icons.Default.PersonAdd
         NotificationType.Mention -> Icons.Default.ChatBubble


### PR DESCRIPTION
Remove the follow requests item from the navigation drawer. Addionally, use a consistent favorite icon in the drawer, notification and timelines.