### PR TITLE
fix: inbox layout and content display

### DIFF
--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/Mappings.kt
@@ -177,7 +177,7 @@ internal fun Notification.toModel() =
         id = id,
         type = type.toModel(),
         user = account?.toModel(),
-        entry = status?.toModel(),
+        entry = status?.toModelWithReply(),
     )
 
 internal fun Relationship.toModel() =

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationHeaderUserInfo.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationHeaderUserInfo.kt
@@ -23,12 +23,12 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 @Composable
 internal fun NotificationHeaderUserInfo(
     modifier: Modifier = Modifier,
-    account: UserModel,
+    user: UserModel,
     onOpenUser: ((UserModel) -> Unit)? = null,
 ) {
     val iconSize = IconSize.s
-    val creatorName = account?.let { it.displayName ?: it.handle }.orEmpty()
-    val creatorAvatar = account?.avatar.orEmpty()
+    val creatorName = user.let { it.displayName ?: it.handle }.orEmpty()
+    val creatorAvatar = user.avatar.orEmpty()
     val fullColor = MaterialTheme.colorScheme.onBackground
 
     Row(
@@ -41,9 +41,7 @@ internal fun NotificationHeaderUserInfo(
                 modifier =
                     Modifier
                         .clickable {
-                            if (account != null) {
-                                onOpenUser?.invoke(account)
-                            }
+                            onOpenUser?.invoke(user)
                         }.padding(Spacing.xxxs)
                         .size(iconSize)
                         .clip(RoundedCornerShape(iconSize / 2)),
@@ -55,9 +53,7 @@ internal fun NotificationHeaderUserInfo(
             PlaceholderImage(
                 modifier =
                     Modifier.clickable {
-                        if (account != null) {
-                            onOpenUser?.invoke(account)
-                        }
+                        onOpenUser?.invoke(user)
                     },
                 size = iconSize,
                 title = creatorName,
@@ -66,7 +62,7 @@ internal fun NotificationHeaderUserInfo(
 
         Text(
             text = creatorName,
-            style = MaterialTheme.typography.bodyLarge,
+            style = MaterialTheme.typography.bodySmall,
             color = fullColor,
         )
     }

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationItem.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationItem.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
@@ -70,14 +71,16 @@ internal fun NotificationItem(
             if (user != null) {
                 NotificationHeaderUserInfo(
                     modifier = Modifier.padding(start = Spacing.xs),
-                    account = user,
+                    user = user,
                     onOpenUser = onOpenUser,
                 )
             }
             Text(
                 modifier = Modifier.padding(horizontal = Spacing.xxs),
                 text = notification.type.toReadableName(),
-                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.bodySmall,
                 color = ancillaryColor,
             )
         }
@@ -92,6 +95,11 @@ internal fun NotificationItem(
         ) {
             if (entry != null) {
                 TimelineItem(
+                    modifier =
+                        Modifier.padding(
+                            top = Spacing.s,
+                            bottom = Spacing.s,
+                        ),
                     entry = entry,
                     actionsEnabled = false,
                     onClick = {
@@ -103,7 +111,7 @@ internal fun NotificationItem(
             } else if (user != null) {
                 NotificationUserInfo(
                     modifier = Modifier.padding(bottom = Spacing.m),
-                    account = user,
+                    user = user,
                     onOpenUrl = onOpenUrl,
                     onClick = {
                         onOpenUser?.invoke(user)

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationUserInfo.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationUserInfo.kt
@@ -35,18 +35,18 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 
 @Composable
 fun NotificationUserInfo(
-    account: UserModel,
+    user: UserModel,
     modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null,
     onOpenUrl: ((String) -> Unit)? = null,
     onRelationshipClicked: ((RelationshipStatusNextAction) -> Unit)? = null,
 ) {
-    val banner = account.header.orEmpty()
-    val avatar = account.avatar.orEmpty()
+    val banner = user.header.orEmpty()
+    val avatar = user.avatar.orEmpty()
     val avatarSize = 60.dp
     val fullColor = MaterialTheme.colorScheme.onBackground
     val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha)
-    val relationshipStatus = account.relationshipStatus
+    val relationshipStatus = user.relationshipStatus
 
     Column(
         modifier =
@@ -86,7 +86,7 @@ fun NotificationUserInfo(
                 } else {
                     PlaceholderImage(
                         size = avatarSize,
-                        title = account.displayName ?: account.handle ?: "?",
+                        title = user.displayName ?: user.handle ?: "?",
                     )
                 }
             }
@@ -101,12 +101,12 @@ fun NotificationUserInfo(
                     verticalArrangement = Arrangement.spacedBy(Spacing.xs),
                 ) {
                     Text(
-                        text = account.displayName ?: account.username ?: "",
+                        text = user.displayName ?: user.username ?: "",
                         style = MaterialTheme.typography.titleMedium,
                         color = fullColor,
                     )
                     Text(
-                        text = account.handle ?: account.username ?: "",
+                        text = user.handle ?: user.username ?: "",
                         style = MaterialTheme.typography.titleSmall,
                         color = ancillaryColor,
                     )
@@ -117,7 +117,7 @@ fun NotificationUserInfo(
                 if (relationshipStatus != null) {
                     UserRelationshipButton(
                         status = relationshipStatus,
-                        pending = account.relationshipStatusPending,
+                        pending = user.relationshipStatusPending,
                         onClick = onRelationshipClicked,
                     )
                 }
@@ -128,13 +128,13 @@ fun NotificationUserInfo(
             val annotatedContent =
                 buildAnnotatedString {
                     withStyle(SpanStyle(color = fullColor)) {
-                        append("${account.followers}")
+                        append("${user.followers}")
                     }
                     append(" ")
                     append(followerDesc)
                     append(" • ")
                     withStyle(SpanStyle(color = fullColor)) {
-                        append("${account.following}")
+                        append("${user.following}")
                     }
                     append(" ")
                     append(followingDesc)
@@ -144,7 +144,7 @@ fun NotificationUserInfo(
                 style = MaterialTheme.typography.labelSmall.copy(color = ancillaryColor),
             )
 
-            account.bio?.takeIf { it.isNotEmpty() }?.let { bio ->
+            user.bio?.takeIf { it.isNotEmpty() }?.let { bio ->
                 ContentBody(
                     modifier = Modifier.padding(top = Spacing.s),
                     content = bio,


### PR DESCRIPTION
This PR solves a couple of layout issues in the inbox screen for posts:
- incorrect padding for post cards
- reblogs were not displayed correctly.

Additionally, since there were remnants of the old "account" naming for "user", variables have been renamed.