### PR TITLE
fix: initial startup theme color

### DIFF
--- a/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/DefaultColorSchemeProvider.kt
+++ b/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/DefaultColorSchemeProvider.kt
@@ -25,6 +25,7 @@ internal class DefaultColorSchemeProvider(
         theme: UiTheme,
         dynamic: Boolean,
         customSeed: Color?,
+        isSystemInDarkTheme: Boolean,
     ): ColorScheme =
         when (theme) {
             UiTheme.Dark -> {
@@ -76,13 +77,17 @@ internal class DefaultColorSchemeProvider(
                     customSeed != null -> {
                         dynamicColorScheme(
                             seedColor = customSeed,
-                            isDark = false,
+                            isDark = isSystemInDarkTheme,
                             isAmoled = false,
                         )
                     }
 
                     else -> {
-                        LightColors
+                        if (isSystemInDarkTheme) {
+                            DarkColors
+                        } else {
+                            LightColors
+                        }
                     }
                 }
             }

--- a/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/data/UiTheme.kt
+++ b/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/data/UiTheme.kt
@@ -10,7 +10,9 @@ import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
 
 sealed interface UiTheme {
     data object Light : UiTheme
+
     data object Dark : UiTheme
+
     data object Black : UiTheme
 
     data object Default : UiTheme

--- a/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/AppTheme.kt
+++ b/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/AppTheme.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.UiBarTheme
-import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.UiTheme
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.di.getBarColorProvider
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.di.getColorSchemeProvider
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.di.getThemeRepository
@@ -26,19 +25,13 @@ fun AppTheme(
 
     val themeState by repository.theme.collectAsState()
     val customSeedColor by repository.customSeedColor.collectAsState()
-    val defaultTheme =
-        if (isSystemInDarkTheme()) {
-            UiTheme.Dark
-        } else {
-            UiTheme.Light
-        }
-
     val colorSchemeProvider = remember { getColorSchemeProvider() }
     val colorScheme =
         colorSchemeProvider.getColorScheme(
-            theme = themeState ?: defaultTheme,
+            theme = themeState,
             dynamic = useDynamicColors,
             customSeed = customSeedColor,
+            isSystemInDarkTheme = isSystemInDarkTheme(),
         )
 
     val fontFamily by repository.fontFamily.collectAsState()
@@ -46,7 +39,7 @@ fun AppTheme(
 
     val barColorProvider = remember { getBarColorProvider() }
     barColorProvider.setBarColorAccordingToTheme(
-        theme = themeState ?: defaultTheme,
+        theme = themeState,
         barTheme = barTheme,
     )
 

--- a/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/ColorSchemeProvider.kt
+++ b/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/ColorSchemeProvider.kt
@@ -13,6 +13,7 @@ interface ColorSchemeProvider {
         theme: UiTheme,
         dynamic: Boolean,
         customSeed: Color? = null,
+        isSystemInDarkTheme: Boolean = false,
     ): ColorScheme
 }
 

--- a/core/appearance/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/DefaultColorSchemeProvider.kt
+++ b/core/appearance/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/DefaultColorSchemeProvider.kt
@@ -12,6 +12,7 @@ internal class DefaultColorSchemeProvider : ColorSchemeProvider {
         theme: UiTheme,
         dynamic: Boolean,
         customSeed: Color?,
+        isSystemInDarkTheme: Boolean,
     ): ColorScheme =
         when (theme) {
             UiTheme.Dark -> {
@@ -42,11 +43,15 @@ internal class DefaultColorSchemeProvider : ColorSchemeProvider {
                 if (customSeed != null) {
                     dynamicColorScheme(
                         seedColor = customSeed,
-                        isDark = false,
+                        isDark = isSystemInDarkTheme,
                         isAmoled = false,
                     )
                 } else {
-                    LightColors
+                    if (isSystemInDarkTheme) {
+                        DarkColors
+                    } else {
+                        LightColors
+                    }
                 }
             }
         }


### PR DESCRIPTION
The system color (which is the default when installing the app from scratch) was not applied correctly, defaulting to light. This PR fixes this issue.