### PR TITLE
fix: drawer and login screen

### DIFF
--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerViewModel.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerViewModel.kt
@@ -27,20 +27,16 @@ class DrawerViewModel(
                         )
                     }
                 }.launchIn(this)
-            apiConfigurationRepository.isLogged
-                .onEach { isLogged ->
-                    if (isLogged) {
-                        refreshUser()
-                    } else {
+            accountRepository
+                .getActiveAsFlow()
+                .onEach { activeAccount ->
+                    if (activeAccount == null) {
                         updateState { it.copy(user = null) }
+                    } else {
+                        val currentUser = userRepository.getByHandle(activeAccount.handle)
+                        updateState { it.copy(user = currentUser) }
                     }
                 }.launchIn(this)
         }
-    }
-
-    private suspend fun refreshUser() {
-        val handle = accountRepository.getActive()?.handle.orEmpty()
-        val currentAccount = userRepository.getByHandle(handle)
-        updateState { it.copy(user = currentAccount) }
     }
 }

--- a/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/LoginViewModel.kt
+++ b/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/LoginViewModel.kt
@@ -3,17 +3,26 @@ package com.livefast.eattrash.raccoonforfriendica.feature.login
 import cafe.adriel.voyager.core.model.screenModelScope
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
 import com.livefast.eattrash.raccoonforfriendica.core.utils.validation.ValidationError
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.CredentialsRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.LoginUseCase
 import kotlinx.coroutines.launch
 
 class LoginViewModel(
     private val credentialsRepository: CredentialsRepository,
+    private val apiConfigurationRepository: ApiConfigurationRepository,
     private val loginUseCase: LoginUseCase,
 ) : DefaultMviModel<LoginMviModel.Intent, LoginMviModel.State, LoginMviModel.Effect>(
         initialState = LoginMviModel.State(),
     ),
     LoginMviModel {
+    init {
+        screenModelScope.launch {
+            val currentNode = apiConfigurationRepository.node.value
+            updateState { it.copy(nodeName = currentNode) }
+        }
+    }
+
     override fun reduce(intent: LoginMviModel.Intent) {
         when (intent) {
             is LoginMviModel.Intent.SetNodeName ->

--- a/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/di/LoginModule.kt
+++ b/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/di/LoginModule.kt
@@ -9,6 +9,7 @@ val featureLoginModule =
         factory<LoginMviModel> {
             LoginViewModel(
                 credentialsRepository = get(),
+                apiConfigurationRepository = get(),
                 loginUseCase = get(),
             )
         }


### PR DESCRIPTION
This PR fixes a couple of issues in the navigation drawer and login screen:
- user info in the drawer is in synch with active account (thanks to Room flow queries)
- current node name is used as default value in the login screen