### PR TITLE
feat: edit and delete options in timeline, entry detail, forum list and forum detail

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/SharedModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/SharedModule.kt
@@ -14,7 +14,7 @@ internal val sharedModule =
         single<DetailOpener> {
             DefaultDetailOpener(
                 navigationCoordinator = get(),
-                apiConfigurationRepository = get(),
+                identityRepository = get(),
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
@@ -6,7 +6,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.NavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.FavoritesType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserListType
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.ComposerScreen
 import com.livefast.eattrash.raccoonforfriendica.feature.entrydetail.EntryDetailScreen
 import com.livefast.eattrash.raccoonforfriendica.feature.favorites.FavoritesScreen
@@ -21,11 +21,15 @@ import com.livefast.eattrash.raccoonforfriendica.feaure.search.SearchScreen
 
 class DefaultDetailOpener(
     private val navigationCoordinator: NavigationCoordinator,
-    private val apiConfigurationRepository: ApiConfigurationRepository,
+    private val identityRepository: IdentityRepository,
 ) : DetailOpener {
-    private val isLogged: Boolean get() = apiConfigurationRepository.isLogged.value
+    private val isLogged: Boolean get() = identityRepository.isLogged.value
+    private val currentUserId: String? get() = identityRepository.currentUser.value?.id
 
     override fun openUserDetail(id: String) {
+        if (id == currentUserId) {
+            return
+        }
         val screen = UserDetailScreen(id)
         navigationCoordinator.push(screen)
     }

--- a/domain/identity/repository/build.gradle.kts
+++ b/domain/identity/repository/build.gradle.kts
@@ -40,6 +40,7 @@ kotlin {
                 implementation(projects.core.preferences)
                 implementation(projects.core.utils)
 
+                implementation(projects.domain.content.data)
                 implementation(projects.domain.identity.data)
             }
         }

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/ApiConfigurationRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/ApiConfigurationRepository.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.flow.StateFlow
 @Stable
 interface ApiConfigurationRepository {
     val node: StateFlow<String>
-    val isLogged: StateFlow<Boolean>
 
     fun changeNode(value: String)
 

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultApiConfigurationRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultApiConfigurationRepository.kt
@@ -13,9 +13,9 @@ private const val DEFAULT_NODE = "poliverso.org"
 internal class DefaultApiConfigurationRepository(
     private val serviceProvider: ServiceProvider,
     private val keyStore: TemporaryKeyStore,
+    private val identityRepository: MutableIdentityRepository,
 ) : ApiConfigurationRepository {
     override val node = MutableStateFlow("")
-    override val isLogged = MutableStateFlow(false)
 
     init {
         val nodeName = keyStore[KEY_LAST_NODE, ""].takeIf { it.isNotEmpty() } ?: DEFAULT_NODE
@@ -35,6 +35,7 @@ internal class DefaultApiConfigurationRepository(
 
     override fun setAuth(credentials: Pair<String, String>?) {
         serviceProvider.setAuth(credentials)
+
         if (credentials != null) {
             keyStore.save(KEY_CRED_1, credentials.first)
             keyStore.save(KEY_CRED_2, credentials.second)
@@ -42,6 +43,7 @@ internal class DefaultApiConfigurationRepository(
             keyStore.remove(KEY_CRED_1)
             keyStore.remove(KEY_CRED_2)
         }
-        isLogged.update { credentials != null }
+
+        identityRepository.changeIsLogged(credentials != null)
     }
 }

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultIdentityRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultIdentityRepository.kt
@@ -1,0 +1,56 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository
+
+import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+internal class DefaultIdentityRepository(
+    private val accountRepository: AccountRepository,
+    private val provider: ServiceProvider,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : IdentityRepository,
+    MutableIdentityRepository {
+    override val isLogged = MutableStateFlow(false)
+    override val currentUser = MutableStateFlow<UserModel?>(null)
+
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+
+    override fun changeIsLogged(value: Boolean) {
+        isLogged.update { value }
+        if (value) {
+            refreshUser()
+        } else {
+            currentUser.update { null }
+        }
+    }
+
+    private fun refreshUser() {
+        scope.launch {
+            val handle = accountRepository.getActive()?.handle.orEmpty()
+            if (handle.isEmpty()) {
+                currentUser.update { null }
+                return@launch
+            }
+
+            try {
+                val user = provider.users.lookup(handle)
+                currentUser.update {
+                    UserModel(
+                        id = user.id,
+                        handle = user.acct,
+                        username = user.username,
+                    )
+                }
+            } catch (e: Throwable) {
+                currentUser.update { null }
+            }
+        }
+    }
+}

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/IdentityRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/IdentityRepository.kt
@@ -1,0 +1,13 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import kotlinx.coroutines.flow.StateFlow
+
+interface IdentityRepository {
+    val isLogged: StateFlow<Boolean>
+    val currentUser: StateFlow<UserModel?>
+}
+
+internal interface MutableIdentityRepository {
+    fun changeIsLogged(value: Boolean)
+}

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/di/IdentityRepositoryModule.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/di/IdentityRepositoryModule.kt
@@ -6,9 +6,13 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Cred
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultAccountRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultApiConfigurationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultCredentialsRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultIdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultSettingsRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.MutableIdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
 import org.koin.core.qualifier.named
+import org.koin.dsl.binds
 import org.koin.dsl.module
 
 val domainIdentityRepositoryModule =
@@ -17,8 +21,16 @@ val domainIdentityRepositoryModule =
             DefaultApiConfigurationRepository(
                 serviceProvider = get(named("default")),
                 keyStore = get(),
+                identityRepository = get(),
             )
         }
+
+        single {
+            DefaultIdentityRepository(
+                accountRepository = get(),
+                provider = get(named("default")),
+            )
+        } binds arrayOf(IdentityRepository::class, MutableIdentityRepository::class)
 
         single<CredentialsRepository> {
             DefaultCredentialsRepository(

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailMviModel.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailMviModel.kt
@@ -24,10 +24,14 @@ interface EntryDetailMviModel :
         data class ToggleBookmark(
             val entry: TimelineEntryModel,
         ) : Intent
+
+        data class DeleteEntry(
+            val entryId: String,
+        ) : Intent
     }
 
     data class State(
-        val isLogged: Boolean = false,
+        val currentUserId: String? = null,
         val refreshing: Boolean = false,
         val initial: Boolean = true,
         val creator: UserModel? = null,

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.material.icons.automirrored.filled.Reply
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
@@ -37,8 +39,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
@@ -92,6 +96,7 @@ class EntryDetailScreen(
         val shareHelper = remember { getShareHelper() }
         val copyToClipboardSuccess = LocalStrings.current.messageTextCopiedToClipboard
         val clipboardManager = LocalClipboardManager.current
+        var confirmDeleteEntryId by remember { mutableStateOf<String?>(null) }
 
         fun goBackToTop() {
             runCatching {
@@ -149,7 +154,7 @@ class EntryDetailScreen(
                 )
             },
             floatingActionButton = {
-                if (uiState.isLogged) {
+                if (uiState.currentUserId != null) {
                     AnimatedVisibility(
                         visible = isFabVisible,
                         enter =
@@ -192,131 +197,190 @@ class EntryDetailScreen(
                     )
                 }
             },
-            content = { padding ->
-                val pullRefreshState =
-                    rememberPullRefreshState(
-                        refreshing = uiState.refreshing,
-                        onRefresh = {
-                            model.reduce(EntryDetailMviModel.Intent.Refresh)
-                        },
-                    )
-                Box(
-                    modifier =
-                        Modifier
-                            .padding(padding)
-                            .nestedScroll(scrollBehavior.nestedScrollConnection)
-                            .nestedScroll(fabNestedScrollConnection)
-                            .pullRefresh(pullRefreshState),
+        ) { padding ->
+            val pullRefreshState =
+                rememberPullRefreshState(
+                    refreshing = uiState.refreshing,
+                    onRefresh = {
+                        model.reduce(EntryDetailMviModel.Intent.Refresh)
+                    },
+                )
+            Box(
+                modifier =
+                    Modifier
+                        .padding(padding)
+                        .nestedScroll(scrollBehavior.nestedScrollConnection)
+                        .nestedScroll(fabNestedScrollConnection)
+                        .pullRefresh(pullRefreshState),
+            ) {
+                LazyColumn(
+                    state = lazyListState,
                 ) {
-                    LazyColumn(
-                        state = lazyListState,
-                    ) {
-                        if (uiState.initial) {
-                            items(5) {
-                                TimelineItemPlaceholder(modifier = Modifier.fillMaxWidth())
-                                HorizontalDivider(
-                                    modifier = Modifier.padding(vertical = Spacing.s),
-                                )
-                            }
-                        }
-
-                        items(
-                            items = uiState.entries,
-                            key = { it.safeKey },
-                        ) { entry ->
-                            TimelineItem(
-                                entry = entry,
-                                extendedSocialInfoEnabled = (entry.id == id),
-                                blurNsfw = uiState.blurNsfw,
-                                onOpenUrl = { url ->
-                                    openUrl(url)
-                                },
-                                onClick = { e ->
-                                    if (e.id != id) {
-                                        detailOpener.openEntryDetail(entry.id)
-                                    }
-                                },
-                                onOpenUser = {
-                                    detailOpener.openUserDetail(it.id)
-                                },
-                                onOpenImage = { imageUrl ->
-                                    detailOpener.openImageDetail(imageUrl)
-                                },
-                                onReblog = { e ->
-                                    model.reduce(EntryDetailMviModel.Intent.ToggleReblog(e))
-                                },
-                                onBookmark = { e ->
-                                    model.reduce(EntryDetailMviModel.Intent.ToggleBookmark(e))
-                                },
-                                onFavorite = { e ->
-                                    model.reduce(EntryDetailMviModel.Intent.ToggleFavorite(e))
-                                },
-                                onOpenUsersFavorite = { e ->
-                                    detailOpener.openEntryUsersFavorite(
-                                        entryId = e.id,
-                                        count = e.favoriteCount,
-                                    )
-                                },
-                                onOpenUsersReblog = { e ->
-                                    detailOpener.openEntryUsersReblog(
-                                        entryId = e.id,
-                                        count = e.reblogCount,
-                                    )
-                                },
-                                onReply = { e ->
-                                    detailOpener.openComposer(
-                                        inReplyToId = e.id,
-                                        inReplyToHandle = e.creator?.handle,
-                                        inReplyToUsername =
-                                            e.creator?.let {
-                                                it.displayName ?: it.username
-                                            },
-                                    )
-                                },
-                                options =
-                                    buildList {
-                                        if (!entry.url.isNullOrBlank()) {
-                                            this += OptionId.Share.toOption()
-                                            this += OptionId.CopyUrl.toOption()
-                                        }
-                                    },
-                                onOptionSelected = { optionId ->
-                                    when (optionId) {
-                                        OptionId.Share -> {
-                                            val urlString = entry.url.orEmpty()
-                                            shareHelper.share(urlString)
-                                        }
-
-                                        OptionId.CopyUrl -> {
-                                            val urlString = entry.url.orEmpty()
-                                            clipboardManager.setText(AnnotatedString(urlString))
-                                            scope.launch {
-                                                snackbarHostState.showSnackbar(copyToClipboardSuccess)
-                                            }
-                                        }
-
-                                        else -> Unit
-                                    }
-                                },
-                            )
+                    if (uiState.initial) {
+                        items(5) {
+                            TimelineItemPlaceholder(modifier = Modifier.fillMaxWidth())
                             HorizontalDivider(
                                 modifier = Modifier.padding(vertical = Spacing.s),
                             )
                         }
-                        item {
-                            Spacer(modifier = Modifier.height(Spacing.xxxl))
-                        }
                     }
 
-                    PullRefreshIndicator(
-                        refreshing = uiState.refreshing,
-                        state = pullRefreshState,
-                        modifier = Modifier.align(Alignment.TopCenter),
-                        backgroundColor = MaterialTheme.colorScheme.background,
-                        contentColor = MaterialTheme.colorScheme.onBackground,
-                    )
+                    items(
+                        items = uiState.entries,
+                        key = { it.safeKey },
+                    ) { entry ->
+                        TimelineItem(
+                            entry = entry,
+                            extendedSocialInfoEnabled = (entry.id == id),
+                            blurNsfw = uiState.blurNsfw,
+                            onOpenUrl = { url ->
+                                openUrl(url)
+                            },
+                            onClick = { e ->
+                                if (e.id != id) {
+                                    detailOpener.openEntryDetail(entry.id)
+                                }
+                            },
+                            onOpenUser = {
+                                detailOpener.openUserDetail(it.id)
+                            },
+                            onOpenImage = { imageUrl ->
+                                detailOpener.openImageDetail(imageUrl)
+                            },
+                            onReblog = { e ->
+                                model.reduce(EntryDetailMviModel.Intent.ToggleReblog(e))
+                            },
+                            onBookmark = { e ->
+                                model.reduce(EntryDetailMviModel.Intent.ToggleBookmark(e))
+                            },
+                            onFavorite = { e ->
+                                model.reduce(EntryDetailMviModel.Intent.ToggleFavorite(e))
+                            },
+                            onOpenUsersFavorite = { e ->
+                                detailOpener.openEntryUsersFavorite(
+                                    entryId = e.id,
+                                    count = e.favoriteCount,
+                                )
+                            },
+                            onOpenUsersReblog = { e ->
+                                detailOpener.openEntryUsersReblog(
+                                    entryId = e.id,
+                                    count = e.reblogCount,
+                                )
+                            },
+                            onReply = { e ->
+                                detailOpener.openComposer(
+                                    inReplyToId = e.id,
+                                    inReplyToHandle = e.creator?.handle,
+                                    inReplyToUsername =
+                                        e.creator?.let {
+                                            it.displayName ?: it.username
+                                        },
+                                )
+                            },
+                            options =
+                                buildList {
+                                    if (!entry.url.isNullOrBlank()) {
+                                        this += OptionId.Share.toOption()
+                                        this += OptionId.CopyUrl.toOption()
+                                    }
+                                    val isByCurrentUser =
+                                        entry.creator?.id == uiState.currentUserId && entry.reblog == null
+                                    val isReblogByCurrentUser =
+                                        entry.reblog?.creator?.id == uiState.currentUserId
+                                    if (isByCurrentUser || isReblogByCurrentUser) {
+                                        this += OptionId.Edit.toOption()
+                                        this += OptionId.Delete.toOption()
+                                    }
+                                },
+                            onOptionSelected = { optionId ->
+                                when (optionId) {
+                                    OptionId.Share -> {
+                                        val urlString = entry.url.orEmpty()
+                                        shareHelper.share(urlString)
+                                    }
+
+                                    OptionId.CopyUrl -> {
+                                        val urlString = entry.url.orEmpty()
+                                        clipboardManager.setText(AnnotatedString(urlString))
+                                        scope.launch {
+                                            snackbarHostState.showSnackbar(copyToClipboardSuccess)
+                                        }
+                                    }
+
+                                    OptionId.Edit -> {
+                                        (entry.reblog ?: entry).also { entryToEdit ->
+                                            detailOpener.openComposer(
+                                                inReplyToId = entryToEdit.inReplyTo?.id,
+                                                inReplyToHandle = entryToEdit.inReplyTo?.creator?.handle,
+                                                inReplyToUsername = entryToEdit.inReplyTo?.creator?.username,
+                                                editedPostId = entryToEdit.id,
+                                            )
+                                        }
+                                    }
+
+                                    OptionId.Delete -> confirmDeleteEntryId = entry.id
+
+                                    else -> Unit
+                                }
+                            },
+                        )
+                        HorizontalDivider(
+                            modifier = Modifier.padding(vertical = Spacing.s),
+                        )
+                    }
+                    item {
+                        Spacer(modifier = Modifier.height(Spacing.xxxl))
+                    }
                 }
-            },
-        )
+
+                PullRefreshIndicator(
+                    refreshing = uiState.refreshing,
+                    state = pullRefreshState,
+                    modifier = Modifier.align(Alignment.TopCenter),
+                    backgroundColor = MaterialTheme.colorScheme.background,
+                    contentColor = MaterialTheme.colorScheme.onBackground,
+                )
+            }
+        }
+
+        if (confirmDeleteEntryId != null) {
+            AlertDialog(
+                onDismissRequest = {
+                    confirmDeleteEntryId = null
+                },
+                title = {
+                    Text(
+                        text = LocalStrings.current.actionDelete,
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                },
+                text = {
+                    Text(text = LocalStrings.current.messageAreYouSure)
+                },
+                dismissButton = {
+                    Button(
+                        onClick = {
+                            confirmDeleteEntryId = null
+                        },
+                    ) {
+                        Text(text = LocalStrings.current.buttonCancel)
+                    }
+                },
+                confirmButton = {
+                    Button(
+                        onClick = {
+                            val entryId = confirmDeleteEntryId ?: ""
+                            confirmDeleteEntryId = null
+                            if (entryId.isNotEmpty()) {
+                                model.reduce(EntryDetailMviModel.Intent.DeleteEntry(entryId))
+                            }
+                        },
+                    ) {
+                        Text(text = LocalStrings.current.buttonConfirm)
+                    }
+                },
+            )
+        }
     }
 }

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/di/EntryDetailModule.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/di/EntryDetailModule.kt
@@ -10,7 +10,7 @@ val featureEntryDetailModule =
             EntryDetailViewModel(
                 id = params[0],
                 timelineEntryRepository = get(),
-                apiConfigurationRepository = get(),
+                identityRepository = get(),
                 settingsRepository = get(),
             )
         }

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreViewModel.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreViewModel.kt
@@ -11,7 +11,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.Explo
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.ExplorePaginationSpecification
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
 import com.livefast.eattrash.raccoonforfriendica.feature.explore.data.ExploreSection
 import kotlinx.coroutines.flow.combine
@@ -23,7 +23,7 @@ class ExploreViewModel(
     private val paginationManager: ExplorePaginationManager,
     private val userRepository: UserRepository,
     private val timelineEntryRepository: TimelineEntryRepository,
-    private val apiConfigurationRepository: ApiConfigurationRepository,
+    private val identityRepository: IdentityRepository,
     private val settingsRepository: SettingsRepository,
 ) : DefaultMviModel<ExploreMviModel.Intent, ExploreMviModel.State, ExploreMviModel.Effect>(
         initialState = ExploreMviModel.State(),
@@ -33,7 +33,7 @@ class ExploreViewModel(
         screenModelScope.launch {
             combine(
                 settingsRepository.current,
-                apiConfigurationRepository.isLogged,
+                identityRepository.isLogged,
             ) { settings, isLogged ->
                 settings to isLogged
             }.onEach { (settings, isLogged) ->

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/di/ExploreModule.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/di/ExploreModule.kt
@@ -11,7 +11,7 @@ val featureExploreModule =
                 paginationManager = get(),
                 userRepository = get(),
                 timelineEntryRepository = get(),
-                apiConfigurationRepository = get(),
+                identityRepository = get(),
                 settingsRepository = get(),
             )
         }

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
@@ -8,7 +8,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.NotificationsPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.NotificationsPaginationSpecification
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -17,7 +17,7 @@ import kotlinx.coroutines.launch
 class InboxViewModel(
     private val paginationManager: NotificationsPaginationManager,
     private val userRepository: UserRepository,
-    private val apiConfigurationRepository: ApiConfigurationRepository,
+    private val identityRepository: IdentityRepository,
     private val settingsRepository: SettingsRepository,
 ) : DefaultMviModel<InboxMviModel.Intent, InboxMviModel.State, InboxMviModel.Effect>(
         initialState = InboxMviModel.State(),
@@ -25,7 +25,7 @@ class InboxViewModel(
     InboxMviModel {
     init {
         screenModelScope.launch {
-            apiConfigurationRepository.isLogged
+            identityRepository.isLogged
                 .onEach { isLogged ->
                     updateState {
                         it.copy(isLogged = isLogged)

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/di/InboxModule.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/di/InboxModule.kt
@@ -10,7 +10,7 @@ val featureInboxModule =
             InboxViewModel(
                 paginationManager = get(),
                 userRepository = get(),
-                apiConfigurationRepository = get(),
+                identityRepository = get(),
                 settingsRepository = get(),
             )
         }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileViewModel.kt
@@ -2,7 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.feature.profile
 
 import cafe.adriel.voyager.core.model.screenModelScope
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.LogoutUseCase
 import com.livefast.eattrash.raccoonforfriendica.feature.profile.domain.MyAccountCache
 import kotlinx.coroutines.flow.launchIn
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 class ProfileViewModel(
-    private val apiConfigurationRepository: ApiConfigurationRepository,
+    private val identityRepository: IdentityRepository,
     private val logoutUseCase: LogoutUseCase,
     private val myAccountCache: MyAccountCache,
 ) : DefaultMviModel<ProfileMviModel.Intent, ProfileMviModel.State, ProfileMviModel.Effect>(
@@ -19,7 +19,7 @@ class ProfileViewModel(
     ProfileMviModel {
     init {
         screenModelScope.launch {
-            apiConfigurationRepository.isLogged
+            identityRepository.isLogged
                 .onEach { isLogged ->
                     updateState {
                         it.copy(isLogged = isLogged)

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/di/ProfileModule.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/di/ProfileModule.kt
@@ -12,7 +12,7 @@ val featureProfileModule =
     module {
         factory<ProfileMviModel> {
             ProfileViewModel(
-                apiConfigurationRepository = get(),
+                identityRepository = get(),
                 logoutUseCase = get(),
                 myAccountCache = get(),
             )

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsViewModel.kt
@@ -14,7 +14,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineTyp
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toInt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toTimelineType
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -26,14 +26,14 @@ class SettingsViewModel(
     private val themeRepository: ThemeRepository,
     private val colorSchemeProvider: ColorSchemeProvider,
     private val themeColorRepository: ThemeColorRepository,
-    private val apiConfigurationRepository: ApiConfigurationRepository,
+    private val identityRepository: IdentityRepository,
 ) : DefaultMviModel<SettingsMviModel.Intent, SettingsMviModel.State, SettingsMviModel.Effect>(
         initialState = SettingsMviModel.State(),
     ),
     SettingsMviModel {
     init {
         screenModelScope.launch {
-            apiConfigurationRepository.isLogged
+            identityRepository.isLogged
                 .onEach { isLogged ->
                     updateState {
                         it.copy(

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/di/SettingsModule.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/di/SettingsModule.kt
@@ -13,7 +13,7 @@ val featureSettingsModule =
                 settingsRepository = get(),
                 colorSchemeProvider = get(),
                 themeColorRepository = get(),
-                apiConfigurationRepository = get(),
+                identityRepository = get(),
             )
         }
     }

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadMviModel.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadMviModel.kt
@@ -27,10 +27,14 @@ interface ThreadMviModel :
         data class LoadMoreReplies(
             val entry: TimelineEntryModel,
         ) : Intent
+
+        data class DeleteEntry(
+            val entryId: String,
+        ) : Intent
     }
 
     data class State(
-        val isLogged: Boolean = false,
+        val currentUserId: String? = null,
         val refreshing: Boolean = false,
         val loading: Boolean = false,
         val initial: Boolean = true,

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/di/ThreadModule.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/di/ThreadModule.kt
@@ -18,7 +18,7 @@ val featureThreadModule =
                 entryId = params[0],
                 populateThreadUseCase = get(),
                 timelineEntryRepository = get(),
-                apiConfigurationRepository = get(),
+                identityRepository = get(),
                 settingsRepository = get(),
             )
         }

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineMviModel.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineMviModel.kt
@@ -30,10 +30,14 @@ interface TimelineMviModel :
         data class ToggleBookmark(
             val entry: TimelineEntryModel,
         ) : Intent
+
+        data class DeleteEntry(
+            val entryId: String,
+        ) : Intent
     }
 
     data class State(
-        val isLogged: Boolean = false,
+        val currentUserId: String? = null,
         val refreshing: Boolean = false,
         val loading: Boolean = false,
         val initial: Boolean = true,

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/di/TimelineModule.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/di/TimelineModule.kt
@@ -9,7 +9,7 @@ val featureTimelineModule =
         factory<TimelineMviModel> {
             TimelineViewModel(
                 paginationManager = get(),
-                apiConfigurationRepository = get(),
+                identityRepository = get(),
                 timelineEntryRepository = get(),
                 settingsRepository = get(),
             )

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailViewModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailViewModel.kt
@@ -11,7 +11,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.Timel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -22,7 +22,7 @@ class UserDetailViewModel(
     private val userRepository: UserRepository,
     private val paginationManager: TimelinePaginationManager,
     private val timelineEntryRepository: TimelineEntryRepository,
-    private val apiConfigurationRepository: ApiConfigurationRepository,
+    private val identityRepository: IdentityRepository,
     private val accountRepository: AccountRepository,
     private val settingsRepository: SettingsRepository,
 ) : DefaultMviModel<UserDetailMviModel.Intent, UserDetailMviModel.State, UserDetailMviModel.Effect>(
@@ -31,12 +31,9 @@ class UserDetailViewModel(
     UserDetailMviModel {
     init {
         screenModelScope.launch {
-            apiConfigurationRepository.isLogged
-                .onEach {
-                    val currentUserHandle = accountRepository.getActive()?.handle.orEmpty()
-                    val currentUser = userRepository.getByHandle(currentUserHandle)
-                    updateState { it.copy(currentUserId = currentUser?.id) }
-
+            identityRepository.currentUser
+                .onEach { user ->
+                    updateState { it.copy(currentUserId = user?.id) }
                     loadUser()
                 }.launchIn(this)
 

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/di/UserDetailModule.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/di/UserDetailModule.kt
@@ -14,7 +14,7 @@ val featureUserDetailModule =
                 userRepository = get(),
                 paginationManager = get(),
                 timelineEntryRepository = get(),
-                apiConfigurationRepository = get(),
+                identityRepository = get(),
                 accountRepository = get(),
                 settingsRepository = get(),
             )
@@ -25,7 +25,7 @@ val featureUserDetailModule =
                 userRepository = get(),
                 paginationManager = get(),
                 timelineEntryRepository = get(),
-                apiConfigurationRepository = get(),
+                identityRepository = get(),
                 settingsRepository = get(),
             )
         }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListMviModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListMviModel.kt
@@ -26,10 +26,14 @@ interface ForumListMviModel :
         data class ToggleBookmark(
             val entry: TimelineEntryModel,
         ) : Intent
+
+        data class DeleteEntry(
+            val entryId: String,
+        ) : Intent
     }
 
     data class State(
-        val isLogged: Boolean = false,
+        val currentUserId: String? = null,
         val refreshing: Boolean = false,
         val loading: Boolean = false,
         val initial: Boolean = true,


### PR DESCRIPTION
This PR makes the `Delete` and `Edit` options introduced just in the profile screen in #73 and #78 global to more screens. Moreover, it introduces an `IdentityRepository` which replaces `ApiConfigurationRepostiory` for information about the current user.