### PR TITLE
fix: load feed type at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The app is under ongoing development, here is a list of the features that are be
 - [x] mute/unmute user and see list of muted users
 - [x] block/unblock user and see list of blocked users
 - [ ] switch from basic auth to OAuth
+- [ ] support post spoiler text
 - [ ] edit one's own profile
 - [ ] manage one's own circles (Friendica-specific)
 - [ ] manage one's own lists

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineMviModel.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineMviModel.kt
@@ -52,7 +52,7 @@ interface TimelineMviModel :
         val loading: Boolean = false,
         val initial: Boolean = true,
         val canFetchMore: Boolean = true,
-        val timelineType: TimelineType = TimelineType.Local,
+        val timelineType: TimelineType? = null,
         val availableTimelineTypes: List<TimelineType> = emptyList(),
         val entries: List<TimelineEntryModel> = emptyList(),
         val blurNsfw: Boolean = true,

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
@@ -150,7 +150,7 @@ class TimelineScreen : Screen {
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
-                            text = uiState.timelineType.toReadableName(),
+                            text = uiState.timelineType?.toReadableName().orEmpty(),
                             style = MaterialTheme.typography.titleMedium,
                         )
                     },

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
@@ -44,9 +44,7 @@ class TimelineViewModel(
                                 }
                                 this += TimelineType.Local
                             },
-                        timelineType =
-                            settings?.defaultTimelineType?.toTimelineType()
-                                ?: TimelineType.Local,
+                        timelineType = settings?.defaultTimelineType?.toTimelineType(),
                         blurNsfw = settings?.blurNsfw ?: true,
                         currentUserId = currentUser?.id,
                     )
@@ -108,7 +106,7 @@ class TimelineViewModel(
         }
         paginationManager.reset(
             TimelinePaginationSpecification.Feed(
-                timelineType = uiState.value.timelineType,
+                timelineType = uiState.value.timelineType ?: TimelineType.Local,
                 includeNsfw = settingsRepository.current.value?.includeNsfw ?: false,
             ),
         )


### PR DESCRIPTION
This PR fixes a glitch when first opening the app because the "Local" feed type is shown before the correct default one.