### PR TITLE
fix: refinement on 0.1.0-alpha05

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
@@ -79,10 +80,19 @@ class MainActivity : ComponentActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        val authManager = getAuthManager()
-        val uri = intent.data.toString()
-        lifecycleScope.launch {
-            authManager.performTokenExchange(uri)
+        intent.data?.also {
+            handleIncomingUrl(it)
+        }
+    }
+
+    private fun handleIncomingUrl(uri: Uri) {
+        if (uri.scheme == "raccoonforfriendica" && uri.host == "auth") {
+            val authManager = getAuthManager()
+            lifecycleScope.launch {
+                kotlin.runCatching {
+                    authManager.performTokenExchange(uri.toString())
+                }
+            }
         }
     }
 }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultExplorePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultExplorePaginationManager.kt
@@ -52,15 +52,18 @@ internal class DefaultExplorePaginationManager(
                             ),
                         )
                     }
-            }.apply {
-                offset = size
-                canFetchMore = isNotEmpty()
-            }.deduplicate()
+            }.deduplicate().updatePaginationData()
         history.addAll(results)
 
         // return a copy
         return history.map { it }
     }
+
+    private fun List<ExploreItemModel>.updatePaginationData(): List<ExploreItemModel> =
+        apply {
+            offset = size
+            canFetchMore = isNotEmpty()
+        }
 
     private fun List<ExploreItemModel>.deduplicate(): List<ExploreItemModel> =
         filter { e1 ->

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFavoritesPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFavoritesPaginationManager.kt
@@ -25,28 +25,30 @@ internal class DefaultFavoritesPaginationManager(
         val results =
             when (specification) {
                 is FavoritesPaginationSpecification.Bookmarks ->
-                    timelineEntryRepository.getBookmarks(pageCursor = pageCursor)
-                        .apply {
-                            lastOrNull()?.also {
-                                pageCursor = it.id
-                            }
-                            canFetchMore = isNotEmpty()
-                        }.filterNsfw(specification.includeNsfw)
+                    timelineEntryRepository
+                        .getBookmarks(pageCursor = pageCursor)
+                        .updatePaginationData()
+                        .filterNsfw(specification.includeNsfw)
 
                 is FavoritesPaginationSpecification.Favorites ->
-                    timelineEntryRepository.getFavorites(pageCursor = pageCursor)
-                        .apply {
-                            lastOrNull()?.also {
-                                pageCursor = it.id
-                            }
-                            canFetchMore = isNotEmpty()
-                        }.filterNsfw(specification.includeNsfw)
+                    timelineEntryRepository
+                        .getFavorites(pageCursor = pageCursor)
+                        .updatePaginationData()
+                        .filterNsfw(specification.includeNsfw)
             }.deduplicate()
         history.addAll(results)
 
         // return a copy
         return history.map { it }
     }
+
+    private fun List<TimelineEntryModel>.updatePaginationData(): List<TimelineEntryModel> =
+        apply {
+            lastOrNull()?.also {
+                pageCursor = it.id
+            }
+            canFetchMore = isNotEmpty()
+        }
 
     private fun List<TimelineEntryModel>.deduplicate(): List<TimelineEntryModel> =
         filter { e1 ->

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFollowedHashtagsPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFollowedHashtagsPaginationManager.kt
@@ -18,17 +18,18 @@ internal class DefaultFollowedHashtagsPaginationManager(
 
     override suspend fun loadNextPage(): List<TagModel> {
         val (tags, cursor) = tagRepository.getFollowed()
-        val results =
-            tags
-                .apply {
-                    pageCursor = cursor
-                    canFetchMore = isNotEmpty()
-                }.deduplicate()
+        val results = tags.deduplicate().updatePaginationData(cursor)
         history.addAll(results)
 
         // return a copy
         return history.map { it }
     }
+
+    private fun List<TagModel>.updatePaginationData(cursor: String?): List<TagModel> =
+        apply {
+            pageCursor = cursor
+            canFetchMore = isNotEmpty()
+        }
 
     private fun List<TagModel>.deduplicate(): List<TagModel> =
         filter { e1 ->

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultNotificationsPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultNotificationsPaginationManager.kt
@@ -34,18 +34,22 @@ internal class DefaultNotificationsPaginationManager(
                             pageCursor = pageCursor,
                             types = specification.types,
                         ).determineRelationshipStatus()
-                        .apply {
-                            lastOrNull()?.also {
-                                pageCursor = it.id
-                            }
-                            canFetchMore = isNotEmpty()
-                        }.filterNsfw(specification.includeNsfw)
+                        .updatePaginationData()
+                        .filterNsfw(specification.includeNsfw)
             }.deduplicate()
         history.addAll(results)
 
         // return a copy
         return history.map { it }
     }
+
+    private suspend fun List<NotificationModel>.updatePaginationData(): List<NotificationModel> =
+        apply {
+            lastOrNull()?.also {
+                pageCursor = it.id
+            }
+            canFetchMore = isNotEmpty()
+        }
 
     private suspend fun List<NotificationModel>.determineRelationshipStatus(): List<NotificationModel> =
         run {

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultSearchPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultSearchPaginationManager.kt
@@ -30,12 +30,7 @@ internal class DefaultSearchPaginationManager(
                             query = specification.query,
                             pageCursor = pageCursor,
                             type = SearchResultType.Entries,
-                        ).apply {
-                            lastOrNull()?.also {
-                                pageCursor = it.id
-                            }
-                            canFetchMore = isNotEmpty()
-                        }.filterNsfw(specification.includeNsfw)
+                        ).filterNsfw(specification.includeNsfw)
 
                 is SearchPaginationSpecification.Hashtags ->
                     searchRepository
@@ -43,12 +38,7 @@ internal class DefaultSearchPaginationManager(
                             query = specification.query,
                             pageCursor = pageCursor,
                             type = SearchResultType.Hashtags,
-                        ).apply {
-                            lastOrNull()?.also {
-                                pageCursor = it.id
-                            }
-                            canFetchMore = isNotEmpty()
-                        }
+                        )
 
                 is SearchPaginationSpecification.Users ->
                     searchRepository
@@ -56,18 +46,21 @@ internal class DefaultSearchPaginationManager(
                             query = specification.query,
                             pageCursor = pageCursor,
                             type = SearchResultType.Users,
-                        ).apply {
-                            lastOrNull()?.also {
-                                pageCursor = it.id
-                            }
-                            canFetchMore = isNotEmpty()
-                        }
-            }.deduplicate()
+                        )
+            }.deduplicate().updatePaginationData()
         history.addAll(results)
 
         // return an object containing copies
         return history.map { it }
     }
+
+    private fun List<ExploreItemModel>.updatePaginationData(): List<ExploreItemModel> =
+        apply {
+            lastOrNull()?.also {
+                pageCursor = it.id
+            }
+            canFetchMore = isNotEmpty()
+        }
 
     private fun List<ExploreItemModel>.deduplicate(): List<ExploreItemModel> =
         filter { e1 ->

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
@@ -43,23 +43,14 @@ internal class DefaultTimelinePaginationManager(
                             timelineRepository.getLocal(
                                 pageCursor = pageCursor,
                             )
-                    }.apply {
-                        lastOrNull()?.also {
-                            pageCursor = it.id
-                        }
-                        canFetchMore = isNotEmpty()
-                    }.filterNsfw(specification.includeNsfw)
+                    }.updatePaginationData().filterNsfw(specification.includeNsfw)
                 }
 
                 is TimelinePaginationSpecification.Hashtag -> {
                     timelineRepository
                         .getHashtag(specification.hashtag)
-                        .apply {
-                            lastOrNull()?.also {
-                                pageCursor = it.id
-                            }
-                            canFetchMore = isNotEmpty()
-                        }.filterNsfw(specification.includeNsfw)
+                        .updatePaginationData()
+                        .filterNsfw(specification.includeNsfw)
                 }
 
                 is TimelinePaginationSpecification.User ->
@@ -71,12 +62,8 @@ internal class DefaultTimelinePaginationManager(
                             excludeReblogs = specification.excludeReblogs,
                             onlyMedia = specification.onlyMedia,
                             pinned = specification.pinned,
-                        ).apply {
-                            lastOrNull()?.also {
-                                pageCursor = it.id
-                            }
-                            canFetchMore = isNotEmpty()
-                        }.filterNsfw(specification.includeNsfw)
+                        ).updatePaginationData()
+                        .filterNsfw(specification.includeNsfw)
             }.deduplicate()
         history.addAll(results)
 
@@ -101,6 +88,14 @@ internal class DefaultTimelinePaginationManager(
             history.addAll(it.history)
         }
     }
+
+    private fun List<TimelineEntryModel>.updatePaginationData(): List<TimelineEntryModel> =
+        apply {
+            lastOrNull()?.also {
+                pageCursor = it.id
+            }
+            canFetchMore = isNotEmpty()
+        }
 
     private fun List<TimelineEntryModel>.deduplicate(): List<TimelineEntryModel> =
         filter { e1 ->

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUserPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUserPaginationManager.kt
@@ -33,12 +33,6 @@ internal class DefaultUserPaginationManager(
                             id = specification.userId,
                             pageCursor = pageCursor,
                         ).determineRelationshipStatus()
-                        .apply {
-                            lastOrNull()?.also {
-                                pageCursor = it.id
-                            }
-                            canFetchMore = isNotEmpty()
-                        }
 
                 is UserPaginationSpecification.Following ->
                     userRepository
@@ -46,12 +40,6 @@ internal class DefaultUserPaginationManager(
                             id = specification.userId,
                             pageCursor = pageCursor,
                         ).determineRelationshipStatus()
-                        .apply {
-                            lastOrNull()?.also {
-                                pageCursor = it.id
-                            }
-                            canFetchMore = isNotEmpty()
-                        }
 
                 is UserPaginationSpecification.EntryUsersFavorite ->
                     timelineEntryRepository
@@ -59,12 +47,6 @@ internal class DefaultUserPaginationManager(
                             id = specification.entryId,
                             pageCursor = pageCursor,
                         ).determineRelationshipStatus()
-                        .apply {
-                            lastOrNull()?.also {
-                                pageCursor = it.id
-                            }
-                            canFetchMore = isNotEmpty()
-                        }
 
                 is UserPaginationSpecification.EntryUsersReblog ->
                     timelineEntryRepository
@@ -72,12 +54,6 @@ internal class DefaultUserPaginationManager(
                             id = specification.entryId,
                             pageCursor = pageCursor,
                         ).determineRelationshipStatus()
-                        .apply {
-                            lastOrNull()?.also {
-                                pageCursor = it.id
-                            }
-                            canFetchMore = isNotEmpty()
-                        }
 
                 is UserPaginationSpecification.Search ->
                     userRepository
@@ -88,40 +64,32 @@ internal class DefaultUserPaginationManager(
                                     .indexOfLast { it.id == pageCursor }
                                     .takeIf { it >= 0 } ?: 0,
                         ).determineRelationshipStatus()
-                        .apply {
-                            lastOrNull()?.also {
-                                pageCursor = it.id
-                            }
-                            canFetchMore = isNotEmpty()
-                        }
 
                 UserPaginationSpecification.Blocked ->
                     userRepository
                         .getBlocked(
                             pageCursor = pageCursor,
-                        ).apply {
-                            lastOrNull()?.also {
-                                pageCursor = it.id
-                            }
-                            canFetchMore = isNotEmpty()
-                        }
+                        )
 
                 UserPaginationSpecification.Muted ->
                     userRepository
                         .getMuted(
                             pageCursor = pageCursor,
-                        ).apply {
-                            lastOrNull()?.also {
-                                pageCursor = it.id
-                            }
-                            canFetchMore = isNotEmpty()
-                        }
-            }.deduplicate()
+                        )
+            }.deduplicate().updatePaginationData()
         history.addAll(results)
 
         // return a copy
         return history.map { it }
     }
+
+    private fun List<UserModel>.updatePaginationData(): List<UserModel> =
+        apply {
+            lastOrNull()?.also {
+                pageCursor = it.id
+            }
+            canFetchMore = isNotEmpty()
+        }
 
     private suspend fun List<UserModel>.determineRelationshipStatus(): List<UserModel> =
         run {

--- a/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListScreen.kt
+++ b/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.style.TextOverflow
 import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.core.screen.ScreenKey
 import cafe.adriel.voyager.koin.getScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.UserItem
@@ -53,6 +54,35 @@ import org.koin.core.parameter.parametersOf
 class UserListScreen(
     private val type: UserListType,
 ) : Screen {
+    override val key: ScreenKey
+        get() =
+            super.key +
+                when (type) {
+                    is UserListType.Follower ->
+                        buildString {
+                            append("follower-")
+                            append(type.userId)
+                        }
+
+                    is UserListType.Following ->
+                        buildString {
+                            append("following-")
+                            append(type.userId)
+                        }
+
+                    is UserListType.UsersFavorite ->
+                        buildString {
+                            append("favorites-")
+                            append(type.entryId)
+                        }
+
+                    is UserListType.UsersReblog ->
+                        buildString {
+                            append("reblogs-")
+                            append(type.entryId)
+                        }
+                }
+
     @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
     @Composable
     override fun Content() {


### PR DESCRIPTION
This PR fixes the following bugs:
- there was an issue with new Intent handling which lead the app to crash
- pagination for hashtags (in Explore and Search) and users was not working properly after #84 (this is a partial revert)
- the user list screen for following/followers was not updating due to a navigation issue.