### PR TITLE
feat: check for unread notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The app is under ongoing development, here is a list of the features that are be
 - [x] post detail, i.e. opening a conversation or reply in its context
 - [x] user detail with ability to see posts/post and replies/pinned/media posts
 - [x] login/logout to one's own instance
-- [x] view notification list
+- [x] view notifications and check for unread items
 - [x] view one's own profile
 - [x] see trending posts/hashtags/news
 - [x] see following recommendations

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/bottomnavigation/Extensions.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/bottomnavigation/Extensions.kt
@@ -6,7 +6,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.navigation.BottomNavigatio
 fun BottomNavigationSection.toTab(): Tab =
     when (this) {
         BottomNavigationSection.Explore -> ExploreTab
-        BottomNavigationSection.Inbox -> InboxTab
+        is BottomNavigationSection.Inbox -> InboxTab
         BottomNavigationSection.Profile -> ProfileTab
         else -> HomeTab
     }

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/bottomnavigation/TabNavigationItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/bottomnavigation/TabNavigationItem.kt
@@ -2,19 +2,26 @@ package com.livefast.eattrash.raccoonforfriendica.bottomnavigation
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.offset
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Explore
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Inbox
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.BottomNavigationSection
 
@@ -33,10 +40,26 @@ internal fun RowScope.BottomNavigationItem(
         selected = selected,
         interactionSource = interactionSource,
         icon = {
-            Icon(
-                imageVector = section.toIcon(),
-                contentDescription = null,
-            )
+            BadgedBox(
+                badge = {
+                    val unreadCount = (section as? BottomNavigationSection.Inbox)?.unreadItems ?: 0
+                    if (unreadCount > 0) {
+                        Badge(
+                            modifier = Modifier.align(Alignment.TopEnd).offset(x = (-5).dp),
+                        ) {
+                            Text(
+                                text = if (unreadCount <= 10) "$unreadCount" else "10+",
+                                style = MaterialTheme.typography.labelSmall.copy(fontSize = 8.sp),
+                            )
+                        }
+                    }
+                },
+            ) {
+                Icon(
+                    imageVector = section.toIcon(),
+                    contentDescription = null,
+                )
+            }
         },
         label = {
             Text(
@@ -53,7 +76,7 @@ private fun BottomNavigationSection.toIcon(): ImageVector =
     when (this) {
         BottomNavigationSection.Explore -> Icons.Default.Explore
         BottomNavigationSection.Home -> Icons.Default.Home
-        BottomNavigationSection.Inbox -> Icons.Default.Inbox
+        is BottomNavigationSection.Inbox -> Icons.Default.Inbox
         BottomNavigationSection.Profile -> Icons.Default.AccountCircle
     }
 
@@ -62,6 +85,6 @@ private fun BottomNavigationSection.toReadableName(): String =
     when (this) {
         BottomNavigationSection.Explore -> LocalStrings.current.sectionTitleExplore
         BottomNavigationSection.Home -> LocalStrings.current.sectionTitleHome
-        BottomNavigationSection.Inbox -> LocalStrings.current.sectionTitleInbox
+        is BottomNavigationSection.Inbox -> LocalStrings.current.sectionTitleInbox
         BottomNavigationSection.Profile -> LocalStrings.current.sectionTitleProfile
     }

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/SharedModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/SharedModule.kt
@@ -11,7 +11,10 @@ import org.koin.dsl.module
 internal val sharedModule =
     module {
         factory<MainMviModel> {
-            MainViewModel()
+            MainViewModel(
+                identityRepository = get(),
+                inboxManager = get(),
+            )
         }
         single<DetailOpener> {
             DefaultDetailOpener(

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/main/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/main/MainViewModel.kt
@@ -3,22 +3,33 @@ package com.livefast.eattrash.raccoonforfriendica.main
 import cafe.adriel.voyager.core.model.screenModelScope
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.BottomNavigationSection
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.InboxManager
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
-class MainViewModel :
-    DefaultMviModel<MainMviModel.Intent, MainMviModel.UiState, MainMviModel.Effect>(
-        initialState =
-            MainMviModel.UiState(
-                bottomNavigationSections =
-                    listOf(
-                        BottomNavigationSection.Home,
-                        BottomNavigationSection.Explore,
-                        BottomNavigationSection.Inbox,
-                        BottomNavigationSection.Profile,
-                    ),
-            ),
+class MainViewModel(
+    private val inboxManager: InboxManager,
+    private val identityRepository: IdentityRepository,
+) : DefaultMviModel<MainMviModel.Intent, MainMviModel.UiState, MainMviModel.Effect>(
+        initialState = MainMviModel.UiState(),
     ),
     MainMviModel {
+    init {
+        screenModelScope.launch {
+            inboxManager.unreadCount
+                .onEach { inboxUnread ->
+                    updateState {
+                        it.copy(bottomNavigationSections = getSections(inboxUnread))
+                    }
+                }.launchIn(this)
+            identityRepository.isLogged
+                .onEach {
+                    inboxManager.refreshUnreadCount()
+                }.launchIn(this)
+        }
+    }
 
     override fun reduce(intent: MainMviModel.Intent) {
         when (intent) {
@@ -29,4 +40,14 @@ class MainViewModel :
             }
         }
     }
+
+    private fun getSections(inboxUnread: Int) =
+        listOf(
+            BottomNavigationSection.Home,
+            BottomNavigationSection.Explore,
+            BottomNavigationSection.Inbox(
+                unreadItems = inboxUnread,
+            ),
+            BottomNavigationSection.Profile,
+        )
 }

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Notification.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Notification.kt
@@ -8,6 +8,7 @@ data class Notification(
     @SerialName("id") val id: String,
     @SerialName("type") val type: NotificationType,
     @SerialName("created_at") val createdAt: String? = null,
+    @SerialName("dismissed") val dismissed: Boolean = false,
     @SerialName("account") val account: Account? = null,
     @SerialName("status") val status: Status? = null,
 )

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/NotificationService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/NotificationService.kt
@@ -3,6 +3,8 @@ package com.livefast.eattrash.raccoonforfriendica.core.api.service
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Notification
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.NotificationType
 import de.jensklingenberg.ktorfit.http.GET
+import de.jensklingenberg.ktorfit.http.POST
+import de.jensklingenberg.ktorfit.http.Path
 import de.jensklingenberg.ktorfit.http.Query
 
 interface NotificationService {
@@ -11,6 +13,15 @@ interface NotificationService {
         @Query("types") types: List<NotificationType>,
         @Query("max_id") maxId: String? = null,
         @Query("min_id") minId: String? = null,
+        @Query("include_all") includeAll: Boolean = false,
         @Query("limit") limit: Int = 20,
     ): List<Notification>
+
+    @POST("v1/notifications/{id}/dismiss")
+    suspend fun dismiss(
+        @Path("id") id: String,
+    )
+
+    @POST("v1/notifications/clear")
+    suspend fun dismissAll()
 }

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/BottomNavigationSection.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/BottomNavigationSection.kt
@@ -5,7 +5,9 @@ sealed interface BottomNavigationSection {
 
     data object Explore : BottomNavigationSection
 
-    data object Inbox : BottomNavigationSection
+    data class Inbox(
+        val unreadItems: Int = 0,
+    ) : BottomNavigationSection
 
     data object Profile : BottomNavigationSection
 }

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NotificationModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NotificationModel.kt
@@ -3,6 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.data
 data class NotificationModel(
     val id: String,
     val type: NotificationType = NotificationType.Unknown,
+    val read: Boolean = true,
     val user: UserModel? = null,
     val entry: TimelineEntryModel? = null,
 )

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultNotificationsPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultNotificationsPaginationManager.kt
@@ -33,6 +33,7 @@ internal class DefaultNotificationsPaginationManager(
                         .getAll(
                             pageCursor = pageCursor,
                             types = specification.types,
+                            includeUnread = true,
                         ).determineRelationshipStatus()
                         .updatePaginationData()
                         .filterNsfw(specification.includeNsfw)
@@ -43,7 +44,7 @@ internal class DefaultNotificationsPaginationManager(
         return history.map { it }
     }
 
-    private suspend fun List<NotificationModel>.updatePaginationData(): List<NotificationModel> =
+    private fun List<NotificationModel>.updatePaginationData(): List<NotificationModel> =
         apply {
             lastOrNull()?.also {
                 pageCursor = it.id

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultInboxManager.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultInboxManager.kt
@@ -1,0 +1,33 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationType
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.getAndUpdate
+import kotlinx.coroutines.flow.update
+
+internal class DefaultInboxManager(
+    private val notificationRepository: NotificationRepository,
+) : InboxManager {
+    override val unreadCount = MutableStateFlow(0)
+
+    override suspend fun refreshUnreadCount() {
+        val types =
+            listOf(
+                NotificationType.Follow,
+                NotificationType.FollowRequest,
+                NotificationType.Mention,
+                NotificationType.Entry,
+                NotificationType.Update,
+            )
+        val notifications = notificationRepository.getAll(types)
+        unreadCount.update {
+            notifications.count { !it.read }
+        }
+    }
+
+    override suspend fun decrementUnreadCount() {
+        unreadCount.getAndUpdate {
+            (it - 1).coerceAtLeast(0)
+        }
+    }
+}

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/InboxManager.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/InboxManager.kt
@@ -1,0 +1,11 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import kotlinx.coroutines.flow.StateFlow
+
+interface InboxManager {
+    val unreadCount: StateFlow<Int>
+
+    suspend fun refreshUnreadCount()
+
+    suspend fun decrementUnreadCount()
+}

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/Mappings.kt
@@ -176,6 +176,7 @@ internal fun Notification.toModel() =
     NotificationModel(
         id = id,
         type = type.toModel(),
+        read = dismissed,
         user = account?.toModel(),
         entry = status?.toModelWithReply(),
     )

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/NotificationRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/NotificationRepository.kt
@@ -6,6 +6,11 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.Notificatio
 interface NotificationRepository {
     suspend fun getAll(
         types: List<NotificationType> = emptyList(),
+        includeUnread: Boolean = false,
         pageCursor: String? = null,
     ): List<NotificationModel>
+
+    suspend fun markAsRead(id: String): Boolean
+
+    suspend fun markAllAsRead(): Boolean
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
@@ -1,5 +1,6 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.repository.di
 
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultInboxManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultNotificationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultPhotoRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultSearchRepository
@@ -8,6 +9,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Defau
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultTimelineRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultTrendingRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultUserRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.InboxManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.NotificationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.PhotoRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SearchRepository
@@ -59,6 +61,11 @@ val domainContentRepositoryModule =
         single<SearchRepository> {
             DefaultSearchRepository(
                 provider = get(named("default")),
+            )
+        }
+        single<InboxManager> {
+            DefaultInboxManager(
+                notificationRepository = get(),
             )
         }
     }

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -212,6 +212,7 @@ class EntryDetailScreen(
                 modifier =
                     Modifier
                         .padding(padding)
+                        .fillMaxWidth()
                         .nestedScroll(scrollBehavior.nestedScrollConnection)
                         .nestedScroll(fabNestedScrollConnection)
                         .pullRefresh(pullRefreshState),

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
@@ -195,6 +195,7 @@ class ExploreScreen : Screen {
                 modifier =
                     Modifier
                         .padding(padding)
+                        .fillMaxWidth()
                         .then(
                             if (connection != null) {
                                 Modifier.nestedScroll(connection)

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
@@ -147,6 +147,7 @@ class FavoritesScreen(
                 modifier =
                     Modifier
                         .padding(padding)
+                        .fillMaxWidth()
                         .then(
                             if (connection != null) {
                                 Modifier.nestedScroll(connection)

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/followed/FollowedHashtagsScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/followed/FollowedHashtagsScreen.kt
@@ -111,6 +111,7 @@ class FollowedHashtagsScreen : Screen {
                 modifier =
                     Modifier
                         .padding(padding)
+                        .fillMaxWidth()
                         .then(
                             if (connection != null) {
                                 Modifier.nestedScroll(connection)

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
@@ -167,6 +167,7 @@ class HashtagScreen(
                 modifier =
                     Modifier
                         .padding(padding)
+                        .fillMaxWidth()
                         .then(
                             if (connection != null) {
                                 Modifier.nestedScroll(connection)

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
@@ -87,7 +87,7 @@ class InboxScreen : Screen {
         LaunchedEffect(navigationCoordinator) {
             navigationCoordinator.onDoubleTabSelection
                 .onEach { section ->
-                    if (section == BottomNavigationSection.Inbox) {
+                    if (section is BottomNavigationSection.Inbox) {
                         goBackToTop()
                     }
                 }.launchIn(this)
@@ -130,6 +130,7 @@ class InboxScreen : Screen {
                 modifier =
                     Modifier
                         .padding(padding)
+                        .fillMaxWidth()
                         .then(
                             if (connection != null) {
                                 Modifier.nestedScroll(connection)

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
@@ -7,6 +7,8 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toNotificat
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.NotificationsPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.NotificationsPaginationSpecification
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.InboxManager
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.NotificationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
@@ -19,6 +21,8 @@ class InboxViewModel(
     private val userRepository: UserRepository,
     private val identityRepository: IdentityRepository,
     private val settingsRepository: SettingsRepository,
+    private val notificationRepository: NotificationRepository,
+    private val inboxManager: InboxManager,
 ) : DefaultMviModel<InboxMviModel.Intent, InboxMviModel.State, InboxMviModel.Effect>(
         initialState = InboxMviModel.State(),
     ),
@@ -51,6 +55,7 @@ class InboxViewModel(
 
             InboxMviModel.Intent.Refresh ->
                 screenModelScope.launch {
+                    markAllAsRead()
                     refresh()
                 }
 
@@ -172,5 +177,12 @@ class InboxViewModel(
                 )
             }
         }
+    }
+
+    private suspend fun markAllAsRead() {
+        for (item in uiState.value.notifications) {
+            notificationRepository.markAsRead(item.id)
+        }
+        inboxManager.refreshUnreadCount()
     }
 }

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationItem.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationItem.kt
@@ -5,8 +5,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChatBubble
@@ -84,6 +86,21 @@ internal fun NotificationItem(
                 style = MaterialTheme.typography.bodySmall,
                 color = ancillaryColor,
             )
+            Spacer(modifier = Modifier.weight(1f))
+
+            // unread indicator
+            if (!notification.read) {
+                Box(
+                    modifier =
+                        Modifier
+                            .size(IconSize.xs)
+                            .padding(2.dp)
+                            .background(
+                                color = MaterialTheme.colorScheme.onBackground,
+                                shape = CircleShape,
+                            ),
+                )
+            }
         }
 
         Box(

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/di/InboxModule.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/di/InboxModule.kt
@@ -12,6 +12,8 @@ val featureInboxModule =
                 userRepository = get(),
                 identityRepository = get(),
                 settingsRepository = get(),
+                notificationRepository = get(),
+                inboxManager = get(),
             )
         }
     }

--- a/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/ManageBlocksScreen.kt
+++ b/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/ManageBlocksScreen.kt
@@ -151,6 +151,7 @@ class ManageBlocksScreen : Screen {
                 modifier =
                     Modifier
                         .padding(padding)
+                        .fillMaxWidth()
                         .then(
                             if (connection != null) {
                                 Modifier.nestedScroll(connection)

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
@@ -127,7 +127,10 @@ class MyAccountScreen : Screen {
                 },
             )
         Box(
-            modifier = Modifier.pullRefresh(pullRefreshState),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .pullRefresh(pullRefreshState),
         ) {
             LazyColumn(
                 state = lazyListState,

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
@@ -178,6 +178,7 @@ class SearchScreen : Screen {
                 modifier =
                     Modifier
                         .padding(padding)
+                        .fillMaxWidth()
                         .nestedScroll(scrollBehavior.nestedScrollConnection)
                         .pullRefresh(pullRefreshState),
             ) {

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
@@ -192,6 +192,7 @@ class ThreadScreen(
                 modifier =
                     Modifier
                         .padding(padding)
+                        .fillMaxWidth()
                         .nestedScroll(scrollBehavior.nestedScrollConnection)
                         .nestedScroll(fabNestedScrollConnection)
                         .pullRefresh(pullRefreshState),

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
@@ -222,6 +222,7 @@ class TimelineScreen : Screen {
                 modifier =
                     Modifier
                         .padding(padding)
+                        .fillMaxWidth()
                         .then(
                             if (connection != null) {
                                 Modifier.nestedScroll(connection)

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -186,6 +186,7 @@ class UserDetailScreen(
                     modifier =
                         Modifier
                             .padding(padding)
+                            .fillMaxWidth()
                             .nestedScroll(scrollBehavior.nestedScrollConnection)
                             .pullRefresh(pullRefreshState),
                 ) {

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
@@ -201,6 +201,7 @@ class ForumListScreen(
                 modifier =
                     Modifier
                         .padding(padding)
+                        .fillMaxWidth()
                         .nestedScroll(scrollBehavior.nestedScrollConnection)
                         .nestedScroll(fabNestedScrollConnection)
                         .pullRefresh(pullRefreshState),

--- a/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListScreen.kt
+++ b/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListScreen.kt
@@ -176,6 +176,7 @@ class UserListScreen(
                     modifier =
                         Modifier
                             .padding(padding)
+                            .fillMaxWidth()
                             .nestedScroll(scrollBehavior.nestedScrollConnection)
                             .pullRefresh(pullRefreshState),
                 ) {


### PR DESCRIPTION
This PR adds the check for unread notifications at startup, shows a badge in the navigation bar it there are any and visually differentiates unread and read items in the inbox screen.

Thanks to Relatica for the undocumented parameters (`include_all`) in the endpoint.