### PR TITLE
feat: manage circles • part 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ The app is under ongoing development, here is a list of the features that are be
 - [x] block/unblock user and see list of blocked users
 - [x] OAuth and HTTP basic authentication modes
 - [x] pin/unpin status to profile
+- [ ] manage one's own circles (Friendica-specific)
 - [ ] support post spoiler text
 - [ ] edit one's own profile
-- [ ] manage one's own circles (Friendica-specific)
 - [ ] manage one's own lists
 - [ ] see private conversations
 - [ ] advanced media visualization (videos, GIFs, etc.)

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -74,6 +74,7 @@ kotlin {
             implementation(projects.domain.identity.repository)
             implementation(projects.domain.identity.usecase)
 
+            implementation(projects.feature.circles)
             implementation(projects.feature.composer)
             implementation(projects.feature.drawer)
             implementation(projects.feature.entrydetail)

--- a/composeApp/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/DiHelper.kt
+++ b/composeApp/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/DiHelper.kt
@@ -18,6 +18,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.di.do
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.di.domainContentRepositoryModule
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di.domainIdentityRepositoryModule
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.domainIdentityUseCaseModule
+import com.livefast.eattrash.raccoonforfriendica.feature.circles.di.featureCirclesModule
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.di.featureComposerModule
 import com.livefast.eattrash.raccoonforfriendica.feature.drawer.di.featureDrawerModule
 import com.livefast.eattrash.raccoonforfriendica.feature.entrydetail.di.featureEntryDetailModule
@@ -58,6 +59,7 @@ val sharedHelperModule =
             domainContentRepositoryModule,
             domainIdentityRepositoryModule,
             domainIdentityUseCaseModule,
+            featureCirclesModule,
             featureComposerModule,
             featureTimelineModule,
             featureEntryDetailModule,

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
@@ -7,6 +7,8 @@ import com.livefast.eattrash.raccoonforfriendica.core.navigation.NavigationCoord
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.FavoritesType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserListType
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
+import com.livefast.eattrash.raccoonforfriendica.feature.circles.detail.CircleDetailScreen
+import com.livefast.eattrash.raccoonforfriendica.feature.circles.list.CirclesScreen
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.ComposerScreen
 import com.livefast.eattrash.raccoonforfriendica.feature.entrydetail.EntryDetailScreen
 import com.livefast.eattrash.raccoonforfriendica.feature.favorites.FavoritesScreen
@@ -144,6 +146,16 @@ class DefaultDetailOpener(
 
     override fun openBlockedAndMuted() {
         val screen = ManageBlocksScreen()
+        navigationCoordinator.push(screen)
+    }
+
+    override fun openCircles() {
+        val screen = CirclesScreen()
+        navigationCoordinator.push(screen)
+    }
+
+    override fun openCircle(groupId: String) {
+        val screen = CircleDetailScreen(groupId)
         navigationCoordinator.push(screen)
     }
 }

--- a/composeApp/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/DiHelper.kt
+++ b/composeApp/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/DiHelper.kt
@@ -18,6 +18,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.di.do
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.di.domainContentRepositoryModule
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di.domainIdentityRepositoryModule
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.domainIdentityUseCaseModule
+import com.livefast.eattrash.raccoonforfriendica.feature.circles.di.featureCirclesModule
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.di.featureComposerModule
 import com.livefast.eattrash.raccoonforfriendica.feature.drawer.di.featureDrawerModule
 import com.livefast.eattrash.raccoonforfriendica.feature.entrydetail.di.featureEntryDetailModule
@@ -60,6 +61,7 @@ fun initKoin(): Koin {
                 domainContentRepositoryModule,
                 domainIdentityRepositoryModule,
                 domainIdentityUseCaseModule,
+                featureCirclesModule,
                 featureComposerModule,
                 featureTimelineModule,
                 featureEntryDetailModule,

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/FriendicaCircle.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/FriendicaCircle.kt
@@ -1,0 +1,11 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FriendicaCircle(
+    @SerialName("name") val name: String = "",
+    @SerialName("gid") val id: Long,
+    @SerialName("user") val users: List<FriendicaContact> = emptyList(),
+)

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/FriendicaContact.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/FriendicaContact.kt
@@ -1,0 +1,19 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FriendicaContact(
+    @SerialName("id_str") val id: String,
+    @SerialName("name") val username: String,
+    @SerialName("screen_name") val displayName: String,
+    @SerialName("location") val location: String,
+    @SerialName("url") val url: String,
+    @SerialName("description") val note: String,
+    @SerialName("profile_image_url") val avatar: String,
+    @SerialName("created_at") val createdAt: String? = null,
+    @SerialName("followers_count") val followersCount: Int = 0,
+    @SerialName("protected") val locked: Boolean = false,
+    @SerialName("statuses_count") val statusesCount: Int = 0,
+)

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/DefaultServiceProvider.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/DefaultServiceProvider.kt
@@ -1,6 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.core.api.provider
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.AppService
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.CircleService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.NotificationService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.PhotoService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.SearchService
@@ -38,6 +39,7 @@ internal class DefaultServiceProvider(
     private var currentNode: String = ""
 
     override lateinit var apps: AppService
+    override lateinit var circles: CircleService
     override lateinit var photo: PhotoService
     override lateinit var notifications: NotificationService
     override lateinit var search: SearchService
@@ -126,6 +128,7 @@ internal class DefaultServiceProvider(
                 .converterFactories(ResponseConverterFactory())
                 .build()
         apps = ktorfit.create()
+        circles = ktorfit.create()
         photo = ktorfit.create()
         notifications = ktorfit.create()
         search = ktorfit.create()

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/ServiceProvider.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/ServiceProvider.kt
@@ -1,6 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.core.api.provider
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.AppService
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.CircleService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.NotificationService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.PhotoService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.SearchService
@@ -12,6 +13,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.service.UserService
 
 interface ServiceProvider {
     val apps: AppService
+    val circles: CircleService
     val photo: PhotoService
     val notifications: NotificationService
     val search: SearchService

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/CircleService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/CircleService.kt
@@ -1,0 +1,9 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.service
+
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaCircle
+import de.jensklingenberg.ktorfit.http.GET
+
+interface CircleService {
+    @GET("friendica/group_show")
+    suspend fun getAll(): List<FriendicaCircle>
+}

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/PlaceholderImage.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/PlaceholderImage.kt
@@ -33,7 +33,7 @@ fun PlaceholderImage(
                 ),
         contentAlignment = Alignment.Center,
     ) {
-        val translationAmount = with(LocalDensity.current) { 2.dp.toPx() }
+        val translationAmount = with(LocalDensity.current) { 1.dp.toPx() }
         Text(
             modifier =
                 Modifier.graphicsLayer {

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -184,4 +184,5 @@ internal open class DefaultStrings : Strings {
     override val settingsAboutViewGithub = "View on GitHub"
     override val settingsAboutReportIssue = "Report an issue"
     override val settingsAboutViewFriendica = "View on Friendica"
+    override val manageCirclesTitle = "Circles"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -189,4 +189,5 @@ internal val ItStrings =
         override val settingsAboutViewGithub = "Vedi su GitHub"
         override val settingsAboutReportIssue = "Apri una segnalazione"
         override val settingsAboutViewFriendica = "Vedi su Friendica"
+        override val manageCirclesTitle = "Cerchie"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -174,6 +174,7 @@ interface Strings {
     val settingsAboutViewGithub: String
     val settingsAboutReportIssue: String
     val settingsAboutViewFriendica: String
+    val manageCirclesTitle: String
 }
 
 object Locales {

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DetailOpener.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DetailOpener.kt
@@ -50,4 +50,8 @@ interface DetailOpener {
     fun openImageDetail(url: String)
 
     fun openBlockedAndMuted()
+
+    fun openCircles()
+
+    fun openCircle(groupId: String)
 }

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/CircleModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/CircleModel.kt
@@ -1,0 +1,7 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.data
+
+data class CircleModel(
+    val id: String,
+    val name: String = "",
+    val users: List<UserModel> = emptyList(),
+)

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/CirclesRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/CirclesRepository.kt
@@ -1,0 +1,7 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.CircleModel
+
+interface CirclesRepository {
+    suspend fun getAll(): List<CircleModel>
+}

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultCirclesRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultCirclesRepository.kt
@@ -1,0 +1,18 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.CircleModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
+
+internal class DefaultCirclesRepository(
+    private val provider: ServiceProvider,
+) : CirclesRepository {
+    override suspend fun getAll(): List<CircleModel> =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                provider.circles.getAll().map { it.toModel() }
+            }.getOrElse { emptyList() }
+        }
+}

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/Mappings.kt
@@ -3,6 +3,8 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Account
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.ContentVisibility
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Field
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaCircle
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaContact
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaPhoto
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.HistoryItem
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.MediaAttachment
@@ -18,6 +20,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.dto.StatusContext
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Tag
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.TrendsLink
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.AttachmentModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.CircleModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.FieldModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.HashtagHistoryItem
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.LinkModel
@@ -212,4 +215,24 @@ internal fun FriendicaPhoto.toModel() =
         type = MediaType.Image,
         description = desc,
         album = album,
+    )
+
+internal fun FriendicaCircle.toModel() =
+    CircleModel(
+        name = name,
+        id = "$id",
+        users = users.map { it.toModel() },
+    )
+
+internal fun FriendicaContact.toModel() =
+    UserModel(
+        avatar = avatar,
+        bio = note,
+        created = createdAt,
+        displayName = displayName,
+        entryCount = statusesCount,
+        followers = followersCount,
+        id = id,
+        locked = locked,
+        username = username,
     )

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
@@ -1,5 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.repository.di
 
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.CirclesRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultCirclesRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultInboxManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultNotificationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultPhotoRepository
@@ -60,6 +62,11 @@ val domainContentRepositoryModule =
         }
         single<SearchRepository> {
             DefaultSearchRepository(
+                provider = get(named("default")),
+            )
+        }
+        single<CirclesRepository> {
+            DefaultCirclesRepository(
                 provider = get(named("default")),
             )
         }

--- a/feature/circles/build.gradle.kts
+++ b/feature/circles/build.gradle.kts
@@ -1,0 +1,70 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.jetbrains.compose)
+    alias(libs.plugins.compose.compiler)
+}
+
+@OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
+kotlin {
+    applyDefaultHierarchyTemplate()
+    androidTarget {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_1_8)
+        }
+    }
+    listOf(
+        iosX64(),
+        iosArm64(),
+        iosSimulatorArm64(),
+    ).forEach {
+        it.binaries.framework {
+            baseName = "feature.circles"
+            isStatic = true
+        }
+    }
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(compose.runtime)
+                implementation(compose.foundation)
+                implementation(compose.material)
+                implementation(compose.material3)
+                implementation(compose.materialIconsExtended)
+
+                implementation(libs.koin.core)
+                implementation(libs.voyager.navigator)
+                implementation(libs.voyager.screenmodel)
+                implementation(libs.voyager.koin)
+
+                implementation(projects.core.appearance)
+                implementation(projects.core.architecture)
+                implementation(projects.core.commonui.components)
+                implementation(projects.core.commonui.content)
+                implementation(projects.core.l10n)
+                implementation(projects.core.navigation)
+                implementation(projects.core.utils)
+
+                implementation(projects.domain.content.data)
+                implementation(projects.domain.content.repository)
+            }
+        }
+    }
+}
+
+android {
+    namespace = "com.livefast.eattrash.raccoonforfriendica.feature.circles"
+    compileSdk =
+        libs.versions.android.targetSdk
+            .get()
+            .toInt()
+    defaultConfig {
+        minSdk =
+            libs.versions.android.minSdk
+                .get()
+                .toInt()
+    }
+}

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/detail/CircleDetailMviModel.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/detail/CircleDetailMviModel.kt
@@ -1,0 +1,16 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.circles.detail
+
+import cafe.adriel.voyager.core.model.ScreenModel
+import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
+
+interface CircleDetailMviModel :
+    ScreenModel,
+    MviModel<CircleDetailMviModel.Intent, CircleDetailMviModel.State, CircleDetailMviModel.Effect> {
+    sealed interface Intent
+
+    data class State(
+        val initial: Boolean = true,
+    )
+
+    sealed interface Effect
+}

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/detail/CircleDetailScreen.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/detail/CircleDetailScreen.kt
@@ -1,0 +1,22 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.circles.detail
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.core.screen.ScreenKey
+import cafe.adriel.voyager.koin.getScreenModel
+import org.koin.core.parameter.parametersOf
+
+class CircleDetailScreen(
+    val id: String,
+) : Screen {
+    override val key: ScreenKey
+        get() = super.key + id
+
+    @Composable
+    override fun Content() {
+        val model = getScreenModel<CircleDetailMviModel>(parameters = { parametersOf(id) })
+        val uiState by model.uiState.collectAsState()
+    }
+}

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/detail/CircleDetailViewModel.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/detail/CircleDetailViewModel.kt
@@ -1,0 +1,17 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.circles.detail
+
+import cafe.adriel.voyager.core.model.screenModelScope
+import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
+import kotlinx.coroutines.launch
+
+class CircleDetailViewModel(
+    private val id: String,
+) : DefaultMviModel<CircleDetailMviModel.Intent, CircleDetailMviModel.State, CircleDetailMviModel.Effect>(
+        initialState = CircleDetailMviModel.State(),
+    ),
+    CircleDetailMviModel {
+    init {
+        screenModelScope.launch {
+        }
+    }
+}

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/di/CirclesModule.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/di/CirclesModule.kt
@@ -1,0 +1,21 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.circles.di
+
+import com.livefast.eattrash.raccoonforfriendica.feature.circles.detail.CircleDetailMviModel
+import com.livefast.eattrash.raccoonforfriendica.feature.circles.detail.CircleDetailViewModel
+import com.livefast.eattrash.raccoonforfriendica.feature.circles.list.CirclesMviModel
+import com.livefast.eattrash.raccoonforfriendica.feature.circles.list.CirclesViewModel
+import org.koin.dsl.module
+
+val featureCirclesModule =
+    module {
+        factory<CirclesMviModel> {
+            CirclesViewModel(
+                circlesRepository = get(),
+            )
+        }
+        factory<CircleDetailMviModel> { params ->
+            CircleDetailViewModel(
+                id = params[0],
+            )
+        }
+    }

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/list/CircleItem.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/list/CircleItem.kt
@@ -1,0 +1,115 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.circles.list
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.DpOffset
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomDropDown
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.PlaceholderImage
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.Option
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.CircleModel
+
+@Composable
+internal fun CircleItem(
+    circle: CircleModel,
+    modifier: Modifier = Modifier,
+    options: List<Option> = emptyList(),
+    onClick: (() -> Unit)? = null,
+    onOptionSelected: ((OptionId) -> Unit)? = null,
+) {
+    var optionsOffset by remember { mutableStateOf(Offset.Zero) }
+    var optionsMenuOpen by remember { mutableStateOf(false) }
+
+    Row(
+        modifier =
+            modifier
+                .clickable {
+                    onClick?.invoke()
+                }.padding(Spacing.s),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        PlaceholderImage(
+            size = IconSize.l,
+            title = circle.name,
+        )
+
+        Column(
+            modifier = Modifier.weight(1f),
+        ) {
+            Text(
+                text = circle.name,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+        }
+
+        if (options.isNotEmpty()) {
+            Box {
+                Icon(
+                    modifier =
+                        Modifier
+                            .size(IconSize.m)
+                            .padding(Spacing.xs)
+                            .onGloballyPositioned {
+                                optionsOffset = it.positionInParent()
+                            }.clickable {
+                                optionsMenuOpen = true
+                            },
+                    imageVector = Icons.Default.MoreVert,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onBackground,
+                )
+                CustomDropDown(
+                    expanded = optionsMenuOpen,
+                    onDismiss = {
+                        optionsMenuOpen = false
+                    },
+                    offset =
+                        with(LocalDensity.current) {
+                            DpOffset(
+                                x = optionsOffset.x.toDp(),
+                                y = optionsOffset.y.toDp(),
+                            )
+                        },
+                ) {
+                    options.forEach { option ->
+                        DropdownMenuItem(
+                            text = {
+                                Text(option.label)
+                            },
+                            onClick = {
+                                optionsMenuOpen = false
+                                onOptionSelected?.invoke(option.id)
+                            },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/list/CircleItemPlaceholder.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/list/CircleItemPlaceholder.kt
@@ -1,0 +1,53 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.circles.list
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.utils.compose.shimmerEffect
+
+@Composable
+internal fun CircleItemPlaceholder(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier.padding(horizontal = Spacing.xs),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .size(IconSize.l)
+                    .clip(CircleShape)
+                    .shimmerEffect(),
+        )
+
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+        ) {
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(end = Spacing.xs)
+                        .height(30.dp)
+                        .clip(RoundedCornerShape(CornerSize.s))
+                        .shimmerEffect(),
+            )
+        }
+    }
+}

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/list/CirclesMviModel.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/list/CirclesMviModel.kt
@@ -1,0 +1,22 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.circles.list
+
+import cafe.adriel.voyager.core.model.ScreenModel
+import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.CircleModel
+
+interface CirclesMviModel :
+    ScreenModel,
+    MviModel<CirclesMviModel.Intent, CirclesMviModel.State, CirclesMviModel.Effect> {
+    sealed interface Intent {
+        data object Refresh : Intent
+    }
+
+    data class State(
+        val initial: Boolean = true,
+        val refreshing: Boolean = false,
+        val loading: Boolean = false,
+        val items: List<CircleModel> = emptyList(),
+    )
+
+    sealed interface Effect
+}

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/list/CirclesScreen.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/list/CirclesScreen.kt
@@ -1,0 +1,259 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.circles.list
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.text.style.TextAlign
+import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.koin.getScreenModel
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.getFabNestedScrollConnection
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toOption
+import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDetailOpener
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
+import kotlinx.coroutines.launch
+
+class CirclesScreen : Screen {
+    @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
+    @Composable
+    override fun Content() {
+        val model = getScreenModel<CirclesMviModel>()
+        val uiState by model.uiState.collectAsState()
+        val topAppBarState = rememberTopAppBarState()
+        val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
+        val navigationCoordinator = remember { getNavigationCoordinator() }
+        val lazyListState = rememberLazyListState()
+        val fabNestedScrollConnection = remember { getFabNestedScrollConnection() }
+        val isFabVisible by fabNestedScrollConnection.isFabVisible.collectAsState()
+        val scope = rememberCoroutineScope()
+        val detailOpener = remember { getDetailOpener() }
+        var confirmDeleteItemId by remember { mutableStateOf<String?>(null) }
+
+        fun goBackToTop() {
+            runCatching {
+                scope.launch {
+                    lazyListState.scrollToItem(0)
+                    topAppBarState.heightOffset = 0f
+                    topAppBarState.contentOffset = 0f
+                }
+            }
+        }
+
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    modifier = Modifier.clickable { scope.launch { goBackToTop() } },
+                    scrollBehavior = scrollBehavior,
+                    title = {
+                        Text(
+                            text = LocalStrings.current.manageCirclesTitle,
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                    },
+                    navigationIcon = {
+                        if (navigationCoordinator.canPop.value) {
+                            Image(
+                                modifier =
+                                    Modifier.clickable {
+                                        navigationCoordinator.pop()
+                                    },
+                                imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                                contentDescription = null,
+                                colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
+                            )
+                        }
+                    },
+                )
+            },
+            floatingActionButton = {
+                AnimatedVisibility(
+                    visible = isFabVisible,
+                    enter =
+                        slideInVertically(
+                            initialOffsetY = { it * 2 },
+                        ),
+                    exit =
+                        slideOutVertically(
+                            targetOffsetY = { it * 2 },
+                        ),
+                ) {
+                    FloatingActionButton(
+                        onClick = {
+                            // open editor to create (coming soon)
+                        },
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Add,
+                            contentDescription = null,
+                        )
+                    }
+                }
+            },
+        ) { padding ->
+            val pullRefreshState =
+                rememberPullRefreshState(
+                    refreshing = uiState.refreshing,
+                    onRefresh = {
+                        model.reduce(CirclesMviModel.Intent.Refresh)
+                    },
+                )
+            Box(
+                modifier =
+                    Modifier
+                        .padding(padding)
+                        .fillMaxWidth()
+                        .nestedScroll(scrollBehavior.nestedScrollConnection)
+                        .nestedScroll(fabNestedScrollConnection)
+                        .pullRefresh(pullRefreshState),
+            ) {
+                LazyColumn(
+                    state = lazyListState,
+                ) {
+                    if (uiState.initial) {
+                        items(20) {
+                            CircleItemPlaceholder(modifier = Modifier.fillMaxWidth())
+                            Spacer(modifier = Modifier.height(Spacing.interItem))
+                        }
+                    }
+
+                    items(
+                        items = uiState.items,
+                        key = { e -> e.id },
+                    ) { circle ->
+                        CircleItem(
+                            circle = circle,
+                            onClick = {
+                                detailOpener.openCircle(circle.id)
+                            },
+                            options =
+                                buildList {
+                                    this += OptionId.Delete.toOption()
+                                },
+                            onOptionSelected = { optionId ->
+                                when (optionId) {
+                                    OptionId.Delete -> confirmDeleteItemId = circle.id
+                                    else -> Unit
+                                }
+                            },
+                        )
+                        Spacer(modifier = Modifier.height(Spacing.interItem))
+                    }
+
+                    item {
+                        if (uiState.loading && !uiState.refreshing) {
+                            Box(
+                                modifier = Modifier.fillMaxWidth(),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                ListLoadingIndicator()
+                            }
+                        }
+                    }
+                    if (!uiState.initial && !uiState.loading && uiState.items.isEmpty()) {
+                        item {
+                            Text(
+                                modifier = Modifier.fillMaxWidth().padding(top = Spacing.m),
+                                text = LocalStrings.current.messageEmptyList,
+                                textAlign = TextAlign.Center,
+                                style = MaterialTheme.typography.bodyLarge,
+                            )
+                        }
+                    }
+
+                    item {
+                        Spacer(modifier = Modifier.height(Spacing.xxxl))
+                    }
+                }
+
+                PullRefreshIndicator(
+                    refreshing = uiState.refreshing,
+                    state = pullRefreshState,
+                    modifier = Modifier.align(Alignment.TopCenter),
+                    backgroundColor = MaterialTheme.colorScheme.background,
+                    contentColor = MaterialTheme.colorScheme.onBackground,
+                )
+            }
+        }
+
+        if (confirmDeleteItemId != null) {
+            AlertDialog(
+                onDismissRequest = {
+                    confirmDeleteItemId = null
+                },
+                title = {
+                    Text(
+                        text = LocalStrings.current.actionDelete,
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                },
+                text = {
+                    Text(text = LocalStrings.current.messageAreYouSure)
+                },
+                dismissButton = {
+                    Button(
+                        onClick = {
+                            confirmDeleteItemId = null
+                        },
+                    ) {
+                        Text(text = LocalStrings.current.buttonCancel)
+                    }
+                },
+                confirmButton = {
+                    Button(
+                        onClick = {
+                            val itemId = confirmDeleteItemId ?: ""
+                            confirmDeleteItemId = null
+                            if (itemId.isNotEmpty()) {
+                                // remove circle (coming soon)
+                            }
+                        },
+                    ) {
+                        Text(text = LocalStrings.current.buttonConfirm)
+                    }
+                },
+            )
+        }
+    }
+}

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/list/CirclesViewModel.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/list/CirclesViewModel.kt
@@ -1,0 +1,44 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.circles.list
+
+import cafe.adriel.voyager.core.model.screenModelScope
+import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.CirclesRepository
+import kotlinx.coroutines.launch
+
+class CirclesViewModel(
+    private val circlesRepository: CirclesRepository,
+) : DefaultMviModel<CirclesMviModel.Intent, CirclesMviModel.State, CirclesMviModel.Effect>(
+        initialState = CirclesMviModel.State(),
+    ),
+    CirclesMviModel {
+    init {
+        screenModelScope.launch {
+            if (uiState.value.initial) {
+                refresh(initial = true)
+            }
+        }
+    }
+
+    override fun reduce(intent: CirclesMviModel.Intent) {
+        when (intent) {
+            CirclesMviModel.Intent.Refresh ->
+                screenModelScope.launch {
+                    refresh()
+                }
+        }
+    }
+
+    private suspend fun refresh(initial: Boolean = false) {
+        updateState {
+            it.copy(initial = initial, refreshing = !initial)
+        }
+        val items = circlesRepository.getAll()
+        updateState {
+            it.copy(
+                initial = false,
+                refreshing = false,
+                items = items,
+            )
+        }
+    }
+}

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerContent.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerContent.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Tag
+import androidx.compose.material.icons.filled.Workspaces
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
@@ -83,7 +84,17 @@ class DrawerContent : Screen {
                         handleOpen { detailOpener.openFollowedHashtags() }
                     },
                 )
+
+                DrawerShortcut(
+                    title = LocalStrings.current.manageCirclesTitle,
+                    icon = Icons.Default.Workspaces,
+                    onSelected = {
+                        handleOpen { detailOpener.openCircles() }
+                    },
+                )
             }
+
+            HorizontalDivider()
 
             DrawerShortcut(
                 title = LocalStrings.current.settingsTitle,

--- a/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListScreen.kt
+++ b/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListScreen.kt
@@ -164,8 +164,8 @@ class UserListScreen(
                     },
                 )
             },
-            content = { padding ->
-                val pullRefreshState =
+        ) { padding ->
+            val pullRefreshState =
                     rememberPullRefreshState(
                         refreshing = uiState.refreshing,
                         onRefresh = {
@@ -240,8 +240,7 @@ class UserListScreen(
                         contentColor = MaterialTheme.colorScheme.onBackground,
                     )
                 }
-            },
-        )
+        }
 
         if (confirmUnfollowDialogUserId != null) {
             AlertDialog(

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -49,6 +49,7 @@ include(":domain:identity:data")
 include(":domain:identity:repository")
 include(":domain:identity:usecase")
 
+include(":feature:circles")
 include(":feature:composer")
 include(":feature:drawer")
 include(":feature:entrydetail")


### PR DESCRIPTION
This is the first PR of a series, aimed at adding the circle management feature. This one sets up the basic stucture (item in drawer, navigation, etc.), the networking to retrieve the list of items and a basic list screen to display them.
<div align="center">
    <img src="https://github.com/user-attachments/assets/50bab531-b7d7-4a1c-90fd-850cb3f00993" width="310" />
</div>
