### PR TITLE
fix: user header and notification layout

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentHeader.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentHeader.kt
@@ -25,6 +25,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.Custom
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.PlaceholderImage
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.prettifyDate
+import com.livefast.eattrash.raccoonforfriendica.core.utils.ellipsize
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 
 @Composable
@@ -89,7 +90,7 @@ fun ContentHeader(
                     text =
                         buildString {
                             if (!user?.handle.isNullOrBlank()) {
-                                append(user?.handle)
+                                append(user?.handle?.ellipsize(25))
                             }
                             if (!date.isNullOrBlank()) {
                                 if (isNotEmpty()) {

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserHeader.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserHeader.kt
@@ -29,6 +29,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillary
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomImage
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.PlaceholderImage
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
+import com.livefast.eattrash.raccoonforfriendica.core.utils.ellipsize
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationStatusNextAction
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.RelationshipStatusNextAction
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
@@ -181,7 +182,7 @@ fun UserHeader(
                         color = fullColor,
                     )
                     Text(
-                        text = user?.handle ?: user?.username ?: "",
+                        text = (user?.handle ?: user?.username ?: "").ellipsize(25),
                         style = MaterialTheme.typography.titleMedium,
                         color = ancillaryColor,
                     )

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/Extensions.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/Extensions.kt
@@ -1,0 +1,14 @@
+package com.livefast.eattrash.raccoonforfriendica.core.utils
+
+fun String?.ellipsize(
+    length: Int = 100,
+    ellipsis: String = "…",
+): String {
+    if (isNullOrEmpty() || length == 0) {
+        return ""
+    }
+    if (this.length < length) {
+        return this
+    }
+    return take(length - 1) + ellipsis
+}

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationUserInfo.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationUserInfo.kt
@@ -30,6 +30,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.Placeh
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ContentBody
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.UserRelationshipButton
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
+import com.livefast.eattrash.raccoonforfriendica.core.utils.ellipsize
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.RelationshipStatusNextAction
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 
@@ -108,7 +109,7 @@ fun NotificationUserInfo(
                         color = fullColor,
                     )
                     Text(
-                        text = user.handle ?: user.username ?: "",
+                        text = (user.handle ?: user.username ?: "").ellipsize(25),
                         style = MaterialTheme.typography.titleMedium,
                         color = ancillaryColor,
                     )
@@ -138,6 +139,7 @@ fun NotificationUserInfo(
                     append(LocalStrings.current.accountFollowing(following))
                 }
             Text(
+                modifier = Modifier.padding(top = Spacing.s),
                 text = annotatedContent,
                 style = MaterialTheme.typography.labelMedium.copy(color = ancillaryColor),
             )


### PR DESCRIPTION
This PR makes sure no layouts are broken due to user handles (`acct`) being too long.