### PR TITLE
fix: trending links loading; timeline circle after update/delete

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/TrendsLink.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/TrendsLink.kt
@@ -9,5 +9,5 @@ data class TrendsLink(
     @SerialName("description") val description: String? = null,
     @SerialName("image") val image: String? = null,
     @SerialName("title") val title: String? = null,
-    @SerialName("url") val url: String,
+    @SerialName("url") val url: String?,
 )

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultExplorePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultExplorePaginationManager.kt
@@ -33,8 +33,12 @@ internal class DefaultExplorePaginationManager(
                     }
 
                 ExplorePaginationSpecification.Links ->
-                    trendingRepository.getLinks(offset).map {
-                        ExploreItemModel.Link(it)
+                    trendingRepository.getLinks(offset).mapNotNull {
+                        if (it.url.isBlank()) {
+                            null
+                        } else {
+                            ExploreItemModel.Link(it)
+                        }
                     }
 
                 is ExplorePaginationSpecification.Posts ->

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/Mappings.kt
@@ -203,7 +203,7 @@ internal fun Relationship.toModel() =
 
 internal fun TrendsLink.toModel() =
     LinkModel(
-        url = url,
+        url = url.orEmpty(),
         title = title.orEmpty(),
         authorName = authorName,
         description = description,


### PR DESCRIPTION
This PR contains a couple of fixes for the latest alpha:
- the URL property of links has been made optional so that remote fetching does not break for missing data
- the case when the current circle is edited/deleted in the Circles screen when selected in the Home screen as timeline types are now handled on referesh.