### PR TITLE
fix: sticky headers; inbox refresh; tag search

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/HashtagItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/HashtagItem.kt
@@ -59,31 +59,31 @@ fun HashtagItem(
                 style = MaterialTheme.typography.bodyLarge,
                 color = fullColor,
             )
-            Text(
-                text =
-                    buildString {
-                        val count =
-                            hashtag.history
-                                .first()
-                                .users
-                                .toInt()
-                        append(count)
-                        append(" ")
-                        append(LocalStrings.current.hashtagPeopleUsing(count))
-                    },
-                style = MaterialTheme.typography.labelMedium,
-                color = ancillaryColor,
-            )
+            if (hashtag.history.isNotEmpty()) {
+                val count = hashtag.history.run { first().users.toInt() }
+                Text(
+                    text =
+                        buildString {
+                            append(count)
+                            append(" ")
+                            append(LocalStrings.current.hashtagPeopleUsing(count))
+                        },
+                    style = MaterialTheme.typography.labelMedium,
+                    color = ancillaryColor,
+                )
+            }
         }
 
-        HashtagChart(
-            modifier =
-                Modifier
-                    .weight(0.25f)
-                    .padding(end = Spacing.s)
-                    .aspectRatio(3f),
-            dataset = hashtag.history,
-        )
+        if (hashtag.history.isNotEmpty()) {
+            HashtagChart(
+                modifier =
+                    Modifier
+                        .weight(0.25f)
+                        .padding(end = Spacing.s)
+                        .aspectRatio(3f),
+                dataset = hashtag.history,
+            )
+        }
     }
 }
 

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserFields.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserFields.kt
@@ -30,7 +30,7 @@ fun UserFields(
         for (field in fields) {
             Row {
                 Text(
-                    modifier = Modifier.weight(0.4f),
+                    modifier = Modifier.weight(0.5f),
                     text = field.key.uppercase(),
                     color = ancillaryColor,
                     style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Light),

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.feature.explore
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
@@ -49,6 +50,7 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.AnnotatedString
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Dimensions
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
@@ -213,7 +215,12 @@ class ExploreScreen : Screen {
                 ) {
                     stickyHeader {
                         SectionSelector(
-                            modifier = Modifier.padding(bottom = Spacing.s),
+                            Modifier
+                                .background(MaterialTheme.colorScheme.background)
+                                .padding(
+                                    top = Dimensions.maxTopBarInset * topAppBarState.collapsedFraction,
+                                    bottom = Spacing.s,
+                                ),
                             titles =
                                 uiState.availableSections.map {
                                     it.toReadableName()

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
@@ -184,10 +184,12 @@ class InboxViewModel(
         }
     }
 
-    private suspend fun markAllAsRead() {
-        for (item in uiState.value.notifications) {
-            notificationRepository.markAsRead(item.id)
+    private fun markAllAsRead() {
+        screenModelScope.launch {
+            for (item in uiState.value.notifications) {
+                notificationRepository.markAsRead(item.id)
+            }
+            inboxManager.refreshUnreadCount()
         }
-        inboxManager.refreshUnreadCount()
     }
 }

--- a/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/ManageBlocksScreen.kt
+++ b/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/ManageBlocksScreen.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.feature.manageblocks
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
@@ -44,6 +45,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.style.TextAlign
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Dimensions
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
@@ -168,7 +170,13 @@ class ManageBlocksScreen : Screen {
                 ) {
                     stickyHeader {
                         SectionSelector(
-                            modifier = Modifier.padding(bottom = Spacing.s),
+                            modifier =
+                                Modifier
+                                    .background(MaterialTheme.colorScheme.background)
+                                    .padding(
+                                        top = Dimensions.maxTopBarInset * topAppBarState.collapsedFraction,
+                                        bottom = Spacing.s,
+                                    ),
                             titles =
                                 listOf(
                                     ManageBlocksSection.Muted.toReadableName(),

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
@@ -16,8 +16,10 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarState
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -50,62 +52,70 @@ class ProfileScreen : Screen {
         val drawerCoordinator = remember { getDrawerCoordinator() }
         var confirmLogoutDialogOpened by remember { mutableStateOf(false) }
 
-        Scaffold(
-            topBar = {
-                TopAppBar(
-                    windowInsets = topAppBarState.toWindowInsets(),
-                    scrollBehavior = scrollBehavior,
-                    title = {
-                        Text(
-                            text = LocalStrings.current.sectionTitleProfile,
-                            style = MaterialTheme.typography.titleMedium,
-                        )
-                    },
-                    navigationIcon = {
-                        Image(
-                            modifier =
-                                Modifier.clickable {
-                                    scope.launch {
-                                        drawerCoordinator.toggleDrawer()
-                                    }
-                                },
-                            imageVector = Icons.Default.Menu,
-                            contentDescription = null,
-                            colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
-                        )
-                    },
-                    actions = {
-                        if (uiState.isLogged) {
-                            Icon(
-                                modifier =
-                                    Modifier
-                                        .padding(horizontal = Spacing.xs)
-                                        .clickable {
-                                            confirmLogoutDialogOpened = true
-                                        },
-                                imageVector = Icons.AutoMirrored.Default.Logout,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.onBackground,
+        CompositionLocalProvider(
+            LocalProfileTopAppBarStateWrapper provides
+                object : ProfileTopAppBarStateWrapper {
+                    override val topAppBarState: TopAppBarState
+                        get() = topAppBarState
+                },
+        ) {
+            Scaffold(
+                topBar = {
+                    TopAppBar(
+                        windowInsets = topAppBarState.toWindowInsets(),
+                        scrollBehavior = scrollBehavior,
+                        title = {
+                            Text(
+                                text = LocalStrings.current.sectionTitleProfile,
+                                style = MaterialTheme.typography.titleMedium,
                             )
+                        },
+                        navigationIcon = {
+                            Image(
+                                modifier =
+                                    Modifier.clickable {
+                                        scope.launch {
+                                            drawerCoordinator.toggleDrawer()
+                                        }
+                                    },
+                                imageVector = Icons.Default.Menu,
+                                contentDescription = null,
+                                colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
+                            )
+                        },
+                        actions = {
+                            if (uiState.isLogged) {
+                                Icon(
+                                    modifier =
+                                        Modifier
+                                            .padding(horizontal = Spacing.xs)
+                                            .clickable {
+                                                confirmLogoutDialogOpened = true
+                                            },
+                                    imageVector = Icons.AutoMirrored.Default.Logout,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onBackground,
+                                )
+                            }
+                        },
+                    )
+                },
+                content = { padding ->
+                    Box(
+                        modifier =
+                            Modifier
+                                .padding(padding)
+                                .nestedScroll(scrollBehavior.nestedScrollConnection),
+                    ) {
+                        if (!uiState.isLogged) {
+                            Navigator(AnonymousScreen())
+                        } else {
+                            Navigator(MyAccountScreen())
                         }
-                    },
-                )
-            },
-            content = { padding ->
-                Box(
-                    modifier =
-                        Modifier
-                            .padding(padding)
-                            .nestedScroll(scrollBehavior.nestedScrollConnection),
-                ) {
-                    if (!uiState.isLogged) {
-                        Navigator(AnonymousScreen())
-                    } else {
-                        Navigator(MyAccountScreen())
                     }
-                }
-            },
-        )
+                },
+            )
+        }
 
         if (confirmLogoutDialogOpened) {
             AlertDialog(

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileTopAppBarStateWrapper.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileTopAppBarStateWrapper.kt
@@ -1,0 +1,19 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.profile
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.TopAppBarState
+import androidx.compose.runtime.compositionLocalOf
+
+internal interface ProfileTopAppBarStateWrapper {
+    @OptIn(ExperimentalMaterial3Api::class)
+    val topAppBarState: TopAppBarState
+}
+
+internal val LocalProfileTopAppBarStateWrapper =
+    compositionLocalOf<ProfileTopAppBarStateWrapper> {
+        object : ProfileTopAppBarStateWrapper {
+            @OptIn(ExperimentalMaterial3Api::class)
+            override val topAppBarState: TopAppBarState
+                get() = throw IllegalStateException("No TopAppBarState found in composition locals")
+        }
+    }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
@@ -1,6 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.profile.myaccount
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -15,6 +16,7 @@ import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Snackbar
@@ -60,12 +62,17 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.prettifyDat
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getShareHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.FieldModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
+import com.livefast.eattrash.raccoonforfriendica.feature.profile.LocalProfileTopAppBarStateWrapper
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 class MyAccountScreen : Screen {
-    @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterialApi::class)
+    @OptIn(
+        ExperimentalFoundationApi::class,
+        ExperimentalMaterialApi::class,
+        ExperimentalMaterial3Api::class,
+    )
     @Composable
     override fun Content() {
         val model = getScreenModel<MyAccountMviModel>()
@@ -81,6 +88,7 @@ class MyAccountScreen : Screen {
         val copyToClipboardSuccess = LocalStrings.current.messageTextCopiedToClipboard
         val clipboardManager = LocalClipboardManager.current
         var confirmDeleteEntryId by remember { mutableStateOf<String?>(null) }
+        val topAppBarState = LocalProfileTopAppBarStateWrapper.current.topAppBarState
 
         suspend fun goBackToTop() {
             runCatching {
@@ -185,7 +193,13 @@ class MyAccountScreen : Screen {
 
                 stickyHeader {
                     SectionSelector(
-                        modifier = Modifier.padding(bottom = Spacing.s),
+                        modifier =
+                            Modifier
+                                .background(MaterialTheme.colorScheme.background)
+                                .padding(
+                                    top = Dimensions.maxTopBarInset * topAppBarState.collapsedFraction,
+                                    bottom = Spacing.s,
+                                ),
                         titles =
                             listOf(
                                 UserSection.Posts.toReadableName(),

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchMviModel.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchMviModel.kt
@@ -48,11 +48,6 @@ interface SearchMviModel :
             val entry: TimelineEntryModel,
         ) : Intent
 
-        data class ToggleTagFollow(
-            val name: String,
-            val newValue: Boolean,
-        ) : Intent
-
         data class DeleteEntry(
             val entryId: String,
         ) : Intent

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.feaure.search
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
@@ -48,6 +49,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Dimensions
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
@@ -189,8 +191,14 @@ class SearchScreen : Screen {
                 ) {
                     stickyHeader {
                         SectionSelector(
-                            modifier = Modifier.padding(bottom = Spacing.s),
-                            titles =
+                            modifier =
+                                Modifier
+                                    .background(MaterialTheme.colorScheme.background)
+                                    .padding(
+                                        top = Dimensions.maxTopBarInset * topAppBarState.collapsedFraction,
+                                        bottom = Spacing.s,
+                                ),
+                                titles =
                                 listOf(
                                     SearchSection.Hashtags.toReadableName(),
                                     SearchSection.Posts.toReadableName(),

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
@@ -53,8 +53,8 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowI
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.SearchField
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.SectionSelector
-import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.FollowHashtagItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.GenericPlaceholder
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.HashtagItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.PollVoteErrorDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
@@ -101,7 +101,6 @@ class SearchScreen : Screen {
         val clipboardManager = LocalClipboardManager.current
         var confirmUnfollowDialogUserId by remember { mutableStateOf<String?>(null) }
         var confirmDeleteFollowRequestDialogUserId by remember { mutableStateOf<String?>(null) }
-        var confirmUnfollowHashtagName by remember { mutableStateOf<String?>(null) }
         var confirmDeleteEntryId by remember { mutableStateOf<String?>(null) }
         var confirmMuteEntry by remember { mutableStateOf<TimelineEntryModel?>(null) }
         var confirmBlockEntry by remember { mutableStateOf<TimelineEntryModel?>(null) }
@@ -368,22 +367,10 @@ class SearchScreen : Screen {
                             }
 
                             is ExploreItemModel.HashTag -> {
-                                FollowHashtagItem(
+                                HashtagItem(
                                     hashtag = item.hashtag,
                                     onOpen = {
                                         detailOpener.openHashtag(it)
-                                    },
-                                    onToggleFollow = { newFollow ->
-                                        if (newFollow) {
-                                            model.reduce(
-                                                SearchMviModel.Intent.ToggleTagFollow(
-                                                    item.hashtag.name,
-                                                    newFollow,
-                                                ),
-                                            )
-                                        } else {
-                                            confirmUnfollowHashtagName = item.hashtag.name
-                                        }
                                     },
                                 )
                                 Spacer(modifier = Modifier.height(Spacing.interItem))
@@ -532,50 +519,6 @@ class SearchScreen : Screen {
                             confirmUnfollowDialogUserId = null
                             if (userId.isNotEmpty()) {
                                 model.reduce(SearchMviModel.Intent.Unfollow(userId))
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
-                    }
-                },
-            )
-        }
-
-        if (confirmUnfollowHashtagName != null) {
-            AlertDialog(
-                onDismissRequest = {
-                    confirmUnfollowHashtagName = null
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionUnfollow,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmUnfollowHashtagName = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val oldtag = confirmUnfollowHashtagName
-                            confirmUnfollowHashtagName = null
-                            if (oldtag != null) {
-                                model.reduce(
-                                    SearchMviModel.Intent.ToggleTagFollow(
-                                        name = oldtag,
-                                        newValue = false,
-                                    ),
-                                )
                             }
                         },
                     ) {

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.feature.userdetail.classic
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
@@ -50,6 +51,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.core.screen.ScreenKey
 import cafe.adriel.voyager.koin.getScreenModel
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Dimensions
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
@@ -283,7 +285,13 @@ class UserDetailScreen(
 
                         stickyHeader {
                             SectionSelector(
-                                modifier = Modifier.padding(bottom = Spacing.s),
+                                modifier =
+                                    Modifier
+                                        .background(MaterialTheme.colorScheme.background)
+                                        .padding(
+                                            top = Dimensions.maxTopBarInset * topAppBarState.collapsedFraction,
+                                            bottom = Spacing.s,
+                                        ),
                                 titles =
                                     listOf(
                                         UserSection.Posts.toReadableName(),


### PR DESCRIPTION
This PR contains various fixes:
- the sticky headers are not overlapping the status bar any more
- notification refresh does not block while marking elements as read before setting refreshing to true (so now the refresh indicator appears as soon as possible)
- the following status of hashtags in the search screen is not available from the backend, so follow/unfollow actions have been removed
- the fields section of the user profile did not play well with increased font size.