### PR TITLE
feat: add inbox filters

### DIFF
--- a/core/htmlparse/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/htmlparse/ParseHtml.kt
+++ b/core/htmlparse/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/htmlparse/ParseHtml.kt
@@ -53,7 +53,6 @@ fun String.parseHtml(
                     else -> println("onCloseTag: Unhandled span $name")
                 }
             }.onText { text ->
-                println("text=$text")
                 string.append(text)
             }.build()
 

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -218,4 +218,15 @@ internal open class DefaultStrings : Strings {
     override val pollExpiresIn = "Expires in"
     override val actionHideResults = "Show results"
     override val actionShowResults = "Hide results"
+    override val inboxConfigureFilterDialogTitle = "Configure filters"
+    override val inboxConfigureFilterDialogSubtitle =
+        "If any value is deselected, the filter will only return unread items"
+    override val notificationTypeEntryName = "Post notifications"
+    override val notificationTypeFavoriteName = "Favorites"
+    override val notificationTypeFollowName = "New followers"
+    override val notificationTypeFollowRequestName = "Follow requests"
+    override val notificationTypeMentionName = "Mentions & Replies"
+    override val notificationTypePollName = "Polls"
+    override val notificationTypeReblogName = "Re-shares"
+    override val notificationTypeUpdateName = "Post updates"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -223,4 +223,15 @@ internal val ItStrings =
         override val pollExpiresIn = "Si chiude tra"
         override val actionHideResults = "Mostra risultati"
         override val actionShowResults = "Nascondi risultati"
+        override val inboxConfigureFilterDialogTitle = "Configura filtri"
+        override val inboxConfigureFilterDialogSubtitle =
+            "Se un valore qualsiasi viene deselezionato, il filtro si applicherà solo agli elementi non letti"
+        override val notificationTypeEntryName = "Notifiche post"
+        override val notificationTypeFavoriteName = "Preferiti"
+        override val notificationTypeFollowName = "Nuovi seguaci"
+        override val notificationTypeFollowRequestName = "Richieste di seguirti"
+        override val notificationTypeMentionName = "Menzioni & Risposte"
+        override val notificationTypePollName = "Sondaggi"
+        override val notificationTypeReblogName = "Ricondivisioni"
+        override val notificationTypeUpdateName = "Modifiche post"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -203,6 +203,16 @@ interface Strings {
     val pollExpiresIn: String
     val actionShowResults: String
     val actionHideResults: String
+    val inboxConfigureFilterDialogTitle: String
+    val inboxConfigureFilterDialogSubtitle: String
+    val notificationTypeEntryName: String
+    val notificationTypeFavoriteName: String
+    val notificationTypeFollowName: String
+    val notificationTypeFollowRequestName: String
+    val notificationTypeMentionName: String
+    val notificationTypePollName: String
+    val notificationTypeReblogName: String
+    val notificationTypeUpdateName: String
 }
 
 object Locales {

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NotificationType.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NotificationType.kt
@@ -1,5 +1,8 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.data
 
+import androidx.compose.runtime.Composable
+import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
+
 sealed interface NotificationType {
     data object Mention : NotificationType
 
@@ -18,4 +21,30 @@ sealed interface NotificationType {
     data object Update : NotificationType
 
     data object Unknown : NotificationType
+
+    companion object {
+        val ALL =
+            listOf(
+                Follow,
+                FollowRequest,
+                Mention,
+                Entry,
+                Update,
+                Poll,
+            )
+    }
 }
+
+@Composable
+fun NotificationType.toReadableName(): String =
+    when (this) {
+        NotificationType.Entry -> LocalStrings.current.notificationTypeEntryName
+        NotificationType.Favorite -> LocalStrings.current.notificationTypeFavoriteName
+        NotificationType.Follow -> LocalStrings.current.notificationTypeFollowName
+        NotificationType.FollowRequest -> LocalStrings.current.notificationTypeFollowRequestName
+        NotificationType.Mention -> LocalStrings.current.notificationTypeMentionName
+        NotificationType.Poll -> LocalStrings.current.notificationTypePollName
+        NotificationType.Reblog -> LocalStrings.current.notificationTypeReblogName
+        NotificationType.Update -> LocalStrings.current.notificationTypeUpdateName
+        else -> ""
+    }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultNotificationsPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultNotificationsPaginationManager.kt
@@ -1,6 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
 
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isNsfw
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toNotificationStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toStatus
@@ -33,7 +34,7 @@ internal class DefaultNotificationsPaginationManager(
                         .getAll(
                             pageCursor = pageCursor,
                             types = specification.types,
-                            includeUnread = true,
+                            includeAll = specification.types.toSet() == NotificationType.ALL.toSet(),
                         ).determineRelationshipStatus()
                         .updatePaginationData()
                         .filterNsfw(specification.includeNsfw)

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/NotificationsPaginationSpecification.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/NotificationsPaginationSpecification.kt
@@ -2,19 +2,9 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
 
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationType
 
-private val DEFAULT_TYPES =
-    listOf(
-        NotificationType.Follow,
-        NotificationType.FollowRequest,
-        NotificationType.Mention,
-        NotificationType.Entry,
-        NotificationType.Update,
-        NotificationType.Poll,
-)
-
 sealed interface NotificationsPaginationSpecification {
     data class Default(
-        val types: List<NotificationType> = DEFAULT_TYPES,
+        val types: List<NotificationType>,
         val includeNsfw: Boolean = true,
     ) : NotificationsPaginationSpecification
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNotificationRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNotificationRepository.kt
@@ -11,7 +11,7 @@ internal class DefaultNotificationRepository(
 ) : NotificationRepository {
     override suspend fun getAll(
         types: List<NotificationType>,
-        includeUnread: Boolean,
+        includeAll: Boolean,
         pageCursor: String?,
     ) = withContext(Dispatchers.IO) {
         runCatching {
@@ -19,7 +19,7 @@ internal class DefaultNotificationRepository(
                 provider.notifications.get(
                     types = types.mapNotNull { it.toDto() },
                     maxId = pageCursor,
-                    includeAll = includeUnread,
+                    includeAll = includeAll,
                     limit = DEFAULT_PAGE_SIZE,
                 )
             response.map { it.toModel() }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/NotificationRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/NotificationRepository.kt
@@ -6,7 +6,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.Notificatio
 interface NotificationRepository {
     suspend fun getAll(
         types: List<NotificationType> = emptyList(),
-        includeUnread: Boolean = false,
+        includeAll: Boolean = false,
         pageCursor: String? = null,
     ): List<NotificationModel>
 

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxMviModel.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxMviModel.kt
@@ -3,6 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica.feature.inbox
 import cafe.adriel.voyager.core.model.ScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationType
 
 interface InboxMviModel :
     ScreenModel,
@@ -23,6 +24,10 @@ interface InboxMviModel :
         data class Unfollow(
             val userId: String,
         ) : Intent
+
+        data class ChangeSelectedNotificationTypes(
+            val types: List<NotificationType>,
+        ) : Intent
     }
 
     data class State(
@@ -33,7 +38,10 @@ interface InboxMviModel :
         val canFetchMore: Boolean = true,
         val notifications: List<NotificationModel> = emptyList(),
         val blurNsfw: Boolean = true,
+        val selectedNotificationTypes: List<NotificationType> = NotificationType.ALL,
     )
 
-    sealed interface Effect
+    sealed interface Effect {
+        data object BackToTop : Effect
+    }
 }

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
@@ -61,6 +61,15 @@ class InboxViewModel(
                     refresh()
                 }
 
+            is InboxMviModel.Intent.ChangeSelectedNotificationTypes ->
+                screenModelScope.launch {
+                    updateState {
+                        it.copy(selectedNotificationTypes = intent.types)
+                    }
+                    emitEffect(InboxMviModel.Effect.BackToTop)
+                    refresh(initial = true)
+                }
+
             is InboxMviModel.Intent.AcceptFollowRequest -> acceptFollowRequest(intent.userId)
             is InboxMviModel.Intent.Follow -> follow(intent.userId)
             is InboxMviModel.Intent.Unfollow -> unfollow(intent.userId)
@@ -73,6 +82,7 @@ class InboxViewModel(
         }
         paginationManager.reset(
             NotificationsPaginationSpecification.Default(
+                types = uiState.value.selectedNotificationTypes,
                 includeNsfw = settingsRepository.current.value?.includeNsfw ?: false,
             ),
         )

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/ConfigureNotificationTypeDialog.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/ConfigureNotificationTypeDialog.kt
@@ -1,0 +1,123 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.inbox.composable
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.surfaceColorAtElevation
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationType
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toReadableName
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ConfigureNotificationTypeDialog(
+    initialSelection: List<NotificationType>,
+    availableTypes: List<NotificationType>,
+    onClose: ((List<NotificationType>?) -> Unit)? = null,
+) {
+    val currentSelection =
+        remember { mutableStateListOf<NotificationType>().apply { addAll(initialSelection) } }
+
+    BasicAlertDialog(
+        modifier = Modifier.clip(RoundedCornerShape(CornerSize.xxl)),
+        onDismissRequest = {
+            onClose?.invoke(null)
+        },
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .background(color = MaterialTheme.colorScheme.surfaceColorAtElevation(5.dp))
+                    .padding(Spacing.m),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
+        ) {
+            Text(
+                text = LocalStrings.current.inboxConfigureFilterDialogTitle,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+            Spacer(modifier = Modifier.height(Spacing.s))
+            Text(
+                text = LocalStrings.current.inboxConfigureFilterDialogSubtitle,
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+
+            Spacer(modifier = Modifier.height(Spacing.xs))
+
+            LazyColumn(
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                items(availableTypes) { type ->
+                    val selected = currentSelection.contains(type)
+                    Row(
+                        modifier = Modifier.padding(vertical = Spacing.xs),
+                    ) {
+                        Text(
+                            text = type.toReadableName(),
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                        Spacer(modifier = Modifier.weight(1f))
+                        Checkbox(
+                            modifier = Modifier.size(IconSize.s),
+                            checked = selected,
+                            onCheckedChange = {
+                                if (selected) {
+                                    currentSelection -= type
+                                } else {
+                                    currentSelection += type
+                                }
+                            },
+                        )
+                    }
+                }
+            }
+            Spacer(modifier = Modifier.height(Spacing.xs))
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+            ) {
+                Spacer(modifier = Modifier.weight(1f))
+                Button(
+                    onClick = {
+                        onClose?.invoke(null)
+                    },
+                ) {
+                    Text(text = LocalStrings.current.buttonCancel)
+                }
+                Button(
+                    onClick = {
+                        onClose?.invoke(currentSelection.toList())
+                    },
+                ) {
+                    Text(text = LocalStrings.current.buttonConfirm)
+                }
+            }
+        }
+    }
+}

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/di/SearchModule.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/di/SearchModule.kt
@@ -11,7 +11,6 @@ val featureSearchModule =
                 paginationManager = get(),
                 userRepository = get(),
                 timelineEntryRepository = get(),
-                tagRepository = get(),
                 settingsRepository = get(),
                 identityRepository = get(),
                 hapticFeedback = get(),


### PR DESCRIPTION
This PR adds the possibility to filter inbox items. Unfortunately, due to how the BE works, notification types are applied only if the `include_all` parameter is set to false, which implies all unread items are not returned if using any sub-filter.