### PR TITLE
feat: specify mute duration; disable notification when muting

### DIFF
--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/CustomModalBottomSheet.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/CustomModalBottomSheet.kt
@@ -4,7 +4,9 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -54,6 +56,7 @@ fun CustomModalBottomSheet(
                     text = title,
                     style = MaterialTheme.typography.titleMedium,
                 )
+                Spacer(modifier = Modifier.height(Spacing.xs))
                 LazyColumn {
                     itemsIndexed(items = items) { idx, item ->
                         Surface(

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ConfirmMuteUserBottomSheet.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ConfirmMuteUserBottomSheet.kt
@@ -1,0 +1,136 @@
+package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
+import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.getPrettyDuration
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ConfirmMuteUserBottomSheet(
+    userHandle: String,
+    sheetState: SheetState = rememberModalBottomSheetState(),
+    initialValue: Duration = Duration.INFINITE,
+    availableValues: List<Duration> =
+        listOf(
+            Duration.INFINITE,
+            5.minutes,
+            30.minutes,
+            1.hours,
+            6.hours,
+            1.days,
+            3.days,
+            7.days,
+        ),
+    onClose: (
+        (
+            Pair<Duration, Boolean>?,
+        ) -> Unit
+    )? = null,
+) {
+    var selectedDuration by remember { mutableStateOf(initialValue) }
+    var selectedDisableNotifications by remember { mutableStateOf(true) }
+    var selectDurationDialogOpened by remember { mutableStateOf(false) }
+
+    if (selectDurationDialogOpened) {
+        SelectDurationDialog(
+            initialValue = selectedDuration,
+            availableValues = availableValues,
+            onClose = { newDuration ->
+                selectDurationDialogOpened = false
+                if (newDuration != null) {
+                    selectedDuration = newDuration
+                }
+            },
+        )
+    }
+
+    ModalBottomSheet(
+        sheetState = sheetState,
+        onDismissRequest = {
+            onClose?.invoke(null)
+        },
+    ) {
+        Column(
+            modifier = Modifier.padding(bottom = Spacing.xl),
+            verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+        ) {
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center,
+                text =
+                    buildString {
+                        append(LocalStrings.current.actionMute)
+                        if (userHandle.isNotEmpty()) {
+                            append(" @$userHandle")
+                        }
+                    },
+                style = MaterialTheme.typography.titleMedium,
+            )
+
+            Spacer(modifier = Modifier.height(Spacing.xs))
+
+            SettingsRow(
+                title = LocalStrings.current.muteDurationItem,
+                value =
+                    if (selectedDuration.isInfinite()) {
+                        LocalStrings.current.muteDurationIndefinite
+                    } else {
+                        selectedDuration.getPrettyDuration(
+                            secondsLabel = LocalStrings.current.timeSecondShort,
+                            minutesLabel = LocalStrings.current.timeMinuteShort,
+                            hoursLabel = LocalStrings.current.timeHourShort,
+                            daysLabel = LocalStrings.current.dateDayShort,
+                            finePrecision = false,
+                        )
+                    },
+                onTap = {
+                    selectDurationDialogOpened = true
+                },
+            )
+            SettingsSwitchRow(
+                title = LocalStrings.current.muteDisableNotificationsItem,
+                value = selectedDisableNotifications,
+                onValueChanged = {
+                    selectedDisableNotifications = it
+                },
+            )
+
+            Button(
+                modifier = Modifier.padding(horizontal = Spacing.m).fillMaxWidth(),
+                onClick = {
+                    onClose?.invoke(selectedDuration to selectedDisableNotifications)
+                },
+            ) {
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = LocalStrings.current.buttonConfirm,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
+    }
+}

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SelectDurationDialog.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SelectDurationDialog.kt
@@ -1,0 +1,130 @@
+package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.surfaceColorAtElevation
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
+import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.getPrettyDuration
+import kotlin.time.Duration
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SelectDurationDialog(
+    initialValue: Duration,
+    availableValues: List<Duration>,
+    onClose: ((Duration?) -> Unit)? = null,
+) {
+    var currentSelection by remember { mutableStateOf(initialValue) }
+    BasicAlertDialog(
+        modifier = Modifier.clip(RoundedCornerShape(CornerSize.xxl)),
+        onDismissRequest = {
+            onClose?.invoke(null)
+        },
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .background(color = MaterialTheme.colorScheme.surfaceColorAtElevation(5.dp))
+                    .padding(Spacing.m),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
+        ) {
+            Text(
+                text = LocalStrings.current.selectDurationDialogTitle,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+            Spacer(modifier = Modifier.height(Spacing.xs))
+            LazyColumn(
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                items(availableValues) { value ->
+                    Row(
+                        modifier =
+                            Modifier
+                                .padding(vertical = Spacing.s, horizontal = Spacing.s)
+                                .clickable(
+                                    interactionSource = remember { MutableInteractionSource() },
+                                    indication = null,
+                                ) {
+                                    currentSelection = value
+                                },
+                    ) {
+                        Text(
+                            text =
+                                if (value.isInfinite()) {
+                                    LocalStrings.current.muteDurationIndefinite
+                                } else {
+                                    value.getPrettyDuration(
+                                        secondsLabel = LocalStrings.current.timeSecondShort,
+                                        minutesLabel = LocalStrings.current.timeMinuteShort,
+                                        hoursLabel = LocalStrings.current.timeHourShort,
+                                        daysLabel = LocalStrings.current.dateDayShort,
+                                        finePrecision = false,
+                                    )
+                                },
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                        Spacer(modifier = Modifier.weight(1f))
+                        RadioButton(
+                            modifier = Modifier.size(IconSize.s),
+                            selected = value == currentSelection,
+                            onClick = {
+                                currentSelection = value
+                            },
+                        )
+                    }
+                }
+            }
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+            ) {
+                Spacer(modifier = Modifier.weight(1f))
+                Button(
+                    onClick = {
+                        onClose?.invoke(null)
+                    },
+                ) {
+                    Text(text = LocalStrings.current.buttonCancel)
+                }
+                Button(
+                    onClick = {
+                        onClose?.invoke(currentSelection)
+                    },
+                ) {
+                    Text(text = LocalStrings.current.buttonConfirm)
+                }
+            }
+        }
+    }
+}

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -229,4 +229,8 @@ internal open class DefaultStrings : Strings {
     override val notificationTypePollName = "Polls"
     override val notificationTypeReblogName = "Re-shares"
     override val notificationTypeUpdateName = "Post updates"
+    override val muteDurationIndefinite = "Indefinite"
+    override val selectDurationDialogTitle = "Select duration"
+    override val muteDurationItem = "You will not see any posts by this user for"
+    override val muteDisableNotificationsItem = "Disable notifications"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -234,4 +234,8 @@ internal val ItStrings =
         override val notificationTypePollName = "Sondaggi"
         override val notificationTypeReblogName = "Ricondivisioni"
         override val notificationTypeUpdateName = "Modifiche post"
+        override val muteDurationIndefinite = "Indefinita"
+        override val selectDurationDialogTitle = "Seleziona durata"
+        override val muteDurationItem = "Non vedrai più post da questo utente per"
+        override val muteDisableNotificationsItem = "Disabilita notifiche"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -213,6 +213,10 @@ interface Strings {
     val notificationTypePollName: String
     val notificationTypeReblogName: String
     val notificationTypeUpdateName: String
+    val muteDurationIndefinite: String
+    val selectDurationDialogTitle: String
+    val muteDurationItem: String
+    val muteDisableNotificationsItem: String
 }
 
 object Locales {

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/UserModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/UserModel.kt
@@ -18,8 +18,14 @@ data class UserModel(
     val id: String,
     val locked: Boolean = false,
     val username: String? = null,
+    @Transient
     val relationshipStatus: RelationshipStatus? = null,
+    @Transient
     val notificationStatus: NotificationStatus? = null,
+    @Transient
+    val muted: Boolean = false,
+    @Transient
+    val blocked: Boolean = false,
     @Transient
     val relationshipStatusPending: Boolean = false,
     @Transient

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepository.kt
@@ -150,12 +150,14 @@ internal class DefaultUserRepository(
     override suspend fun mute(
         id: String,
         durationSeconds: Long,
+        notifications: Boolean,
     ): RelationshipModel? =
         runCatching {
             withContext(Dispatchers.IO) {
                 val data =
                     MuteUserForm(
                         duration = durationSeconds,
+                        notifications = notifications,
                     )
                 provider.users
                     .mute(

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/UserRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/UserRepository.kt
@@ -44,6 +44,7 @@ interface UserRepository {
     suspend fun mute(
         id: String,
         durationSeconds: Long = 0,
+        notifications: Boolean = true,
     ): RelationshipModel?
 
     suspend fun unmute(id: String): RelationshipModel?

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailMviModel.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailMviModel.kt
@@ -5,6 +5,7 @@ import cafe.adriel.voyager.core.model.ScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import kotlin.time.Duration
 
 @Stable
 interface EntryDetailMviModel :
@@ -32,6 +33,8 @@ interface EntryDetailMviModel :
         data class MuteUser(
             val userId: String,
             val entryId: String,
+            val duration: Duration = Duration.INFINITE,
+            val disableNotifications: Boolean = true,
         ) : Intent
 
         data class BlockUser(

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -57,6 +57,7 @@ import cafe.adriel.voyager.koin.getScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.getFabNestedScrollConnection
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ConfirmMuteUserBottomSheet
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.PollVoteErrorDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
@@ -411,56 +412,28 @@ class EntryDetailScreen(
         }
 
         if (confirmMuteEntry != null) {
-            val creator = confirmMuteEntry?.reblog?.creator ?: confirmMuteEntry?.creator
-            AlertDialog(
-                onDismissRequest = {
-                    confirmMuteEntry = null
-                },
-                title = {
-                    Text(
-                        text =
-                            buildString {
-                                append(LocalStrings.current.actionMute)
-                                val handle = creator?.handle ?: ""
-                                if (handle.isNotEmpty()) {
-                                    append(" @$handle")
-                                }
-                            },
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmMuteEntry = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val entryId = confirmMuteEntry?.id
-                            val creatorId = creator?.id
-                            confirmMuteEntry = null
-                            if (entryId != null && creatorId != null) {
+            (confirmMuteEntry?.reblog?.creator ?: confirmMuteEntry?.creator)?.also { user ->
+                ConfirmMuteUserBottomSheet(
+                    userHandle = user.handle.orEmpty(),
+                    onClose = { pair ->
+                        val entryId = confirmMuteEntry?.id
+                        confirmMuteEntry = null
+                        if (pair != null) {
+                            val (duration, disableNotifications) = pair
+                            if (entryId != null) {
                                 model.reduce(
                                     EntryDetailMviModel.Intent.MuteUser(
-                                        userId = creatorId,
+                                        userId = user.id,
                                         entryId = entryId,
+                                        duration = duration,
+                                        disableNotifications = disableNotifications,
                                     ),
                                 )
                             }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
-                    }
-                },
-            )
+                        }
+                    },
+                )
+            }
         }
 
         if (confirmBlockEntry != null) {

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailViewModel.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlin.time.Duration
 
 class EntryDetailViewModel(
     private val id: String,
@@ -57,6 +58,8 @@ class EntryDetailViewModel(
                 mute(
                     entryId = intent.entryId,
                     userId = intent.entryId,
+                    duration = intent.duration,
+                    disableNotifications = intent.disableNotifications,
                 )
             is EntryDetailMviModel.Intent.BlockUser ->
                 block(
@@ -245,9 +248,16 @@ class EntryDetailViewModel(
     private fun mute(
         userId: String,
         entryId: String,
+        duration: Duration,
+        disableNotifications: Boolean,
     ) {
         screenModelScope.launch {
-            val res = userRepository.mute(userId)
+            val res =
+                userRepository.mute(
+                    id = userId,
+                    durationSeconds = if (duration.isInfinite()) 0 else duration.inWholeSeconds,
+                    notifications = disableNotifications,
+                )
             if (res != null) {
                 removeEntryFromState(entryId)
             }

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreMviModel.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreMviModel.kt
@@ -6,6 +6,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.ExploreItemModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.feature.explore.data.ExploreSection
+import kotlin.time.Duration
 
 @Stable
 interface ExploreMviModel :
@@ -51,6 +52,8 @@ interface ExploreMviModel :
         data class MuteUser(
             val userId: String,
             val entryId: String,
+            val duration: Duration = Duration.INFINITE,
+            val disableNotifications: Boolean = true,
         ) : Intent
 
         data class BlockUser(

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Snackbar
@@ -165,16 +166,16 @@ class ExploreScreen : Screen {
                         )
                     },
                     actions = {
-                        Icon(
-                            modifier =
-                                Modifier
-                                    .padding(horizontal = Spacing.xs)
-                                    .clickable {
-                                        detailOpener.openSearch()
-                                    },
-                            imageVector = Icons.Default.Search,
-                            contentDescription = null,
-                        )
+                        IconButton(
+                            onClick = {
+                                detailOpener.openSearch()
+                            },
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Search,
+                                contentDescription = null,
+                            )
+                        }
                     },
                 )
             },

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
@@ -55,6 +55,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.SectionSelector
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ConfirmMuteUserBottomSheet
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.GenericPlaceholder
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.HashtagItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.LinkItem
@@ -596,56 +597,28 @@ class ExploreScreen : Screen {
         }
 
         if (confirmMuteEntry != null) {
-            val creator = confirmMuteEntry?.reblog?.creator ?: confirmMuteEntry?.creator
-            AlertDialog(
-                onDismissRequest = {
-                    confirmMuteEntry = null
-                },
-                title = {
-                    Text(
-                        text =
-                            buildString {
-                                append(LocalStrings.current.actionMute)
-                                val handle = creator?.handle ?: ""
-                                if (handle.isNotEmpty()) {
-                                    append(" @$handle")
-                                }
-                            },
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmMuteEntry = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val entryId = confirmMuteEntry?.id
-                            val creatorId = creator?.id
-                            confirmMuteEntry = null
-                            if (entryId != null && creatorId != null) {
+            (confirmMuteEntry?.reblog?.creator ?: confirmMuteEntry?.creator)?.also { user ->
+                ConfirmMuteUserBottomSheet(
+                    userHandle = user.handle.orEmpty(),
+                    onClose = { pair ->
+                        val entryId = confirmMuteEntry?.id
+                        confirmMuteEntry = null
+                        if (pair != null) {
+                            val (duration, disableNotifications) = pair
+                            if (entryId != null) {
                                 model.reduce(
                                     ExploreMviModel.Intent.MuteUser(
-                                        userId = creatorId,
+                                        userId = user.id,
                                         entryId = entryId,
+                                        duration = duration,
+                                        disableNotifications = disableNotifications,
                                     ),
                                 )
                             }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
-                    }
-                },
-            )
+                        }
+                    },
+                )
+            }
         }
 
         if (confirmBlockEntry != null) {

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreViewModel.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreViewModel.kt
@@ -18,6 +18,7 @@ import com.livefast.eattrash.raccoonforfriendica.feature.explore.data.ExploreSec
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlin.time.Duration
 
 class ExploreViewModel(
     private val paginationManager: ExplorePaginationManager,
@@ -96,6 +97,8 @@ class ExploreViewModel(
                 mute(
                     userId = intent.userId,
                     entryId = intent.entryId,
+                    duration = intent.duration,
+                    disableNotifications = intent.disableNotifications,
                 )
             is ExploreMviModel.Intent.BlockUser ->
                 block(
@@ -385,9 +388,16 @@ class ExploreViewModel(
     private fun mute(
         userId: String,
         entryId: String,
+        duration: Duration,
+        disableNotifications: Boolean,
     ) {
         screenModelScope.launch {
-            val res = userRepository.mute(userId)
+            val res =
+                userRepository.mute(
+                    id = userId,
+                    durationSeconds = if (duration.isInfinite()) 0 else duration.inWholeSeconds,
+                    notifications = disableNotifications,
+                )
             if (res != null) {
                 removeEntryFromState(entryId)
             }

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesMviModel.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesMviModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Stable
 import cafe.adriel.voyager.core.model.ScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+import kotlin.time.Duration
 
 @Stable
 interface FavoritesMviModel :
@@ -33,6 +34,8 @@ interface FavoritesMviModel :
         data class MuteUser(
             val userId: String,
             val entryId: String,
+            val duration: Duration = Duration.INFINITE,
+            val disableNotifications: Boolean = true,
         ) : Intent
 
         data class BlockUser(

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
@@ -49,6 +49,7 @@ import cafe.adriel.voyager.koin.getScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ConfirmMuteUserBottomSheet
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.PollVoteErrorDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
@@ -366,56 +367,28 @@ class FavoritesScreen(
         }
 
         if (confirmMuteEntry != null) {
-            val creator = confirmMuteEntry?.reblog?.creator ?: confirmMuteEntry?.creator
-            AlertDialog(
-                onDismissRequest = {
-                    confirmMuteEntry = null
-                },
-                title = {
-                    Text(
-                        text =
-                            buildString {
-                                append(LocalStrings.current.actionMute)
-                                val handle = creator?.handle ?: ""
-                                if (handle.isNotEmpty()) {
-                                    append(" @$handle")
-                                }
-                            },
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmMuteEntry = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val entryId = confirmMuteEntry?.id
-                            val creatorId = creator?.id
-                            confirmMuteEntry = null
-                            if (entryId != null && creatorId != null) {
+            (confirmMuteEntry?.reblog?.creator ?: confirmMuteEntry?.creator)?.also { user ->
+                ConfirmMuteUserBottomSheet(
+                    userHandle = user.handle.orEmpty(),
+                    onClose = { pair ->
+                        val entryId = confirmMuteEntry?.id
+                        confirmMuteEntry = null
+                        if (pair != null) {
+                            val (duration, disableNotifications) = pair
+                            if (entryId != null) {
                                 model.reduce(
                                     FavoritesMviModel.Intent.MuteUser(
-                                        userId = creatorId,
+                                        userId = user.id,
                                         entryId = entryId,
+                                        duration = duration,
+                                        disableNotifications = disableNotifications,
                                     ),
                                 )
                             }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
-                    }
-                },
-            )
+                        }
+                    },
+                )
+            }
         }
 
         if (confirmBlockEntry != null) {

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesViewModel.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesViewModel.kt
@@ -14,6 +14,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Sett
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlin.time.Duration
 
 class FavoritesViewModel(
     private val type: FavoritesType,
@@ -63,6 +64,8 @@ class FavoritesViewModel(
                 mute(
                     userId = intent.userId,
                     entryId = intent.entryId,
+                    duration = intent.duration,
+                    disableNotifications = intent.disableNotifications,
                 )
             is FavoritesMviModel.Intent.BlockUser ->
                 block(
@@ -260,9 +263,16 @@ class FavoritesViewModel(
     private fun mute(
         userId: String,
         entryId: String,
+        duration: Duration,
+        disableNotifications: Boolean,
     ) {
         screenModelScope.launch {
-            val res = userRepository.mute(userId)
+            val res =
+                userRepository.mute(
+                    id = userId,
+                    durationSeconds = if (duration.isInfinite()) 0 else duration.inWholeSeconds,
+                    notifications = disableNotifications,
+                )
             if (res != null) {
                 removeEntryFromState(entryId)
             }

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagMviModel.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagMviModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Stable
 import cafe.adriel.voyager.core.model.ScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+import kotlin.time.Duration
 
 @Stable
 interface HashtagMviModel :
@@ -37,6 +38,8 @@ interface HashtagMviModel :
         data class MuteUser(
             val userId: String,
             val entryId: String,
+            val duration: Duration = Duration.INFINITE,
+            val disableNotifications: Boolean = true,
         ) : Intent
 
         data class BlockUser(

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
@@ -50,6 +50,7 @@ import cafe.adriel.voyager.koin.getScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ConfirmMuteUserBottomSheet
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.PollVoteErrorDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
@@ -423,56 +424,28 @@ class HashtagScreen(
         }
 
         if (confirmMuteEntry != null) {
-            val creator = confirmMuteEntry?.reblog?.creator ?: confirmMuteEntry?.creator
-            AlertDialog(
-                onDismissRequest = {
-                    confirmMuteEntry = null
-                },
-                title = {
-                    Text(
-                        text =
-                            buildString {
-                                append(LocalStrings.current.actionMute)
-                                val handle = creator?.handle ?: ""
-                                if (handle.isNotEmpty()) {
-                                    append(" @$handle")
-                                }
-                            },
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmMuteEntry = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val entryId = confirmMuteEntry?.id
-                            val creatorId = creator?.id
-                            confirmMuteEntry = null
-                            if (entryId != null && creatorId != null) {
+            (confirmMuteEntry?.reblog?.creator ?: confirmMuteEntry?.creator)?.also { user ->
+                ConfirmMuteUserBottomSheet(
+                    userHandle = user.handle.orEmpty(),
+                    onClose = { pair ->
+                        val entryId = confirmMuteEntry?.id
+                        confirmMuteEntry = null
+                        if (pair != null) {
+                            val (duration, disableNotifications) = pair
+                            if (entryId != null) {
                                 model.reduce(
                                     HashtagMviModel.Intent.MuteUser(
-                                        userId = creatorId,
+                                        userId = user.id,
                                         entryId = entryId,
+                                        duration = duration,
+                                        disableNotifications = disableNotifications,
                                     ),
                                 )
                             }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
-                    }
-                },
-            )
+                        }
+                    },
+                )
+            }
         }
 
         if (confirmBlockEntry != null) {

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagViewModel.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagViewModel.kt
@@ -14,6 +14,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Sett
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlin.time.Duration
 
 class HashtagViewModel(
     private val tag: String,
@@ -71,6 +72,8 @@ class HashtagViewModel(
                 mute(
                     userId = intent.userId,
                     entryId = intent.entryId,
+                    duration = intent.duration,
+                    disableNotifications = intent.disableNotifications,
                 )
             is HashtagMviModel.Intent.BlockUser ->
                 block(
@@ -273,9 +276,16 @@ class HashtagViewModel(
     private fun mute(
         userId: String,
         entryId: String,
+        duration: Duration,
+        disableNotifications: Boolean,
     ) {
         screenModelScope.launch {
-            val res = userRepository.mute(userId)
+            val res =
+                userRepository.mute(
+                    id = userId,
+                    durationSeconds = if (duration.isInfinite()) 0 else duration.inWholeSeconds,
+                    notifications = disableNotifications,
+                )
             if (res != null) {
                 removeEntryFromState(entryId)
             }

--- a/feature/imagedetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/imagedetail/ImageDetailScreen.kt
+++ b/feature/imagedetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/imagedetail/ImageDetailScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Snackbar
@@ -33,7 +34,6 @@ import androidx.compose.ui.layout.ContentScale
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.core.screen.ScreenKey
 import cafe.adriel.voyager.koin.getScreenModel
-import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomModalBottomSheet
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomModalBottomSheetItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ProgressHud
@@ -105,41 +105,36 @@ class ImageDetailScreen(
                         )
                     },
                     actions = {
-                        Icon(
-                            modifier =
-                                Modifier
-                                    .padding(horizontal = Spacing.xs)
-                                    .clickable {
-                                        model.reduce(
-                                            ImageDetailMviModel.Intent.SaveToGallery,
-                                        )
-                                    },
-                            imageVector = Icons.Default.Download,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onBackground,
-                        )
-                        Icon(
-                            modifier =
-                                Modifier
-                                    .padding(horizontal = Spacing.xs)
-                                    .clickable {
-                                        shareModeBottomSheetOpened = true
-                                    },
-                            imageVector = Icons.Default.Share,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onBackground,
-                        )
-                        Icon(
-                            modifier =
-                                Modifier
-                                    .padding(horizontal = Spacing.xs)
-                                    .clickable {
-                                        scaleModeBottomSheetOpened = true
-                                    },
-                            imageVector = Icons.Default.AspectRatio,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onBackground,
-                        )
+                        IconButton(
+                            onClick = {
+                                model.reduce(ImageDetailMviModel.Intent.SaveToGallery)
+                            },
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Download,
+                                contentDescription = null,
+                            )
+                        }
+                        IconButton(
+                            onClick = {
+                                shareModeBottomSheetOpened = true
+                            },
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Share,
+                                contentDescription = null,
+                            )
+                        }
+                        IconButton(
+                            onClick = {
+                                scaleModeBottomSheetOpened = true
+                            },
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.AspectRatio,
+                                contentDescription = null,
+                            )
+                        }
                     },
                 )
             },

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -130,16 +131,16 @@ class InboxScreen : Screen {
                         )
                     },
                     actions = {
-                        Icon(
-                            modifier =
-                                Modifier
-                                    .padding(horizontal = Spacing.xs)
-                                    .clickable {
-                                        configureSelectedTypesDialogOpen = true
-                                    },
-                            imageVector = Icons.Default.FilterList,
-                            contentDescription = null,
-                        )
+                        IconButton(
+                            onClick = {
+                                configureSelectedTypesDialogOpen = true
+                            },
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.FilterList,
+                                contentDescription = null,
+                            )
+                        }
                     },
                 )
             },

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/ConfigureNotificationTypeDialog.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/ConfigureNotificationTypeDialog.kt
@@ -77,7 +77,7 @@ internal fun ConfigureNotificationTypeDialog(
                 items(availableTypes) { type ->
                     val selected = currentSelection.contains(type)
                     Row(
-                        modifier = Modifier.padding(vertical = Spacing.xs),
+                        modifier = Modifier.padding(vertical = Spacing.s, horizontal = Spacing.s),
                     ) {
                         Text(
                             text = type.toReadableName(),
@@ -98,7 +98,6 @@ internal fun ConfigureNotificationTypeDialog(
                     }
                 }
             }
-            Spacer(modifier = Modifier.height(Spacing.xs))
             Row(
                 horizontalArrangement = Arrangement.spacedBy(Spacing.s),
             ) {

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -32,7 +33,6 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
 import cafe.adriel.voyager.navigator.Navigator
-import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDrawerCoordinator
@@ -85,17 +85,16 @@ class ProfileScreen : Screen {
                         },
                         actions = {
                             if (uiState.isLogged) {
-                                Icon(
-                                    modifier =
-                                        Modifier
-                                            .padding(horizontal = Spacing.xs)
-                                            .clickable {
-                                                confirmLogoutDialogOpened = true
-                                            },
-                                    imageVector = Icons.AutoMirrored.Default.Logout,
-                                    contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.onBackground,
-                                )
+                                IconButton(
+                                    onClick = {
+                                        confirmLogoutDialogOpened = true
+                                    },
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.AutoMirrored.Default.Logout,
+                                        contentDescription = null,
+                                    )
+                                }
                             }
                         },
                     )

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchMviModel.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchMviModel.kt
@@ -6,6 +6,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.ExploreItemModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.feaure.search.data.SearchSection
+import kotlin.time.Duration
 
 @Stable
 interface SearchMviModel :
@@ -55,6 +56,8 @@ interface SearchMviModel :
         data class MuteUser(
             val userId: String,
             val entryId: String,
+            val duration: Duration = Duration.INFINITE,
+            val disableNotifications: Boolean = true,
         ) : Intent
 
         data class BlockUser(

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
@@ -55,6 +55,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowI
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.SearchField
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.SectionSelector
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ConfirmMuteUserBottomSheet
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.GenericPlaceholder
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.HashtagItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
@@ -197,8 +198,8 @@ class SearchScreen : Screen {
                                     .padding(
                                         top = Dimensions.maxTopBarInset * topAppBarState.collapsedFraction,
                                         bottom = Spacing.s,
-                                ),
-                                titles =
+                                    ),
+                            titles =
                                 listOf(
                                     SearchSection.Hashtags.toReadableName(),
                                     SearchSection.Posts.toReadableName(),
@@ -576,56 +577,28 @@ class SearchScreen : Screen {
         }
 
         if (confirmMuteEntry != null) {
-            val creator = confirmMuteEntry?.reblog?.creator ?: confirmMuteEntry?.creator
-            AlertDialog(
-                onDismissRequest = {
-                    confirmMuteEntry = null
-                },
-                title = {
-                    Text(
-                        text =
-                            buildString {
-                                append(LocalStrings.current.actionMute)
-                                val handle = creator?.handle ?: ""
-                                if (handle.isNotEmpty()) {
-                                    append(" @$handle")
-                                }
-                            },
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmMuteEntry = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val entryId = confirmMuteEntry?.id
-                            val creatorId = creator?.id
-                            confirmMuteEntry = null
-                            if (entryId != null && creatorId != null) {
+            (confirmMuteEntry?.reblog?.creator ?: confirmMuteEntry?.creator)?.also { user ->
+                ConfirmMuteUserBottomSheet(
+                    userHandle = user.handle.orEmpty(),
+                    onClose = { pair ->
+                        val entryId = confirmMuteEntry?.id
+                        confirmMuteEntry = null
+                        if (pair != null) {
+                            val (duration, disableNotifications) = pair
+                            if (entryId != null) {
                                 model.reduce(
                                     SearchMviModel.Intent.MuteUser(
-                                        userId = creatorId,
+                                        userId = user.id,
                                         entryId = entryId,
+                                        duration = duration,
+                                        disableNotifications = disableNotifications,
                                     ),
                                 )
                             }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
-                    }
-                },
-            )
+                        }
+                    },
+                )
+            }
         }
 
         if (confirmBlockEntry != null) {

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchViewModel.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchViewModel.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlin.time.Duration
 
 @OptIn(FlowPreview::class)
 class SearchViewModel(
@@ -98,6 +99,8 @@ class SearchViewModel(
                 mute(
                     userId = intent.userId,
                     entryId = intent.entryId,
+                    duration = intent.duration,
+                    disableNotifications = intent.disableNotifications,
                 )
             is SearchMviModel.Intent.BlockUser ->
                 block(
@@ -388,9 +391,16 @@ class SearchViewModel(
     private fun mute(
         userId: String,
         entryId: String,
+        duration: Duration,
+        disableNotifications: Boolean,
     ) {
         screenModelScope.launch {
-            val res = userRepository.mute(userId)
+            val res =
+                userRepository.mute(
+                    id = userId,
+                    durationSeconds = if (duration.isInfinite()) 0 else duration.inWholeSeconds,
+                    notifications = disableNotifications,
+                )
             if (res != null) {
                 removeEntryFromState(entryId)
             }

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadMviModel.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadMviModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Stable
 import cafe.adriel.voyager.core.model.ScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+import kotlin.time.Duration
 
 @Stable
 interface ThreadMviModel :
@@ -35,6 +36,8 @@ interface ThreadMviModel :
         data class MuteUser(
             val userId: String,
             val entryId: String,
+            val duration: Duration = Duration.INFINITE,
+            val disableNotifications: Boolean = true,
         ) : Intent
 
         data class BlockUser(

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
@@ -61,6 +61,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSiz
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.getFabNestedScrollConnection
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ConfirmMuteUserBottomSheet
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.PollVoteErrorDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
@@ -488,56 +489,28 @@ class ThreadScreen(
         }
 
         if (confirmMuteEntry != null) {
-            val creator = confirmMuteEntry?.reblog?.creator ?: confirmMuteEntry?.creator
-            AlertDialog(
-                onDismissRequest = {
-                    confirmMuteEntry = null
-                },
-                title = {
-                    Text(
-                        text =
-                            buildString {
-                                append(LocalStrings.current.actionMute)
-                                val handle = creator?.handle ?: ""
-                                if (handle.isNotEmpty()) {
-                                    append(" @$handle")
-                                }
-                            },
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmMuteEntry = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val entryId = confirmMuteEntry?.id
-                            val creatorId = creator?.id
-                            confirmMuteEntry = null
-                            if (entryId != null && creatorId != null) {
+            (confirmMuteEntry?.reblog?.creator ?: confirmMuteEntry?.creator)?.also { user ->
+                ConfirmMuteUserBottomSheet(
+                    userHandle = user.handle.orEmpty(),
+                    onClose = { pair ->
+                        val entryId = confirmMuteEntry?.id
+                        confirmMuteEntry = null
+                        if (pair != null) {
+                            val (duration, disableNotifications) = pair
+                            if (entryId != null) {
                                 model.reduce(
                                     ThreadMviModel.Intent.MuteUser(
-                                        userId = creatorId,
+                                        userId = user.id,
                                         entryId = entryId,
+                                        duration = duration,
+                                        disableNotifications = disableNotifications,
                                     ),
                                 )
                             }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
-                    }
-                },
-            )
+                        }
+                    },
+                )
+            }
         }
 
         if (confirmBlockEntry != null) {

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadViewModel.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadViewModel.kt
@@ -12,6 +12,7 @@ import com.livefast.eattrash.raccoonforfriendica.feature.thread.usecase.Populate
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlin.time.Duration
 
 class ThreadViewModel(
     private val entryId: String,
@@ -62,6 +63,8 @@ class ThreadViewModel(
                 mute(
                     userId = intent.userId,
                     entryId = intent.entryId,
+                    duration = intent.duration,
+                    disableNotifications = intent.disableNotifications,
                 )
             is ThreadMviModel.Intent.BlockUser ->
                 block(
@@ -273,9 +276,16 @@ class ThreadViewModel(
     private fun mute(
         userId: String,
         entryId: String,
+        duration: Duration,
+        disableNotifications: Boolean,
     ) {
         screenModelScope.launch {
-            val res = userRepository.mute(userId)
+            val res =
+                userRepository.mute(
+                    id = userId,
+                    durationSeconds = if (duration.isInfinite()) 0 else duration.inWholeSeconds,
+                    notifications = disableNotifications,
+                )
             if (res != null) {
                 removeEntryFromState(entryId)
             }

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineMviModel.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineMviModel.kt
@@ -5,6 +5,7 @@ import cafe.adriel.voyager.core.model.ScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineType
+import kotlin.time.Duration
 
 @Stable
 interface TimelineMviModel :
@@ -38,6 +39,8 @@ interface TimelineMviModel :
         data class MuteUser(
             val userId: String,
             val entryId: String,
+            val duration: Duration = Duration.INFINITE,
+            val disableNotifications: Boolean = true,
         ) : Intent
 
         data class BlockUser(

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
@@ -64,6 +64,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.Custom
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomModalBottomSheetItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.getFabNestedScrollConnection
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ConfirmMuteUserBottomSheet
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.PollVoteErrorDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
@@ -458,56 +459,28 @@ class TimelineScreen : Screen {
         }
 
         if (confirmMuteEntry != null) {
-            val creator = confirmMuteEntry?.reblog?.creator ?: confirmMuteEntry?.creator
-            AlertDialog(
-                onDismissRequest = {
-                    confirmMuteEntry = null
-                },
-                title = {
-                    Text(
-                        text =
-                            buildString {
-                                append(LocalStrings.current.actionMute)
-                                val handle = creator?.handle ?: ""
-                                if (handle.isNotEmpty()) {
-                                    append(" @$handle")
-                                }
-                            },
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmMuteEntry = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val entryId = confirmMuteEntry?.id
-                            val creatorId = creator?.id
-                            confirmMuteEntry = null
-                            if (entryId != null && creatorId != null) {
+            (confirmMuteEntry?.reblog?.creator ?: confirmMuteEntry?.creator)?.also { user ->
+                ConfirmMuteUserBottomSheet(
+                    userHandle = user.handle.orEmpty(),
+                    onClose = { pair ->
+                        val entryId = confirmMuteEntry?.id
+                        confirmMuteEntry = null
+                        if (pair != null) {
+                            val (duration, disableNotifications) = pair
+                            if (entryId != null) {
                                 model.reduce(
                                     TimelineMviModel.Intent.MuteUser(
-                                        userId = creatorId,
+                                        userId = user.id,
                                         entryId = entryId,
+                                        duration = duration,
+                                        disableNotifications = disableNotifications,
                                     ),
                                 )
                             }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
-                    }
-                },
-            )
+                        }
+                    },
+                )
+            }
         }
 
         if (confirmBlockEntry != null) {

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlin.time.Duration
 
 class TimelineViewModel(
     private val paginationManager: TimelinePaginationManager,
@@ -93,6 +94,8 @@ class TimelineViewModel(
                 mute(
                     userId = intent.userId,
                     entryId = intent.entryId,
+                    duration = intent.duration,
+                    disableNotifications = intent.disableNotifications,
                 )
             is TimelineMviModel.Intent.BlockUser ->
                 block(
@@ -317,9 +320,16 @@ class TimelineViewModel(
     private fun mute(
         userId: String,
         entryId: String,
+        duration: Duration,
+        disableNotifications: Boolean,
     ) {
         screenModelScope.launch {
-            val res = userRepository.mute(userId)
+            val res =
+                userRepository.mute(
+                    id = userId,
+                    durationSeconds = if (duration.isInfinite()) 0 else duration.inWholeSeconds,
+                    notifications = disableNotifications,
+                )
             if (res != null) {
                 removeEntryFromState(entryId)
             }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailMviModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailMviModel.kt
@@ -6,6 +6,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.UserSection
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import kotlin.time.Duration
 
 @Stable
 interface UserDetailMviModel :
@@ -45,6 +46,16 @@ interface UserDetailMviModel :
         data class SubmitPollVote(
             val entry: TimelineEntryModel,
             val choices: List<Int>,
+        ) : Intent
+
+        data class ToggleMute(
+            val muted: Boolean,
+            val duration: Duration = Duration.INFINITE,
+            val disableNotifications: Boolean = true,
+        ) : Intent
+
+        data class ToggleBlock(
+            val blocked: Boolean,
         ) : Intent
     }
 

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListMviModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListMviModel.kt
@@ -6,6 +6,7 @@ import com.livefast.eattrash.feature.userdetail.classic.UserDetailMviModel.Inten
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import kotlin.time.Duration
 
 @Stable
 interface ForumListMviModel :
@@ -35,6 +36,8 @@ interface ForumListMviModel :
         data class MuteUser(
             val userId: String,
             val entryId: String,
+            val duration: Duration = Duration.INFINITE,
+            val disableNotifications: Boolean = true,
         ) : Intent
 
         data class BlockUser(

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
@@ -59,6 +59,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.getFabNestedScrollConnection
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ConfirmMuteUserBottomSheet
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.PollVoteErrorDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
@@ -411,56 +412,28 @@ class ForumListScreen(
         }
 
         if (confirmMuteEntry != null) {
-            val creator = confirmMuteEntry?.reblog?.creator ?: confirmMuteEntry?.creator
-            AlertDialog(
-                onDismissRequest = {
-                    confirmMuteEntry = null
-                },
-                title = {
-                    Text(
-                        text =
-                            buildString {
-                                append(LocalStrings.current.actionMute)
-                                val handle = creator?.handle ?: ""
-                                if (handle.isNotEmpty()) {
-                                    append(" @$handle")
-                                }
-                            },
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmMuteEntry = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val entryId = confirmMuteEntry?.id
-                            val creatorId = creator?.id
-                            confirmMuteEntry = null
-                            if (entryId != null && creatorId != null) {
+            (confirmMuteEntry?.reblog?.creator ?: confirmMuteEntry?.creator)?.also { user ->
+                ConfirmMuteUserBottomSheet(
+                    userHandle = user.handle.orEmpty(),
+                    onClose = { pair ->
+                        val entryId = confirmMuteEntry?.id
+                        confirmMuteEntry = null
+                        if (pair != null) {
+                            val (duration, disableNotifications) = pair
+                            if (entryId != null) {
                                 model.reduce(
                                     ForumListMviModel.Intent.MuteUser(
-                                        userId = creatorId,
+                                        userId = user.id,
                                         entryId = entryId,
+                                        duration = duration,
+                                        disableNotifications = disableNotifications,
                                     ),
                                 )
                             }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
-                    }
-                },
-            )
+                        }
+                    },
+                )
+            }
         }
 
         if (confirmBlockEntry != null) {

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListViewModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListViewModel.kt
@@ -13,6 +13,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Sett
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlin.time.Duration
 
 class ForumListViewModel(
     private val id: String,
@@ -64,6 +65,8 @@ class ForumListViewModel(
                 mute(
                     userId = intent.userId,
                     entryId = intent.entryId,
+                    duration = intent.duration,
+                    disableNotifications = intent.disableNotifications,
                 )
             is ForumListMviModel.Intent.BlockUser ->
                 block(
@@ -258,9 +261,16 @@ class ForumListViewModel(
     private fun mute(
         userId: String,
         entryId: String,
+        duration: Duration,
+        disableNotifications: Boolean,
     ) {
         screenModelScope.launch {
-            val res = userRepository.mute(userId)
+            val res =
+                userRepository.mute(
+                    id = userId,
+                    durationSeconds = if (duration.isInfinite()) 0 else duration.inWholeSeconds,
+                    notifications = disableNotifications,
+                )
             if (res != null) {
                 removeEntryFromState(entryId)
             }


### PR DESCRIPTION
This PR adds the possibility to configure a custom duration for the mute action as well as disabling notifications from the user during the specified duration.

Additionally, it introduces the possibility to mute/unmute and block/unblock users directly fro the use detail screen (from the top bar "More" button).

<div align="center">
<img src="https://github.com/user-attachments/assets/3e4c11fc-6ba5-4c03-9417-f47321613ccd" width="310" />
<img src="https://github.com/user-attachments/assets/3d6125a9-ccf7-480a-813e-ce69c4211908" width="310" />
</div>