### PR TITLE
enhancement: relationship button for locked accounts

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserHeader.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserHeader.kt
@@ -157,6 +157,7 @@ fun UserHeader(
                         if (relationshipStatus != null) {
                             UserRelationshipButton(
                                 status = relationshipStatus,
+                                locked = user.locked,
                                 pending = user.relationshipStatusPending,
                                 onClick = onRelationshipClicked,
                             )

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserItem.kt
@@ -104,6 +104,7 @@ fun UserItem(
             UserRelationshipButton(
                 status = relationshipStatus,
                 pending = user.relationshipStatusPending,
+                locked = user.locked,
                 onClick = onRelationshipClicked,
             )
         }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserRelationshipButton.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserRelationshipButton.kt
@@ -25,6 +25,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toReadableN
 fun UserRelationshipButton(
     status: RelationshipStatus,
     modifier: Modifier = Modifier,
+    locked: Boolean = false,
     pending: Boolean = false,
     onClick: ((RelationshipStatusNextAction) -> Unit)? = null,
 ) {
@@ -40,7 +41,7 @@ fun UserRelationshipButton(
                     color = MaterialTheme.colorScheme.onPrimary,
                 )
             }
-            Text(status.toReadableName())
+            Text(status.toReadableName(userLocked = locked))
         }
     }
     val buttonPadding =

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -233,4 +233,5 @@ internal open class DefaultStrings : Strings {
     override val selectDurationDialogTitle = "Select duration"
     override val muteDurationItem = "You will not see any posts by this user for"
     override val muteDisableNotificationsItem = "Disable notifications"
+    override val actionSendFollowRequest = "Send request"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -238,4 +238,5 @@ internal val ItStrings =
         override val selectDurationDialogTitle = "Seleziona durata"
         override val muteDurationItem = "Non vedrai più post da questo utente per"
         override val muteDisableNotificationsItem = "Disabilita notifiche"
+        override val actionSendFollowRequest = "Invia richiesta"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -217,6 +217,7 @@ interface Strings {
     val selectDurationDialogTitle: String
     val muteDurationItem: String
     val muteDisableNotificationsItem: String
+    val actionSendFollowRequest: String
 }
 
 object Locales {

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/RelationshipStatus.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/RelationshipStatus.kt
@@ -28,14 +28,15 @@ fun RelationshipModel.toStatus(): RelationshipStatus =
     }
 
 @Composable
-fun RelationshipStatus.toReadableName(): String =
-    when (this) {
-        RelationshipStatus.Following -> LocalStrings.current.relationshipStatusFollowing
-        RelationshipStatus.FollowsYou -> LocalStrings.current.relationshipStatusFollowsYou
-        RelationshipStatus.MutualFollow -> LocalStrings.current.relationshipStatusMutual
-        RelationshipStatus.RequestedToOther -> LocalStrings.current.relationshipStatusRequestedToOther
-        RelationshipStatus.RequestedToYou -> LocalStrings.current.relationshipStatusRequestedToYou
-        RelationshipStatus.Undetermined -> LocalStrings.current.actionFollow
+fun RelationshipStatus.toReadableName(userLocked: Boolean = false): String =
+    when {
+        this == RelationshipStatus.Following -> LocalStrings.current.relationshipStatusFollowing
+        this == RelationshipStatus.FollowsYou -> LocalStrings.current.relationshipStatusFollowsYou
+        this == RelationshipStatus.MutualFollow -> LocalStrings.current.relationshipStatusMutual
+        this == RelationshipStatus.RequestedToOther -> LocalStrings.current.relationshipStatusRequestedToOther
+        this == RelationshipStatus.RequestedToYou -> LocalStrings.current.relationshipStatusRequestedToYou
+        userLocked -> LocalStrings.current.actionSendFollowRequest
+        else -> LocalStrings.current.actionFollow
     }
 
 @Composable

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationUserInfo.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationUserInfo.kt
@@ -120,6 +120,7 @@ fun NotificationUserInfo(
                 if (relationshipStatus != null) {
                     UserRelationshipButton(
                         status = relationshipStatus,
+                        locked = user.locked,
                         pending = user.relationshipStatusPending,
                         onClick = onRelationshipClicked,
                     )


### PR DESCRIPTION
It can be determined beforehand whether the relationship button will follow a user or just send a follow request, using the `locked` property of accounts.

This PR makes it possible to see whether you are going to follow another user or just send a follow request.