### PR TITLE
fix: sticky header top offset in user detail and my profile screens

### DIFF
--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
@@ -1,5 +1,6 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.profile.myaccount
 
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -37,6 +38,7 @@ import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Dimensions
@@ -89,6 +91,13 @@ class MyAccountScreen : Screen {
         val clipboardManager = LocalClipboardManager.current
         var confirmDeleteEntryId by remember { mutableStateOf<String?>(null) }
         val topAppBarState = LocalProfileTopAppBarStateWrapper.current.topAppBarState
+        val stickyHeaderTopOffset by animateDpAsState(
+            if (lazyListState.firstVisibleItemIndex >= 2) {
+                Dimensions.maxTopBarInset * topAppBarState.collapsedFraction
+            } else {
+                0.dp
+            },
+        )
 
         suspend fun goBackToTop() {
             runCatching {
@@ -197,7 +206,7 @@ class MyAccountScreen : Screen {
                             Modifier
                                 .background(MaterialTheme.colorScheme.background)
                                 .padding(
-                                    top = Dimensions.maxTopBarInset * topAppBarState.collapsedFraction,
+                                    top = stickyHeaderTopOffset,
                                     bottom = Spacing.s,
                                 ),
                         titles =

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.livefast.eattrash.feature.userdetail.classic
 
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -57,6 +58,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.core.screen.ScreenKey
 import cafe.adriel.voyager.koin.getScreenModel
@@ -117,6 +119,13 @@ class UserDetailScreen(
         val scope = rememberCoroutineScope()
         val snackbarHostState = remember { SnackbarHostState() }
         val shareHelper = remember { getShareHelper() }
+        val stickyHeaderTopOffset by animateDpAsState(
+            if (lazyListState.firstVisibleItemIndex >= 2) {
+                Dimensions.maxTopBarInset * topAppBarState.collapsedFraction
+            } else {
+                0.dp
+            },
+        )
         val copyToClipboardSuccess = LocalStrings.current.messageTextCopiedToClipboard
         val clipboardManager = LocalClipboardManager.current
         var confirmUnfollowDialogOpen by remember { mutableStateOf(false) }
@@ -389,7 +398,7 @@ class UserDetailScreen(
                                     Modifier
                                         .background(MaterialTheme.colorScheme.background)
                                         .padding(
-                                            top = Dimensions.maxTopBarInset * topAppBarState.collapsedFraction,
+                                            top = stickyHeaderTopOffset,
                                             bottom = Spacing.s,
                                         ),
                                 titles =


### PR DESCRIPTION
The sticky header for list sections in user detail and my profile screens was incorrectly scaled when the list was started scrolling down, instead this should be done only if it the header is the topmost item in the `LazyColumn`.