### PR TITLE
fix: poll percentage rounding

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/PollCard.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/PollCard.kt
@@ -234,7 +234,11 @@ private fun PollCardOption(
                 modifier = Modifier.widthIn(min = 40.dp),
                 text =
                     buildString {
-                        append(percentage)
+                        if ((percentage * 10).roundToInt() % 10 == 0) {
+                            append(percentage.roundToInt())
+                        } else {
+                            append(percentage)
+                        }
                         append("%")
                     },
                 textAlign = TextAlign.End,


### PR DESCRIPTION
Avoid showing the decimal part if it is null in poll result percentage.