### PR TITLE
chore: update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="https://img.shields.io/badge/Kotlin-2.0.0-7F52FF?logo=kotlin" />
+  <img src="https://img.shields.io/badge/Kotlin-2.0.10-7F52FF?logo=kotlin" />
   <img src="https://img.shields.io/badge/Gradle-8.7-02303A?logo=gradle" />
   <img src="https://img.shields.io/badge/Android-26+-34A853?logo=android" />
   <img src="https://img.shields.io/badge/Compose-1.6.7-4285F4?logo=jetpackcompose" />
@@ -19,8 +19,11 @@ lot of common heritage.
 ## Want to try it?
 
 Here are some options to install the application on your device. The best way to install testing APKs
-is Obtainium, please insert this repository's URL as a source and make sure to check the
-"Include pre-releases" option (in order to receive all alpha and beta builds):
+is Obtainium, please insert this repository's URL as a source.
+
+> [!TIP]
+> Make sure to check the "Include pre-releases" option (in order to receive all alpha and beta
+> builds):
 
 ```
 https://github.com/LiveFastEatTrashRaccoon/RaccoonForFriendica
@@ -46,7 +49,7 @@ https://github.com/LiveFastEatTrashRaccoon/RaccoonForFriendica
   <img width="310" src="https://github.com/user-attachments/assets/08a9d437-d4af-48fa-b2de-efb56c21d0be" alt="thread screen within a group with replies" />
 </div>
 
-## Why was the project started?
+## Why was the project started and why is it called like that?
 
 Because raccoons are so adorable, aren't they? 🦝🦝🦝
 
@@ -114,13 +117,27 @@ The app is under ongoing development, here is a list of the features that are be
 - [ ] custom emojis
 - [ ] scheduled posts
 
-#### Disclaimer
+## Technologies used
 
-This is an experimental project and some technologies it is build upon are still in pre-production
-stage, moreover this is a side-project developed by volunteers in their spare time, so use _at your
-own risk_, please don't expect a full-fledged and fully functional app and be prepared to occasional
-failures and yet-to-implement features.
+- [Compose Multiplatform](https://www.jetbrains.com/lp/compose-multiplatform) for UI
+- [Room](https://developer.android.com/kotlin/multiplatform/room) for local persistence
+- [Koin](https://insert-koin.io/) for dependency injection
+- [Voyager](https://voyager.adriel.cafe/) for navigation
+- [Ktor](https://ktor.io/) and [Ktorfit](https://foso.github.io/Ktorfit) for networking
+- [Lyricist](https://github.com/adrielcafe/lyricist) for l10n
+- [Multiplatform settings](https://github.com/russhwolf/multiplatform-settings) for encrypted
+  preferences
+- [MaterialKolor](https://github.com/jordond/MaterialKolor) for custom theme generation
+- [Ksoup](https://github.com/MohamedRejeb/Ksoup) for HTML parsing
 
-Please be willing to contribute if you can, requests and reports will be evaluated depending on the
-time available.
+## Disclaimer
 
+> [!WARNING]
+> This is an experimental project and some technologies it is build upon are still in pre-production
+> stage, moreover this is a side-project developed by volunteers in their spare time, so use
+> _at your own risk_.
+
+You shouldn't expect a full-fledged and fully functional app; you should be prepared to occasional
+failures, yet-to-implement features and areas where (a lot of) polish is needed. Contributions are
+welcome and new feature requests (outside the agreed roadmap) will be evaluated depending on the
+available time.

--- a/core/api/build.gradle.kts
+++ b/core/api/build.gradle.kts
@@ -67,3 +67,7 @@ dependencies {
     add("kspIosArm64", libs.ktorfit.ksp)
     add("kspIosSimulatorArm64", libs.ktorfit.ksp)
 }
+
+kotlin.sourceSets.commonMain {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/DefaultServiceProvider.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/DefaultServiceProvider.kt
@@ -11,6 +11,18 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.service.TagsService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.TimelineService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.TrendsService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.UserService
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.createAppService
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.createListService
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.createNotificationService
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.createPhotoService
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.createPollService
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.createSearchService
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.createStatusService
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.createTagsService
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.createTimelineService
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.createTrendsService
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.createUserService
+import com.livefast.eattrash.raccoonforfriendica.core.api.utils.defaultLogger
 import com.livefast.eattrash.raccoonforfriendica.core.utils.debug.AppInfoRepository
 import com.livefast.eattrash.raccoonforfriendica.core.utils.network.provideHttpClientEngine
 import de.jensklingenberg.ktorfit.Ktorfit
@@ -130,16 +142,16 @@ internal class DefaultServiceProvider(
                 .httpClient(client)
                 .converterFactories(ResponseConverterFactory())
                 .build()
-        apps = ktorfit.create()
-        lists = ktorfit.create()
-        photo = ktorfit.create()
-        notifications = ktorfit.create()
-        polls = ktorfit.create()
-        search = ktorfit.create()
-        statuses = ktorfit.create()
-        tags = ktorfit.create()
-        timeline = ktorfit.create()
-        trends = ktorfit.create()
-        users = ktorfit.create()
+        apps = ktorfit.createAppService()
+        lists = ktorfit.createListService()
+        photo = ktorfit.createPhotoService()
+        notifications = ktorfit.createNotificationService()
+        polls = ktorfit.createPollService()
+        search = ktorfit.createSearchService()
+        statuses = ktorfit.createStatusService()
+        tags = ktorfit.createTagsService()
+        timeline = ktorfit.createTimelineService()
+        trends = ktorfit.createTrendsService()
+        users = ktorfit.createUserService()
     }
 }

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/utils/Logger.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/utils/Logger.kt
@@ -1,4 +1,4 @@
-package com.livefast.eattrash.raccoonforfriendica.core.api.provider
+package com.livefast.eattrash.raccoonforfriendica.core.api.utils
 
 import com.livefast.eattrash.raccoonforfriendica.core.utils.debug.logDebug
 import io.ktor.client.plugins.logging.Logger

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/LinkItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/LinkItem.kt
@@ -43,7 +43,7 @@ fun LinkItem(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
                 ) {
-                    if (url != null) {
+                    if (url.isNotEmpty()) {
                         onOpen?.invoke(url)
                     }
                 }.border(

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/uuid/GetUuid.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/uuid/GetUuid.kt
@@ -2,4 +2,4 @@ package com.livefast.eattrash.raccoonforfriendica.core.utils.uuid
 
 import platform.Foundation.NSUUID
 
-fun getUuid(): String = NSUUID.UUID().UUIDString
+actual fun getUuid(): String = NSUUID.UUID().UUIDString

--- a/domain/identity/data/build.gradle.kts
+++ b/domain/identity/data/build.gradle.kts
@@ -43,7 +43,7 @@ kotlin {
 }
 
 android {
-    namespace = "com.livefast.eattrash.raccoonforfriendica.domain.identity.repository"
+    namespace = "com.livefast.eattrash.raccoonforfriendica.domain.identity.data"
     compileSdk =
         libs.versions.android.targetSdk
             .get()

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/ApiCredentials.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/ApiCredentials.kt
@@ -26,7 +26,5 @@ internal fun ApiCredentials.toServiceCredentials() =
             ServiceCredentials.OAuth2(
                 accessToken = accessToken,
                 refreshToken = refreshToken,
-        )
-
-    else -> null
-}
+            )
+    }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,31 +4,32 @@ android-compileSdk = "34"
 android-minSdk = "26"
 android-targetSdk = "34"
 
-androidx-activity = "1.9.0"
+androidx-activity = "1.9.1"
 androidx-appcompat = "1.7.0"
 androidx-browser = "1.8.0"
 androidx-core-ktx = "1.13.1"
 androidx-crypto = "1.0.0"
 androidx-material = "1.12.0"
 androidx-splashscreen = "1.0.1"
-androidx-sqlite = "2.5.0-alpha5"
+androidx-sqlite = "2.5.0-alpha07"
 androidx-test-junit = "1.2.1"
 coil = "3.0.0-alpha09"
 compose-plugin = "1.6.11"
 koin = "3.5.6"
-kotlin = "2.0.0"
+kotlin = "2.0.10"
 kotlincrypto = "0.5.1"
 kotlinx-coroutines = "1.8.1"
 kotlinx-serialization-json = "1.7.1"
 ksoup = "0.4.0"
-ksp = "2.0.0-1.0.23"
+ksp = "2.0.10-1.0.24"
 ktor = "2.3.12"
-ktorfit = "2.0.0-rc01"
+ktorfit = "2.0.1"
+ktorfit-ksp = "2.0.1-1.0.24"
 lyricist = "1.7.0"
 materialKolor = "1.7.0"
 mockk = "1.13.12"
 multiplatform-settings = "1.1.1"
-room = "2.7.0-alpha05"
+room = "2.7.0-alpha07"
 stately = "2.0.7"
 turbine = "1.1.0"
 voyager = "1.0.0"
@@ -69,7 +70,7 @@ ktor-contentnegotiation = { module = "io.ktor:ktor-client-content-negotiation", 
 ktor-auth = { module = "io.ktor:ktor-client-auth", version.ref = "ktor" }
 ktor-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
-ktorfit-ksp = { module = "de.jensklingenberg.ktorfit:ktorfit-ksp", version.ref = "ktorfit" }
+ktorfit-ksp = { module = "de.jensklingenberg.ktorfit:ktorfit-ksp", version.ref = "ktorfit-ksp" }
 ktorfit-lib = { module = "de.jensklingenberg.ktorfit:ktorfit-lib", version.ref = "ktorfit" }
 ktorfit-converters-response = { module = "de.jensklingenberg.ktorfit:ktorfit-converters-response", version.ref = "ktorfit" }
 


### PR DESCRIPTION
This PR applies the following version upgrades:
- androidx-activity from 1.9.0 to 1.9.1
- androidx-sqlite from 2.5.0-alpha5 to 2.5.0-alpha07
- kotlin from 2.0.0 to 2.0.10
- ksp from 2.0.0-1.0.23 to 2.0.10-1.0.24
- ktorfit from 2.0.0-rc01 to 2.0.1
- room from 2.7.0-alpha05 to 2.7.0-alpha07

Since Ktorfit 2.0.1 was incompatible with the previous version, the required changes have been applied. Needless to say that the Ktorfit KSP plugin and the KSP update itself broke everything and made me lose ~1 hour.