### PR TITLE
fix: notification shown as read after refresh

### DIFF
--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
@@ -96,9 +96,18 @@ class InboxViewModel(
 
         updateState { it.copy(loading = true) }
         val notifications = paginationManager.loadNextPage()
+        val isRefreshing = uiState.value.refreshing
         updateState {
             it.copy(
-                notifications = notifications,
+                notifications =
+                    notifications.map { notification ->
+                        if (isRefreshing) {
+                            // when refreshing they have all been marked as read
+                            notification.copy(read = true)
+                        } else {
+                            notification
+                        }
+                    },
                 canFetchMore = paginationManager.canFetchMore,
                 loading = false,
                 initial = false,


### PR DESCRIPTION
Unread notifications were still displayed as read after a refresh (while being marked as read in the background). This fixes this visualization issue.