### PR TITLE
fix: item pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The app is under ongoing development, here is a list of the features that are be
 - [x] pin/unpin status to profile
 - [x] manage one's own circles/following lists
 - [x] polls (read-only, since the submit vote method is unimplemented in the backend)
-- [ ] manage follow requests
+- [x] manage follow requests
 - [ ] support post spoiler text (both in creation and in timeline)
 - [ ] support post title (in creation, in timeline it is already included)
 - [ ] edit one's own profile

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultExplorePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultExplorePaginationManager.kt
@@ -72,7 +72,7 @@ internal class DefaultExplorePaginationManager(
     private fun List<ExploreItemModel>.deduplicate(): List<ExploreItemModel> =
         filter { e1 ->
             history.none { e2 -> e1.id == e2.id }
-        }
+        }.distinctBy { it.id }
 
     private fun List<ExploreItemModel>.filterNsfw(included: Boolean): List<ExploreItemModel> = filter { included || !it.isNsfw }
 }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFavoritesPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFavoritesPaginationManager.kt
@@ -53,7 +53,7 @@ internal class DefaultFavoritesPaginationManager(
     private fun List<TimelineEntryModel>.deduplicate(): List<TimelineEntryModel> =
         filter { e1 ->
             history.none { e2 -> e1.id == e2.id }
-        }
+        }.distinctBy { it.id }
 
     private fun List<TimelineEntryModel>.filterNsfw(included: Boolean): List<TimelineEntryModel> = filter { included || !it.isNsfw }
 }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFollowRequestPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFollowRequestPaginationManager.kt
@@ -34,5 +34,5 @@ internal class DefaultFollowRequestPaginationManager(
     private fun List<UserModel>.deduplicate(): List<UserModel> =
         filter { e1 ->
             history.none { e2 -> e1.id == e2.id }
-        }
+        }.distinctBy { it.id }
 }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFollowedHashtagsPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFollowedHashtagsPaginationManager.kt
@@ -34,5 +34,5 @@ internal class DefaultFollowedHashtagsPaginationManager(
     private fun List<TagModel>.deduplicate(): List<TagModel> =
         filter { e1 ->
             history.none { e2 -> e1.name == e2.name }
-        }
+        }.distinctBy { it.name }
 }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultNotificationsPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultNotificationsPaginationManager.kt
@@ -73,7 +73,7 @@ internal class DefaultNotificationsPaginationManager(
     private fun List<NotificationModel>.deduplicate(): List<NotificationModel> =
         filter { e1 ->
             history.none { e2 -> e1.id == e2.id }
-        }
+        }.distinctBy { it.id }
 
     private fun List<NotificationModel>.filterNsfw(included: Boolean): List<NotificationModel> =
         filter { included || it.entry?.isNsfw != true }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultSearchPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultSearchPaginationManager.kt
@@ -65,7 +65,7 @@ internal class DefaultSearchPaginationManager(
     private fun List<ExploreItemModel>.deduplicate(): List<ExploreItemModel> =
         filter { e1 ->
             history.none { e2 -> e1.id == e2.id }
-        }
+        }.distinctBy { it.id }
 
     private fun List<ExploreItemModel>.filterNsfw(included: Boolean): List<ExploreItemModel> = filter { included || !it.isNsfw }
 }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
@@ -106,7 +106,7 @@ internal class DefaultTimelinePaginationManager(
     private fun List<TimelineEntryModel>.deduplicate(): List<TimelineEntryModel> =
         filter { e1 ->
             history.none { e2 -> e1.id == e2.id }
-        }
+        }.distinctBy { it.id }
 
     private fun List<TimelineEntryModel>.filterNsfw(included: Boolean): List<TimelineEntryModel> = filter { included || !it.isNsfw }
 }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUserPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUserPaginationManager.kt
@@ -34,8 +34,8 @@ internal class DefaultUserPaginationManager(
                         .getFollowers(
                             id = specification.userId,
                             pageCursor = pageCursor,
-                        ).determineRelationshipStatus()
-                        .deduplicate()
+                        ).deduplicate()
+                        .determineRelationshipStatus()
                         .updatePaginationData()
 
                 is UserPaginationSpecification.Following ->
@@ -43,8 +43,8 @@ internal class DefaultUserPaginationManager(
                         .getFollowing(
                             id = specification.userId,
                             pageCursor = pageCursor,
-                        ).determineRelationshipStatus()
-                        .deduplicate()
+                        ).deduplicate()
+                        .determineRelationshipStatus()
                         .updatePaginationData()
 
                 is UserPaginationSpecification.EntryUsersFavorite ->
@@ -61,8 +61,8 @@ internal class DefaultUserPaginationManager(
                         .getUsersWhoReblogged(
                             id = specification.entryId,
                             pageCursor = pageCursor,
-                        ).determineRelationshipStatus()
-                        .deduplicate()
+                        ).deduplicate()
+                        .determineRelationshipStatus()
                         .updatePaginationData()
 
                 is UserPaginationSpecification.Search ->
@@ -73,8 +73,8 @@ internal class DefaultUserPaginationManager(
                                 history
                                     .indexOfLast { it.id == pageCursor }
                                     .takeIf { it >= 0 } ?: 0,
-                        ).determineRelationshipStatus()
-                        .deduplicate()
+                        ).deduplicate()
+                        .determineRelationshipStatus()
                         .updatePaginationData()
 
                 UserPaginationSpecification.Blocked ->
@@ -92,10 +92,11 @@ internal class DefaultUserPaginationManager(
                         .updatePaginationData()
 
                 is UserPaginationSpecification.CircleMembers ->
-                    circlesRepository.getMembers(
-                        id = specification.id,
-                        pageCursor = pageCursor,
-                    ).deduplicate()
+                    circlesRepository
+                        .getMembers(
+                            id = specification.id,
+                            pageCursor = pageCursor,
+                        ).deduplicate()
                         .updatePaginationData()
                         .filter(specification.query)
             }
@@ -129,7 +130,7 @@ internal class DefaultUserPaginationManager(
     private fun List<UserModel>.deduplicate(): List<UserModel> =
         filter { e1 ->
             history.none { e2 -> e1.id == e2.id }
-        }
+        }.distinctBy { it.id }
 
     private fun List<UserModel>.filter(query: String): List<UserModel> =
         filter {


### PR DESCRIPTION
This PR fixes a crash that may occur if duplicated data appear within the same page (which happens sometimes in following/followers pagination).