### PR TITLE
fix: selection after link insertion

### DIFF
--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
@@ -107,10 +107,16 @@ class ComposerViewModel(
             is ComposerMviModel.Intent.AddLink -> {
                 screenModelScope.launch {
                     val (anchor, url) = intent.link
-                    val additionalPart = "<a href=\"$url\">$anchor</a>"
+                    val before = "<a href=\"$url\">"
+                    val after = "</a>"
                     updateBodyValue(
-                        additionalPart = additionalPart,
-                        offsetAfter = additionalPart.length,
+                        additionalPart =
+                            buildString {
+                                append(before)
+                                append(anchor)
+                                append(after)
+                            },
+                        offsetAfter = before.length,
                     )
                 }
             }


### PR DESCRIPTION
This PR fixes the text selection when inserting a link to an URL after using the current selection as an anchor.