### PR TITLE
fix: login flow

### DIFF
--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultApiConfigurationRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultApiConfigurationRepository.kt
@@ -41,6 +41,7 @@ internal class DefaultApiConfigurationRepository(
         }
 
         identityRepository.changeIsLogged(credentials != null)
+        identityRepository.refreshCurrentUser()
     }
 
     override suspend fun hasCachedAuthCredentials(): Boolean {

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultIdentityRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultIdentityRepository.kt
@@ -24,14 +24,9 @@ internal class DefaultIdentityRepository(
 
     override fun changeIsLogged(value: Boolean) {
         isLogged.update { value }
-        if (value) {
-            refreshUser()
-        } else {
-            currentUser.update { null }
-        }
     }
 
-    private fun refreshUser() {
+    override fun refreshCurrentUser() {
         scope.launch {
             val handle = accountRepository.getActive()?.handle.orEmpty()
             if (handle.isEmpty()) {
@@ -46,6 +41,7 @@ internal class DefaultIdentityRepository(
                         id = user.id,
                         handle = user.acct,
                         username = user.username,
+                        avatar = user.avatar,
                     )
                 }
             } catch (e: Throwable) {

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/IdentityRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/IdentityRepository.kt
@@ -6,8 +6,10 @@ import kotlinx.coroutines.flow.StateFlow
 interface IdentityRepository {
     val isLogged: StateFlow<Boolean>
     val currentUser: StateFlow<UserModel?>
+
+    fun refreshCurrentUser()
 }
 
-internal interface MutableIdentityRepository {
+internal interface MutableIdentityRepository : IdentityRepository {
     fun changeIsLogged(value: Boolean)
 }

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultLoginUseCase.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultLoginUseCase.kt
@@ -6,6 +6,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Acco
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiCredentials
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.CredentialsRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
 
 internal class DefaultLoginUseCase(
@@ -13,6 +14,7 @@ internal class DefaultLoginUseCase(
     private val credentialsRepository: CredentialsRepository,
     private val accountRepository: AccountRepository,
     private val settingsRepository: SettingsRepository,
+    private val identityRepository: IdentityRepository,
 ) : LoginUseCase {
     override suspend fun invoke(
         node: String,
@@ -46,6 +48,8 @@ internal class DefaultLoginUseCase(
 
             val settings = settingsRepository.get(accountId) ?: defaultSettings
             settingsRepository.changeCurrent(settings)
+
+            identityRepository.refreshCurrentUser()
         }
     }
 }

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
@@ -25,6 +25,7 @@ val domainIdentityUseCaseModule =
                 apiConfigurationRepository = get(),
                 accountRepository = get(),
                 settingsRepository = get(),
+                identityRepository = get(),
             )
         }
 

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerViewModel.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerViewModel.kt
@@ -2,17 +2,15 @@ package com.livefast.eattrash.raccoonforfriendica.feature.drawer
 
 import cafe.adriel.voyager.core.model.screenModelScope
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 class DrawerViewModel(
     private val apiConfigurationRepository: ApiConfigurationRepository,
-    private val accountRepository: AccountRepository,
-    private val userRepository: UserRepository,
+    private val identityRepository: IdentityRepository,
 ) : DefaultMviModel<DrawerMviModel.Intent, DrawerMviModel.State, DrawerMviModel.Effect>(
         initialState = DrawerMviModel.State(),
     ),
@@ -27,15 +25,9 @@ class DrawerViewModel(
                         )
                     }
                 }.launchIn(this)
-            accountRepository
-                .getActiveAsFlow()
-                .onEach { activeAccount ->
-                    if (activeAccount == null) {
-                        updateState { it.copy(user = null) }
-                    } else {
-                        val currentUser = userRepository.getByHandle(activeAccount.handle)
-                        updateState { it.copy(user = currentUser) }
-                    }
+            identityRepository.currentUser
+                .onEach { currentUser ->
+                    updateState { it.copy(user = currentUser) }
                 }.launchIn(this)
         }
     }

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/di/DrawerModule.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/di/DrawerModule.kt
@@ -9,8 +9,7 @@ val featureDrawerModule =
         single<DrawerMviModel> {
             DrawerViewModel(
                 apiConfigurationRepository = get(),
-                accountRepository = get(),
-                userRepository = get(),
+                identityRepository = get(),
             )
         }
     }

--- a/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/oauth/LoginViewModel.kt
+++ b/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/oauth/LoginViewModel.kt
@@ -70,7 +70,9 @@ class LoginViewModel(
                 return@launch
             }
 
-            updateState { it.copy(loading = true) }
+            updateState {
+                it.copy(loading = true)
+            }
             try {
                 val url = authManager.startOAuthFlow(node)
                 emitEffect(LoginMviModel.Effect.OpenUrl(url))
@@ -87,7 +89,6 @@ class LoginViewModel(
                 node = node,
                 credentials = credentials,
             )
-            updateState { it.copy(loading = false) }
             emitEffect(LoginMviModel.Effect.Success)
         } catch (e: Throwable) {
             updateState { it.copy(loading = false) }

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
@@ -117,7 +117,7 @@ class TimelineViewModel(
     }
 
     private suspend fun refreshCirclesInTimelineTypes() {
-        val isLogged = uiState.value.currentUserId != null
+        val isLogged = identityRepository.isLogged.value
         val circles = circlesRepository.getAll()
         val settings = settingsRepository.current.value
         val defaultTimelineTypes =
@@ -153,6 +153,7 @@ class TimelineViewModel(
     }
 
     private suspend fun refresh(initial: Boolean = false) {
+        // needed as a last-resort to update circles if edited elsewhere
         refreshCirclesInTimelineTypes()
         updateState {
             it.copy(initial = initial, refreshing = !initial)


### PR DESCRIPTION
This PR solves a series of minor issues in the login flow:
- the submit button in the OAuth2 login form could be clicked even after the success, leading to duplicate flows
- the feed type bottom sheet did not include "Subscriptions" after login
- sometimes the navigation drawer was not in sync with the currently logged user

Additionally, `ApiConfigurationRepository` and `IdentityRepository` have been slightly refactored to separate more clearly responsibilities.