### PR TITLE
fix: avoid fetching current user info in composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The app is under ongoing development, here is a list of the features that are be
 - [x] manage follow requests
 - [ ] support post spoiler text (both in creation and in timeline)
 - [ ] support post title (in creation, in timeline it is already included)
+- [ ] multi-account
 - [ ] edit one's own profile
 - [ ] private conversations
 - [ ] advanced media visualization (image carousels, videos, GIFs, etc.)

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/di/ComposerModule.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/di/ComposerModule.kt
@@ -11,8 +11,7 @@ val featureComposerModule =
                 inReplyToId = params[0],
                 timelineEntryRepository = get(),
                 photoRepository = get(),
-                accountRepository = get(),
-                userRepository = get(),
+                identityRepository = get(),
                 userPaginationManager = get(),
                 circlesRepository = get(),
             )


### PR DESCRIPTION
This PR simplifies the way `ComposerViewModel` loads the information about the current user.