### PR TITLE
enhancement: empty messages

### DIFF
--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -241,4 +241,6 @@ internal open class DefaultStrings : Strings {
     override val actionAccept = "Accept"
     override val actionReject = "Reject"
     override val actionHideContent = "Hide content"
+    override val messageEmptyInbox =
+        "🎉 You are all caught up! 🎉\n\nYou'll see new notifications in this page as soon as they arrive"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -246,4 +246,6 @@ internal val ItStrings =
         override val actionAccept = "Accetta"
         override val actionReject = "Rifiuta"
         override val actionHideContent = "Nascondi contenuto"
+        override val messageEmptyInbox =
+            "🎉 Sei già al passo! 🎉\n\nVedrai comparire le notifiche in questa pagina non appena ce ne saranno di nuove"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -225,6 +225,7 @@ interface Strings {
     val actionAccept: String
     val actionReject: String
     val actionHideContent: String
+    val messageEmptyInbox: String
 }
 
 object Locales {

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.style.TextAlign
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
@@ -180,6 +181,17 @@ class FavoritesScreen(
                             TimelineItemPlaceholder(modifier = Modifier.fillMaxWidth())
                             HorizontalDivider(
                                 modifier = Modifier.padding(vertical = Spacing.s),
+                            )
+                        }
+                    }
+
+                    if (!uiState.initial && !uiState.refreshing && !uiState.loading && uiState.entries.isEmpty()) {
+                        item {
+                            Text(
+                                modifier = Modifier.fillMaxWidth().padding(top = Spacing.m),
+                                text = LocalStrings.current.messageEmptyList,
+                                textAlign = TextAlign.Center,
+                                style = MaterialTheme.typography.bodyLarge,
                             )
                         }
                     }

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.style.TextAlign
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.core.screen.ScreenKey
 import cafe.adriel.voyager.koin.getScreenModel
@@ -205,6 +206,18 @@ class HashtagScreen(
                             )
                         }
                     }
+
+                    if (!uiState.initial && !uiState.refreshing && !uiState.loading && uiState.entries.isEmpty()) {
+                        item {
+                            Text(
+                                modifier = Modifier.fillMaxWidth().padding(top = Spacing.m),
+                                text = LocalStrings.current.messageEmptyList,
+                                textAlign = TextAlign.Center,
+                                style = MaterialTheme.typography.bodyLarge,
+                            )
+                        }
+                    }
+
                     itemsIndexed(
                         items = uiState.entries,
                         key = { _, e -> e.safeKey },

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
@@ -251,7 +251,7 @@ class InboxScreen : Screen {
                                 modifier = Modifier.fillMaxWidth().padding(top = Spacing.m),
                                 text =
                                     if (uiState.isLogged) {
-                                        LocalStrings.current.messageEmptyList
+                                        LocalStrings.current.messageEmptyInbox
                                     } else {
                                         LocalStrings.current.messageUserUnlogged
                                     },


### PR DESCRIPTION
This PR adds the empty message to the favorites and bookmark screens, to the hashtag timeline screen and reviews the empty inbox one to make it a little more cheerful.