### PR TITLE
fix: layout improvements

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentImage.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentImage.kt
@@ -36,7 +36,7 @@ fun ContentImage(
     url: String,
     modifier: Modifier = Modifier,
     sensitive: Boolean = false,
-    minHeight: Dp = 200.dp,
+    minHeight: Dp = 50.dp,
     maxHeight: Dp = Dp.Unspecified,
     onClick: (() -> Unit)? = null,
 ) {

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
@@ -6,9 +6,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
@@ -178,12 +176,10 @@ fun TimelineItem(
                 )
             }
             if (entryToDisplay.isSpoilerActive || spoiler.isEmpty()) {
-                if (spoiler.isNotEmpty()) {
-                    Spacer(modifier = Modifier.height(Spacing.xxxs))
-                }
-                entryToDisplay.title?.let { title ->
+                val title = entryToDisplay.title
+                if (title != null) {
                     ContentTitle(
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier.fillMaxWidth().padding(top = Spacing.xxs),
                         content = title,
                         onClick = { onClick?.invoke(entryToDisplay) },
                         onOpenUrl = onOpenUrl,
@@ -191,7 +187,14 @@ fun TimelineItem(
                 }
 
                 ContentBody(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier =
+                        Modifier.fillMaxWidth().then(
+                            if (title == null) {
+                                Modifier.padding(top = Spacing.xxs)
+                            } else {
+                                Modifier.padding(top = Spacing.xxxs)
+                            },
+                        ),
                     content = entryToDisplay.content,
                     onClick = { onClick?.invoke(entryToDisplay) },
                     onOpenUrl = onOpenUrl,


### PR DESCRIPTION
This PR contains a couple of layout improvements:
- a vertical space if always added before the title/body of posts no matter whether there is a spoiler before or not (previously if was added only if there was a spoiler, but the readability improvement is significant even when there is no spoiler)
- the minimum height of image blocks is reduced, since it lead to a large unwanted margins on images with a high aspect ratio.