### PR TITLE
feat: multi-account support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The app is under ongoing development, here is a list of the features that are be
 - [x] polls (read-only, since the submit vote method is unimplemented in the backend)
 - [x] manage follow requests
 - [x] support for post addons (spoilers and titles)
-- [ ] multi-account
+- [x] multi-account
 - [ ] edit one's own profile
 - [ ] private conversations
 - [ ] advanced media visualization (image carousels, videos, GIFs, etc.)

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/CustomModalBottomSheet.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/CustomModalBottomSheet.kt
@@ -1,10 +1,12 @@
 package com.livefast.eattrash.raccoonforfriendica.core.commonui.components
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -25,24 +27,31 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
 
 data class CustomModalBottomSheetItem(
     val leadingContent: @Composable (() -> Unit)? = null,
     val label: String,
+    val subtitle: String? = null,
     val customLabelStyle: TextStyle? = null,
     val trailingContent: @Composable (() -> Unit)? = null,
 )
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun CustomModalBottomSheet(
     sheetState: SheetState = rememberModalBottomSheetState(),
     title: String = "",
     items: List<CustomModalBottomSheetItem> = emptyList(),
     onSelected: ((Int?) -> Unit)? = null,
+    onLongPress: ((Int) -> Unit)? = null,
 ) {
+    val fullColor = MaterialTheme.colorScheme.onBackground
+    val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha)
+
     ModalBottomSheet(
         sheetState = sheetState,
+        windowInsets = WindowInsets(0, 0, 0, 0),
         onDismissRequest = {
             onSelected?.invoke(null)
         },
@@ -55,6 +64,7 @@ fun CustomModalBottomSheet(
                     textAlign = TextAlign.Center,
                     text = title,
                     style = MaterialTheme.typography.titleMedium,
+                    color = fullColor,
                 )
                 Spacer(modifier = Modifier.height(Spacing.xs))
                 LazyColumn {
@@ -66,9 +76,14 @@ fun CustomModalBottomSheet(
                                 modifier =
                                     Modifier
                                         .fillMaxWidth()
-                                        .clickable {
-                                            onSelected?.invoke(idx)
-                                        }.padding(
+                                        .combinedClickable(
+                                            onClick = {
+                                                onSelected?.invoke(idx)
+                                            },
+                                            onLongClick = {
+                                                onLongPress?.invoke(idx)
+                                            },
+                                        ).padding(
                                             horizontal = Spacing.s,
                                             vertical = Spacing.s,
                                         ),
@@ -76,13 +91,25 @@ fun CustomModalBottomSheet(
                                 horizontalArrangement = Arrangement.spacedBy(Spacing.s),
                             ) {
                                 item.leadingContent?.invoke()
-                                Text(
+                                Column(
                                     modifier = Modifier.weight(1f),
-                                    text = item.label,
-                                    style =
-                                        item.customLabelStyle
-                                            ?: MaterialTheme.typography.bodyLarge,
-                                )
+                                    verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+                                ) {
+                                    Text(
+                                        text = item.label,
+                                        style =
+                                            item.customLabelStyle
+                                                ?: MaterialTheme.typography.bodyLarge,
+                                        color = fullColor,
+                                    )
+                                    if (!item.subtitle.isNullOrEmpty()) {
+                                        Text(
+                                            text = item.subtitle,
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            color = ancillaryColor,
+                                        )
+                                    }
+                                }
                                 item.trailingContent?.invoke()
                             }
                         }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -245,4 +245,6 @@ internal open class DefaultStrings : Strings {
         "🎉 You are all caught up! 🎉\n\nYou'll see new notifications in this page as soon as they arrive"
     override val createPostSpoilerPlaceholder = "Spoiler text"
     override val createPostTitlePlaceholder = "Title (optional)"
+    override val actionSwitchAccount = "Switch account"
+    override val actionDeleteAccount = "Delete account"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -250,4 +250,6 @@ internal val ItStrings =
             "🎉 Sei già al passo! 🎉\n\nVedrai comparire le notifiche in questa pagina non appena ce ne saranno di nuove"
         override val createPostSpoilerPlaceholder = "Testo dello spoiler"
         override val createPostTitlePlaceholder = "Titolo (facoltativo)"
+        override val actionSwitchAccount = "Cambia account"
+        override val actionDeleteAccount = "Elimina account"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -228,6 +228,8 @@ interface Strings {
     val messageEmptyInbox: String
     val createPostSpoilerPlaceholder: String
     val createPostTitlePlaceholder: String
+    val actionSwitchAccount: String
+    val actionDeleteAccount: String
 }
 
 object Locales {

--- a/core/persistence/schemas/com.livefast.eattrash.raccoonforfriendica.core.persistence.AppDatabase/4.json
+++ b/core/persistence/schemas/com.livefast.eattrash.raccoonforfriendica.core.persistence.AppDatabase/4.json
@@ -1,0 +1,163 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "137fb3b947b29d358f5a21d819f80bfc",
+    "entities": [
+      {
+        "tableName": "AccountEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `handle` TEXT NOT NULL, `active` INTEGER NOT NULL DEFAULT 0, `remoteId` TEXT, `avatar` TEXT, `displayName` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "handle",
+            "columnName": "handle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "active",
+            "columnName": "active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "avatar",
+            "columnName": "avatar",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AccountEntity_handle",
+            "unique": false,
+            "columnNames": [
+              "handle"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AccountEntity_handle` ON `${TABLE_NAME}` (`handle`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SettingsEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `accountId` INTEGER NOT NULL DEFAULT 0, `lang` TEXT NOT NULL DEFAULT 'en', `theme` INTEGER NOT NULL DEFAULT 0, `fontFamily` INTEGER NOT NULL DEFAULT 0, `fontScale` INTEGER NOT NULL DEFAULT 0, `dynamicColors` INTEGER NOT NULL DEFAULT 0, `customSeedColor` INTEGER, `defaultTimelineType` INTEGER NOT NULL DEFAULT 0, `includeNsfw` INTEGER NOT NULL DEFAULT 0, `blurNsfw` INTEGER NOT NULL DEFAULT 0, `urlOpeningMode` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lang",
+            "columnName": "lang",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'en'"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "fontScale",
+            "columnName": "fontScale",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "dynamicColors",
+            "columnName": "dynamicColors",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "customSeedColor",
+            "columnName": "customSeedColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "defaultTimelineType",
+            "columnName": "defaultTimelineType",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "includeNsfw",
+            "columnName": "includeNsfw",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "blurNsfw",
+            "columnName": "blurNsfw",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "urlOpeningMode",
+            "columnName": "urlOpeningMode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '137fb3b947b29d358f5a21d819f80bfc')"
+    ]
+  }
+}

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/AppDatabase.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/AppDatabase.kt
@@ -13,10 +13,11 @@ import com.livefast.eattrash.raccoonforfriendica.core.persistence.entities.Setti
         AccountEntity::class,
         SettingsEntity::class,
     ],
-    version = 3,
+    version = 4,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
+        AutoMigration(from = 3, to = 4),
 
     ],
 )

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/dao/AccountDao.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/dao/AccountDao.kt
@@ -16,6 +16,9 @@ interface AccountDao {
     @Query("SELECT * FROM AccountEntity")
     suspend fun getAll(): List<AccountEntity>
 
+    @Query("SELECT * FROM AccountEntity")
+    fun getAllAsFlow(): Flow<List<AccountEntity>>
+
     @Query("SELECT * FROM AccountEntity WHERE handle = :handle")
     suspend fun getBy(handle: String): AccountEntity?
 

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/entities/AccountEntity.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/entities/AccountEntity.kt
@@ -9,4 +9,7 @@ data class AccountEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
     @ColumnInfo(index = true) val handle: String,
     @ColumnInfo(defaultValue = "0") val active: Boolean = false,
+    @ColumnInfo val remoteId: String? = null,
+    @ColumnInfo val avatar: String? = null,
+    @ColumnInfo val displayName: String? = null,
 )

--- a/domain/identity/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/data/AccountModel.kt
+++ b/domain/identity/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/data/AccountModel.kt
@@ -1,7 +1,10 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.identity.data
 
 data class AccountModel(
-    val id: Long = 0,
-    val handle: String = "",
     val active: Boolean = false,
+    val avatar: String? = null,
+    val handle: String = "",
+    val id: Long = 0,
+    val remoteId: String? = null,
+    val displayName: String? = null,
 )

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/AccountCredentialsCache.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/AccountCredentialsCache.kt
@@ -1,0 +1,12 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository
+
+interface AccountCredentialsCache {
+    fun get(accountId: Long): ApiCredentials?
+
+    fun save(
+        accountId: Long,
+        credentials: ApiCredentials,
+    )
+
+    fun remove(accountId: Long)
+}

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/AccountRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/AccountRepository.kt
@@ -6,11 +6,13 @@ import kotlinx.coroutines.flow.Flow
 interface AccountRepository {
     suspend fun getAll(): List<AccountModel>
 
+    fun getAllAsFlow(): Flow<List<AccountModel>>
+
     suspend fun getBy(handle: String): AccountModel?
 
     suspend fun getActive(): AccountModel?
 
-    suspend fun getActiveAsFlow(): Flow<AccountModel?>
+    fun getActiveAsFlow(): Flow<AccountModel?>
 
     suspend fun create(account: AccountModel)
 

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultAccountCredentialsCache.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultAccountCredentialsCache.kt
@@ -1,0 +1,74 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository
+
+import com.livefast.eattrash.raccoonforfriendica.core.preferences.TemporaryKeyStore
+
+internal class DefaultAccountCredentialsCache(
+    private val keyStore: TemporaryKeyStore,
+) : AccountCredentialsCache {
+    override fun get(accountId: Long): ApiCredentials? {
+        val type = keyStore[getKeyForType(accountId), ""]
+        val part1 = keyStore[getKeyForPart1(accountId), ""]
+        val part2 = keyStore[getKeyForPart2(accountId), ""]
+        return when {
+            type == METHOD_BASIC && part1.isNotEmpty() && part2.isNotEmpty() ->
+                ApiCredentials.HttpBasic(
+                    user = part1,
+                    pass = part2,
+                )
+
+            type == METHOD_OAUTH_2 && part1.isNotEmpty() ->
+                ApiCredentials.OAuth2(
+                    accessToken = part1,
+                    refreshToken = part2,
+                )
+
+            else -> null
+        }
+    }
+
+    override fun save(
+        accountId: Long,
+        credentials: ApiCredentials,
+    ) {
+        val type: String
+        val part1: String
+        val part2: String
+        when (credentials) {
+            is ApiCredentials.HttpBasic -> {
+                type = METHOD_BASIC
+                part1 = credentials.user
+                part2 = credentials.pass
+            }
+
+            is ApiCredentials.OAuth2 -> {
+                type = METHOD_OAUTH_2
+                part1 = credentials.accessToken
+                part2 = credentials.refreshToken
+            }
+        }
+        keyStore.save(getKeyForType(accountId), type)
+        keyStore.save(getKeyForPart1(accountId), part1)
+        keyStore.save(getKeyForPart2(accountId), part2)
+    }
+
+    override fun remove(accountId: Long) {
+        keyStore.remove(getKeyForType(accountId))
+        keyStore.remove(getKeyForPart1(accountId))
+        keyStore.remove(getKeyForPart2(accountId))
+    }
+
+    private fun getKeyForPart1(accountId: Long) = "$PREFIX.$accountId.$KEY_PART_1"
+
+    private fun getKeyForPart2(accountId: Long) = "$PREFIX.$accountId.$KEY_PART_2"
+
+    private fun getKeyForType(accountId: Long) = "$PREFIX.$accountId.$KEY_TYPE"
+
+    companion object {
+        private const val PREFIX = "AccountCredentialsRepository"
+        private const val KEY_PART_1 = "part1"
+        private const val KEY_PART_2 = "part2"
+        private const val KEY_TYPE = "type"
+        private const val METHOD_BASIC = "HTTPBasic"
+        private const val METHOD_OAUTH_2 = "OAuth2"
+    }
+}

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultAccountRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultAccountRepository.kt
@@ -1,11 +1,8 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository
 
-import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.toUiTheme
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.dao.AccountDao
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.entities.AccountEntity
-import com.livefast.eattrash.raccoonforfriendica.core.persistence.entities.SettingsEntity
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -14,11 +11,16 @@ internal class DefaultAccountRepository(
 ) : AccountRepository {
     override suspend fun getAll(): List<AccountModel> = accountDao.getAll().map { it.toModel() }
 
+    override fun getAllAsFlow(): Flow<List<AccountModel>> =
+        accountDao.getAllAsFlow().map { list ->
+            list.map { it.toModel() }
+        }
+
     override suspend fun getBy(handle: String): AccountModel? = accountDao.getBy(handle)?.toModel()
 
     override suspend fun getActive(): AccountModel? = accountDao.getActive()?.toModel()
 
-    override suspend fun getActiveAsFlow(): Flow<AccountModel?> =
+    override fun getActiveAsFlow(): Flow<AccountModel?> =
         accountDao.getActiveAsFlow().map { list ->
             list.firstOrNull()?.toModel()
         }
@@ -41,6 +43,9 @@ private fun AccountModel.toEntity() =
         id = id,
         handle = handle,
         active = active,
+        remoteId = remoteId,
+        avatar = avatar,
+        displayName = displayName,
     )
 
 private fun AccountEntity.toModel() =
@@ -48,10 +53,7 @@ private fun AccountEntity.toModel() =
         id = id,
         handle = handle,
         active = active,
-    )
-
-private fun SettingsEntity.toModel() =
-    SettingsModel(
-        lang = lang,
-        theme = theme.toUiTheme(),
+        remoteId = remoteId,
+        avatar = avatar,
+        displayName = displayName,
     )

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultCredentialsRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultCredentialsRepository.kt
@@ -145,6 +145,7 @@ private fun CredentialAccount.toModel() =
         handle = acct,
         id = id,
         username = username,
+        avatar = avatar,
     )
 
 private fun OAuthToken.toModel(): ApiCredentials =

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultIdentityRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultIdentityRepository.kt
@@ -28,19 +28,15 @@ internal class DefaultIdentityRepository(
 
     override fun refreshCurrentUser() {
         scope.launch {
-            val handle = accountRepository.getActive()?.handle.orEmpty()
-            if (handle.isEmpty()) {
+            val userId = accountRepository.getActive()?.remoteId.orEmpty()
+            if (userId.isEmpty()) {
                 currentUser.update { null }
                 return@launch
             }
 
             try {
                 val user =
-                    provider.users
-                        .search(
-                            query = handle,
-                            resolve = true,
-                        ).first()
+                    provider.users.getById(userId)
                 currentUser.update {
                     UserModel(
                         id = user.id,

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultSettingsRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultSettingsRepository.kt
@@ -30,6 +30,10 @@ internal class DefaultSettingsRepository(
     override suspend fun update(settings: SettingsModel) {
         settingsDao.update(settings.toEntity())
     }
+
+    override suspend fun delete(settings: SettingsModel) {
+        settingsDao.delete(settings.toEntity())
+    }
 }
 
 private fun SettingsEntity.toModel() =

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/SettingsRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/SettingsRepository.kt
@@ -12,5 +12,7 @@ interface SettingsRepository {
 
     suspend fun update(settings: SettingsModel)
 
+    suspend fun delete(settings: SettingsModel)
+
     fun changeCurrent(settings: SettingsModel)
 }

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/di/IdentityRepositoryModule.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/di/IdentityRepositoryModule.kt
@@ -1,8 +1,10 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di
 
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountCredentialsCache
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.CredentialsRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultAccountCredentialsCache
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultAccountRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultApiConfigurationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultCredentialsRepository
@@ -48,6 +50,11 @@ val domainIdentityRepositoryModule =
         single<SettingsRepository> {
             DefaultSettingsRepository(
                 settingsDao = get(),
+            )
+        }
+        single<AccountCredentialsCache> {
+            DefaultAccountCredentialsCache(
+                keyStore = get(),
             )
         }
     }

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultDeleteAccountUseCase.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultDeleteAccountUseCase.kt
@@ -1,0 +1,25 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
+
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountCredentialsCache
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
+
+internal class DefaultDeleteAccountUseCase(
+    private val accountRepository: AccountRepository,
+    private val settingsRepository: SettingsRepository,
+    private val accountCredentialsCache: AccountCredentialsCache,
+) : DeleteAccountUseCase {
+    override suspend fun invoke(account: AccountModel) {
+        val activeId = accountRepository.getActive()?.id
+        val accountId = account.id
+        check(activeId != accountId) { "The active account can not be deleted" }
+
+        accountCredentialsCache.remove(accountId)
+        val settings = settingsRepository.get(accountId)
+        if (settings != null) {
+            settingsRepository.delete(settings)
+        }
+        accountRepository.delete(account)
+    }
+}

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultLogoutUseCase.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultLogoutUseCase.kt
@@ -3,12 +3,14 @@ package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
 
 internal class DefaultLogoutUseCase(
     private val apiConfigurationRepository: ApiConfigurationRepository,
     private val accountRepository: AccountRepository,
     private val settingsRepository: SettingsRepository,
+    private val identityRepository: IdentityRepository,
 ) : LogoutUseCase {
     override suspend fun invoke() {
         apiConfigurationRepository.setAuth(null)
@@ -21,6 +23,8 @@ internal class DefaultLogoutUseCase(
             val anonymousAccountId = accountRepository.getBy("")?.id ?: 0
             val defaultSettings = settingsRepository.get(anonymousAccountId) ?: SettingsModel()
             settingsRepository.changeCurrent(defaultSettings)
+
+            identityRepository.refreshCurrentUser()
         }
     }
 }

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultSwitchAccountUseCase.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultSwitchAccountUseCase.kt
@@ -1,0 +1,40 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
+
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountCredentialsCache
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
+
+internal class DefaultSwitchAccountUseCase(
+    private val apiConfigurationRepository: ApiConfigurationRepository,
+    private val accountRepository: AccountRepository,
+    private val settingsRepository: SettingsRepository,
+    private val identityRepository: IdentityRepository,
+    private val accountCredentialsCache: AccountCredentialsCache,
+) : SwitchAccountUseCase {
+    override suspend fun invoke(account: AccountModel) {
+        val oldActive = accountRepository.getActive()
+        if (oldActive != null) {
+            accountRepository.update(oldActive.copy(active = false))
+        }
+
+        val newAccount = account.copy(active = true)
+        accountRepository.update(newAccount)
+
+        val accountId = account.id
+        val anonymousAccountId = accountRepository.getBy("")?.id ?: 0
+        val defaultSettings = settingsRepository.get(anonymousAccountId) ?: SettingsModel()
+        val settings = settingsRepository.get(accountId) ?: defaultSettings
+        settingsRepository.changeCurrent(settings)
+
+        val credentials = accountCredentialsCache.get(accountId)
+        val node = account.handle.substringAfter("@")
+        apiConfigurationRepository.changeNode(node)
+        apiConfigurationRepository.setAuth(credentials)
+
+        identityRepository.refreshCurrentUser()
+    }
+}

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DeleteAccountUseCase.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DeleteAccountUseCase.kt
@@ -1,0 +1,7 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
+
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
+
+interface DeleteAccountUseCase {
+    suspend operator fun invoke(account: AccountModel)
+}

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/SwitchAccountUseCase.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/SwitchAccountUseCase.kt
@@ -1,0 +1,7 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
+
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
+
+interface SwitchAccountUseCase {
+    suspend operator fun invoke(account: AccountModel)
+}

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
@@ -26,6 +26,7 @@ val domainIdentityUseCaseModule =
                 accountRepository = get(),
                 settingsRepository = get(),
                 identityRepository = get(),
+                accountCredentialsCache = get(),
             )
         }
 

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
@@ -35,6 +35,7 @@ val domainIdentityUseCaseModule =
                 apiConfigurationRepository = get(),
                 accountRepository = get(),
                 settingsRepository = get(),
+                identityRepository = get(),
             )
         }
         single<CustomUriHandler> { params ->

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
@@ -2,10 +2,12 @@ package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di
 
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.CustomUriHandler
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultCustomUriHandler
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultDeleteAccountUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultLoginUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultLogoutUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultSetupAccountUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultSwitchAccountUseCase
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DeleteAccountUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.LoginUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.LogoutUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.SetupAccountUseCase
@@ -56,6 +58,13 @@ val domainIdentityUseCaseModule =
                 accountRepository = get(),
                 settingsRepository = get(),
                 identityRepository = get(),
+                accountCredentialsCache = get(),
+            )
+        }
+        single<DeleteAccountUseCase> {
+            DefaultDeleteAccountUseCase(
+                accountRepository = get(),
+                settingsRepository = get(),
                 accountCredentialsCache = get(),
             )
         }

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
@@ -5,9 +5,11 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.Default
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultLoginUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultLogoutUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultSetupAccountUseCase
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultSwitchAccountUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.LoginUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.LogoutUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.SetupAccountUseCase
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.SwitchAccountUseCase
 import org.koin.dsl.module
 
 val domainIdentityUseCaseModule =
@@ -46,6 +48,15 @@ val domainIdentityUseCaseModule =
                 userRepository = get(),
                 customTabsHelper = get(),
                 settingsRepository = get(),
+            )
+        }
+        single<SwitchAccountUseCase> {
+            DefaultSwitchAccountUseCase(
+                apiConfigurationRepository = get(),
+                accountRepository = get(),
+                settingsRepository = get(),
+                identityRepository = get(),
+                accountCredentialsCache = get(),
             )
         }
     }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileMviModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileMviModel.kt
@@ -3,6 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica.feature.profile
 import androidx.compose.runtime.Stable
 import cafe.adriel.voyager.core.model.ScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
 
 @Stable
 interface ProfileMviModel :
@@ -10,10 +11,19 @@ interface ProfileMviModel :
     MviModel<ProfileMviModel.Intent, ProfileMviModel.State, ProfileMviModel.Effect> {
     sealed interface Intent {
         data object Logout : Intent
+
+        data class SwitchAccount(
+            val account: AccountModel,
+        ) : Intent
+
+        data class DeleteAccount(
+            val account: AccountModel,
+        ) : Intent
     }
 
     data class State(
-        val isLogged: Boolean = false,
+        val currentUserId: String? = null,
+        val availableAccounts: List<AccountModel> = emptyList(),
     )
 
     sealed interface Effect

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
@@ -4,8 +4,11 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Logout
+import androidx.compose.material.icons.filled.ManageAccounts
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -13,11 +16,13 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarState
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -28,14 +33,23 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.ContentScale
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
 import cafe.adriel.voyager.navigator.Navigator
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomImage
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomModalBottomSheet
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomModalBottomSheetItem
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.PlaceholderImage
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDrawerCoordinator
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
 import com.livefast.eattrash.raccoonforfriendica.feature.profile.anonymous.AnonymousScreen
 import com.livefast.eattrash.raccoonforfriendica.feature.profile.myaccount.MyAccountScreen
 import kotlinx.coroutines.launch
@@ -51,6 +65,8 @@ class ProfileScreen : Screen {
         val scope = rememberCoroutineScope()
         val drawerCoordinator = remember { getDrawerCoordinator() }
         var confirmLogoutDialogOpened by remember { mutableStateOf(false) }
+        var manageAccountsDialogOpened by remember { mutableStateOf(false) }
+        var confirmDeleteAccount by remember { mutableStateOf<AccountModel?>(null) }
 
         CompositionLocalProvider(
             LocalProfileTopAppBarStateWrapper provides
@@ -84,7 +100,17 @@ class ProfileScreen : Screen {
                             )
                         },
                         actions = {
-                            if (uiState.isLogged) {
+                            if (uiState.currentUserId != null) {
+                                IconButton(
+                                    onClick = {
+                                        manageAccountsDialogOpened = true
+                                    },
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Default.ManageAccounts,
+                                        contentDescription = null,
+                                    )
+                                }
                                 IconButton(
                                     onClick = {
                                         confirmLogoutDialogOpened = true
@@ -106,11 +132,105 @@ class ProfileScreen : Screen {
                                 .padding(padding)
                                 .nestedScroll(scrollBehavior.nestedScrollConnection),
                     ) {
-                        if (!uiState.isLogged) {
+                        if (uiState.currentUserId == null) {
                             Navigator(AnonymousScreen())
                         } else {
                             Navigator(MyAccountScreen())
                         }
+                    }
+                },
+            )
+        }
+
+        if (manageAccountsDialogOpened) {
+            val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+            val items =
+                uiState.availableAccounts.map { account ->
+                    CustomModalBottomSheetItem(
+                        label = account.displayName.orEmpty(),
+                        subtitle = account.handle,
+                        leadingContent = {
+                            val avatar = account.avatar.orEmpty()
+                            val avatarSize = IconSize.xl
+                            if (avatar.isNotEmpty()) {
+                                CustomImage(
+                                    modifier =
+                                        Modifier
+                                            .size(avatarSize)
+                                            .clip(RoundedCornerShape(avatarSize / 2)),
+                                    url = avatar,
+                                    quality = FilterQuality.Low,
+                                    contentScale = ContentScale.FillBounds,
+                                )
+                            } else {
+                                PlaceholderImage(
+                                    size = avatarSize,
+                                    title = account.displayName ?: account.handle,
+                                )
+                            }
+                        },
+                        trailingContent = {
+                            RadioButton(
+                                selected = account.active,
+                                onClick = {},
+                            )
+                        },
+                    )
+                }
+            CustomModalBottomSheet(
+                title = LocalStrings.current.actionSwitchAccount,
+                sheetState = sheetState,
+                items = items,
+                onSelected = { index ->
+                    manageAccountsDialogOpened = false
+                    if (index != null) {
+                        val selectedAccount = uiState.availableAccounts[index]
+                        model.reduce(ProfileMviModel.Intent.SwitchAccount(selectedAccount))
+                    }
+                },
+                onLongPress = { index ->
+                    val selectedAccount = uiState.availableAccounts[index]
+                    if (!selectedAccount.active) {
+                        confirmDeleteAccount = selectedAccount
+                    }
+                },
+            )
+        }
+
+        if (confirmDeleteAccount != null) {
+            AlertDialog(
+                onDismissRequest = {
+                    confirmDeleteAccount = null
+                },
+                title = {
+                    Text(
+                        text = LocalStrings.current.actionDeleteAccount,
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                },
+                text = {
+                    Text(text = LocalStrings.current.messageAreYouSure)
+                },
+                dismissButton = {
+                    Button(
+                        onClick = {
+                            confirmDeleteAccount = null
+                        },
+                    ) {
+                        Text(text = LocalStrings.current.buttonCancel)
+                    }
+                },
+                confirmButton = {
+                    Button(
+                        onClick = {
+                            val account = confirmDeleteAccount
+                            confirmDeleteAccount = null
+                            if (account != null) {
+                                model.reduce(ProfileMviModel.Intent.DeleteAccount(account))
+                            }
+                        },
+                    ) {
+                        Text(text = LocalStrings.current.buttonConfirm)
                     }
                 },
             )

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/di/ProfileModule.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/di/ProfileModule.kt
@@ -15,7 +15,10 @@ val featureProfileModule =
         factory<ProfileMviModel> {
             ProfileViewModel(
                 identityRepository = get(),
+                accountRepository = get(),
                 logoutUseCase = get(),
+                switchAccountUseCase = get(),
+                deleteAccountUseCase = get(),
                 myAccountCache = get(),
             )
         }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
@@ -35,11 +35,11 @@ class MyAccountViewModel(
                 .getActiveAsFlow()
                 .distinctUntilChanged()
                 .onEach { account ->
-                    val handle = account?.handle.orEmpty()
+                    val userId = account?.remoteId.orEmpty()
                     val cachedUser = myAccountCache.retrieveUser()
                     val cachedPaginationState = myAccountCache.retrievePaginationState()
-                    if (cachedUser?.handle != handle) {
-                        val currentAccount = userRepository.getByHandle(handle)
+                    if (cachedUser?.id != userId) {
+                        val currentAccount = userRepository.getById(userId)
                         updateState { it.copy(user = currentAccount) }
                         refresh(initial = true)
                     } else {


### PR DESCRIPTION
This PR adds the ability to support multiple account at the same time (even on different platforms e.g. Friendica & Mastodon), each with its individual settings.

It is possible to switch from one account to another in the profile screen and, with a long press on an item in the bottom sheet, accounts can be deleted permanently.