### PR TITLE
refactor: centralize usages of confirm dialogs

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ConfirmMuteUserBottomSheet.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ConfirmMuteUserBottomSheet.kt
@@ -3,6 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -69,6 +70,7 @@ fun ConfirmMuteUserBottomSheet(
     }
 
     ModalBottomSheet(
+        windowInsets = WindowInsets(0, 0, 0, 0),
         sheetState = sheetState,
         onDismissRequest = {
             onClose?.invoke(null)

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CustomConfirmDialog.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CustomConfirmDialog.kt
@@ -1,0 +1,54 @@
+package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
+
+@Composable
+fun CustomConfirmDialog(
+    title: String,
+    body: String = LocalStrings.current.messageAreYouSure,
+    confirmButtonLabel: String? = LocalStrings.current.buttonConfirm,
+    cancelButtonLabel: String? = LocalStrings.current.buttonCancel,
+    onClose: ((Boolean) -> Unit)? = null,
+) {
+    AlertDialog(
+        onDismissRequest = {
+            onClose?.invoke(false)
+        },
+        title = {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+            )
+        },
+        text = {
+            Text(text = body)
+        },
+        dismissButton = {
+            if (cancelButtonLabel != null) {
+                Button(
+                    onClick = {
+                        onClose?.invoke(false)
+                    },
+                ) {
+                    Text(text = cancelButtonLabel)
+                }
+            }
+        },
+        confirmButton = {
+            if (confirmButtonLabel != null) {
+                Button(
+                    onClick = {
+                        onClose?.invoke(true)
+                    },
+                ) {
+                    Text(text = confirmButtonLabel)
+                }
+            }
+        },
+    )
+}

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/detail/CircleDetailScreen.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/detail/CircleDetailScreen.kt
@@ -20,8 +20,6 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -54,6 +52,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.getFabNestedScrollConnection
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.UserItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.UserItemPlaceholder
@@ -257,39 +256,13 @@ class CircleDetailScreen(
         }
 
         if (confirmRemoveUserId != null) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionDelete,
+                onClose = { confirm ->
+                    val userId = confirmRemoveUserId
                     confirmRemoveUserId = null
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionDelete,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmRemoveUserId = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val userId = confirmRemoveUserId ?: ""
-                            confirmRemoveUserId = null
-                            if (userId.isNotEmpty()) {
-                                model.reduce(CircleDetailMviModel.Intent.Remove(userId))
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm && userId != null) {
+                        model.reduce(CircleDetailMviModel.Intent.Remove(userId))
                     }
                 },
             )

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/list/CirclesScreen.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/list/CirclesScreen.kt
@@ -20,8 +20,6 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -53,6 +51,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.getFabNestedScrollConnection
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toOption
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
@@ -211,6 +210,7 @@ class CirclesScreen : Screen {
                                     OptionId.Edit -> {
                                         model.reduce(CirclesMviModel.Intent.OpenEditor(circle))
                                     }
+
                                     OptionId.Delete -> confirmDeleteItemId = circle.id
                                     else -> Unit
                                 }
@@ -256,59 +256,33 @@ class CirclesScreen : Screen {
         }
 
         if (confirmDeleteItemId != null) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionDelete,
+                onClose = { confirm ->
+                    val itemId = confirmDeleteItemId
                     confirmDeleteItemId = null
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionDelete,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmDeleteItemId = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val itemId = confirmDeleteItemId ?: ""
-                            confirmDeleteItemId = null
-                            if (itemId.isNotEmpty()) {
-                                model.reduce(CirclesMviModel.Intent.Delete(itemId))
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm && itemId != null) {
+                        model.reduce(CirclesMviModel.Intent.Delete(itemId))
                     }
                 },
             )
-        }
 
-        val editorData = uiState.editorData
-        if (editorData != null) {
-            CircleEditorDialog(
-                data = editorData,
-                onDataChanged = { newData ->
-                    model.reduce(CirclesMviModel.Intent.UpdateEditorData(newData))
-                },
-                onClose = { success ->
-                    if (success) {
-                        model.reduce(CirclesMviModel.Intent.SubmitEditorData)
-                    } else {
-                        model.reduce(CirclesMviModel.Intent.DismissEditor)
-                    }
-                },
-            )
+            val editorData = uiState.editorData
+            if (editorData != null) {
+                CircleEditorDialog(
+                    data = editorData,
+                    onDataChanged = { newData ->
+                        model.reduce(CirclesMviModel.Intent.UpdateEditorData(newData))
+                    },
+                    onClose = { success ->
+                        if (success) {
+                            model.reduce(CirclesMviModel.Intent.SubmitEditorData)
+                        } else {
+                            model.reduce(CirclesMviModel.Intent.DismissEditor)
+                        }
+                    },
+                )
+            }
         }
     }
 }

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -20,8 +20,6 @@ import androidx.compose.material.icons.automirrored.filled.Reply
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
@@ -58,6 +56,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.getFabNestedScrollConnection
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ConfirmMuteUserBottomSheet
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.PollVoteErrorDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
@@ -380,39 +379,13 @@ class EntryDetailScreen(
         }
 
         if (confirmDeleteEntryId != null) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionDelete,
+                onClose = { confirm ->
+                    val entryId = confirmDeleteEntryId ?: ""
                     confirmDeleteEntryId = null
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionDelete,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmDeleteEntryId = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val entryId = confirmDeleteEntryId ?: ""
-                            confirmDeleteEntryId = null
-                            if (entryId.isNotEmpty()) {
-                                model.reduce(EntryDetailMviModel.Intent.DeleteEntry(entryId))
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm && entryId.isNotEmpty()) {
+                        model.reduce(EntryDetailMviModel.Intent.DeleteEntry(entryId))
                     }
                 },
             )
@@ -445,52 +418,26 @@ class EntryDetailScreen(
 
         if (confirmBlockEntry != null) {
             val creator = confirmBlockEntry?.reblog?.creator ?: confirmBlockEntry?.creator
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title =
+                    buildString {
+                        append(LocalStrings.current.actionBlock)
+                        val handle = creator?.handle ?: ""
+                        if (handle.isNotEmpty()) {
+                            append(" @$handle")
+                        }
+                    },
+                onClose = { confirm ->
+                    val entryId = confirmBlockEntry?.id
+                    val creatorId = creator?.id
                     confirmBlockEntry = null
-                },
-                title = {
-                    Text(
-                        text =
-                            buildString {
-                                append(LocalStrings.current.actionBlock)
-                                val handle = creator?.handle ?: ""
-                                if (handle.isNotEmpty()) {
-                                    append(" @$handle")
-                                }
-                            },
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmBlockEntry = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val entryId = confirmBlockEntry?.id
-                            val creatorId = creator?.id
-                            confirmBlockEntry = null
-                            if (entryId != null && creatorId != null) {
-                                model.reduce(
-                                    EntryDetailMviModel.Intent.BlockUser(
-                                        userId = creatorId,
-                                        entryId = entryId,
-                                    ),
-                                )
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm && entryId != null && creatorId != null) {
+                        model.reduce(
+                            EntryDetailMviModel.Intent.BlockUser(
+                                userId = creatorId,
+                                entryId = entryId,
+                            ),
+                        )
                     }
                 },
             )

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
@@ -19,8 +19,6 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -58,6 +56,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowI
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.SectionSelector
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ConfirmMuteUserBottomSheet
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.GenericPlaceholder
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.HashtagItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.LinkItem
@@ -492,117 +491,38 @@ class ExploreScreen : Screen {
         }
 
         if (confirmUnfollowDialogUserId != null) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionUnfollow,
+                onClose = { confirm ->
+                    val userId = confirmUnfollowDialogUserId
                     confirmUnfollowDialogUserId = null
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionUnfollow,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmUnfollowDialogUserId = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val userId = confirmUnfollowDialogUserId ?: ""
-                            confirmUnfollowDialogUserId = null
-                            if (userId.isNotEmpty()) {
-                                model.reduce(ExploreMviModel.Intent.Unfollow(userId))
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm && userId != null) {
+                        model.reduce(ExploreMviModel.Intent.Unfollow(userId))
                     }
                 },
             )
         }
 
         if (confirmDeleteFollowRequestDialogUserId != null) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionDeleteFollowRequest,
+                onClose = { confirm ->
+                    val userId = confirmUnfollowDialogUserId
                     confirmUnfollowDialogUserId = null
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionDeleteFollowRequest,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmUnfollowDialogUserId = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val userId = confirmUnfollowDialogUserId ?: ""
-                            confirmUnfollowDialogUserId = null
-                            if (userId.isNotEmpty()) {
-                                model.reduce(ExploreMviModel.Intent.Unfollow(userId))
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm && userId != null) {
+                        model.reduce(ExploreMviModel.Intent.Unfollow(userId))
                     }
                 },
             )
         }
 
         if (confirmDeleteEntryId != null) {
-            AlertDialog(
-                onDismissRequest = {
-                    confirmDeleteEntryId = null
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionDelete,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmDeleteEntryId = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val entryId = confirmDeleteEntryId ?: ""
-                            confirmDeleteEntryId = null
-                            if (entryId.isNotEmpty()) {
-                                model.reduce(ExploreMviModel.Intent.DeleteEntry(entryId))
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionDelete,
+                onClose = { confirm ->
+                    val entryId = confirmDeleteEntryId
+                    if (confirm && entryId != null) {
+                        model.reduce(ExploreMviModel.Intent.DeleteEntry(entryId))
                     }
                 },
             )
@@ -635,54 +555,28 @@ class ExploreScreen : Screen {
 
         if (confirmBlockEntry != null) {
             val creator = confirmBlockEntry?.reblog?.creator ?: confirmBlockEntry?.creator
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title =
+                    buildString {
+                        append(LocalStrings.current.actionBlock)
+                        val handle = creator?.handle ?: ""
+                        if (handle.isNotEmpty()) {
+                            append(" @$handle")
+                        }
+                    },
+                onClose = { confirm ->
+                    val entryId = confirmBlockEntry?.id
+                    val creatorId = creator?.id
                     confirmBlockEntry = null
-                },
-                title = {
-                    Text(
-                        text =
-                            buildString {
-                                append(LocalStrings.current.actionBlock)
-                                val handle = creator?.handle ?: ""
-                                if (handle.isNotEmpty()) {
-                                    append(" @$handle")
-                                }
-                            },
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmBlockEntry = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
+                    if (confirm && entryId != null && creatorId != null) {
+                        model.reduce(
+                            ExploreMviModel.Intent.BlockUser(
+                                userId = creatorId,
+                                entryId = entryId,
+                            ),
+                        )
                     }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val entryId = confirmBlockEntry?.id
-                            val creatorId = creator?.id
-                            confirmBlockEntry = null
-                            if (entryId != null && creatorId != null) {
-                                model.reduce(
-                                    ExploreMviModel.Intent.BlockUser(
-                                        userId = creatorId,
-                                        entryId = entryId,
-                                    ),
-                                )
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
-                    }
-                },
+                }
             )
         }
 

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
@@ -16,8 +16,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -51,6 +49,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ConfirmMuteUserBottomSheet
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.PollVoteErrorDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
@@ -343,39 +342,13 @@ class FavoritesScreen(
         }
 
         if (confirmDeleteEntryId != null) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionDelete,
+                onClose = { confirm ->
+                    val entryId = confirmDeleteEntryId
                     confirmDeleteEntryId = null
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionDelete,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmDeleteEntryId = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val entryId = confirmDeleteEntryId ?: ""
-                            confirmDeleteEntryId = null
-                            if (entryId.isNotEmpty()) {
-                                model.reduce(FavoritesMviModel.Intent.DeleteEntry(entryId))
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm && entryId != null) {
+                        model.reduce(FavoritesMviModel.Intent.DeleteEntry(entryId))
                     }
                 },
             )
@@ -408,54 +381,28 @@ class FavoritesScreen(
 
         if (confirmBlockEntry != null) {
             val creator = confirmBlockEntry?.reblog?.creator ?: confirmBlockEntry?.creator
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title =
+                    buildString {
+                        append(LocalStrings.current.actionBlock)
+                        val handle = creator?.handle ?: ""
+                        if (handle.isNotEmpty()) {
+                            append(" @$handle")
+                        }
+                    },
+                onClose = { confirm ->
+                    val entryId = confirmBlockEntry?.id
+                    val creatorId = creator?.id
                     confirmBlockEntry = null
-                },
-                title = {
-                    Text(
-                        text =
-                            buildString {
-                                append(LocalStrings.current.actionBlock)
-                                val handle = creator?.handle ?: ""
-                                if (handle.isNotEmpty()) {
-                                    append(" @$handle")
-                                }
-                            },
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmBlockEntry = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
+                    if (confirm && entryId != null && creatorId != null) {
+                        model.reduce(
+                            FavoritesMviModel.Intent.BlockUser(
+                                userId = creatorId,
+                                entryId = entryId,
+                            ),
+                        )
                     }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val entryId = confirmBlockEntry?.id
-                            val creatorId = creator?.id
-                            confirmBlockEntry = null
-                            if (entryId != null && creatorId != null) {
-                                model.reduce(
-                                    FavoritesMviModel.Intent.BlockUser(
-                                        userId = creatorId,
-                                        entryId = entryId,
-                                    ),
-                                )
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
-                    }
-                },
+                }
             )
         }
 

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/followed/FollowedHashtagsScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/followed/FollowedHashtagsScreen.kt
@@ -16,8 +16,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -42,6 +40,7 @@ import cafe.adriel.voyager.koin.getScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.FollowHashtagItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.GenericPlaceholder
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
@@ -192,44 +191,18 @@ class FollowedHashtagsScreen : Screen {
         }
 
         if (confirmUnfollowHashtagName != null) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionUnfollow,
+                onClose = { confirm ->
+                    val oldTag = confirmUnfollowHashtagName
                     confirmUnfollowHashtagName = null
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionUnfollow,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmUnfollowHashtagName = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val oldTag = confirmUnfollowHashtagName
-                            confirmUnfollowHashtagName = null
-                            if (oldTag != null) {
-                                model.reduce(
-                                    FollowedHashtagsMviModel.Intent.ToggleTagFollow(
-                                        name = oldTag,
-                                        newValue = false,
-                                    ),
-                                )
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm && oldTag != null) {
+                        model.reduce(
+                            FollowedHashtagsMviModel.Intent.ToggleTagFollow(
+                                name = oldTag,
+                                newValue = false,
+                            ),
+                        )
                     }
                 },
             )

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
@@ -16,8 +16,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -52,6 +50,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ConfirmMuteUserBottomSheet
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.PollVoteErrorDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
@@ -365,75 +364,25 @@ class HashtagScreen(
         }
 
         if (confirmUnfollowHashtagDialogOpen) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionUnfollow,
+                onClose = { confirm ->
                     confirmUnfollowHashtagDialogOpen = false
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionUnfollow,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmUnfollowHashtagDialogOpen = false
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            confirmUnfollowHashtagDialogOpen = false
-                            model.reduce(HashtagMviModel.Intent.ToggleTagFollow(false))
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm) {
+                        model.reduce(HashtagMviModel.Intent.ToggleTagFollow(false))
                     }
                 },
             )
         }
 
         if (confirmDeleteEntryId != null) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionDelete,
+                onClose = { confirm ->
+                    val entryId = confirmDeleteEntryId
                     confirmDeleteEntryId = null
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionDelete,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmDeleteEntryId = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val entryId = confirmDeleteEntryId ?: ""
-                            confirmDeleteEntryId = null
-                            if (entryId.isNotEmpty()) {
-                                model.reduce(HashtagMviModel.Intent.DeleteEntry(entryId))
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm && entryId != null) {
+                        model.reduce(HashtagMviModel.Intent.DeleteEntry(entryId))
                     }
                 },
             )
@@ -466,54 +415,28 @@ class HashtagScreen(
 
         if (confirmBlockEntry != null) {
             val creator = confirmBlockEntry?.reblog?.creator ?: confirmBlockEntry?.creator
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title =
+                    buildString {
+                        append(LocalStrings.current.actionBlock)
+                        val handle = creator?.handle ?: ""
+                        if (handle.isNotEmpty()) {
+                            append(" @$handle")
+                        }
+                    },
+                onClose = { confirm ->
+                    val entryId = confirmBlockEntry?.id
+                    val creatorId = creator?.id
                     confirmBlockEntry = null
-                },
-                title = {
-                    Text(
-                        text =
-                            buildString {
-                                append(LocalStrings.current.actionBlock)
-                                val handle = creator?.handle ?: ""
-                                if (handle.isNotEmpty()) {
-                                    append(" @$handle")
-                                }
-                            },
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmBlockEntry = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
+                    if (confirm && entryId != null && creatorId != null) {
+                        model.reduce(
+                            HashtagMviModel.Intent.BlockUser(
+                                userId = creatorId,
+                                entryId = entryId,
+                            ),
+                        )
                     }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val entryId = confirmBlockEntry?.id
-                            val creatorId = creator?.id
-                            confirmBlockEntry = null
-                            if (entryId != null && creatorId != null) {
-                                model.reduce(
-                                    HashtagMviModel.Intent.BlockUser(
-                                        userId = creatorId,
-                                        entryId = entryId,
-                                    ),
-                                )
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
-                    }
-                },
+                }
             )
         }
 

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
@@ -17,8 +17,6 @@ import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -48,6 +46,7 @@ import cafe.adriel.voyager.koin.getScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.BottomNavigationSection
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDetailOpener
@@ -277,78 +276,26 @@ class InboxScreen : Screen {
         }
 
         if (confirmUnfollowDialogUserId != null) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionUnfollow,
+                onClose = { confirm ->
+                    val userId = confirmUnfollowDialogUserId ?: ""
                     confirmUnfollowDialogUserId = null
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionUnfollow,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmUnfollowDialogUserId = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val userId = confirmUnfollowDialogUserId ?: ""
-                            confirmUnfollowDialogUserId = null
-                            if (userId.isNotEmpty()) {
-                                model.reduce(InboxMviModel.Intent.Unfollow(userId))
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm && userId.isNotEmpty()) {
+                        model.reduce(InboxMviModel.Intent.Unfollow(userId))
                     }
                 },
             )
         }
 
         if (confirmDeleteFollowRequestDialogUserId != null) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionDeleteFollowRequest,
+                onClose = { confirm ->
+                    val userId = confirmUnfollowDialogUserId ?: ""
                     confirmUnfollowDialogUserId = null
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionDeleteFollowRequest,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmUnfollowDialogUserId = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val userId = confirmUnfollowDialogUserId ?: ""
-                            confirmUnfollowDialogUserId = null
-                            if (userId.isNotEmpty()) {
-                                model.reduce(InboxMviModel.Intent.Unfollow(userId))
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm && userId.isNotEmpty()) {
+                        model.reduce(InboxMviModel.Intent.Unfollow(userId))
                     }
                 },
             )

--- a/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/ManageBlocksScreen.kt
+++ b/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/ManageBlocksScreen.kt
@@ -18,8 +18,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -50,6 +48,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.SectionSelector
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.UserItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.UserItemPlaceholder
@@ -277,78 +276,26 @@ class ManageBlocksScreen : Screen {
         }
 
         if (confirmUnmuteUserId != null) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionUnmute,
+                onClose = { confirm ->
+                    val userId = confirmUnmuteUserId
                     confirmUnmuteUserId = null
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionUnmute,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmUnmuteUserId = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val userId = confirmUnmuteUserId ?: ""
-                            confirmUnmuteUserId = null
-                            if (userId.isNotEmpty()) {
-                                model.reduce(ManageBlocksMviModel.Intent.ToggleMute(userId))
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm && userId != null) {
+                        model.reduce(ManageBlocksMviModel.Intent.ToggleMute(userId))
                     }
                 },
             )
         }
 
         if (confirmUnblockUserId != null) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionUnblock,
+                onClose = { confirm ->
+                    val userId = confirmUnblockUserId
                     confirmUnblockUserId = null
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionUnblock,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmUnblockUserId = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val userId = confirmUnblockUserId ?: ""
-                            confirmUnblockUserId = null
-                            if (userId.isNotEmpty()) {
-                                model.reduce(ManageBlocksMviModel.Intent.ToggleBlock(userId))
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm && userId != null) {
+                        model.reduce(ManageBlocksMviModel.Intent.ToggleBlock(userId))
                     }
                 },
             )

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
@@ -10,8 +10,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Logout
 import androidx.compose.material.icons.filled.ManageAccounts
 import androidx.compose.material.icons.filled.Menu
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -47,6 +45,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.Custom
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomModalBottomSheet
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomModalBottomSheetItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.PlaceholderImage
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDrawerCoordinator
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
@@ -198,75 +197,25 @@ class ProfileScreen : Screen {
         }
 
         if (confirmDeleteAccount != null) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionDeleteAccount,
+                onClose = { confirm ->
+                    val account = confirmDeleteAccount
                     confirmDeleteAccount = null
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionDeleteAccount,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmDeleteAccount = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val account = confirmDeleteAccount
-                            confirmDeleteAccount = null
-                            if (account != null) {
-                                model.reduce(ProfileMviModel.Intent.DeleteAccount(account))
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm && account != null) {
+                        model.reduce(ProfileMviModel.Intent.DeleteAccount(account))
                     }
                 },
             )
         }
 
         if (confirmLogoutDialogOpened) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionLogout,
+                onClose = { confirm ->
                     confirmLogoutDialogOpened = false
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionLogout,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmLogoutDialogOpened = false
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            confirmLogoutDialogOpened = false
-                            model.reduce(ProfileMviModel.Intent.Logout)
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm) {
+                        model.reduce(ProfileMviModel.Intent.Logout)
                     }
                 },
             )

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
@@ -15,8 +15,6 @@ import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -45,6 +43,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Dimension
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.SectionSelector
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItemPlaceholder
@@ -394,39 +393,13 @@ class MyAccountScreen : Screen {
         }
 
         if (confirmDeleteEntryId != null) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionDelete,
+                onClose = { confirm ->
+                    val entryId = confirmDeleteEntryId
                     confirmDeleteEntryId = null
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionDelete,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmDeleteEntryId = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val entryId = confirmDeleteEntryId ?: ""
-                            confirmDeleteEntryId = null
-                            if (entryId.isNotEmpty()) {
-                                model.reduce(MyAccountMviModel.Intent.DeleteEntry(entryId))
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm && entryId != null) {
+                        model.reduce(MyAccountMviModel.Intent.DeleteEntry(entryId))
                     }
                 },
             )

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
@@ -18,8 +18,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -58,6 +56,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLo
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.SearchField
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.SectionSelector
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ConfirmMuteUserBottomSheet
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.GenericPlaceholder
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.HashtagItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
@@ -490,117 +489,39 @@ class SearchScreen : Screen {
         }
 
         if (confirmUnfollowDialogUserId != null) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionUnfollow,
+                onClose = { confirm ->
+                    val userId = confirmUnfollowDialogUserId
                     confirmUnfollowDialogUserId = null
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionUnfollow,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmUnfollowDialogUserId = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val userId = confirmUnfollowDialogUserId ?: ""
-                            confirmUnfollowDialogUserId = null
-                            if (userId.isNotEmpty()) {
-                                model.reduce(SearchMviModel.Intent.Unfollow(userId))
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm && userId != null) {
+                        model.reduce(SearchMviModel.Intent.Unfollow(userId))
                     }
                 },
             )
         }
 
         if (confirmDeleteFollowRequestDialogUserId != null) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionDeleteFollowRequest,
+                onClose = { confirm ->
+                    val userId = confirmUnfollowDialogUserId
                     confirmUnfollowDialogUserId = null
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionDeleteFollowRequest,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmUnfollowDialogUserId = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val userId = confirmUnfollowDialogUserId ?: ""
-                            confirmUnfollowDialogUserId = null
-                            if (userId.isNotEmpty()) {
-                                model.reduce(SearchMviModel.Intent.Unfollow(userId))
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm && userId != null) {
+                        model.reduce(SearchMviModel.Intent.Unfollow(userId))
                     }
                 },
             )
         }
 
         if (confirmDeleteEntryId != null) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionDelete,
+                onClose = { confirm ->
+                    val entryId = confirmDeleteEntryId
                     confirmDeleteEntryId = null
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionDelete,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmDeleteEntryId = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val entryId = confirmDeleteEntryId ?: ""
-                            confirmDeleteEntryId = null
-                            if (entryId.isNotEmpty()) {
-                                model.reduce(SearchMviModel.Intent.DeleteEntry(entryId))
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm && entryId != null) {
+                        model.reduce(SearchMviModel.Intent.DeleteEntry(entryId))
                     }
                 },
             )
@@ -633,52 +554,26 @@ class SearchScreen : Screen {
 
         if (confirmBlockEntry != null) {
             val creator = confirmBlockEntry?.reblog?.creator ?: confirmBlockEntry?.creator
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title =
+                    buildString {
+                        append(LocalStrings.current.actionBlock)
+                        val handle = creator?.handle ?: ""
+                        if (handle.isNotEmpty()) {
+                            append(" @$handle")
+                        }
+                    },
+                onClose = { confirm ->
+                    val entryId = confirmBlockEntry?.id
+                    val creatorId = creator?.id
                     confirmBlockEntry = null
-                },
-                title = {
-                    Text(
-                        text =
-                            buildString {
-                                append(LocalStrings.current.actionBlock)
-                                val handle = creator?.handle ?: ""
-                                if (handle.isNotEmpty()) {
-                                    append(" @$handle")
-                                }
-                            },
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmBlockEntry = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val entryId = confirmBlockEntry?.id
-                            val creatorId = creator?.id
-                            confirmBlockEntry = null
-                            if (entryId != null && creatorId != null) {
-                                model.reduce(
-                                    SearchMviModel.Intent.BlockUser(
-                                        userId = creatorId,
-                                        entryId = entryId,
-                                    ),
-                                )
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm && entryId != null && creatorId != null) {
+                        model.reduce(
+                            SearchMviModel.Intent.BlockUser(
+                                userId = creatorId,
+                                entryId = entryId,
+                            ),
+                        )
                     }
                 },
             )

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.material.icons.automirrored.filled.Reply
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
@@ -62,6 +61,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.getFabNestedScrollConnection
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ConfirmMuteUserBottomSheet
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.PollVoteErrorDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
@@ -453,39 +453,13 @@ class ThreadScreen(
         }
 
         if (confirmDeleteEntryId != null) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionDelete,
+                onClose = { confirm ->
+                    val entryId = confirmDeleteEntryId
                     confirmDeleteEntryId = null
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionDelete,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmDeleteEntryId = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val entryId = confirmDeleteEntryId ?: ""
-                            confirmDeleteEntryId = null
-                            if (entryId.isNotEmpty()) {
-                                model.reduce(ThreadMviModel.Intent.DeleteEntry(entryId))
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm && entryId != null) {
+                        model.reduce(ThreadMviModel.Intent.DeleteEntry(entryId))
                     }
                 },
             )
@@ -518,52 +492,26 @@ class ThreadScreen(
 
         if (confirmBlockEntry != null) {
             val creator = confirmBlockEntry?.reblog?.creator ?: confirmBlockEntry?.creator
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title =
+                    buildString {
+                        append(LocalStrings.current.actionBlock)
+                        val handle = creator?.handle ?: ""
+                        if (handle.isNotEmpty()) {
+                            append(" @$handle")
+                        }
+                    },
+                onClose = { confirm ->
+                    val entryId = confirmBlockEntry?.id
+                    val creatorId = creator?.id
                     confirmBlockEntry = null
-                },
-                title = {
-                    Text(
-                        text =
-                            buildString {
-                                append(LocalStrings.current.actionBlock)
-                                val handle = creator?.handle ?: ""
-                                if (handle.isNotEmpty()) {
-                                    append(" @$handle")
-                                }
-                            },
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmBlockEntry = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val entryId = confirmBlockEntry?.id
-                            val creatorId = creator?.id
-                            confirmBlockEntry = null
-                            if (entryId != null && creatorId != null) {
-                                model.reduce(
-                                    ThreadMviModel.Intent.BlockUser(
-                                        userId = creatorId,
-                                        entryId = entryId,
-                                    ),
-                                )
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm && entryId != null && creatorId != null) {
+                        model.reduce(
+                            ThreadMviModel.Intent.BlockUser(
+                                userId = creatorId,
+                                entryId = entryId,
+                            ),
+                        )
                     }
                 },
             )

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
@@ -23,8 +23,6 @@ import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
@@ -66,6 +64,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.Custom
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.getFabNestedScrollConnection
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ConfirmMuteUserBottomSheet
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.PollVoteErrorDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
@@ -435,39 +434,13 @@ class TimelineScreen : Screen {
         }
 
         if (confirmDeleteEntryId != null) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionDelete,
+                onClose = { confirm ->
+                    val entryId = confirmDeleteEntryId ?: ""
                     confirmDeleteEntryId = null
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionDelete,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmDeleteEntryId = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val entryId = confirmDeleteEntryId ?: ""
-                            confirmDeleteEntryId = null
-                            if (entryId.isNotEmpty()) {
-                                model.reduce(TimelineMviModel.Intent.DeleteEntry(entryId))
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm && entryId.isNotEmpty()) {
+                        model.reduce(TimelineMviModel.Intent.DeleteEntry(entryId))
                     }
                 },
             )
@@ -500,52 +473,27 @@ class TimelineScreen : Screen {
 
         if (confirmBlockEntry != null) {
             val creator = confirmBlockEntry?.reblog?.creator ?: confirmBlockEntry?.creator
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title =
+                    buildString {
+                        append(LocalStrings.current.actionBlock)
+                        val handle = creator?.handle ?: ""
+                        if (handle.isNotEmpty()) {
+                            append(" @$handle")
+                        }
+                    },
+                onClose = { confirm ->
+                    val entryId = confirmBlockEntry?.id
                     confirmBlockEntry = null
-                },
-                title = {
-                    Text(
-                        text =
-                            buildString {
-                                append(LocalStrings.current.actionBlock)
-                                val handle = creator?.handle ?: ""
-                                if (handle.isNotEmpty()) {
-                                    append(" @$handle")
-                                }
-                            },
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmBlockEntry = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val entryId = confirmBlockEntry?.id
-                            val creatorId = creator?.id
-                            confirmBlockEntry = null
-                            if (entryId != null && creatorId != null) {
-                                model.reduce(
-                                    TimelineMviModel.Intent.BlockUser(
-                                        userId = creatorId,
-                                        entryId = entryId,
-                                    ),
-                                )
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    val creatorId = creator?.id
+                    confirmBlockEntry = null
+                    if (confirm && entryId != null && creatorId != null) {
+                        model.reduce(
+                            TimelineMviModel.Intent.BlockUser(
+                                userId = creatorId,
+                                entryId = entryId,
+                            ),
+                        )
                     }
                 },
             )

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -20,8 +20,6 @@ import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -69,6 +67,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.Custom
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.SectionSelector
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ConfirmMuteUserBottomSheet
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.PollVoteErrorDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
@@ -557,108 +556,36 @@ class UserDetailScreen(
         )
 
         if (confirmUnfollowDialogOpen) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionUnfollow,
+                onClose = { confirm ->
                     confirmUnfollowDialogOpen = false
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionUnfollow,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmUnfollowDialogOpen = false
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            confirmUnfollowDialogOpen = false
-                            model.reduce(UserDetailMviModel.Intent.Unfollow)
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm) {
+                        model.reduce(UserDetailMviModel.Intent.Unfollow)
                     }
                 },
             )
         }
 
         if (confirmDeleteFollowRequestDialogOpen) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionDeleteFollowRequest,
+                onClose = { confirm ->
                     confirmDeleteFollowRequestDialogOpen = false
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionDeleteFollowRequest,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmDeleteFollowRequestDialogOpen = false
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            confirmDeleteFollowRequestDialogOpen = false
-                            model.reduce(UserDetailMviModel.Intent.Unfollow)
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm) {
+                        model.reduce(UserDetailMviModel.Intent.Unfollow)
                     }
                 },
             )
         }
 
         if (confirmMuteNotificationsDialogOpen) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionMuteNotifications,
+                onClose = { confirm ->
                     confirmMuteNotificationsDialogOpen = false
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionMuteNotifications,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmMuteNotificationsDialogOpen = false
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            confirmMuteNotificationsDialogOpen = false
-                            model.reduce(UserDetailMviModel.Intent.DisableNotifications)
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm) {
+                        model.reduce(UserDetailMviModel.Intent.DisableNotifications)
                     }
                 },
             )
@@ -684,45 +611,19 @@ class UserDetailScreen(
         }
 
         if (confirmBlockUserDialogOpen) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title =
+                    buildString {
+                        append(LocalStrings.current.actionBlock)
+                        val handle = uiState.user?.handle ?: ""
+                        if (handle.isNotEmpty()) {
+                            append(" @$handle")
+                        }
+                    },
+                onClose = { confirm ->
                     confirmBlockUserDialogOpen = false
-                },
-                title = {
-                    Text(
-                        text =
-                            buildString {
-                                append(LocalStrings.current.actionBlock)
-                                val handle = uiState.user?.handle ?: ""
-                                if (handle.isNotEmpty()) {
-                                    append(" @$handle")
-                                }
-                            },
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmBlockUserDialogOpen = false
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            confirmBlockUserDialogOpen = false
-                            model.reduce(
-                                UserDetailMviModel.Intent.ToggleBlock(blocked = true),
-                            )
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm) {
+                        model.reduce(UserDetailMviModel.Intent.ToggleBlock(blocked = true))
                     }
                 },
             )

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
@@ -20,8 +20,6 @@ import androidx.compose.material.icons.filled.Create
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
@@ -60,6 +58,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowI
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.getFabNestedScrollConnection
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ConfirmMuteUserBottomSheet
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.PollVoteErrorDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
@@ -376,39 +375,13 @@ class ForumListScreen(
         }
 
         if (confirmDeleteEntryId != null) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionDelete,
+                onClose = { confirm ->
+                    val entryId = confirmDeleteEntryId
                     confirmDeleteEntryId = null
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionDelete,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmDeleteEntryId = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val entryId = confirmDeleteEntryId ?: ""
-                            confirmDeleteEntryId = null
-                            if (entryId.isNotEmpty()) {
-                                model.reduce(ForumListMviModel.Intent.DeleteEntry(entryId))
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm && entryId != null) {
+                        model.reduce(ForumListMviModel.Intent.DeleteEntry(entryId))
                     }
                 },
             )
@@ -441,52 +414,26 @@ class ForumListScreen(
 
         if (confirmBlockEntry != null) {
             val creator = confirmBlockEntry?.reblog?.creator ?: confirmBlockEntry?.creator
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title =
+                    buildString {
+                        append(LocalStrings.current.actionBlock)
+                        val handle = creator?.handle ?: ""
+                        if (handle.isNotEmpty()) {
+                            append(" @$handle")
+                        }
+                    },
+                onClose = { confirm ->
+                    val entryId = confirmBlockEntry?.id
+                    val creatorId = creator?.id
                     confirmBlockEntry = null
-                },
-                title = {
-                    Text(
-                        text =
-                            buildString {
-                                append(LocalStrings.current.actionBlock)
-                                val handle = creator?.handle ?: ""
-                                if (handle.isNotEmpty()) {
-                                    append(" @$handle")
-                                }
-                            },
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmBlockEntry = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val entryId = confirmBlockEntry?.id
-                            val creatorId = creator?.id
-                            confirmBlockEntry = null
-                            if (entryId != null && creatorId != null) {
-                                model.reduce(
-                                    ForumListMviModel.Intent.BlockUser(
-                                        userId = creatorId,
-                                        entryId = entryId,
-                                    ),
-                                )
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm && entryId != null && creatorId != null) {
+                        model.reduce(
+                            ForumListMviModel.Intent.BlockUser(
+                                userId = creatorId,
+                                entryId = entryId,
+                            ),
+                        )
                     }
                 },
             )

--- a/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListScreen.kt
+++ b/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListScreen.kt
@@ -16,8 +16,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -42,6 +40,7 @@ import cafe.adriel.voyager.core.screen.ScreenKey
 import cafe.adriel.voyager.koin.getScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.UserItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.UserItemPlaceholder
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
@@ -244,78 +243,26 @@ class UserListScreen(
         }
 
         if (confirmUnfollowDialogUserId != null) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionUnfollow,
+                onClose = { confirm ->
+                    val userId = confirmUnfollowDialogUserId
                     confirmUnfollowDialogUserId = null
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionUnfollow,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmUnfollowDialogUserId = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val userId = confirmUnfollowDialogUserId ?: ""
-                            confirmUnfollowDialogUserId = null
-                            if (userId.isNotEmpty()) {
-                                model.reduce(UserListMviModel.Intent.Unfollow(userId))
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm && userId != null) {
+                        model.reduce(UserListMviModel.Intent.Unfollow(userId))
                     }
                 },
             )
         }
 
         if (confirmDeleteFollowRequestDialogUserId != null) {
-            AlertDialog(
-                onDismissRequest = {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionDeleteFollowRequest,
+                onClose = { confirm ->
+                    val userId = confirmUnfollowDialogUserId
                     confirmUnfollowDialogUserId = null
-                },
-                title = {
-                    Text(
-                        text = LocalStrings.current.actionDeleteFollowRequest,
-                        style = MaterialTheme.typography.titleMedium,
-                    )
-                },
-                text = {
-                    Text(text = LocalStrings.current.messageAreYouSure)
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            confirmUnfollowDialogUserId = null
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonCancel)
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            val userId = confirmUnfollowDialogUserId ?: ""
-                            confirmUnfollowDialogUserId = null
-                            if (userId.isNotEmpty()) {
-                                model.reduce(UserListMviModel.Intent.Unfollow(userId))
-                            }
-                        },
-                    ) {
-                        Text(text = LocalStrings.current.buttonConfirm)
+                    if (confirm && userId != null) {
+                        model.reduce(UserListMviModel.Intent.Unfollow(userId))
                     }
                 },
             )


### PR DESCRIPTION
This PR introduces a new `CustomConfirmDialog` Composable to use to ask user for confirmation. All previous usages of AlertDialog for that purpose have been refactored.