### PR TITLE
enhancement: optional title in post creation

### DIFF
--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
@@ -95,6 +95,8 @@ interface ComposerMviModel :
 
         data object ToggleHasSpoiler : Intent
 
+        data object ToggleHasTitle : Intent
+
         data object Submit : Intent
     }
 
@@ -121,6 +123,7 @@ interface ComposerMviModel :
         val userSearchQuery: String = "",
         val availableCircles: List<CircleModel> = emptyList(),
         val hasSpoiler: Boolean = false,
+        val hasTitle: Boolean = false,
     )
 
     sealed interface Effect {

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
@@ -96,6 +96,11 @@ class ComposerViewModel(
                     updateState { it.copy(hasSpoiler = !it.hasSpoiler) }
                 }
 
+            ComposerMviModel.Intent.ToggleHasTitle ->
+                screenModelScope.launch {
+                    updateState { it.copy(hasTitle = !it.hasTitle) }
+                }
+
             is ComposerMviModel.Intent.SetVisibility ->
                 screenModelScope.launch {
                     updateState { it.copy(visibility = intent.visibility) }
@@ -446,7 +451,7 @@ class ComposerViewModel(
         }
 
         val spoiler = currentState.spoilerValue.text.takeIf { currentState.hasSpoiler }
-        val title = currentState.titleValue.text.takeIf { it.isNotBlank() }
+        val title = currentState.titleValue.text.takeIf { it.isNotBlank() && currentState.hasTitle }
         val text = currentState.bodyValue.text
         // use the mediaId for this call otherwise the backend returns a 500
         val attachmentIds = currentState.attachments.map { it.mediaId }

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/components/UtilsBar.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/components/UtilsBar.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.filled.FormatItalic
 import androidx.compose.material.icons.filled.FormatUnderlined
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.PhotoLibrary
+import androidx.compose.material.icons.filled.Title
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -31,6 +32,7 @@ internal fun UtilsBar(
     onItalicClicked: (() -> Unit)? = null,
     onUnderlineClicked: (() -> Unit)? = null,
     onSpoilerClicked: (() -> Unit)? = null,
+    onTitleClicked: (() -> Unit)? = null,
 ) {
     Row(
         modifier =
@@ -68,10 +70,10 @@ internal fun UtilsBar(
             modifier =
                 Modifier
                     .clickable {
-                        onSpoilerClicked?.invoke()
+                        onMentionClicked?.invoke()
                     }.padding(Spacing.xs)
                     .size(IconSize.m),
-            imageVector = Icons.Default.Explicit,
+            imageVector = Icons.Default.AlternateEmail,
             contentDescription = null,
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -79,10 +81,21 @@ internal fun UtilsBar(
             modifier =
                 Modifier
                     .clickable {
-                        onMentionClicked?.invoke()
+                        onTitleClicked?.invoke()
                     }.padding(Spacing.xs)
                     .size(IconSize.m),
-            imageVector = Icons.Default.AlternateEmail,
+            imageVector = Icons.Default.Title,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Icon(
+            modifier =
+                Modifier
+                    .clickable {
+                        onSpoilerClicked?.invoke()
+                    }.padding(Spacing.xs)
+                    .size(IconSize.m),
+            imageVector = Icons.Default.Explicit,
             contentDescription = null,
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
         )


### PR DESCRIPTION
This PR makes the title field in the create post form invisible by default, toggling its presence from the formatting toolbar.

This is due to titles not being supported on all platforms, notably Mastodon, so making this less prominent improves compatibility.