### PR TITLE
refactor: auth management

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -30,7 +30,7 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-            <intent-filter android:label="authentication_deep_link">
+            <intent-filter android:label="@string/app_name">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/App.kt
@@ -27,6 +27,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di.g
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di.getSettingsRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.ProvideCustomFontScale
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.ProvideCustomUriHandler
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getActiveAccountMonitor
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getSetupAccountUseCase
 import com.livefast.eattrash.raccoonforfriendica.feature.drawer.DrawerContent
 import com.livefast.eattrash.raccoonforfriendica.main.MainScreen
@@ -40,6 +41,7 @@ fun App(onLoadingFinished: (() -> Unit)? = null) {
     val l10nManager = remember { getL10nManager() }
     val themeRepository = remember { getThemeRepository() }
     val settingsRepository = remember { getSettingsRepository() }
+    val activeAccountMonitor = remember { getActiveAccountMonitor() }
     val setupAccountUseCase = remember { getSetupAccountUseCase() }
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
     val drawerCoordinator = remember { getDrawerCoordinator() }
@@ -66,6 +68,8 @@ fun App(onLoadingFinished: (() -> Unit)? = null) {
                     }
                 }
             }.launchIn(this)
+
+        activeAccountMonitor.start()
         setupAccountUseCase()
     }
 

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/main/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/main/MainScreen.kt
@@ -114,7 +114,9 @@ object MainScreen : Screen {
 
             Scaffold(
                 snackbarHost = {
-                    SnackbarHost(snackbarHostState) { data ->
+                    SnackbarHost(
+                        hostState = snackbarHostState,
+                    ) { data ->
                         Snackbar(
                             modifier =
                                 Modifier

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/main/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/main/MainViewModel.kt
@@ -24,7 +24,7 @@ class MainViewModel(
                         it.copy(bottomNavigationSections = getSections(inboxUnread))
                     }
                 }.launchIn(this)
-            identityRepository.isLogged
+            identityRepository.currentUser
                 .onEach {
                     inboxManager.refreshUnreadCount()
                 }.launchIn(this)

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
@@ -26,8 +26,8 @@ class DefaultDetailOpener(
     private val navigationCoordinator: NavigationCoordinator,
     private val identityRepository: IdentityRepository,
 ) : DetailOpener {
-    private val isLogged: Boolean get() = identityRepository.isLogged.value
     private val currentUserId: String? get() = identityRepository.currentUser.value?.id
+    private val isLogged: Boolean get() = currentUserId != null
 
     override fun openUserDetail(id: String) {
         if (id == currentUserId) {

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/dao/AccountDao.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/dao/AccountDao.kt
@@ -4,33 +4,43 @@ import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
+import androidx.room.Transaction
 import androidx.room.Update
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.entities.AccountEntity
 import kotlinx.coroutines.flow.Flow
 
 @Dao
-interface AccountDao {
+abstract class AccountDao {
     @Insert
-    suspend fun insert(item: AccountEntity)
+    abstract suspend fun insert(item: AccountEntity)
 
     @Query("SELECT * FROM AccountEntity")
-    suspend fun getAll(): List<AccountEntity>
+    abstract suspend fun getAll(): List<AccountEntity>
 
     @Query("SELECT * FROM AccountEntity")
-    fun getAllAsFlow(): Flow<List<AccountEntity>>
+    abstract fun getAllAsFlow(): Flow<List<AccountEntity>>
 
     @Query("SELECT * FROM AccountEntity WHERE handle = :handle")
-    suspend fun getBy(handle: String): AccountEntity?
+    abstract suspend fun getBy(handle: String): AccountEntity?
 
     @Query("SELECT * FROM AccountEntity WHERE active = 1")
-    suspend fun getActive(): AccountEntity?
+    abstract suspend fun getActive(): AccountEntity?
 
     @Query("SELECT * FROM AccountEntity WHERE active = 1")
-    fun getActiveAsFlow(): Flow<List<AccountEntity>>
+    abstract fun getActiveAsFlow(): Flow<List<AccountEntity>>
 
     @Update
-    suspend fun update(item: AccountEntity)
+    abstract suspend fun update(item: AccountEntity)
+
+    @Transaction
+    open suspend fun replaceActive(
+        old: AccountEntity,
+        new: AccountEntity,
+    ) {
+        update(old)
+        update(new)
+    }
 
     @Delete
-    suspend fun delete(item: AccountEntity)
+    abstract suspend fun delete(item: AccountEntity)
 }

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/AccountRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/AccountRepository.kt
@@ -16,7 +16,10 @@ interface AccountRepository {
 
     suspend fun create(account: AccountModel)
 
-    suspend fun update(account: AccountModel)
+    suspend fun setActive(
+        account: AccountModel,
+        active: Boolean,
+    )
 
     suspend fun delete(account: AccountModel)
 }

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/ApiConfigurationRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/ApiConfigurationRepository.kt
@@ -6,6 +6,8 @@ import kotlinx.coroutines.flow.StateFlow
 @Stable
 interface ApiConfigurationRepository {
     val node: StateFlow<String>
+    val isLogged: StateFlow<Boolean>
+    val defaultNode: String
 
     suspend fun initialize()
 

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultAccountRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultAccountRepository.kt
@@ -29,8 +29,19 @@ internal class DefaultAccountRepository(
         accountDao.insert(account.toEntity())
     }
 
-    override suspend fun update(account: AccountModel) {
-        accountDao.update(account.toEntity())
+    override suspend fun setActive(
+        account: AccountModel,
+        active: Boolean,
+    ) {
+        val old = accountDao.getActive()
+        if (old != null && active) {
+            accountDao.replaceActive(
+                old = old.copy(active = false),
+                new = account.copy(active = true).toEntity(),
+            )
+        } else {
+            accountDao.update(account.copy(active = active).toEntity())
+        }
     }
 
     override suspend fun delete(account: AccountModel) {

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/IdentityRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/IdentityRepository.kt
@@ -4,12 +4,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import kotlinx.coroutines.flow.StateFlow
 
 interface IdentityRepository {
-    val isLogged: StateFlow<Boolean>
     val currentUser: StateFlow<UserModel?>
 
-    fun refreshCurrentUser()
-}
-
-internal interface MutableIdentityRepository : IdentityRepository {
-    fun changeIsLogged(value: Boolean)
+    suspend fun refreshCurrentUser(userId: String?)
 }

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/di/IdentityRepositoryModule.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/di/IdentityRepositoryModule.kt
@@ -11,10 +11,8 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Defa
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultIdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultSettingsRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.MutableIdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
 import org.koin.core.qualifier.named
-import org.koin.dsl.binds
 import org.koin.dsl.module
 
 val domainIdentityRepositoryModule =
@@ -23,17 +21,15 @@ val domainIdentityRepositoryModule =
             DefaultApiConfigurationRepository(
                 serviceProvider = get(named("default")),
                 keyStore = get(),
-                identityRepository = get(),
                 credentialsRepository = get(),
             )
         }
 
-        single {
+        single<IdentityRepository> {
             DefaultIdentityRepository(
-                accountRepository = get(),
                 provider = get(named("default")),
             )
-        } binds arrayOf(IdentityRepository::class, MutableIdentityRepository::class)
+        }
 
         single<CredentialsRepository> {
             DefaultCredentialsRepository(

--- a/domain/identity/usecase/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/Utils.kt
+++ b/domain/identity/usecase/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/Utils.kt
@@ -1,10 +1,16 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di
 
 import androidx.compose.ui.platform.UriHandler
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.ActiveAccountMonitor
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.CustomUriHandler
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.SetupAccountUseCase
 import org.koin.core.parameter.parametersOf
 import org.koin.java.KoinJavaComponent
+
+actual fun getActiveAccountMonitor(): ActiveAccountMonitor {
+    val res by KoinJavaComponent.inject<ActiveAccountMonitor>(ActiveAccountMonitor::class.java)
+    return res
+}
 
 actual fun getSetupAccountUseCase(): SetupAccountUseCase {
     val res by KoinJavaComponent.inject<SetupAccountUseCase>(SetupAccountUseCase::class.java)

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/ActiveAccountMonitor.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/ActiveAccountMonitor.kt
@@ -1,0 +1,8 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
+
+import androidx.compose.runtime.Stable
+
+@Stable
+interface ActiveAccountMonitor {
+    fun start()
+}

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitor.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitor.kt
@@ -1,0 +1,55 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
+
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountCredentialsCache
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+
+internal class DefaultActiveAccountMonitor(
+    private val accountRepository: AccountRepository,
+    private val apiConfigurationRepository: ApiConfigurationRepository,
+    private val identityRepository: IdentityRepository,
+    private val accountCredentialsCache: AccountCredentialsCache,
+    private val settingsRepository: SettingsRepository,
+    coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : ActiveAccountMonitor {
+    private val scope = CoroutineScope(SupervisorJob() + coroutineDispatcher)
+
+    override fun start() {
+        scope.launch {
+            accountRepository
+                .getActiveAsFlow()
+                .distinctUntilChanged()
+                .onEach { account ->
+                    if (account == null) {
+                        apiConfigurationRepository.setAuth(null)
+                        identityRepository.refreshCurrentUser(null)
+                    } else {
+                        val node =
+                            account.handle
+                                .substringAfter("@")
+                                .takeIf { it.isNotEmpty() } ?: apiConfigurationRepository.defaultNode
+                        apiConfigurationRepository.changeNode(node)
+                        val credentials = accountCredentialsCache.get(account.id)
+                        apiConfigurationRepository.setAuth(credentials)
+
+                        identityRepository.refreshCurrentUser(account.remoteId)
+
+                        val defaultSettings = settingsRepository.get(account.id) ?: SettingsModel()
+                        settingsRepository.changeCurrent(defaultSettings)
+                    }
+                }.launchIn(this)
+        }
+    }
+}

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultLogoutUseCase.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultLogoutUseCase.kt
@@ -1,30 +1,22 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
 
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
 
 internal class DefaultLogoutUseCase(
     private val apiConfigurationRepository: ApiConfigurationRepository,
     private val accountRepository: AccountRepository,
-    private val settingsRepository: SettingsRepository,
-    private val identityRepository: IdentityRepository,
 ) : LogoutUseCase {
     override suspend fun invoke() {
         apiConfigurationRepository.setAuth(null)
-
         val activeAccount = accountRepository.getActive()
         if (activeAccount != null) {
-            val newAccount = activeAccount.copy(active = false)
-            accountRepository.update(newAccount)
-
-            val anonymousAccountId = accountRepository.getBy("")?.id ?: 0
-            val defaultSettings = settingsRepository.get(anonymousAccountId) ?: SettingsModel()
-            settingsRepository.changeCurrent(defaultSettings)
-
-            identityRepository.refreshCurrentUser()
+            val anonymousAccount = accountRepository.getBy(handle = "")
+            if (anonymousAccount != null) {
+                accountRepository.setActive(anonymousAccount, true)
+            } else {
+                accountRepository.setActive(activeAccount, false)
+            }
         }
     }
 }

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultSwitchAccountUseCase.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultSwitchAccountUseCase.kt
@@ -1,40 +1,12 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
 
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountCredentialsCache
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
 
 internal class DefaultSwitchAccountUseCase(
-    private val apiConfigurationRepository: ApiConfigurationRepository,
     private val accountRepository: AccountRepository,
-    private val settingsRepository: SettingsRepository,
-    private val identityRepository: IdentityRepository,
-    private val accountCredentialsCache: AccountCredentialsCache,
 ) : SwitchAccountUseCase {
     override suspend fun invoke(account: AccountModel) {
-        val oldActive = accountRepository.getActive()
-        if (oldActive != null) {
-            accountRepository.update(oldActive.copy(active = false))
-        }
-
-        val newAccount = account.copy(active = true)
-        accountRepository.update(newAccount)
-
-        val accountId = account.id
-        val anonymousAccountId = accountRepository.getBy("")?.id ?: 0
-        val defaultSettings = settingsRepository.get(anonymousAccountId) ?: SettingsModel()
-        val settings = settingsRepository.get(accountId) ?: defaultSettings
-        settingsRepository.changeCurrent(settings)
-
-        val credentials = accountCredentialsCache.get(accountId)
-        val node = account.handle.substringAfter("@")
-        apiConfigurationRepository.changeNode(node)
-        apiConfigurationRepository.setAuth(credentials)
-
-        identityRepository.refreshCurrentUser()
+        accountRepository.setActive(account, true)
     }
 }

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
@@ -1,6 +1,8 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di
 
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.ActiveAccountMonitor
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.CustomUriHandler
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultActiveAccountMonitor
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultCustomUriHandler
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultDeleteAccountUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultLoginUseCase
@@ -29,7 +31,6 @@ val domainIdentityUseCaseModule =
                 apiConfigurationRepository = get(),
                 accountRepository = get(),
                 settingsRepository = get(),
-                identityRepository = get(),
                 accountCredentialsCache = get(),
             )
         }
@@ -38,8 +39,6 @@ val domainIdentityUseCaseModule =
             DefaultLogoutUseCase(
                 apiConfigurationRepository = get(),
                 accountRepository = get(),
-                settingsRepository = get(),
-                identityRepository = get(),
             )
         }
         single<CustomUriHandler> { params ->
@@ -54,16 +53,21 @@ val domainIdentityUseCaseModule =
         }
         single<SwitchAccountUseCase> {
             DefaultSwitchAccountUseCase(
-                apiConfigurationRepository = get(),
                 accountRepository = get(),
-                settingsRepository = get(),
-                identityRepository = get(),
-                accountCredentialsCache = get(),
             )
         }
         single<DeleteAccountUseCase> {
             DefaultDeleteAccountUseCase(
                 accountRepository = get(),
+                settingsRepository = get(),
+                accountCredentialsCache = get(),
+            )
+        }
+        single<ActiveAccountMonitor> {
+            DefaultActiveAccountMonitor(
+                accountRepository = get(),
+                apiConfigurationRepository = get(),
+                identityRepository = get(),
                 settingsRepository = get(),
                 accountCredentialsCache = get(),
             )

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/Utils.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/Utils.kt
@@ -1,8 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di
 
 import androidx.compose.ui.platform.UriHandler
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.ActiveAccountMonitor
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.CustomUriHandler
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.SetupAccountUseCase
+
+expect fun getActiveAccountMonitor(): ActiveAccountMonitor
 
 expect fun getSetupAccountUseCase(): SetupAccountUseCase
 

--- a/domain/identity/usecase/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/Utils.kt
+++ b/domain/identity/usecase/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/Utils.kt
@@ -1,17 +1,21 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di
 
 import androidx.compose.ui.platform.UriHandler
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.ActiveAccountMonitor
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.CustomUriHandler
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.SetupAccountUseCase
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.koin.core.parameter.parametersOf
 
+actual fun getActiveAccountMonitor(): ActiveAccountMonitor = DomainIdentityUseCaseDiHelper.activeAccountMonitor
+
 actual fun getSetupAccountUseCase(): SetupAccountUseCase = DomainIdentityUseCaseDiHelper.setupAccountUseCase
 
 actual fun getCustomUriHandler(fallback: UriHandler): CustomUriHandler = DomainIdentityUseCaseDiHelper.getCustomUriHandler(fallback)
 
 internal object DomainIdentityUseCaseDiHelper : KoinComponent {
+    val activeAccountMonitor: ActiveAccountMonitor by inject()
     val setupAccountUseCase: SetupAccountUseCase by inject()
 
     fun getCustomUriHandler(default: UriHandler): CustomUriHandler {

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
@@ -33,10 +33,10 @@ class InboxViewModel(
     InboxMviModel {
     init {
         screenModelScope.launch {
-            identityRepository.isLogged
-                .onEach { isLogged ->
+            identityRepository.currentUser
+                .onEach { currentUser ->
                     updateState {
-                        it.copy(isLogged = isLogged)
+                        it.copy(isLogged = currentUser != null)
                     }
                 }.launchIn(this)
             settingsRepository.current

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
@@ -47,12 +47,16 @@ class MyAccountViewModel(
                         if (cachedPaginationState != null) {
                             paginationManager.restoreState(cachedPaginationState)
                             val cachedHistory = paginationManager.history
-                            updateState {
-                                it.copy(
-                                    entries = cachedHistory,
-                                    initial = false,
-                                    section = myAccountCache.retrieveSection(),
-                                )
+                            if (cachedHistory.isEmpty()) {
+                                refresh(initial = true)
+                            } else {
+                                updateState {
+                                    it.copy(
+                                        entries = cachedHistory,
+                                        initial = false,
+                                        section = myAccountCache.retrieveSection(),
+                                    )
+                                }
                             }
                         } else {
                             refresh(initial = true)

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsViewModel.kt
@@ -35,8 +35,9 @@ class SettingsViewModel(
     SettingsMviModel {
     init {
         screenModelScope.launch {
-            identityRepository.isLogged
-                .onEach { isLogged ->
+            identityRepository.currentUser
+                .onEach { currentUser ->
+                    val isLogged = currentUser != null
                     updateState {
                         it.copy(
                             availableTimelineTypes =

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
@@ -47,7 +47,7 @@ class TimelineViewModel(
             identityRepository.currentUser
                 .onEach { currentUser ->
                     updateState { it.copy(currentUserId = currentUser?.id) }
-                    refreshCirclesInTimelineTypes()
+                    refreshCirclesInTimelineTypes(currentUser != null)
                 }.launchIn(this)
 
             combine(
@@ -118,8 +118,7 @@ class TimelineViewModel(
         }
     }
 
-    private suspend fun refreshCirclesInTimelineTypes() {
-        val isLogged = identityRepository.isLogged.value
+    private suspend fun refreshCirclesInTimelineTypes(isLogged: Boolean) {
         val circles = circlesRepository.getAll()
         val settings = settingsRepository.current.value
         val defaultTimelineTypes =
@@ -156,7 +155,8 @@ class TimelineViewModel(
 
     private suspend fun refresh(initial: Boolean = false) {
         // needed as a last-resort to update circles if edited elsewhere
-        refreshCirclesInTimelineTypes()
+        val isLogged = identityRepository.currentUser.value != null
+        refreshCirclesInTimelineTypes(isLogged)
         updateState {
             it.copy(initial = initial, refreshing = !initial)
         }


### PR DESCRIPTION
This activity started as a fix for the profile screen state after logout, it ended up being a major refactor of the auth / active account / current settings management.

The previous implementation had grown over time but lacked an organic and comprehensive approach, so a centralized component responsible for the management of the currently active account (as well as the instance, credentials and settings tied to it) was highly needed. This is why `ActiveAccountMonitor` has been introduced.