### PR TITLE
fix: post actions, light theme, refresh in home and profile, notification layout

### DIFF
--- a/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/DefaultColorSchemeProvider.kt
+++ b/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/DefaultColorSchemeProvider.kt
@@ -68,6 +68,25 @@ internal class DefaultColorSchemeProvider(
                 }
             }
 
+            UiTheme.Light ->
+                when {
+                    dynamic -> {
+                        dynamicLightColorScheme(context)
+                    }
+
+                    customSeed != null -> {
+                        dynamicColorScheme(
+                            seedColor = customSeed,
+                            isDark = false,
+                            isAmoled = false,
+                        )
+                    }
+
+                    else -> {
+                        LightColors
+                }
+            }
+
             else -> {
                 when {
                     dynamic -> {

--- a/core/appearance/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/DefaultColorSchemeProvider.kt
+++ b/core/appearance/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/DefaultColorSchemeProvider.kt
@@ -39,6 +39,17 @@ internal class DefaultColorSchemeProvider : ColorSchemeProvider {
                 }
             }
 
+            UiTheme.Light ->
+                if (customSeed != null) {
+                    dynamicColorScheme(
+                        seedColor = customSeed,
+                        isDark = false,
+                        isAmoled = false,
+                    )
+                } else {
+                    LightColors
+            }
+
             else -> {
                 if (customSeed != null) {
                     dynamicColorScheme(

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -257,15 +257,18 @@ class EntryDetailScreen(
                             onOpenImage = { imageUrl ->
                                 detailOpener.openImageDetail(imageUrl)
                             },
-                            onReblog = { e ->
-                                model.reduce(EntryDetailMviModel.Intent.ToggleReblog(e))
-                            },
-                            onBookmark = { e ->
-                                model.reduce(EntryDetailMviModel.Intent.ToggleBookmark(e))
-                            },
-                            onFavorite = { e ->
-                                model.reduce(EntryDetailMviModel.Intent.ToggleFavorite(e))
-                            },
+                            onReblog =
+                                uiState.currentUserId?.let {
+                                    { e -> model.reduce(EntryDetailMviModel.Intent.ToggleReblog(e)) }
+                                },
+                            onBookmark =
+                                uiState.currentUserId?.let {
+                                    { e -> model.reduce(EntryDetailMviModel.Intent.ToggleBookmark(e)) }
+                                },
+                            onFavorite =
+                                uiState.currentUserId?.let {
+                                    { e -> model.reduce(EntryDetailMviModel.Intent.ToggleFavorite(e)) }
+                                },
                             onOpenUsersFavorite = { e ->
                                 detailOpener.openEntryUsersFavorite(
                                     entryId = e.id,
@@ -278,23 +281,27 @@ class EntryDetailScreen(
                                     count = e.reblogCount,
                                 )
                             },
-                            onReply = { e ->
-                                detailOpener.openComposer(
-                                    inReplyToId = e.id,
-                                    inReplyToHandle = e.creator?.handle,
-                                    inReplyToUsername =
-                                        e.creator?.let {
-                                            it.displayName ?: it.username
-                                        },
-                                )
-                            },
-                            onPollVote = { e, choices ->
-                                model.reduce(
-                                    EntryDetailMviModel.Intent.SubmitPollVote(
-                                        entry = e,
-                                        choices = choices,
-                                    ),
-                                )
+                            onReply =
+                                uiState.currentUserId?.let {
+                                    { e ->
+                                        detailOpener.openComposer(
+                                            inReplyToId = e.id,
+                                            inReplyToHandle = e.creator?.handle,
+                                            inReplyToUsername =
+                                                e.creator?.let { it.displayName ?: it.username },
+                                        )
+                                    }
+                                },
+                            onPollVote =
+                                uiState.currentUserId?.let {
+                                    { e, choices ->
+                                        model.reduce(
+                                            EntryDetailMviModel.Intent.SubmitPollVote(
+                                                entry = e,
+                                                choices = choices,
+                                            ),
+                                    )
+                                }
                             },
                             onToggleSpoilerActive = { e ->
                                 model.reduce(EntryDetailMviModel.Intent.ToggleSpoilerActive(e))

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
@@ -304,30 +304,60 @@ class ExploreScreen : Screen {
                                     onOpenImage = { imageUrl ->
                                         detailOpener.openImageDetail(imageUrl)
                                     },
-                                    onReblog = { e ->
-                                        model.reduce(ExploreMviModel.Intent.ToggleReblog(e))
-                                    },
-                                    onBookmark = { e ->
-                                        model.reduce(ExploreMviModel.Intent.ToggleBookmark(e))
-                                    },
-                                    onFavorite = { e ->
-                                        model.reduce(ExploreMviModel.Intent.ToggleFavorite(e))
-                                    },
-                                    onReply = { e ->
-                                        detailOpener.openComposer(
-                                            inReplyToId = e.id,
-                                            inReplyToHandle = e.creator?.handle,
-                                            inReplyToUsername = e.creator?.let { it.displayName ?: it.username },
-                                        )
-                                    },
-                                    onPollVote = { e, choices ->
-                                        model.reduce(
-                                            ExploreMviModel.Intent.SubmitPollVote(
-                                                entry = e,
-                                                choices = choices,
-                                            ),
-                                        )
-                                    },
+                                    onReblog =
+                                        uiState.currentUserId?.let {
+                                            { e ->
+                                                model.reduce(
+                                                    ExploreMviModel.Intent.ToggleReblog(
+                                                        e,
+                                                    ),
+                                                )
+                                            }
+                                        },
+                                    onBookmark =
+                                        uiState.currentUserId?.let {
+                                            { e ->
+                                                model.reduce(
+                                                    ExploreMviModel.Intent.ToggleBookmark(
+                                                        e,
+                                                    ),
+                                                )
+                                            }
+                                        },
+                                    onFavorite =
+                                        uiState.currentUserId?.let {
+                                            { e ->
+                                                model.reduce(
+                                                    ExploreMviModel.Intent.ToggleFavorite(
+                                                        e,
+                                                    ),
+                                                )
+                                            }
+                                        },
+                                    onReply =
+                                        uiState.currentUserId?.let {
+                                            { e ->
+                                                detailOpener.openComposer(
+                                                    inReplyToId = e.id,
+                                                    inReplyToHandle = e.creator?.handle,
+                                                    inReplyToUsername =
+                                                        e.creator?.let {
+                                                            it.displayName ?: it.username
+                                                        },
+                                                )
+                                            }
+                                        },
+                                    onPollVote =
+                                        uiState.currentUserId?.let {
+                                            { e, choices ->
+                                                model.reduce(
+                                                    ExploreMviModel.Intent.SubmitPollVote(
+                                                        entry = e,
+                                                        choices = choices,
+                                                    ),
+                                                )
+                                            }
+                                        },
                                     onToggleSpoilerActive = { e ->
                                         model.reduce(ExploreMviModel.Intent.ToggleSpoilerActive(e))
                                     },
@@ -576,7 +606,7 @@ class ExploreScreen : Screen {
                             ),
                         )
                     }
-                }
+                },
             )
         }
 

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
@@ -214,36 +214,43 @@ class FavoritesScreen(
                             onOpenImage = { imageUrl ->
                                 detailOpener.openImageDetail(imageUrl)
                             },
-                            onReblog = { e ->
-                                model.reduce(FavoritesMviModel.Intent.ToggleReblog(e))
-                            },
-                            onBookmark = { e ->
-                                model.reduce(FavoritesMviModel.Intent.ToggleBookmark(e))
-                            },
-                            onFavorite = { e ->
-                                model.reduce(FavoritesMviModel.Intent.ToggleFavorite(e))
-                            },
-                            onReply = { e ->
-                                detailOpener.openComposer(
-                                    inReplyToId = e.id,
-                                    inReplyToHandle = e.creator?.handle,
-                                    inReplyToUsername =
-                                        e.creator?.let {
-                                            it.displayName ?: it.username
-                                        },
-                                )
-                            },
+                            onReblog =
+                                uiState.currentUserId?.let {
+                                    { e -> model.reduce(FavoritesMviModel.Intent.ToggleReblog(e)) }
+                                },
+                            onBookmark =
+                                uiState.currentUserId?.let {
+                                    { e -> model.reduce(FavoritesMviModel.Intent.ToggleBookmark(e)) }
+                                },
+                            onFavorite =
+                                uiState.currentUserId?.let {
+                                    { e -> model.reduce(FavoritesMviModel.Intent.ToggleFavorite(e)) }
+                                },
+                            onReply =
+                                uiState.currentUserId?.let {
+                                    { e ->
+                                        detailOpener.openComposer(
+                                            inReplyToId = e.id,
+                                            inReplyToHandle = e.creator?.handle,
+                                            inReplyToUsername =
+                                                e.creator?.let { it.displayName ?: it.username },
+                                        )
+                                    }
+                                },
                             onToggleSpoilerActive = { e ->
                                 model.reduce(FavoritesMviModel.Intent.ToggleSpoilerActive(e))
                             },
-                            onPollVote = { e, choices ->
-                                model.reduce(
-                                    FavoritesMviModel.Intent.SubmitPollVote(
-                                        entry = e,
-                                        choices = choices,
-                                    ),
-                                )
-                            },
+                            onPollVote =
+                                uiState.currentUserId?.let {
+                                    { e, choices ->
+                                        model.reduce(
+                                            FavoritesMviModel.Intent.SubmitPollVote(
+                                                entry = e,
+                                                choices = choices,
+                                            ),
+                                        )
+                                    }
+                                },
                             options =
                                 buildList {
                                     if (!entry.url.isNullOrBlank()) {
@@ -402,7 +409,7 @@ class FavoritesScreen(
                             ),
                         )
                     }
-                }
+                },
             )
         }
 

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
@@ -236,34 +236,41 @@ class HashtagScreen(
                             onOpenImage = { imageUrl ->
                                 detailOpener.openImageDetail(imageUrl)
                             },
-                            onReblog = { e ->
-                                model.reduce(HashtagMviModel.Intent.ToggleReblog(e))
+                            onReblog =
+                                uiState.currentUserId?.let {
+                                    { e -> model.reduce(HashtagMviModel.Intent.ToggleReblog(e)) }
+                                },
+                            onBookmark =
+                                uiState.currentUserId?.let {
+                                    { e -> model.reduce(HashtagMviModel.Intent.ToggleBookmark(e)) }
+                                },
+                            onFavorite =
+                                uiState.currentUserId?.let {
+                                    { e -> model.reduce(HashtagMviModel.Intent.ToggleFavorite(e)) }
+                                },
+                            onReply =
+                                uiState.currentUserId?.let {
+                                    { e ->
+                                        detailOpener.openComposer(
+                                            inReplyToId = e.id,
+                                            inReplyToHandle = e.creator?.handle,
+                                            inReplyToUsername =
+                                                e.creator?.let { it.displayName ?: it.username },
+                                        )
+                                    }
+                                },
+                            onPollVote =
+                                uiState.currentUserId?.let {
+                                    { e, choices ->
+                                        model.reduce(
+                                            HashtagMviModel.Intent.SubmitPollVote(
+                                                entry = e,
+                                            choices = choices,
+                                        ),
+                                    )
+                                }
                             },
-                            onBookmark = { e ->
-                                model.reduce(HashtagMviModel.Intent.ToggleBookmark(e))
-                            },
-                            onFavorite = { e ->
-                                model.reduce(HashtagMviModel.Intent.ToggleFavorite(e))
-                            },
-                            onReply = { e ->
-                                detailOpener.openComposer(
-                                    inReplyToId = e.id,
-                                    inReplyToHandle = e.creator?.handle,
-                                    inReplyToUsername =
-                                        e.creator?.let {
-                                            it.displayName ?: it.username
-                                        },
-                                )
-                            },
-                            onPollVote = { e, choices ->
-                                model.reduce(
-                                    HashtagMviModel.Intent.SubmitPollVote(
-                                        entry = e,
-                                        choices = choices,
-                                    ),
-                                )
-                            },
-                            onToggleSpoilerActive = { e ->
+                                                onToggleSpoilerActive = { e ->
                                 model.reduce(HashtagMviModel.Intent.ToggleSpoilerActive(e))
                             },
                             options =

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationItem.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationItem.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.filled.QuestionMark
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -52,17 +53,18 @@ internal fun NotificationItem(
     onUserRelationshipClicked: ((String, RelationshipStatusNextAction) -> Unit)? = null,
     onToggleSpoilerActive: ((TimelineEntryModel) -> Unit)? = null,
 ) {
-    val boxColor = MaterialTheme.colorScheme.surfaceVariant
+    val boxColor = MaterialTheme.colorScheme.surfaceColorAtElevation(5.dp)
     val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha)
     val entry = notification.entry
     val user = notification.user
+    val contentHorizontalPadding = Spacing.xs
 
     Column(
         modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(Spacing.s),
+        verticalArrangement = Arrangement.spacedBy(Spacing.xs),
     ) {
         Row(
-            modifier = Modifier.padding(horizontal = Spacing.s),
+            modifier = Modifier.padding(horizontal = contentHorizontalPadding),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
         ) {
@@ -107,6 +109,7 @@ internal fun NotificationItem(
         Box(
             modifier =
                 Modifier
+                    .padding(horizontal = contentHorizontalPadding)
                     .background(
                         color = boxColor,
                         shape = RoundedCornerShape(CornerSize.l),
@@ -132,7 +135,10 @@ internal fun NotificationItem(
                 )
             } else if (user != null) {
                 NotificationUserInfo(
-                    modifier = Modifier.padding(bottom = Spacing.m),
+                    modifier =
+                        Modifier.padding(
+                            bottom = Spacing.m,
+                        ),
                     user = user,
                     onOpenUrl = onOpenUrl,
                     onClick = {

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -32,6 +33,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.AnnotatedString
@@ -90,6 +92,7 @@ class MyAccountScreen : Screen {
         val clipboardManager = LocalClipboardManager.current
         var confirmDeleteEntryId by remember { mutableStateOf<String?>(null) }
         val topAppBarState = LocalProfileTopAppBarStateWrapper.current.topAppBarState
+        val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
         val stickyHeaderTopOffset by animateDpAsState(
             if (lazyListState.firstVisibleItemIndex >= 2) {
                 Dimensions.maxTopBarInset * topAppBarState.collapsedFraction
@@ -108,6 +111,8 @@ class MyAccountScreen : Screen {
                     }
                 } else {
                     lazyListState.scrollToItem(0)
+                    topAppBarState.heightOffset = 0f
+                    topAppBarState.contentOffset = 0f
                 }
             }
         }
@@ -144,6 +149,7 @@ class MyAccountScreen : Screen {
             modifier =
                 Modifier
                     .fillMaxWidth()
+                    .nestedScroll(scrollBehavior.nestedScrollConnection)
                     .pullRefresh(pullRefreshState),
         ) {
             LazyColumn(

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
@@ -306,33 +306,42 @@ class SearchScreen : Screen {
                                     onOpenImage = { imageUrl ->
                                         detailOpener.openImageDetail(imageUrl)
                                     },
-                                    onReblog = { e ->
-                                        model.reduce(SearchMviModel.Intent.ToggleReblog(e))
-                                    },
-                                    onBookmark = { e ->
-                                        model.reduce(SearchMviModel.Intent.ToggleBookmark(e))
-                                    },
-                                    onFavorite = { e ->
-                                        model.reduce(SearchMviModel.Intent.ToggleFavorite(e))
-                                    },
-                                    onReply = { e ->
-                                        detailOpener.openComposer(
-                                            inReplyToId = e.id,
-                                            inReplyToHandle = e.creator?.handle,
-                                            inReplyToUsername =
-                                                e.creator?.let {
-                                                    it.displayName ?: it.username
-                                                },
-                                        )
-                                    },
-                                    onPollVote = { e, choices ->
-                                        model.reduce(
-                                            SearchMviModel.Intent.SubmitPollVote(
-                                                entry = e,
-                                                choices = choices,
-                                            ),
-                                        )
-                                    },
+                                    onReblog =
+                                        uiState.currentUserId?.let {
+                                            { e -> model.reduce(SearchMviModel.Intent.ToggleReblog(e)) }
+                                        },
+                                    onBookmark =
+                                        uiState.currentUserId?.let {
+                                            { e -> model.reduce(SearchMviModel.Intent.ToggleBookmark(e)) }
+                                        },
+                                    onFavorite =
+                                        uiState.currentUserId?.let {
+                                            { e -> model.reduce(SearchMviModel.Intent.ToggleFavorite(e)) }
+                                        },
+                                    onReply =
+                                        uiState.currentUserId?.let {
+                                            { e ->
+                                                detailOpener.openComposer(
+                                                    inReplyToId = e.id,
+                                                    inReplyToHandle = e.creator?.handle,
+                                                    inReplyToUsername =
+                                                        e.creator?.let {
+                                                            it.displayName ?: it.username
+                                                        },
+                                                )
+                                            }
+                                        },
+                                    onPollVote =
+                                        uiState.currentUserId?.let {
+                                            { e, choices ->
+                                                model.reduce(
+                                                    SearchMviModel.Intent.SubmitPollVote(
+                                                        entry = e,
+                                                        choices = choices,
+                                                    ),
+                                                )
+                                            }
+                                        },
                                     onToggleSpoilerActive = { e ->
                                         model.reduce(SearchMviModel.Intent.ToggleSpoilerActive(e))
                                     },

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
@@ -240,6 +240,7 @@ class ThreadScreen(
                                         ),
                                 entry = original,
                                 reshareAndReplyVisible = false,
+                                extendedSocialInfoEnabled = true,
                                 blurNsfw = uiState.blurNsfw,
                                 onOpenUrl = { url ->
                                     uriHandler.openUri(url)
@@ -250,15 +251,18 @@ class ThreadScreen(
                                 onOpenImage = { imageUrl ->
                                     detailOpener.openImageDetail(imageUrl)
                                 },
-                                onReblog = { e ->
-                                    model.reduce(ThreadMviModel.Intent.ToggleReblog(e))
-                                },
-                                onBookmark = { e ->
-                                    model.reduce(ThreadMviModel.Intent.ToggleBookmark(e))
-                                },
-                                onFavorite = { e ->
-                                    model.reduce(ThreadMviModel.Intent.ToggleFavorite(e))
-                                },
+                                onReblog =
+                                    uiState.currentUserId?.let {
+                                        { e -> model.reduce(ThreadMviModel.Intent.ToggleReblog(e)) }
+                                    },
+                                onBookmark =
+                                    uiState.currentUserId?.let {
+                                        { e -> model.reduce(ThreadMviModel.Intent.ToggleBookmark(e)) }
+                                    },
+                                onFavorite =
+                                    uiState.currentUserId?.let {
+                                        { e -> model.reduce(ThreadMviModel.Intent.ToggleFavorite(e)) }
+                                    },
                                 onOpenUsersFavorite = { e ->
                                     detailOpener.openEntryUsersFavorite(
                                         entryId = e.id,
@@ -271,24 +275,28 @@ class ThreadScreen(
                                         count = e.reblogCount,
                                     )
                                 },
-                                onReply = { e ->
-                                    detailOpener.openComposer(
-                                        inReplyToId = e.id,
-                                        inReplyToHandle = e.creator?.handle,
-                                        inReplyToUsername =
-                                            e.creator?.let {
-                                                it.displayName ?: it.username
-                                            },
-                                    )
-                                },
-                                onPollVote = { e, choices ->
-                                    model.reduce(
-                                        ThreadMviModel.Intent.SubmitPollVote(
-                                            entry = e,
-                                            choices = choices,
-                                        ),
-                                    )
-                                },
+                                onReply =
+                                    uiState.currentUserId?.let {
+                                        { e ->
+                                            detailOpener.openComposer(
+                                                inReplyToId = e.id,
+                                                inReplyToHandle = e.creator?.handle,
+                                                inReplyToUsername =
+                                                    e.creator?.let { it.displayName ?: it.username },
+                                            )
+                                        }
+                                    },
+                                onPollVote =
+                                    uiState.currentUserId?.let {
+                                        { e, choices ->
+                                            model.reduce(
+                                                ThreadMviModel.Intent.SubmitPollVote(
+                                                    entry = e,
+                                                    choices = choices,
+                                                ),
+                                            )
+                                        }
+                                    },
                                 onToggleSpoilerActive = { e ->
                                     model.reduce(ThreadMviModel.Intent.ToggleSpoilerActive(e))
                                 },

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
@@ -279,33 +279,42 @@ class TimelineScreen : Screen {
                             onOpenImage = { imageUrl ->
                                 detailOpener.openImageDetail(imageUrl)
                             },
-                            onReblog = { e ->
-                                model.reduce(TimelineMviModel.Intent.ToggleReblog(e))
-                            },
-                            onBookmark = { e ->
-                                model.reduce(TimelineMviModel.Intent.ToggleBookmark(e))
-                            },
-                            onFavorite = { e ->
-                                model.reduce(TimelineMviModel.Intent.ToggleFavorite(e))
-                            },
-                            onPollVote = { e, choices ->
-                                model.reduce(
-                                    TimelineMviModel.Intent.SubmitPollVote(
-                                        entry = e,
-                                        choices = choices,
-                                    ),
-                                )
-                            },
-                            onReply = { e ->
-                                detailOpener.openComposer(
-                                    inReplyToId = e.id,
-                                    inReplyToUsername =
-                                        e.creator?.let {
-                                            it.displayName ?: it.username
-                                        },
-                                    inReplyToHandle = e.creator?.handle,
-                                )
-                            },
+                            onReblog =
+                                uiState.currentUserId?.let {
+                                    { e -> model.reduce(TimelineMviModel.Intent.ToggleReblog(e)) }
+                                },
+                            onBookmark =
+                                uiState.currentUserId?.let {
+                                    { e -> model.reduce(TimelineMviModel.Intent.ToggleBookmark(e)) }
+                                },
+                            onFavorite =
+                                uiState.currentUserId?.let {
+                                    { e -> model.reduce(TimelineMviModel.Intent.ToggleFavorite(e)) }
+                                },
+                            onPollVote =
+                                uiState.currentUserId?.let {
+                                    { e, choices ->
+                                        model.reduce(
+                                            TimelineMviModel.Intent.SubmitPollVote(
+                                                entry = e,
+                                                choices = choices,
+                                            ),
+                                        )
+                                    }
+                                },
+                            onReply =
+                                uiState.currentUserId?.let {
+                                    { e ->
+                                        detailOpener.openComposer(
+                                            inReplyToId = e.id,
+                                            inReplyToUsername =
+                                                e.creator?.let {
+                                                    it.displayName ?: it.username
+                                                },
+                                            inReplyToHandle = e.creator?.handle,
+                                        )
+                                    }
+                                },
                             onToggleSpoilerActive = { e ->
                                 model.reduce(TimelineMviModel.Intent.ToggleSpoilerActive(e))
                             },

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
@@ -174,6 +174,7 @@ class TimelineViewModel(
             return
         }
 
+        val wasRefreshing = uiState.value.refreshing
         updateState { it.copy(loading = true) }
         val entries = paginationManager.loadNextPage()
         updateState {
@@ -184,6 +185,9 @@ class TimelineViewModel(
                 initial = false,
                 refreshing = false,
             )
+        }
+        if (wasRefreshing) {
+            emitEffect(TimelineMviModel.Effect.BackToTop)
         }
     }
 

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -448,33 +448,50 @@ class UserDetailScreen(
                                 onOpenImage = { imageUrl ->
                                     detailOpener.openImageDetail(imageUrl)
                                 },
-                                onReblog = { e ->
-                                    model.reduce(UserDetailMviModel.Intent.ToggleReblog(e))
-                                },
-                                onBookmark = { e ->
-                                    model.reduce(UserDetailMviModel.Intent.ToggleBookmark(e))
-                                },
-                                onFavorite = { e ->
-                                    model.reduce(UserDetailMviModel.Intent.ToggleFavorite(e))
-                                },
-                                onReply = { e ->
-                                    detailOpener.openComposer(
-                                        inReplyToId = e.id,
-                                        inReplyToHandle = e.creator?.handle,
-                                        inReplyToUsername =
-                                            e.creator?.let {
-                                                it.displayName ?: it.username
-                                            },
-                                    )
-                                },
-                                onPollVote = { e, choices ->
-                                    model.reduce(
-                                        UserDetailMviModel.Intent.SubmitPollVote(
-                                            entry = e,
-                                            choices = choices,
-                                        ),
-                                    )
-                                },
+                                onReblog =
+                                    uiState.currentUserId?.let {
+                                        { e -> model.reduce(UserDetailMviModel.Intent.ToggleReblog(e)) }
+                                    },
+                                onBookmark =
+                                    uiState.currentUserId?.let {
+                                        { e ->
+                                            model.reduce(
+                                                UserDetailMviModel.Intent.ToggleBookmark(e),
+                                            )
+                                        }
+                                    },
+                                onFavorite =
+                                    uiState.currentUserId?.let {
+                                        { e ->
+                                            model.reduce(
+                                                UserDetailMviModel.Intent.ToggleFavorite(e),
+                                            )
+                                        }
+                                    },
+                                onReply =
+                                    uiState.currentUserId?.let {
+                                        { e ->
+                                            detailOpener.openComposer(
+                                                inReplyToId = e.id,
+                                                inReplyToHandle = e.creator?.handle,
+                                                inReplyToUsername =
+                                                    e.creator?.let {
+                                                        it.displayName ?: it.username
+                                                    },
+                                            )
+                                        }
+                                    },
+                                onPollVote =
+                                    uiState.currentUserId?.let {
+                                        { e, choices ->
+                                            model.reduce(
+                                                UserDetailMviModel.Intent.SubmitPollVote(
+                                                    entry = e,
+                                                    choices = choices,
+                                                ),
+                                            )
+                                        }
+                                    },
                                 onToggleSpoilerActive = { e ->
                                     model.reduce(UserDetailMviModel.Intent.ToggleSpoilerActive(e))
                                 },

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
@@ -252,33 +252,42 @@ class ForumListScreen(
                             onOpenImage = { imageUrl ->
                                 detailOpener.openImageDetail(imageUrl)
                             },
-                            onReblog = { e ->
-                                model.reduce(ForumListMviModel.Intent.ToggleReblog(e))
-                            },
-                            onBookmark = { e ->
-                                model.reduce(ForumListMviModel.Intent.ToggleBookmark(e))
-                            },
-                            onFavorite = { e ->
-                                model.reduce(ForumListMviModel.Intent.ToggleFavorite(e))
-                            },
-                            onReply = { e ->
-                                detailOpener.openComposer(
-                                    inReplyToId = e.id,
-                                    inReplyToHandle = e.creator?.handle,
-                                    inReplyToUsername =
-                                        e.creator?.let {
-                                            it.displayName ?: it.username
-                                        },
-                                )
-                            },
-                            onPollVote = { e, choices ->
-                                model.reduce(
-                                    ForumListMviModel.Intent.SubmitPollVote(
-                                        entry = e,
-                                        choices = choices,
-                                    ),
-                                )
-                            },
+                            onReblog =
+                                uiState.currentUserId?.let {
+                                    { e -> model.reduce(ForumListMviModel.Intent.ToggleReblog(e)) }
+                                },
+                            onBookmark =
+                                uiState.currentUserId?.let {
+                                    { e -> model.reduce(ForumListMviModel.Intent.ToggleBookmark(e)) }
+                                },
+                            onFavorite =
+                                uiState.currentUserId?.let {
+                                    { e -> model.reduce(ForumListMviModel.Intent.ToggleFavorite(e)) }
+                                },
+                            onReply =
+                                uiState.currentUserId?.let {
+                                    { e ->
+                                        detailOpener.openComposer(
+                                            inReplyToId = e.id,
+                                            inReplyToHandle = e.creator?.handle,
+                                            inReplyToUsername =
+                                                e.creator?.let {
+                                                    it.displayName ?: it.username
+                                                },
+                                        )
+                                    }
+                                },
+                            onPollVote =
+                                uiState.currentUserId?.let {
+                                    { e, choices ->
+                                        model.reduce(
+                                            ForumListMviModel.Intent.SubmitPollVote(
+                                                entry = e,
+                                                choices = choices,
+                                            ),
+                                        )
+                                    }
+                                },
                             onToggleSpoilerActive = { e ->
                                 model.reduce(ForumListMviModel.Intent.ToggleSpoilerActive(e))
                             },


### PR DESCRIPTION
This PR contains a series of miscellaneous fixes for bugs that have emerged during a test session:
- post actions should not be triggered when there is no user logged
- the light theme was not working with any custom color
- the home screen was not going back to top after a refresh
- the inbox screen had readability issues and poorly chosen color
- the top bar in the profile (logged) screen did not change color according to the scroll amount, due to the nested scroll connection not being correctly tied to the lazy column.