### PR TITLE
feat: fix hide animation for bottom sheet

### DIFF
--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/CustomModalBottomSheet.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/CustomModalBottomSheet.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
@@ -28,6 +29,8 @@ import androidx.compose.ui.text.style.TextAlign
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 data class CustomModalBottomSheetItem(
     val leadingContent: @Composable (() -> Unit)? = null,
@@ -40,6 +43,7 @@ data class CustomModalBottomSheetItem(
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun CustomModalBottomSheet(
+    sheetScope: CoroutineScope = rememberCoroutineScope(),
     sheetState: SheetState = rememberModalBottomSheetState(),
     title: String = "",
     items: List<CustomModalBottomSheetItem> = emptyList(),
@@ -78,10 +82,18 @@ fun CustomModalBottomSheet(
                                         .fillMaxWidth()
                                         .combinedClickable(
                                             onClick = {
-                                                onSelected?.invoke(idx)
+                                                sheetScope.launch {
+                                                    sheetState.hide()
+                                                }.invokeOnCompletion {
+                                                    onSelected?.invoke(idx)
+                                                }
                                             },
                                             onLongClick = {
-                                                onLongPress?.invoke(idx)
+                                                sheetScope.launch {
+                                                    sheetState.hide()
+                                                }.invokeOnCompletion {
+                                                    onLongPress?.invoke(idx)
+                                                }
                                             },
                                         ).padding(
                                             horizontal = Spacing.s,


### PR DESCRIPTION
While porting this over to RFL, I noticed that selecting an option on the bottom sheet would cause it to vanish, instead of slide away. 
This PR calls the close animation, then invokes the onSelected / onLongPress lambda which will actually set the "visibility" to false.  

This is a very, very, small thing, and really not a big deal, but I wanted to contribute my findings back to the origin. 