### PR TITLE
feat: edit profile • part 3

### DIFF
--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -259,4 +259,7 @@ internal open class DefaultStrings : Strings {
     override val unsavedChangesTitle = "Unsaved changes"
     override val messageAreYouSureExit = "Are you sure you want to exit?"
     override val buttonSave = "Save"
+    override val editProfileSectionFields = "Custom fields (experimental)"
+    override val editProfileItemFieldKey = "Key"
+    override val editProfileItemFieldValue = "Value"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -265,4 +265,7 @@ internal val ItStrings =
         override val unsavedChangesTitle = "Modifiche non salvate"
         override val messageAreYouSureExit = "Sei sicuro/a di voler uscire?"
         override val buttonSave = "Salva"
+        override val editProfileSectionFields = "Campi personalizzati  (sperimentale)"
+        override val editProfileItemFieldKey = "Chiave"
+        override val editProfileItemFieldValue = "Valore"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -242,6 +242,9 @@ interface Strings {
     val unsavedChangesTitle: String
     val messageAreYouSureExit: String
     val buttonSave: String
+    val editProfileSectionFields: String
+    val editProfileItemFieldKey: String
+    val editProfileItemFieldValue: String
 }
 
 object Locales {

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepository.kt
@@ -300,15 +300,20 @@ internal class DefaultUserRepository(
                             append("hide_collections", if (hideCollections) "1" else "0")
                         }
                         if (fields != null) {
-                            val encodedMap = mutableMapOf<Int, Map<String, String>>()
-                            fields.entries.forEachIndexed { idx, entry ->
-                                encodedMap[idx] =
-                                    mapOf(
-                                        "name" to entry.key,
-                                        "value" to entry.value,
-                                    )
+                            val serializedFields =
+                                buildList {
+                                    fields.entries.forEachIndexed { idx, entry ->
+                                        val nameKey = "fields_attributes[$idx][name]"
+                                        val nameValue = entry.key
+                                        this += (nameKey to nameValue)
+                                        val valueKey = "fields_attributes[$idx][value]"
+                                        val valueValue = entry.value
+                                        this += (valueKey to valueValue)
+                                    }
+                                }
+                            for (field in serializedFields) {
+                                append(field.first, field.second)
                             }
-                            append("fields_attributes", encodedMap.toString())
                         }
                     },
                 )

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditFieldItem.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditFieldItem.kt
@@ -1,0 +1,64 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.profile.edit
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.FieldModel
+
+@Composable
+internal fun EditFieldItem(
+    field: FieldModel,
+    modifier: Modifier = Modifier,
+    onValueChange: ((String, String) -> Unit)? = null,
+    onDelete: (() -> Unit)? = null,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
+    ) {
+        OutlinedTextField(
+            modifier = Modifier.fillMaxWidth(),
+            label = {
+                Text(text = LocalStrings.current.editProfileItemFieldKey)
+            },
+            textStyle = MaterialTheme.typography.bodySmall,
+            maxLines = 1,
+            value = field.key,
+            onValueChange = {
+                onValueChange?.invoke(it, field.value)
+            },
+            trailingIcon = {
+                IconButton(onClick = { onDelete?.invoke() }) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = null,
+                    )
+                }
+            },
+        )
+        OutlinedTextField(
+            modifier = Modifier.fillMaxWidth().padding(top = Spacing.xxs),
+            label = {
+                Text(text = LocalStrings.current.editProfileItemFieldValue)
+            },
+            textStyle = MaterialTheme.typography.bodySmall,
+            maxLines = 1,
+            value = field.value,
+            onValueChange = {
+                onValueChange?.invoke(field.key, it)
+            },
+        )
+    }
+}

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileMviModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileMviModel.kt
@@ -40,7 +40,7 @@ interface EditProfileMviModel :
         data class EditField(
             val index: Int,
             val key: String,
-            val value: TextFieldValue,
+            val value: String,
         ) : Intent
 
         data class RemoveField(
@@ -60,6 +60,7 @@ interface EditProfileMviModel :
         val discoverable: Boolean = false,
         val noIndex: Boolean = false,
         val fields: List<FieldModel> = emptyList(),
+        val canAddFields: Boolean = false,
     )
 
     sealed interface Effect {

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileScreen.kt
@@ -7,13 +7,18 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.AddCircle
 import androidx.compose.material.icons.outlined.AccountCircle
 import androidx.compose.material.icons.outlined.BuildCircle
+import androidx.compose.material.icons.outlined.ViewAgenda
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -47,6 +52,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.SettingsH
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.SettingsSwitchRow
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
+import com.livefast.eattrash.raccoonforfriendica.core.utils.compose.safeImePadding
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -95,6 +101,7 @@ class EditProfileScreen : Screen {
         }
 
         Scaffold(
+            modifier = Modifier.safeImePadding(),
             topBar = {
                 TopAppBar(
                     modifier = Modifier.clickable { scope.launch { goBackToTop() } },
@@ -193,6 +200,43 @@ class EditProfileScreen : Screen {
                         value = uiState.bio,
                         onValueChange = {
                             model.reduce(EditProfileMviModel.Intent.ChangeBio(it))
+                        },
+                    )
+                }
+                item {
+                    SettingsHeader(
+                        icon = Icons.Outlined.ViewAgenda,
+                        title = LocalStrings.current.editProfileSectionFields,
+                        rightButton = {
+                            IconButton(
+                                enabled = uiState.canAddFields,
+                                onClick = {
+                                    model.reduce(EditProfileMviModel.Intent.AddField)
+                                },
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.AddCircle,
+                                    contentDescription = null,
+                                )
+                            }
+                        },
+                    )
+                }
+                itemsIndexed(uiState.fields) { idx, field ->
+                    EditFieldItem(
+                        modifier = Modifier.padding(horizontal = Spacing.s),
+                        field = field,
+                        onValueChange = { key, value ->
+                            model.reduce(
+                                EditProfileMviModel.Intent.EditField(
+                                    index = idx,
+                                    key = key,
+                                    value = value,
+                                ),
+                            )
+                        },
+                        onDelete = {
+                            model.reduce(EditProfileMviModel.Intent.RemoveField(idx))
                         },
                     )
                 }


### PR DESCRIPTION
This PR adds the management of custom fields in the profile editor. Unfortunately the endpoint is only partially implemented and does not update the fields.