### PR TITLE
feat: edit profile • part 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ The app is under ongoing development, here is a list of the features that are be
 - [x] OAuth and HTTP basic authentication modes
 - [x] pin/unpin status to profile
 - [x] manage one's own circles/following lists
-- [x] polls (read-only, since the submit vote method is unimplemented in the backend)
+- [x] polls (read-only, voting it not supported yet by the back-end)
 - [x] manage follow requests
 - [x] support for post addons (spoilers and titles)
 - [x] multi-account
-- [x] edit one's own profile (partial)
+- [x] edit one's own profile (custom fields and images not supported yet by the back-end)
 - [ ] private conversations
 - [ ] photo gallery
 - [ ] advanced media visualization (image carousels, videos, GIFs, etc.)

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/EditFieldItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/EditFieldItem.kt
@@ -1,4 +1,4 @@
-package com.livefast.eattrash.raccoonforfriendica.feature.profile.edit
+package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -18,7 +18,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.FieldModel
 
 @Composable
-internal fun EditFieldItem(
+fun EditFieldItem(
     field: FieldModel,
     modifier: Modifier = Modifier,
     onValueChange: ((String, String) -> Unit)? = null,

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SettingsImageInfo.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SettingsImageInfo.kt
@@ -1,0 +1,86 @@
+package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FileOpen
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.FilterQuality
+import androidx.compose.ui.layout.ContentScale
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomImage
+import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.toComposeImageBitmap
+
+@Composable
+fun SettingsImageInfo(
+    modifier: Modifier = Modifier,
+    imageModifier: Modifier = Modifier,
+    contentScale: ContentScale = ContentScale.FillBounds,
+    title: String = "",
+    url: String? = null,
+    bytes: ByteArray? = null,
+    onEdit: (() -> Unit)? = null,
+) {
+    val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(alpha = ancillaryTextAlpha)
+    Box(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clickable {
+                    onEdit?.invoke()
+                }.padding(
+                    vertical = Spacing.xs,
+                    horizontal = Spacing.m,
+                ),
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.labelMedium,
+                color = ancillaryColor,
+            )
+
+            if (bytes != null && bytes.isNotEmpty()) {
+                val imageBitmap = bytes.toComposeImageBitmap()
+                Image(
+                    modifier = imageModifier,
+                    bitmap = imageBitmap,
+                    contentDescription = null,
+                    filterQuality = FilterQuality.Low,
+                    contentScale = contentScale,
+                )
+            } else if (url.isNullOrEmpty()) {
+                Box(
+                    modifier = imageModifier,
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.FileOpen,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onBackground,
+                    )
+                }
+            } else {
+                CustomImage(
+                    modifier = imageModifier,
+                    url = url,
+                    quality = FilterQuality.Low,
+                    contentScale = contentScale,
+                )
+            }
+        }
+    }
+}

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -262,4 +262,7 @@ internal open class DefaultStrings : Strings {
     override val editProfileSectionFields = "Custom fields (experimental)"
     override val editProfileItemFieldKey = "Key"
     override val editProfileItemFieldValue = "Value"
+    override val editProfileSectionImages = "Images (experimental)"
+    override val editProfileItemAvatar = "Avatar"
+    override val editProfileItemHeader = "Banner"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -268,4 +268,7 @@ internal val ItStrings =
         override val editProfileSectionFields = "Campi personalizzati  (sperimentale)"
         override val editProfileItemFieldKey = "Chiave"
         override val editProfileItemFieldValue = "Valore"
+        override val editProfileSectionImages = "Immagini (sperimentale)"
+        override val editProfileItemAvatar = "Avatar"
+        override val editProfileItemHeader = "Banner"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -245,6 +245,9 @@ interface Strings {
     val editProfileSectionFields: String
     val editProfileItemFieldKey: String
     val editProfileItemFieldValue: String
+    val editProfileSectionImages: String
+    val editProfileItemAvatar: String
+    val editProfileItemHeader: String
 }
 
 object Locales {

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/ImageUtils.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/ImageUtils.kt
@@ -1,0 +1,7 @@
+package com.livefast.eattrash.raccoonforfriendica.core.utils.imageload
+
+import android.graphics.BitmapFactory
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+
+actual fun ByteArray.toComposeImageBitmap(): ImageBitmap = BitmapFactory.decodeByteArray(this, 0, size).asImageBitmap()

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/ImageUtils.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/ImageUtils.kt
@@ -1,0 +1,5 @@
+package com.livefast.eattrash.raccoonforfriendica.core.utils.imageload
+
+import androidx.compose.ui.graphics.ImageBitmap
+
+expect fun ByteArray.toComposeImageBitmap(): ImageBitmap

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/ImageUtils.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/ImageUtils.kt
@@ -1,0 +1,7 @@
+package com.livefast.eattrash.raccoonforfriendica.core.utils.imageload
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import org.jetbrains.skia.Image
+
+actual fun ByteArray.toComposeImageBitmap(): ImageBitmap = Image.makeFromEncoded(this).toComposeImageBitmap()

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileMviModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileMviModel.kt
@@ -47,21 +47,107 @@ interface EditProfileMviModel :
             val index: Int,
         ) : Intent
 
+        data class AvatarSelected(
+            val value: ByteArray,
+        ) : Intent {
+            override fun equals(other: Any?): Boolean {
+                if (this === other) return true
+                if (other == null || this::class != other::class) return false
+
+                other as AvatarSelected
+
+                return value.contentEquals(other.value)
+            }
+
+            override fun hashCode(): Int = value.contentHashCode()
+        }
+
+        data class HeaderSelected(
+            val value: ByteArray,
+        ) : Intent {
+            override fun equals(other: Any?): Boolean {
+                if (this === other) return true
+                if (other == null || this::class != other::class) return false
+
+                other as HeaderSelected
+
+                return value.contentEquals(other.value)
+            }
+
+            override fun hashCode(): Int = value.contentHashCode()
+        }
+
         data object Submit : Intent
     }
 
     data class State(
         val loading: Boolean = false,
         val hasUnsavedChanges: Boolean = false,
-        val bio: TextFieldValue = TextFieldValue(""),
         val displayName: TextFieldValue = TextFieldValue(""),
+        val bio: TextFieldValue = TextFieldValue(""),
+        val avatar: String? = null,
+        val avatarBytes: ByteArray? = null,
+        val header: String? = null,
+        val headerBytes: ByteArray? = null,
         val bot: Boolean = false,
         val locked: Boolean = false,
         val discoverable: Boolean = false,
         val noIndex: Boolean = false,
         val fields: List<FieldModel> = emptyList(),
         val canAddFields: Boolean = false,
-    )
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || this::class != other::class) return false
+
+            other as State
+
+            if (loading != other.loading) return false
+            if (hasUnsavedChanges != other.hasUnsavedChanges) return false
+            if (displayName != other.displayName) return false
+            if (bio != other.bio) return false
+            if (avatar != other.avatar) return false
+            if (avatarBytes != null) {
+                if (other.avatarBytes == null) return false
+                if (!avatarBytes.contentEquals(other.avatarBytes)) return false
+            } else if (other.avatarBytes != null) {
+                return false
+            }
+            if (header != other.header) return false
+            if (headerBytes != null) {
+                if (other.headerBytes == null) return false
+                if (!headerBytes.contentEquals(other.headerBytes)) return false
+            } else if (other.headerBytes != null) {
+                return false
+            }
+            if (bot != other.bot) return false
+            if (locked != other.locked) return false
+            if (discoverable != other.discoverable) return false
+            if (noIndex != other.noIndex) return false
+            if (fields != other.fields) return false
+            if (canAddFields != other.canAddFields) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = loading.hashCode()
+            result = 31 * result + hasUnsavedChanges.hashCode()
+            result = 31 * result + displayName.hashCode()
+            result = 31 * result + bio.hashCode()
+            result = 31 * result + (avatar?.hashCode() ?: 0)
+            result = 31 * result + (avatarBytes?.contentHashCode() ?: 0)
+            result = 31 * result + (header?.hashCode() ?: 0)
+            result = 31 * result + (headerBytes?.contentHashCode() ?: 0)
+            result = 31 * result + bot.hashCode()
+            result = 31 * result + locked.hashCode()
+            result = 31 * result + discoverable.hashCode()
+            result = 31 * result + noIndex.hashCode()
+            result = 31 * result + fields.hashCode()
+            result = 31 * result + canAddFields.hashCode()
+            return result
+        }
+    }
 
     sealed interface Effect {
         data object Success : Effect


### PR DESCRIPTION
This PR adds the front-end support for avatar and header images, although they do not appear to be supported yet. Unfortunately the PATCH /v1/accounts/update_credentials endpoint is currently not fully implemented so some fields are discarded (at least on Friendica instances).