### PR TITLE
feat: add ability to share user profiles

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Account.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Account.kt
@@ -22,4 +22,5 @@ data class Account(
     @SerialName("username") val username: String,
     @SerialName("discoverable") val discoverable: Boolean = false,
     @SerialName("noindex") val noIndex: Boolean = false,
+    @SerialName("url") val url: String? = null,
 )

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/UserModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/UserModel.kt
@@ -21,6 +21,7 @@ data class UserModel(
     val hideCollections: Boolean = false,
     val noIndex: Boolean = false,
     val username: String? = null,
+    val url: String? = null,
     @Transient
     val relationshipStatus: RelationshipStatus? = null,
     @Transient

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/Mappings.kt
@@ -157,6 +157,7 @@ internal fun Account.toModel() =
         username = username,
         discoverable = discoverable,
         noIndex = noIndex,
+        url = url,
     )
 
 internal fun Field.toModel() =

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -190,8 +190,10 @@ class UserDetailScreen(
                     actions = {
                         val options =
                             buildList {
-                                val user = uiState.user
-                                if (user != null) {
+                                uiState.user?.also { user ->
+                                    if (!user.url.isNullOrEmpty()) {
+                                        this += OptionId.Share.toOption()
+                                    }
                                     if (user.muted) {
                                         this += OptionId.Unmute.toOption()
                                     } else {
@@ -243,6 +245,9 @@ class UserDetailScreen(
                                             onClick = {
                                                 optionsMenuOpen = false
                                                 when (option.id) {
+                                                    OptionId.Share ->
+                                                        shareHelper.share(uiState.user?.url.orEmpty())
+
                                                     OptionId.Mute ->
                                                         confirmMuteUserDialogOpen = true
 


### PR DESCRIPTION
This PR adds, if possible, the "Share" option to the top bar menu in the user detail screen. This will open the system share dialog with an URL pointing to the user profile in their original instance.