### PR TITLE
fix: forum list pagination

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/InReplyToInfo.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/InReplyToInfo.kt
@@ -88,7 +88,6 @@ internal fun InReplyToInfo(
         }
 
         Text(
-            modifier = Modifier.weight(1f),
             text = creatorName,
             style = MaterialTheme.typography.bodyMedium,
             color = fullColor,

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ReblogInfo.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ReblogInfo.kt
@@ -90,7 +90,6 @@ internal fun ReblogInfo(
         }
 
         Text(
-            modifier = Modifier.weight(1f),
             text = creatorName,
             style = MaterialTheme.typography.bodyMedium,
             color = fullColor,

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
@@ -60,6 +60,7 @@ fun TimelineItem(
     onToggleSpoilerActive: ((TimelineEntryModel) -> Unit)? = null,
 ) {
     val isReblog = entry.reblog != null
+    val isReply = entry.inReplyTo != null
     val entryToDisplay = entry.reblog ?: entry
     var optionsOffset by remember { mutableStateOf(Offset.Zero) }
     var optionsMenuOpen by remember { mutableStateOf(false) }
@@ -80,42 +81,40 @@ fun TimelineItem(
         Column(
             verticalArrangement = Arrangement.spacedBy(Spacing.xs),
         ) {
+            if (reshareAndReplyVisible) {
+                Column(
+                    modifier = Modifier.padding(horizontal = contentHorizontalPadding),
+                ) {
+                    if (isReblog) {
+                        entry.creator?.let {
+                            ReblogInfo(
+                                user = it,
+                                onOpenUser = onOpenUser,
+                            )
+                        }
+                    }
+                    if (isReply) {
+                        entry.inReplyTo?.creator?.let {
+                            InReplyToInfo(
+                                user = it,
+                                onOpenUser = onOpenUser,
+                            )
+                        }
+                    }
+                }
+            }
+
             Row(
                 modifier = Modifier.padding(horizontal = contentHorizontalPadding),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Column(
-                    modifier = Modifier.weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(Spacing.xs),
-                ) {
-                    if (reshareAndReplyVisible) {
-                        if (isReblog) {
-                            entry.creator?.let {
-                                ReblogInfo(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    user = it,
-                                    onOpenUser = onOpenUser,
-                                )
-                            }
-                        } else {
-                            entry.inReplyTo?.creator?.let {
-                                InReplyToInfo(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    user = it,
-                                    onOpenUser = onOpenUser,
-                                )
-                            }
-                        }
-                    }
-
-                    ContentHeader(
-                        modifier = Modifier.fillMaxWidth(),
-                        user = entryToDisplay.creator,
-                        date = entryToDisplay.edited ?: entryToDisplay.created,
-                        isEdited = entryToDisplay.edited != null,
-                        onOpenUser = onOpenUser,
-                    )
-                }
+                ContentHeader(
+                    modifier = Modifier.fillMaxWidth(),
+                    user = entryToDisplay.creator,
+                    date = entryToDisplay.edited ?: entryToDisplay.created,
+                    isEdited = entryToDisplay.edited != null,
+                    onOpenUser = onOpenUser,
+                )
                 if (options.isNotEmpty()) {
                     Box {
                         Icon(

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
@@ -72,6 +72,16 @@ internal class DefaultTimelinePaginationManager(
                             pinned = specification.pinned,
                         ).updatePaginationData()
                         .filterNsfw(specification.includeNsfw)
+
+                is TimelinePaginationSpecification.Forum ->
+                    timelineEntryRepository
+                        .getByUser(
+                            userId = specification.userId,
+                            pageCursor = pageCursor,
+                            excludeReplies = true,
+                        ).updatePaginationData()
+                        .filterNsfw(specification.includeNsfw)
+                        .filter { it.inReplyTo == null }
             }.deduplicate()
         history.addAll(results)
 

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/TimelinePaginationSpecification.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/TimelinePaginationSpecification.kt
@@ -21,4 +21,9 @@ sealed interface TimelinePaginationSpecification {
         val pinned: Boolean = false,
         val includeNsfw: Boolean = true,
     ) : TimelinePaginationSpecification
+
+    data class Forum(
+        val userId: String,
+        val includeNsfw: Boolean = true,
+    ) : TimelinePaginationSpecification
 }

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/components/CircleAddUsersDialog.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/components/CircleAddUsersDialog.kt
@@ -115,7 +115,8 @@ internal fun CircleAddUserDialog(
                         },
                     )
 
-                    if (idx == users.lastIndex - 5 && !loading && canFetchMore) {
+                    val isNearTheEnd = idx == users.lastIndex - 5 || users.size < 5
+                    if (isNearTheEnd && !loading && canFetchMore) {
                         onLoadMoreUsers?.invoke()
                     }
                 }

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/detail/CircleDetailScreen.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/detail/CircleDetailScreen.kt
@@ -58,6 +58,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.UserItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.UserItemPlaceholder
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toOption
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDetailOpener
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.feature.circles.components.CircleAddUserDialog
 import kotlinx.coroutines.flow.launchIn
@@ -84,6 +85,7 @@ class CircleDetailScreen(
         val isFabVisible by fabNestedScrollConnection.isFabVisible.collectAsState()
         val scope = rememberCoroutineScope()
         val snackbarHostState = remember { SnackbarHostState() }
+        val detailOpener = remember { getDetailOpener() }
         val genericError = LocalStrings.current.messageGenericError
         var confirmRemoveUserId by remember { mutableStateOf<String?>(null) }
 
@@ -205,6 +207,9 @@ class CircleDetailScreen(
                     ) { _, user ->
                         UserItem(
                             user = user,
+                            onClick = {
+                                detailOpener.openUserDetail(user.id)
+                            },
                             options =
                                 buildList {
                                     this += OptionId.Delete.toOption()

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/components/MentionDialog.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/components/MentionDialog.kt
@@ -110,7 +110,8 @@ internal fun MentionDialog(
                         },
                     )
 
-                    if (idx == users.lastIndex - 5 && !loading && canFetchMore) {
+                    val isNearTheEnd = idx == users.lastIndex - 5 || users.size < 5
+                    if (isNearTheEnd && !loading && canFetchMore) {
                         onLoadMoreUsers?.invoke()
                     }
                 }

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
@@ -489,7 +489,9 @@ class ExploreScreen : Screen {
 
                         val canFetchMore =
                             !uiState.initial && !uiState.loading && uiState.canFetchMore
-                        if (idx == uiState.items.lastIndex - 5 && canFetchMore) {
+                        val isNearTheEnd =
+                            idx == uiState.items.lastIndex - 5 || uiState.items.size < 5
+                        if (isNearTheEnd && canFetchMore) {
                             model.reduce(ExploreMviModel.Intent.LoadNextPage)
                         }
                     }

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
@@ -317,7 +317,9 @@ class FavoritesScreen(
 
                         val canFetchMore =
                             !uiState.initial && !uiState.loading && uiState.canFetchMore
-                        if (idx == uiState.entries.lastIndex - 5 && canFetchMore) {
+                        val isNearTheEnd =
+                            idx == uiState.entries.lastIndex - 5 || uiState.entries.size < 5
+                        if (isNearTheEnd && canFetchMore) {
                             model.reduce(FavoritesMviModel.Intent.LoadNextPage)
                         }
                     }

--- a/feature/followrequests/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/followrequests/FollowRequestsScreen.kt
+++ b/feature/followrequests/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/followrequests/FollowRequestsScreen.kt
@@ -162,7 +162,9 @@ class FollowRequestsScreen : Screen {
 
                         val canFetchMore =
                             !uiState.initial && !uiState.loading && uiState.canFetchMore
-                        if (idx == uiState.items.lastIndex - 5 && canFetchMore) {
+                        val isNearTheEnd =
+                            idx == uiState.items.lastIndex - 5 || uiState.items.size < 5
+                        if (isNearTheEnd && canFetchMore) {
                             model.reduce(FollowRequestsMviModel.Intent.LoadNextPage)
                         }
                     }

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/followed/FollowedHashtagsScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/followed/FollowedHashtagsScreen.kt
@@ -159,7 +159,9 @@ class FollowedHashtagsScreen : Screen {
 
                         val canFetchMore =
                             !uiState.initial && !uiState.loading && uiState.canFetchMore
-                        if (idx == uiState.items.lastIndex - 5 && canFetchMore) {
+                        val isNearTheEnd =
+                            idx == uiState.items.lastIndex - 5 || uiState.items.size < 5
+                        if (isNearTheEnd && canFetchMore) {
                             model.reduce(FollowedHashtagsMviModel.Intent.LoadNextPage)
                         }
                     }

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
@@ -265,12 +265,12 @@ class HashtagScreen(
                                         model.reduce(
                                             HashtagMviModel.Intent.SubmitPollVote(
                                                 entry = e,
-                                            choices = choices,
-                                        ),
-                                    )
-                                }
-                            },
-                                                onToggleSpoilerActive = { e ->
+                                                choices = choices,
+                                            ),
+                                        )
+                                    }
+                                },
+                            onToggleSpoilerActive = { e ->
                                 model.reduce(HashtagMviModel.Intent.ToggleSpoilerActive(e))
                             },
                             options =
@@ -339,7 +339,9 @@ class HashtagScreen(
 
                         val canFetchMore =
                             !uiState.initial && !uiState.loading && uiState.canFetchMore
-                        if (idx == uiState.entries.lastIndex - 5 && canFetchMore) {
+                        val isNearTheEnd =
+                            idx == uiState.entries.lastIndex - 5 || uiState.entries.size < 5
+                        if (isNearTheEnd && canFetchMore) {
                             model.reduce(HashtagMviModel.Intent.LoadNextPage)
                         }
                     }
@@ -443,7 +445,7 @@ class HashtagScreen(
                             ),
                         )
                     }
-                }
+                },
             )
         }
 

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
@@ -229,7 +229,9 @@ class InboxScreen : Screen {
 
                         val canFetchMore =
                             !uiState.initial && !uiState.loading && uiState.canFetchMore
-                        if (idx == uiState.notifications.lastIndex - 5 && canFetchMore) {
+                        val isNearTheEnd =
+                            idx == uiState.notifications.lastIndex - 5 || uiState.notifications.size < 5
+                        if (isNearTheEnd && canFetchMore) {
                             model.reduce(InboxMviModel.Intent.LoadNextPage)
                         }
                     }

--- a/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/ManageBlocksScreen.kt
+++ b/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/ManageBlocksScreen.kt
@@ -244,7 +244,9 @@ class ManageBlocksScreen : Screen {
 
                         val canFetchMore =
                             !uiState.initial && !uiState.loading && uiState.canFetchMore
-                        if (idx == uiState.items.lastIndex - 5 && canFetchMore) {
+                        val isNearTheEnd =
+                            idx == uiState.items.lastIndex - 5 || uiState.items.size < 5
+                        if (isNearTheEnd && canFetchMore) {
                             model.reduce(ManageBlocksMviModel.Intent.LoadNextPage)
                         }
                     }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
@@ -348,7 +348,9 @@ class MyAccountScreen : Screen {
 
                     val canFetchMore =
                         !uiState.initial && !uiState.loading && uiState.canFetchMore
-                    if (idx == uiState.entries.lastIndex - 5 && canFetchMore) {
+                    val isNearTheEnd =
+                        idx == uiState.entries.lastIndex - 5 || uiState.entries.size < 5
+                    if (isNearTheEnd && canFetchMore) {
                         model.reduce(MyAccountMviModel.Intent.LoadNextPage)
                     }
                 }

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
@@ -466,7 +466,9 @@ class SearchScreen : Screen {
 
                         val canFetchMore =
                             !uiState.initial && !uiState.loading && uiState.canFetchMore
-                        if (idx == uiState.items.lastIndex - 5 && canFetchMore) {
+                        val isNearTheEnd =
+                            idx == uiState.items.lastIndex - 5 || uiState.items.size < 5
+                        if (isNearTheEnd && canFetchMore) {
                             model.reduce(SearchMviModel.Intent.LoadNextPage)
                         }
                     }

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
@@ -384,7 +384,9 @@ class TimelineScreen : Screen {
 
                         val canFetchMore =
                             !uiState.initial && !uiState.loading && uiState.canFetchMore
-                        if (idx == uiState.entries.lastIndex - 5 && canFetchMore) {
+                        val isNearTheEnd =
+                            idx == uiState.entries.lastIndex - 5 || uiState.entries.size < 5
+                        if (isNearTheEnd && canFetchMore) {
                             model.reduce(TimelineMviModel.Intent.LoadNextPage)
                         }
                     }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -534,7 +534,9 @@ class UserDetailScreen(
 
                             val canFetchMore =
                                 !uiState.initial && !uiState.loading && uiState.canFetchMore
-                            if (idx == uiState.entries.lastIndex - 5 && canFetchMore) {
+                            val isNearTheEnd =
+                                idx == uiState.entries.lastIndex - 5 || uiState.entries.size < 5
+                            if (isNearTheEnd && canFetchMore) {
                                 model.reduce(UserDetailMviModel.Intent.LoadNextPage)
                             }
                         }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
@@ -293,7 +293,7 @@ class ForumListScreen(
                             },
                             options =
                                 buildList {
-                                    if (!entry.url.isNullOrBlank()) {
+                                    if (!entry.reblog?.url.isNullOrBlank()) {
                                         this += OptionId.Share.toOption()
                                         this += OptionId.CopyUrl.toOption()
                                     }
@@ -341,7 +341,9 @@ class ForumListScreen(
 
                         val canFetchMore =
                             !uiState.initial && !uiState.loading && uiState.canFetchMore
-                        if (idx == uiState.entries.lastIndex - 5 && canFetchMore) {
+                        val isNearTheEnd =
+                            idx == uiState.entries.lastIndex - 5 || uiState.entries.size < 5
+                        if (isNearTheEnd && canFetchMore) {
                             model.reduce(ForumListMviModel.Intent.LoadNextPage)
                         }
                     }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListViewModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListViewModel.kt
@@ -91,7 +91,7 @@ class ForumListViewModel(
             it.copy(initial = initial, refreshing = !initial)
         }
         paginationManager.reset(
-            TimelinePaginationSpecification.User(
+            TimelinePaginationSpecification.Forum(
                 userId = id,
                 includeNsfw = settingsRepository.current.value?.includeNsfw ?: false,
             ),
@@ -105,11 +105,7 @@ class ForumListViewModel(
         }
 
         updateState { it.copy(loading = true) }
-        val entries =
-            paginationManager
-                .loadNextPage()
-                // needed because otherwise replies are included
-                .filter { it.inReplyTo == null }
+        val entries = paginationManager.loadNextPage()
         updateState {
             it.copy(
                 entries = entries,

--- a/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListScreen.kt
+++ b/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListScreen.kt
@@ -226,7 +226,11 @@ class UserListScreen(
                         )
                         Spacer(modifier = Modifier.height(Spacing.interItem))
 
-                        if (idx == uiState.users.lastIndex - 5 && uiState.canFetchMore) {
+                        val isNearTheEnd =
+                            idx == uiState.users.lastIndex - 5 || uiState.users.size < 5
+                        val canFetchMore =
+                            !uiState.initial && !uiState.loading && uiState.canFetchMore
+                        if (isNearTheEnd && canFetchMore) {
                             model.reduce(UserListMviModel.Intent.LoadNextPage)
                         }
                     }


### PR DESCRIPTION
This PR solves a bug due to which groups opened in forum mode were not paginating correctly. Since the bug affected all screens with pagination, these have been updated as well.

Additionally, in timeline cards now both re-share and reply info are displayed.

Finally, it is not possible to open a user page from the circle detail page.