### PR TITLE
fix: cancel follow request dialog, inbox refresh, load data for profile edit

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/AccountSource.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/AccountSource.kt
@@ -1,0 +1,13 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AccountSource(
+    @SerialName("fields") val fields: List<Field> = emptyList(),
+    @SerialName("note") val note: String? = null,
+    @SerialName("privacy") val privacy: String? = null,
+    @SerialName("sensitive") val sensitive: Boolean? = null,
+    @SerialName("language") val language: String? = null,
+)

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/CredentialAccount.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/CredentialAccount.kt
@@ -20,4 +20,8 @@ data class CredentialAccount(
     @SerialName("note") val note: String? = null,
     @SerialName("statuses_count") val statusesCount: Int = 0,
     @SerialName("username") val username: String,
+    @SerialName("discoverable") val discoverable: Boolean = false,
+    @SerialName("noindex") val noIndex: Boolean = false,
+    @SerialName("url") val url: String? = null,
+    @SerialName("source") val source: AccountSource? = null,
 )

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserRelationshipButton.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserRelationshipButton.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
@@ -41,7 +42,10 @@ fun UserRelationshipButton(
                     color = MaterialTheme.colorScheme.onPrimary,
                 )
             }
-            Text(status.toReadableName(userLocked = locked))
+            Text(
+                text = status.toReadableName(userLocked = locked),
+                textAlign = TextAlign.Center,
+            )
         }
     }
     val buttonPadding =

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepository.kt
@@ -59,6 +59,13 @@ internal class DefaultUserRepository(
             }.getOrNull()
         }
 
+    override suspend fun getCurrent(): UserModel? =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                provider.users.verifyCredentials().toModel()
+            }.getOrNull()
+        }
+
     override suspend fun getRelationships(ids: List<String>): List<RelationshipModel> =
         withContext(Dispatchers.IO) {
             runCatching {

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/Mappings.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Account
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.ContentVisibility
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.CredentialAccount
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Field
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaPhoto
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.HistoryItem
@@ -147,6 +148,28 @@ internal fun Account.toModel() =
         displayName = displayName,
         entryCount = statusesCount,
         fields = fields.map { it.toModel() },
+        followers = followersCount,
+        following = followingCount,
+        group = group,
+        handle = acct,
+        header = header,
+        id = id,
+        locked = locked,
+        username = username,
+        discoverable = discoverable,
+        noIndex = noIndex,
+        url = url,
+    )
+
+internal fun CredentialAccount.toModel() =
+    UserModel(
+        avatar = avatar,
+        bio = source?.note ?: note,
+        bot = bot,
+        created = createdAt,
+        displayName = displayName,
+        entryCount = statusesCount,
+        fields = (source?.fields ?: fields).map { it.toModel() },
         followers = followersCount,
         following = followingCount,
         group = group,

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/UserRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/UserRepository.kt
@@ -13,6 +13,8 @@ interface UserRepository {
 
     suspend fun getByHandle(handle: String): UserModel?
 
+    suspend fun getCurrent(): UserModel?
+
     suspend fun getRelationships(ids: List<String>): List<RelationshipModel>
 
     suspend fun getSuggestions(): List<UserModel>

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
@@ -98,6 +98,7 @@ class InboxViewModel(
             return
         }
 
+        val wasRefreshing = uiState.value.refreshing
         updateState { it.copy(loading = true) }
         val notifications = paginationManager.loadNextPage()
         updateState {
@@ -108,6 +109,9 @@ class InboxViewModel(
                 initial = false,
                 refreshing = false,
             )
+        }
+        if (wasRefreshing) {
+            emitEffect(InboxMviModel.Effect.BackToTop)
         }
     }
 

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/di/ProfileModule.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/di/ProfileModule.kt
@@ -46,7 +46,6 @@ val featureProfileModule =
         factory<EditProfileMviModel> {
             EditProfileViewModel(
                 userRepository = get(),
-                identityRepository = get(),
             )
         }
     }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileViewModel.kt
@@ -5,16 +5,11 @@ import cafe.adriel.voyager.core.model.screenModelScope
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.FieldModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.mapNotNull
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 class EditProfileViewModel(
-    private val identityRepository: IdentityRepository,
     private val userRepository: UserRepository,
 ) : DefaultMviModel<EditProfileMviModel.Intent, EditProfileMviModel.State, EditProfileMviModel.Effect>(
         initialState = EditProfileMviModel.State(),
@@ -22,24 +17,22 @@ class EditProfileViewModel(
     EditProfileMviModel {
     init {
         screenModelScope.launch {
-            identityRepository.currentUser
-                .mapNotNull { it?.let { u -> userRepository.getById(u.id) } }
-                .onEach { currentUser ->
-                    updateState {
-                        it.copy(
-                            displayName = TextFieldValue(text = currentUser.displayName.orEmpty()),
-                            avatar = currentUser.avatar,
-                            bio = TextFieldValue(text = currentUser.bio.orEmpty()),
-                            bot = currentUser.bot,
-                            header = currentUser.header,
-                            locked = currentUser.locked,
-                            noIndex = currentUser.noIndex,
-                            discoverable = currentUser.discoverable,
-                            fields = currentUser.fields,
-                            canAddFields = currentUser.fields.size < 4,
-                        )
-                    }
-                }.launchIn(this)
+            userRepository.getCurrent()?.also { currentUser ->
+                updateState {
+                    it.copy(
+                        displayName = TextFieldValue(text = currentUser.displayName.orEmpty()),
+                        avatar = currentUser.avatar,
+                        bio = TextFieldValue(text = currentUser.bio.orEmpty()),
+                        bot = currentUser.bot,
+                        header = currentUser.header,
+                        locked = currentUser.locked,
+                        noIndex = currentUser.noIndex,
+                        discoverable = currentUser.discoverable,
+                        fields = currentUser.fields,
+                        canAddFields = currentUser.fields.size < 4,
+                    )
+                }
+            }
         }
     }
 

--- a/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListScreen.kt
+++ b/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListScreen.kt
@@ -263,8 +263,8 @@ class UserListScreen(
             CustomConfirmDialog(
                 title = LocalStrings.current.actionDeleteFollowRequest,
                 onClose = { confirm ->
-                    val userId = confirmUnfollowDialogUserId
-                    confirmUnfollowDialogUserId = null
+                    val userId = confirmDeleteFollowRequestDialogUserId
+                    confirmDeleteFollowRequestDialogUserId = null
                     if (confirm && userId != null) {
                         model.reduce(UserListMviModel.Intent.Unfollow(userId))
                     }


### PR DESCRIPTION
This PR contains a series of fixes for bugs emerged during testing of 0.1.0-alpha16 version:
- incorrect text align in relationship button
- unable to close the dialog to cancel a pending follow request
- inbox does not scroll to top automatically after refresh
- profile data (bio and fields) should be read preferably from the `source` field of CredentialAccount as per Mastodon docs