### PR TITLE
fix: loading feeds after type change

### DIFF
--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
@@ -67,7 +67,7 @@ class InboxViewModel(
             is InboxMviModel.Intent.ChangeSelectedNotificationTypes ->
                 screenModelScope.launch {
                     updateState {
-                        it.copy(selectedNotificationTypes = intent.types)
+                        it.copy(selectedNotificationTypes = intent.types, initial = true)
                     }
                     emitEffect(InboxMviModel.Effect.BackToTop)
                     refresh(initial = true)

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
@@ -81,11 +81,7 @@ class TimelineViewModel(
                     }
 
                     updateState {
-                        it.copy(
-                            timelineType = intent.type,
-                            entries = emptyList(),
-                            canFetchMore = false,
-                        )
+                        it.copy(timelineType = intent.type, initial = true)
                     }
                     emitEffect(TimelineMviModel.Effect.BackToTop)
                     refresh(initial = true)


### PR DESCRIPTION
This avoids the "empty message" list from being displayed during feed loading.