### PR TITLE
fix: prevent editing default lists

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/FriendicaCircle.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/FriendicaCircle.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class InstanceThumbnail(
-    @SerialName("url") val url: String? = null,
-    @SerialName("blurhash") val blurhash: String? = null,
+data class FriendicaCircle(
+    @SerialName("name") val title: String = "",
+    @SerialName("gid") val id: String,
 )

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Instance.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Instance.kt
@@ -11,7 +11,7 @@ data class Instance(
     @SerialName("source_url") val sourceUrl: String? = null,
     @SerialName("description") val description: String? = null,
     @SerialName("usage") val usage: InstanceUsage? = null,
-    @SerialName("thumbnail") val thumbnail: InstanceThumbnail? = null,
+    @SerialName("thumbnail") val thumbnail: String? = null,
     @SerialName("icon") val icon: List<InstanceIcon> = emptyList(),
     @SerialName("languages") val languages: List<String> = emptyList(),
     @SerialName("rules") val rules: List<InstanceRule> = emptyList(),

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/ListService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/ListService.kt
@@ -3,6 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica.core.api.service
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Account
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.EditListForm
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.EditListMembersForm
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaCircle
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.UserList
 import de.jensklingenberg.ktorfit.http.Body
 import de.jensklingenberg.ktorfit.http.DELETE
@@ -17,6 +18,9 @@ import de.jensklingenberg.ktorfit.http.Query
 interface ListService {
     @GET("v1/lists")
     suspend fun getAll(): List<UserList>
+
+    @GET("friendica/group_show")
+    suspend fun getFriendicaCircles(): List<FriendicaCircle>
 
     @GET("v1/lists/{id}")
     suspend fun getBy(

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/CircleModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/CircleModel.kt
@@ -1,8 +1,12 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.data
 
+import kotlin.jvm.Transient
+
 data class CircleModel(
     val id: String,
     val name: String = "",
     val replyPolicy: CircleReplyPolicy = CircleReplyPolicy.List,
     val exclusive: Boolean = false,
+    @Transient
+    val editable: Boolean = false,
 )

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/CirclesRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/CirclesRepository.kt
@@ -7,6 +7,8 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 interface CirclesRepository {
     suspend fun getAll(): List<CircleModel>
 
+    suspend fun getFriendicaCircles(): List<CircleModel>
+
     suspend fun get(id: String): CircleModel?
 
     suspend fun getMembers(

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultCirclesRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultCirclesRepository.kt
@@ -20,6 +20,13 @@ internal class DefaultCirclesRepository(
             }.getOrElse { emptyList() }
         }
 
+    override suspend fun getFriendicaCircles(): List<CircleModel> =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                provider.lists.getFriendicaCircles().map { it.toModel() }
+            }.getOrElse { emptyList() }
+        }
+
     override suspend fun get(id: String): CircleModel? =
         withContext(Dispatchers.IO) {
             runCatching {

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNodeInfoRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNodeInfoRepository.kt
@@ -11,10 +11,9 @@ internal class DefaultNodeInfoRepository(
 ) : NodeInfoRepository {
     override suspend fun getInfo(): NodeInfoModel? =
         withContext(Dispatchers.IO) {
-            kotlin
-                .runCatching {
-                    provider.instance.getInfo().toModel()
-                }.getOrNull()
+            runCatching {
+                provider.instance.getInfo().toModel()
+            }.getOrNull()
         }
 
     override suspend fun isFriendica(): Boolean =

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/Mappings.kt
@@ -4,6 +4,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Account
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.ContentVisibility
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.CredentialAccount
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Field
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaCircle
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaPhoto
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.HistoryItem
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Instance
@@ -300,6 +301,12 @@ internal fun UserList.toModel() =
         replyPolicy = repliesPolicy?.toModel() ?: CircleReplyPolicy.List,
     )
 
+internal fun FriendicaCircle.toModel() =
+    CircleModel(
+        name = title,
+        id = id,
+    )
+
 internal fun Poll.toModel() =
     PollModel(
         id = id,
@@ -327,7 +334,7 @@ internal fun Instance.toModel() =
         sourceUrl = sourceUrl,
         description = description,
         activeUsers = usage?.users?.activeMonth,
-        thumbnail = thumbnail?.url,
+        thumbnail = thumbnail,
         languages = languages,
         rules = rules.mapNotNull { it.text },
         contact = contactAccount?.toModel(),

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/components/CircleItem.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/components/CircleItem.kt
@@ -48,9 +48,15 @@ internal fun CircleItem(
     Row(
         modifier =
             modifier
-                .clickable {
-                    onClick?.invoke()
-                }.padding(Spacing.s),
+                .then(
+                    if (onClick != null) {
+                        Modifier.clickable {
+                            onClick?.invoke()
+                        }
+                    } else {
+                        Modifier
+                    },
+                ).padding(Spacing.s),
         horizontalArrangement = Arrangement.spacedBy(Spacing.s),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/detail/CircleDetailScreen.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/detail/CircleDetailScreen.kt
@@ -117,6 +117,7 @@ class CircleDetailScreen(
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
+                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = uiState.circle?.name.orEmpty(),
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/di/CirclesModule.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/di/CirclesModule.kt
@@ -11,6 +11,7 @@ val featureCirclesModule =
         factory<CirclesMviModel> {
             CirclesViewModel(
                 circlesRepository = get(),
+                nodeInfoRepository = get(),
             )
         }
         factory<CircleDetailMviModel> { params ->

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/list/CirclesScreen.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/list/CirclesScreen.kt
@@ -199,11 +199,13 @@ class CirclesScreen : Screen {
                             circle = circle,
                             onClick = {
                                 detailOpener.openCircle(circle.id)
-                            },
+                            }.takeIf { circle.editable },
                             options =
                                 buildList {
-                                    this += OptionId.Edit.toOption()
-                                    this += OptionId.Delete.toOption()
+                                    if (circle.editable) {
+                                        this += OptionId.Edit.toOption()
+                                        this += OptionId.Delete.toOption()
+                                    }
                                 },
                             onOptionSelected = { optionId ->
                                 when (optionId) {

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/list/CirclesScreen.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/list/CirclesScreen.kt
@@ -110,6 +110,7 @@ class CirclesScreen : Screen {
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
+                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = LocalStrings.current.manageCirclesTitle,
                             style = MaterialTheme.typography.titleMedium,
                         )
@@ -197,9 +198,10 @@ class CirclesScreen : Screen {
                     ) { circle ->
                         CircleItem(
                             circle = circle,
-                            onClick = {
-                                detailOpener.openCircle(circle.id)
-                            }.takeIf { circle.editable },
+                            onClick =
+                                {
+                                    detailOpener.openCircle(circle.id)
+                                }.takeIf { circle.editable },
                             options =
                                 buildList {
                                     if (circle.editable) {

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
@@ -152,20 +152,23 @@ class ComposerScreen(
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
+                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = LocalStrings.current.createPostTitle,
                             style = MaterialTheme.typography.titleMedium,
                         )
                     },
                     navigationIcon = {
-                        Image(
-                            modifier =
-                                Modifier.clickable {
-                                    navigationCoordinator.pop()
-                                },
-                            imageVector = Icons.AutoMirrored.Default.ArrowBack,
-                            contentDescription = null,
-                            colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
-                        )
+                        if (navigationCoordinator.canPop.value) {
+                            Image(
+                                modifier =
+                                    Modifier.clickable {
+                                        navigationCoordinator.pop()
+                                    },
+                                imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                                contentDescription = null,
+                                colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
+                            )
+                        }
                     },
                     actions = {
                         IconButton(

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -132,6 +132,7 @@ class EntryDetailScreen(
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
+                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text =
                                 buildString {
                                     append(LocalStrings.current.postTitle)
@@ -300,9 +301,9 @@ class EntryDetailScreen(
                                                 entry = e,
                                                 choices = choices,
                                             ),
-                                    )
-                                }
-                            },
+                                        )
+                                    }
+                                },
                             onToggleSpoilerActive = { e ->
                                 model.reduce(EntryDetailMviModel.Intent.ToggleSpoilerActive(e))
                             },

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
@@ -148,6 +148,7 @@ class ExploreScreen : Screen {
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
+                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = LocalStrings.current.sectionTitleExplore,
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
@@ -120,6 +120,7 @@ class FavoritesScreen(
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
+                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = type.toReadableName(),
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/followrequests/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/followrequests/FollowRequestsScreen.kt
+++ b/feature/followrequests/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/followrequests/FollowRequestsScreen.kt
@@ -78,6 +78,7 @@ class FollowRequestsScreen : Screen {
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
+                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = LocalStrings.current.followRequestsTitle,
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/followed/FollowedHashtagsScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/followed/FollowedHashtagsScreen.kt
@@ -81,6 +81,7 @@ class FollowedHashtagsScreen : Screen {
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
+                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = LocalStrings.current.followedHashtagsTitle,
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
@@ -124,6 +124,7 @@ class HashtagScreen(
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
+                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = "#$tag",
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/imagedetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/imagedetail/ImageDetailScreen.kt
+++ b/feature/imagedetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/imagedetail/ImageDetailScreen.kt
@@ -94,15 +94,17 @@ class ImageDetailScreen(
                 TopAppBar(
                     title = {},
                     navigationIcon = {
-                        Icon(
-                            modifier =
-                                Modifier.clickable {
-                                    navigationCoordinator.pop()
-                                },
-                            imageVector = Icons.AutoMirrored.Default.ArrowBack,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onBackground,
-                        )
+                        if (navigationCoordinator.canPop.value) {
+                            Icon(
+                                modifier =
+                                    Modifier.clickable {
+                                        navigationCoordinator.pop()
+                                    },
+                                imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onBackground,
+                            )
+                        }
                     },
                     actions = {
                         IconButton(

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
@@ -112,6 +112,7 @@ class InboxScreen : Screen {
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
+                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = LocalStrings.current.sectionTitleInbox,
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/legacy/LegacyLoginScreen.kt
+++ b/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/legacy/LegacyLoginScreen.kt
@@ -112,20 +112,23 @@ class LegacyLoginScreen : Screen {
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
+                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = LocalStrings.current.loginTitle,
                             style = MaterialTheme.typography.titleMedium,
                         )
                     },
                     navigationIcon = {
-                        Image(
-                            modifier =
-                                Modifier.clickable {
-                                    navigationCoordinator.pop()
-                                },
-                            imageVector = Icons.AutoMirrored.Default.ArrowBack,
-                            contentDescription = null,
-                            colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
-                        )
+                        if (navigationCoordinator.canPop.value) {
+                            Image(
+                                modifier =
+                                    Modifier.clickable {
+                                        navigationCoordinator.pop()
+                                    },
+                                imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                                contentDescription = null,
+                                colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
+                            )
+                        }
                     },
                 )
             },

--- a/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/oauth/LoginScreen.kt
+++ b/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/oauth/LoginScreen.kt
@@ -99,20 +99,23 @@ class LoginScreen : Screen {
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
+                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = LocalStrings.current.loginTitle,
                             style = MaterialTheme.typography.titleMedium,
                         )
                     },
                     navigationIcon = {
-                        Image(
-                            modifier =
-                                Modifier.clickable {
-                                    navigationCoordinator.pop()
-                                },
-                            imageVector = Icons.AutoMirrored.Default.ArrowBack,
-                            contentDescription = null,
-                            colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
-                        )
+                        if (navigationCoordinator.canPop.value) {
+                            Image(
+                                modifier =
+                                    Modifier.clickable {
+                                        navigationCoordinator.pop()
+                                    },
+                                imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                                contentDescription = null,
+                                colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
+                            )
+                        }
                     },
                 )
             },

--- a/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/ManageBlocksScreen.kt
+++ b/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/ManageBlocksScreen.kt
@@ -112,6 +112,7 @@ class ManageBlocksScreen : Screen {
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
+                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = LocalStrings.current.settingsItemBlockedAndMuted,
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
@@ -40,6 +40,7 @@ import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
 import cafe.adriel.voyager.navigator.Navigator
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomImage
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomModalBottomSheet
@@ -81,6 +82,7 @@ class ProfileScreen : Screen {
                         scrollBehavior = scrollBehavior,
                         title = {
                             Text(
+                                modifier = Modifier.padding(horizontal = Spacing.s),
                                 text = LocalStrings.current.sectionTitleProfile,
                                 style = MaterialTheme.typography.titleMedium,
                             )

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileScreen.kt
@@ -122,6 +122,7 @@ class EditProfileScreen : Screen {
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
+                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = LocalStrings.current.editProfileTitle,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
@@ -132,6 +132,7 @@ class ThreadScreen(
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
+                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = LocalStrings.current.threadTitle,
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
@@ -154,6 +154,7 @@ class TimelineScreen : Screen {
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
+                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = uiState.timelineType?.toReadableName().orEmpty(),
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -170,6 +170,7 @@ class UserDetailScreen(
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
+                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = uiState.user?.handle.orEmpty(),
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
@@ -134,6 +134,7 @@ class ForumListScreen(
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
+                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text =
                                 buildString {
                                     append(LocalStrings.current.topicTitle)

--- a/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListScreen.kt
+++ b/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListScreen.kt
@@ -115,6 +115,7 @@ class UserListScreen(
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
+                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text =
                                 buildString {
                                     when (type) {


### PR DESCRIPTION
This PR introduces the distinction between Friendica's default lists (a.k.a. "channels") which can not be modified by users via Mastodon-style REST APIs and user-defined circles which, in turn, can.