### PR TITLE
enhancement: propagate update user events • 2

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Account.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Account.kt
@@ -20,7 +20,7 @@ data class Account(
     @SerialName("note") val note: String? = null,
     @SerialName("statuses_count") val statusesCount: Int = 0,
     @SerialName("username") val username: String,
-    @SerialName("discoverable") val discoverable: Boolean = false,
+    @SerialName("discoverable") val discoverable: Boolean? = null,
     @SerialName("noindex") val noIndex: Boolean = false,
     @SerialName("url") val url: String? = null,
 )

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/CredentialAccount.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/CredentialAccount.kt
@@ -20,7 +20,7 @@ data class CredentialAccount(
     @SerialName("note") val note: String? = null,
     @SerialName("statuses_count") val statusesCount: Int = 0,
     @SerialName("username") val username: String,
-    @SerialName("discoverable") val discoverable: Boolean = false,
+    @SerialName("discoverable") val discoverable: Boolean? = null,
     @SerialName("noindex") val noIndex: Boolean = false,
     @SerialName("url") val url: String? = null,
     @SerialName("source") val source: AccountSource? = null,

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
@@ -60,6 +60,7 @@ val domainContentPaginationModule =
         factory<SearchPaginationManager> {
             DefaultSearchPaginationManager(
                 searchRepository = get(),
+                userRepository = get(),
                 notificationCenter = get(),
             )
         }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
@@ -162,7 +162,7 @@ internal fun Account.toModel() =
         id = id,
         locked = locked,
         username = username,
-        discoverable = discoverable,
+        discoverable = discoverable ?: true,
         noIndex = noIndex,
         url = url,
     )
@@ -184,7 +184,7 @@ internal fun CredentialAccount.toModel() =
         id = id,
         locked = locked,
         username = username,
-        discoverable = discoverable,
+        discoverable = discoverable ?: true,
         noIndex = noIndex,
         url = url,
     )

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreViewModel.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreViewModel.kt
@@ -61,6 +61,11 @@ class ExploreViewModel(
                         )
                     }
                 }.launchIn(this)
+            notificationCenter
+                .subscribe(UserUpdatedEvent::class)
+                .onEach { event ->
+                    updateUserInState(event.user.id) { event.user }
+                }.launchIn(this)
             if (uiState.value.initial) {
                 refresh(initial = true)
             }

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchViewModel.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchViewModel.kt
@@ -58,6 +58,11 @@ class SearchViewModel(
                 .onEach {
                     refresh()
                 }.launchIn(this)
+            notificationCenter
+                .subscribe(UserUpdatedEvent::class)
+                .onEach { event ->
+                    updateUserInState(event.user.id) { event.user }
+                }.launchIn(this)
             if (uiState.value.initial) {
                 refresh(initial = true)
             }

--- a/feature/userdetail/build.gradle.kts
+++ b/feature/userdetail/build.gradle.kts
@@ -45,6 +45,7 @@ kotlin {
                 implementation(projects.core.commonui.content)
                 implementation(projects.core.l10n)
                 implementation(projects.core.navigation)
+                implementation(projects.core.notifications)
                 implementation(projects.core.utils)
 
                 implementation(projects.domain.content.data)

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailViewModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailViewModel.kt
@@ -3,6 +3,8 @@ package com.livefast.eattrash.feature.userdetail.classic
 import cafe.adriel.voyager.core.model.screenModelScope
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.UserSection
+import com.livefast.eattrash.raccoonforfriendica.core.notifications.NotificationCenter
+import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.UserUpdatedEvent
 import com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate.HapticFeedback
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toNotificationStatus
@@ -26,6 +28,7 @@ class UserDetailViewModel(
     private val identityRepository: IdentityRepository,
     private val settingsRepository: SettingsRepository,
     private val hapticFeedback: HapticFeedback,
+    private val notificationCenter: NotificationCenter,
 ) : DefaultMviModel<UserDetailMviModel.Intent, UserDetailMviModel.State, UserDetailMviModel.Effect>(
         initialState = UserDetailMviModel.State(),
     ),
@@ -156,11 +159,14 @@ class UserDetailViewModel(
             updateState {
                 it.copy(
                     user =
-                        it.user?.copy(
-                            relationshipStatus = newStatus,
-                            notificationStatus = newNotificationStatus,
-                            relationshipStatusPending = false,
-                        ),
+                        it.user
+                            ?.copy(
+                                relationshipStatus = newStatus,
+                                notificationStatus = newNotificationStatus,
+                                relationshipStatusPending = false,
+                            )?.also { user ->
+                                notificationCenter.send(UserUpdatedEvent(user = user))
+                            },
                 )
             }
         }
@@ -177,11 +183,14 @@ class UserDetailViewModel(
             updateState {
                 it.copy(
                     user =
-                        it.user?.copy(
-                            relationshipStatus = newStatus,
-                            notificationStatus = newNotificationStatus,
-                            relationshipStatusPending = false,
-                        ),
+                        it.user
+                            ?.copy(
+                                relationshipStatus = newStatus,
+                                notificationStatus = newNotificationStatus,
+                                relationshipStatusPending = false,
+                            )?.also { user ->
+                                notificationCenter.send(UserUpdatedEvent(user = user))
+                            },
                 )
             }
         }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/di/UserDetailModule.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/di/UserDetailModule.kt
@@ -17,6 +17,7 @@ val featureUserDetailModule =
                 identityRepository = get(),
                 settingsRepository = get(),
                 hapticFeedback = get(),
+                notificationCenter = get(),
             )
         }
         factory<ForumListMviModel> { params ->

--- a/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListViewModel.kt
+++ b/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListViewModel.kt
@@ -12,6 +12,8 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.UserPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.UserPaginationSpecification
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 internal class UserListViewModel(
@@ -26,6 +28,11 @@ internal class UserListViewModel(
     UserListMviModel {
     init {
         screenModelScope.launch {
+            notificationCenter
+                .subscribe(UserUpdatedEvent::class)
+                .onEach { event ->
+                    updateUserInState(event.user.id) { event.user }
+                }.launchIn(this)
             if (uiState.value.initial) {
                 loadUser()
                 refresh(initial = true)


### PR DESCRIPTION
This PR continues the work of #163 and further improves listening to user updates (e.g. when you follow/unfollow a user in the detail screen and go back to the previous list or you refresh the list).