### PR TITLE
enhancement: listen for update events concerning entries and tags

### DIFF
--- a/core/notifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/notifications/events/Events.kt
+++ b/core/notifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/notifications/events/Events.kt
@@ -1,7 +1,17 @@
 package com.livefast.eattrash.raccoonforfriendica.core.notifications.events
 
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TagModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 
 data class UserUpdatedEvent(
     val user: UserModel,
+) : NotificationCenterEvent
+
+data class TimelineEntryUpdatedEvent(
+    val entry: TimelineEntryModel,
+) : NotificationCenterEvent
+
+data class TagUpdatedEvent(
+    val tag: TagModel,
 ) : NotificationCenterEvent

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultSearchPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultSearchPaginationManager.kt
@@ -1,6 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
 
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.NotificationCenter
+import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.TimelineEntryUpdatedEvent
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.UserUpdatedEvent
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.ExploreItemModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.SearchResultType
@@ -16,6 +17,7 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -33,19 +35,38 @@ internal class DefaultSearchPaginationManager(
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
 
     init {
-        notificationCenter
-            .subscribe(UserUpdatedEvent::class)
-            .onEach { event ->
-                mutex.withLock {
-                    val idx =
-                        history.indexOfFirst { e -> e is ExploreItemModel.User && e.user.id == event.user.id }
-                    if (idx >= 0) {
-                        (history[idx] as? ExploreItemModel.User)?.copy(user = event.user)?.also {
-                            history[idx] = it
+        scope.launch {
+            notificationCenter
+                .subscribe(UserUpdatedEvent::class)
+                .onEach { event ->
+                    mutex.withLock {
+                        val idx =
+                            history.indexOfFirst { e -> e is ExploreItemModel.User && e.user.id == event.user.id }
+                        if (idx >= 0) {
+                            (history[idx] as? ExploreItemModel.User)
+                                ?.copy(user = event.user)
+                                ?.also {
+                                    history[idx] = it
+                                }
                         }
                     }
-                }
-            }.launchIn(scope)
+                }.launchIn(this)
+            notificationCenter
+                .subscribe(TimelineEntryUpdatedEvent::class)
+                .onEach { event ->
+                    mutex.withLock {
+                        val idx =
+                            history.indexOfFirst { e -> e is ExploreItemModel.Entry && e.entry.id == event.entry.id }
+                        if (idx >= 0) {
+                            (history[idx] as? ExploreItemModel.Entry)
+                                ?.copy(entry = event.entry)
+                                ?.also {
+                                    history[idx] = it
+                                }
+                        }
+                    }
+                }.launchIn(this)
+        }
     }
 
     override suspend fun reset(specification: SearchPaginationSpecification) {

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/TimelinePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/TimelinePaginationManager.kt
@@ -12,5 +12,5 @@ interface TimelinePaginationManager {
 
     fun extractState(): TimelinePaginationManagerState
 
-    fun restoreState(state: TimelinePaginationManagerState)
+    suspend fun restoreState(state: TimelinePaginationManagerState)
 }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
@@ -24,6 +24,7 @@ val domainContentPaginationModule =
             DefaultTimelinePaginationManager(
                 timelineRepository = get(),
                 timelineEntryRepository = get(),
+                notificationCenter = get(),
             )
         }
         factory<NotificationsPaginationManager> {

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
@@ -51,6 +51,7 @@ val domainContentPaginationModule =
         factory<FavoritesPaginationManager> {
             DefaultFavoritesPaginationManager(
                 timelineEntryRepository = get(),
+                notificationCenter = get(),
             )
         }
         factory<FollowedHashtagsPaginationManager> {

--- a/feature/entrydetail/build.gradle.kts
+++ b/feature/entrydetail/build.gradle.kts
@@ -45,6 +45,7 @@ kotlin {
                 implementation(projects.core.commonui.content)
                 implementation(projects.core.l10n)
                 implementation(projects.core.navigation)
+                implementation(projects.core.notifications)
                 implementation(projects.core.utils)
 
                 implementation(projects.domain.content.data)

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/di/EntryDetailModule.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/di/EntryDetailModule.kt
@@ -14,6 +14,7 @@ val featureEntryDetailModule =
                 settingsRepository = get(),
                 userRepository = get(),
                 hapticFeedback = get(),
+                notificationCenter = get(),
             )
         }
     }

--- a/feature/favorites/build.gradle.kts
+++ b/feature/favorites/build.gradle.kts
@@ -46,6 +46,7 @@ kotlin {
                 implementation(projects.core.commonui.content)
                 implementation(projects.core.l10n)
                 implementation(projects.core.navigation)
+                implementation(projects.core.notifications)
                 implementation(projects.core.utils)
 
                 implementation(projects.domain.content.data)

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/di/FavoritesModule.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/di/FavoritesModule.kt
@@ -15,6 +15,7 @@ val featureFavoritesModule =
                 identityRepository = get(),
                 userRepository = get(),
                 hapticFeedback = get(),
+                notificationCenter = get(),
             )
         }
     }

--- a/feature/hashtag/build.gradle.kts
+++ b/feature/hashtag/build.gradle.kts
@@ -46,6 +46,7 @@ kotlin {
                 implementation(projects.core.commonui.content)
                 implementation(projects.core.l10n)
                 implementation(projects.core.navigation)
+                implementation(projects.core.notifications)
                 implementation(projects.core.utils)
 
                 implementation(projects.domain.content.data)

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/di/HashtagModule.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/di/HashtagModule.kt
@@ -18,6 +18,7 @@ val featureHashtagModule =
                 identityRepository = get(),
                 userRepository = get(),
                 hapticFeedback = get(),
+                notificationCenter = get(),
             )
         }
         factory<FollowedHashtagsMviModel> {

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/di/HashtagModule.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/di/HashtagModule.kt
@@ -26,6 +26,7 @@ val featureHashtagModule =
                 paginationManager = get(),
                 tagRepository = get(),
                 hapticFeedback = get(),
+                notificationCenter = get(),
             )
         }
     }

--- a/feature/nodeinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/NodeInfoScreen.kt
+++ b/feature/nodeinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/NodeInfoScreen.kt
@@ -350,20 +350,26 @@ private fun ContactUserItem(
                 modifier = Modifier.weight(1f).padding(vertical = Spacing.s),
                 verticalArrangement = Arrangement.spacedBy(Spacing.xs),
             ) {
-                Text(
-                    text = user.displayName ?: user.username ?: "",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = fullColor,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                Text(
-                    text = user.handle ?: "",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = ancillaryColor,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
+                val title = user.displayName ?: user.username ?: ""
+                val subtitle = user.handle ?: ""
+                if (!title.isNullOrBlank()) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = fullColor,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                if (!subtitle.isNullOrBlank()) {
+                    Text(
+                        text = user.handle ?: "",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = ancillaryColor,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
             }
 
             Icon(

--- a/feature/profile/build.gradle.kts
+++ b/feature/profile/build.gradle.kts
@@ -45,6 +45,7 @@ kotlin {
                 implementation(projects.core.commonui.content)
                 implementation(projects.core.l10n)
                 implementation(projects.core.navigation)
+                implementation(projects.core.notifications)
                 implementation(projects.core.utils)
 
                 implementation(projects.domain.content.data)

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/di/ProfileModule.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/di/ProfileModule.kt
@@ -33,6 +33,7 @@ val featureProfileModule =
                 myAccountCache = get(),
                 settingsRepository = get(),
                 hapticFeedback = get(),
+                notificationCenter = get(),
             )
         }
         factory<AnonymousMviModel> {

--- a/feature/thread/build.gradle.kts
+++ b/feature/thread/build.gradle.kts
@@ -45,6 +45,7 @@ kotlin {
                 implementation(projects.core.commonui.content)
                 implementation(projects.core.l10n)
                 implementation(projects.core.navigation)
+                implementation(projects.core.notifications)
                 implementation(projects.core.utils)
 
                 implementation(projects.domain.content.data)

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/di/ThreadModule.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/di/ThreadModule.kt
@@ -22,6 +22,7 @@ val featureThreadModule =
                 settingsRepository = get(),
                 userRepository = get(),
                 hapticFeedback = get(),
+                notificationCenter = get(),
             )
         }
     }

--- a/feature/timeline/build.gradle.kts
+++ b/feature/timeline/build.gradle.kts
@@ -46,6 +46,7 @@ kotlin {
                 implementation(projects.core.commonui.content)
                 implementation(projects.core.l10n)
                 implementation(projects.core.navigation)
+                implementation(projects.core.notifications)
                 implementation(projects.core.utils)
 
                 implementation(projects.domain.content.data)

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/di/TimelineModule.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/di/TimelineModule.kt
@@ -16,6 +16,7 @@ val featureTimelineModule =
                 userRepository = get(),
                 circlesRepository = get(),
                 hapticFeedback = get(),
+                notificationCenter = get(),
             )
         }
     }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/di/UserDetailModule.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/di/UserDetailModule.kt
@@ -29,6 +29,7 @@ val featureUserDetailModule =
                 identityRepository = get(),
                 settingsRepository = get(),
                 hapticFeedback = get(),
+                notificationCenter = get(),
             )
         }
     }

--- a/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListViewModel.kt
+++ b/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListViewModel.kt
@@ -33,6 +33,7 @@ internal class UserListViewModel(
                 .onEach { event ->
                     updateUserInState(event.user.id) { event.user }
                 }.launchIn(this)
+
             if (uiState.value.initial) {
                 loadUser()
                 refresh(initial = true)


### PR DESCRIPTION
This PR extend the work done in #163 and #164 for users to posts and hashtags. Now changes in favorite/bookmark/reshare for posts and follow/unfollow for hashtags are propagated among different screens and pagination.