### PR TITLE
feat: add new account from the manage accounts bottom sheet

### DIFF
--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -268,4 +268,5 @@ internal open class DefaultStrings : Strings {
     override val nodeInfoTitle = "Node info"
     override val nodeInfoSectionRules = "Rules"
     override val nodeInfoSectionContact = "Contact"
+    override val actionAddNew = "Add new"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -274,4 +274,5 @@ internal val ItStrings =
         override val nodeInfoTitle = "Informazioni istanza"
         override val nodeInfoSectionRules = "Regole"
         override val nodeInfoSectionContact = "Contatto"
+        override val actionAddNew = "Aggiungi nuovo"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -251,6 +251,7 @@ interface Strings {
     val nodeInfoTitle: String
     val nodeInfoSectionRules: String
     val nodeInfoSectionContact: String
+    val actionAddNew: String
 }
 
 object Locales {

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileMviModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileMviModel.kt
@@ -19,6 +19,8 @@ interface ProfileMviModel :
         data class DeleteAccount(
             val account: AccountModel,
         ) : Intent
+
+        data object AddAccount : Intent
     }
 
     data class State(

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Logout
+import androidx.compose.material.icons.filled.AddCircle
 import androidx.compose.material.icons.filled.ManageAccounts
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -177,7 +178,20 @@ class ProfileScreen : Screen {
                             )
                         },
                     )
-                }
+                } +
+                    CustomModalBottomSheetItem(
+                        label = LocalStrings.current.actionAddNew,
+                        leadingContent = {
+                            IconButton(
+                                onClick = {},
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.AddCircle,
+                                    contentDescription = null,
+                                )
+                            }
+                        },
+                    )
             CustomModalBottomSheet(
                 title = LocalStrings.current.actionSwitchAccount,
                 sheetState = sheetState,
@@ -185,8 +199,13 @@ class ProfileScreen : Screen {
                 onSelected = { index ->
                     manageAccountsDialogOpened = false
                     if (index != null) {
-                        val selectedAccount = uiState.availableAccounts[index]
-                        model.reduce(ProfileMviModel.Intent.SwitchAccount(selectedAccount))
+                        val accounts = uiState.availableAccounts
+                        if (index in accounts.indices) {
+                            val selectedAccount = accounts[index]
+                            model.reduce(ProfileMviModel.Intent.SwitchAccount(selectedAccount))
+                        } else {
+                            model.reduce(ProfileMviModel.Intent.AddAccount)
+                        }
                     }
                 },
                 onLongPress = { index ->

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileViewModel.kt
@@ -4,6 +4,7 @@ import cafe.adriel.voyager.core.model.screenModelScope
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AuthManager
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DeleteAccountUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.LogoutUseCase
@@ -20,6 +21,7 @@ class ProfileViewModel(
     private val switchAccountUseCase: SwitchAccountUseCase,
     private val deleteAccountUseCase: DeleteAccountUseCase,
     private val myAccountCache: MyAccountCache,
+    private val authManager: AuthManager,
 ) : DefaultMviModel<ProfileMviModel.Intent, ProfileMviModel.State, ProfileMviModel.Effect>(
         initialState = ProfileMviModel.State(),
     ),
@@ -61,6 +63,7 @@ class ProfileViewModel(
 
             is ProfileMviModel.Intent.SwitchAccount -> switchAccount(intent.account)
             is ProfileMviModel.Intent.DeleteAccount -> deleteAccount(intent.account)
+            ProfileMviModel.Intent.AddAccount -> authManager.openLogin()
         }
     }
 

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/di/ProfileModule.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/di/ProfileModule.kt
@@ -22,6 +22,7 @@ val featureProfileModule =
                 switchAccountUseCase = get(),
                 deleteAccountUseCase = get(),
                 myAccountCache = get(),
+                authManager = get(),
             )
         }
         factory<MyAccountMviModel> {


### PR DESCRIPTION
This PR implements the possibility to add a new account directly from the "Manage accounts" bottom sheet, without having to logout first.