### PR TITLE
feat: direct messages • part 2

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -77,6 +77,7 @@ kotlin {
 
             implementation(projects.feature.circles)
             implementation(projects.feature.composer)
+            implementation(projects.feature.directmessages)
             implementation(projects.feature.drawer)
             implementation(projects.feature.entrydetail)
             implementation(projects.feature.explore)

--- a/composeApp/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/DiHelper.kt
+++ b/composeApp/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/DiHelper.kt
@@ -22,6 +22,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di.d
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.domainIdentityUseCaseModule
 import com.livefast.eattrash.raccoonforfriendica.feature.circles.di.featureCirclesModule
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.di.featureComposerModule
+import com.livefast.eattrash.raccoonforfriendica.feature.directmessages.di.featureDirectMessagesModule
 import com.livefast.eattrash.raccoonforfriendica.feature.drawer.di.featureDrawerModule
 import com.livefast.eattrash.raccoonforfriendica.feature.entrydetail.di.featureEntryDetailModule
 import com.livefast.eattrash.raccoonforfriendica.feature.explore.di.featureExploreModule
@@ -85,5 +86,6 @@ val sharedHelperModule =
             featureSearchModule,
             featureThreadModule,
             featureNodeInfoModule,
+            featureDirectMessagesModule,
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
@@ -10,6 +10,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Iden
 import com.livefast.eattrash.raccoonforfriendica.feature.circles.detail.CircleDetailScreen
 import com.livefast.eattrash.raccoonforfriendica.feature.circles.list.CirclesScreen
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.ComposerScreen
+import com.livefast.eattrash.raccoonforfriendica.feature.directmessages.list.DirectMessageListScreen
 import com.livefast.eattrash.raccoonforfriendica.feature.entrydetail.EntryDetailScreen
 import com.livefast.eattrash.raccoonforfriendica.feature.favorites.FavoritesScreen
 import com.livefast.eattrash.raccoonforfriendica.feature.followrequests.FollowRequestsScreen
@@ -174,6 +175,11 @@ class DefaultDetailOpener(
 
     override fun openNodeInfo() {
         val screen = NodeInfoScreen()
+        navigationCoordinator.push(screen)
+    }
+
+    override fun openDirectMessages() {
+        val screen = DirectMessageListScreen()
         navigationCoordinator.push(screen)
     }
 }

--- a/composeApp/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/DiHelper.kt
+++ b/composeApp/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/DiHelper.kt
@@ -22,6 +22,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di.d
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.domainIdentityUseCaseModule
 import com.livefast.eattrash.raccoonforfriendica.feature.circles.di.featureCirclesModule
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.di.featureComposerModule
+import com.livefast.eattrash.raccoonforfriendica.feature.directmessages.di.featureDirectMessagesModule
 import com.livefast.eattrash.raccoonforfriendica.feature.drawer.di.featureDrawerModule
 import com.livefast.eattrash.raccoonforfriendica.feature.entrydetail.di.featureEntryDetailModule
 import com.livefast.eattrash.raccoonforfriendica.feature.explore.di.featureExploreModule
@@ -87,6 +88,7 @@ fun initKoin(): Koin {
                 featureSearchModule,
                 featureThreadModule,
                 featureNodeInfoModule,
+                featureDirectMessagesModule,
             )
         }
     return koinApp.koin

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/FriendicaPrivateMessage.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/FriendicaPrivateMessage.kt
@@ -11,6 +11,7 @@ data class FriendicaPrivateMessage(
     @SerialName("recipient") val recipient: FriendicaContact? = null,
     @SerialName("recipient_id") val recipientId: Long? = null,
     @SerialName("text") val text: String? = null,
+    @SerialName("created_at") val createdAt: String? = null,
     @SerialName("title") val title: String? = null,
     @SerialName("sender_screen_name") val senderScreenName: String? = null,
     @SerialName("recipient_screen_name") val recipientScreenName: String? = null,

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DirectMessageService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DirectMessageService.kt
@@ -10,7 +10,7 @@ import de.jensklingenberg.ktorfit.http.Query
 import io.ktor.client.request.forms.FormDataContent
 
 interface DirectMessageService {
-    @GET("api/direct_messages")
+    @GET("direct_messages")
     suspend fun getAll(
         @Query("count") count: Int,
         @Query("page") page: Int,
@@ -18,7 +18,7 @@ interface DirectMessageService {
         @Query("getText") getText: String = "html",
     ): List<FriendicaPrivateMessage>
 
-    @GET("api/direct_messages/conversation")
+    @GET("direct_messages/conversation")
     suspend fun getConversation(
         @Query("uri") uri: String,
         @Query("count") count: Int,
@@ -27,18 +27,18 @@ interface DirectMessageService {
         @Query("getText") getText: String = "html",
     ): List<FriendicaPrivateMessage>
 
-    @POST("api/direct_messages/new")
+    @POST("direct_messages/new")
     suspend fun create(
         @Body data: FormDataContent,
     ): FriendicaApiResult
 
-    @POST("api/direct_messages/destroy")
+    @POST("direct_messages/destroy")
     @Headers("Content-Type: application/json")
     suspend fun delete(
         @Query("id") id: Long,
     ): FriendicaApiResult
 
-    @GET("api/friendica/direct_messages_setseen")
+    @GET("friendica/direct_messages_setseen")
     suspend fun markAsRead(
         @Query("id") id: Long,
     ): FriendicaApiResult

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -269,4 +269,11 @@ internal open class DefaultStrings : Strings {
     override val nodeInfoSectionRules = "Rules"
     override val nodeInfoSectionContact = "Contact"
     override val actionAddNew = "Add new"
+    override val directMessagesTitle = "Direct messages"
+
+    override fun messages(count: Int): String =
+        when (count) {
+            1 -> "message"
+            else -> "messages"
+        }
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -275,4 +275,11 @@ internal val ItStrings =
         override val nodeInfoSectionRules = "Regole"
         override val nodeInfoSectionContact = "Contatto"
         override val actionAddNew = "Aggiungi nuovo"
+        override val directMessagesTitle = "Messaggi diretti"
+
+        override fun messages(count: Int): String =
+            when (count) {
+                1 -> "messaggio"
+                else -> "messaggi"
+            }
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -252,6 +252,9 @@ interface Strings {
     val nodeInfoSectionRules: String
     val nodeInfoSectionContact: String
     val actionAddNew: String
+    val directMessagesTitle: String
+
+    fun messages(count: Int): String
 }
 
 object Locales {

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DetailOpener.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DetailOpener.kt
@@ -60,4 +60,6 @@ interface DetailOpener {
     fun openEditProfile()
 
     fun openNodeInfo()
+
+    fun openDirectMessages()
 }

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
@@ -15,9 +15,12 @@ import java.time.Duration as JavaDuration
 
 actual fun epochMillis(): Long = System.currentTimeMillis()
 
+private val formatter =
+    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'", Locale.US).apply {
+        timeZone = TimeZone.getTimeZone("UTC")
+    }
+
 actual fun Long.toIso8601Timestamp(): String? {
-    val formatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'", Locale.US)
-    formatter.timeZone = TimeZone.getTimeZone("UTC")
     val date = Date(this)
     return formatter.format(date)
 }
@@ -30,6 +33,16 @@ actual fun getFormattedDate(
     val formatter = DateTimeFormatter.ofPattern(format)
     return date.format(formatter)
 }
+
+actual fun parseDate(
+    value: String,
+    format: String,
+): String =
+    SimpleDateFormat(format, Locale.US)
+        .apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }.parse(value)
+        ?.let { formatter.format(it) }.orEmpty()
 
 actual fun getPrettyDate(
     iso8601Timestamp: String,

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
@@ -13,10 +13,15 @@ expect fun epochMillis(): Long
 expect fun Long.toIso8601Timestamp(): String?
 
 /**
- * Represents a date with a given format.
+ * Converts a date (in the ISO 8601 format) to another given format.
  */
 expect fun getFormattedDate(
     iso8601Timestamp: String,
+    format: String,
+): String
+
+expect fun parseDate(
+    value: String,
     format: String,
 ): String
 

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
@@ -45,6 +45,19 @@ actual fun getFormattedDate(
     return dateFormatter.stringFromDate(date)
 }
 
+actual fun parseDate(
+    value: String,
+    format: String,
+): String {
+    val dateFormatter = NSDateFormatter()
+    dateFormatter.timeZone = NSTimeZone.localTimeZone
+    dateFormatter.locale = NSLocale.autoupdatingCurrentLocale
+    dateFormatter.dateFormat = format
+
+    val date = dateFormatter.dateFromString(value) ?: return ""
+    return NSISO8601DateFormatter().stringFromDate(date)
+}
+
 actual fun getPrettyDate(
     iso8601Timestamp: String,
     yearLabel: String,

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/ConversationModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/ConversationModel.kt
@@ -1,0 +1,7 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.data
+
+data class ConversationModel(
+    val otherUser: UserModel,
+    val lastMessage: DirectMessageModel,
+    val messageCount: Int = 0,
+)

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/DirectMessageModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/DirectMessageModel.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.data
 
 data class DirectMessageModel(
     val id: String,
+    val created: String? = null,
     val text: String? = null,
     val title: String? = null,
     val read: Boolean = true,

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultDirectMessagesPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultDirectMessagesPaginationManager.kt
@@ -1,0 +1,57 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.DirectMessageModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DirectMessageRepository
+
+internal class DefaultDirectMessagesPaginationManager(
+    private val directMessageRepository: DirectMessageRepository,
+) : DirectMessagesPaginationManager {
+    private var specification: DirectMessagesPaginationSpecification? = null
+    private var page = 0
+    override var canFetchMore: Boolean = true
+    private val history = mutableListOf<DirectMessageModel>()
+
+    override suspend fun reset(specification: DirectMessagesPaginationSpecification) {
+        this.specification = specification
+        page = 0
+        history.clear()
+        canFetchMore = true
+    }
+
+    override suspend fun loadNextPage(): List<DirectMessageModel> {
+        val specification = this.specification ?: return emptyList()
+
+        val results =
+            when (specification) {
+                DirectMessagesPaginationSpecification.All ->
+                    directMessageRepository
+                        .getAll(page = page)
+                        .deduplicate()
+                        .updatePaginationData()
+
+                is DirectMessagesPaginationSpecification.Replies ->
+                    directMessageRepository
+                        .getReplies(specification.parentUri)
+                        .deduplicate()
+                        .updatePaginationData()
+            }
+        history.addAll(results)
+
+        // return a copy
+        return history.map { it }
+    }
+
+    private fun List<DirectMessageModel>.updatePaginationData(): List<DirectMessageModel> =
+        apply {
+            val hasData = isNotEmpty()
+            if (hasData) {
+                page++
+            }
+            canFetchMore = hasData
+        }
+
+    private fun List<DirectMessageModel>.deduplicate(): List<DirectMessageModel> =
+        filter { e1 ->
+            history.none { e2 -> e1.id == e2.id }
+        }.distinctBy { it.id }
+}

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultDirectMessagesPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultDirectMessagesPaginationManager.kt
@@ -7,13 +7,13 @@ internal class DefaultDirectMessagesPaginationManager(
     private val directMessageRepository: DirectMessageRepository,
 ) : DirectMessagesPaginationManager {
     private var specification: DirectMessagesPaginationSpecification? = null
-    private var page = 0
+    private var page = 1
     override var canFetchMore: Boolean = true
     private val history = mutableListOf<DirectMessageModel>()
 
     override suspend fun reset(specification: DirectMessagesPaginationSpecification) {
         this.specification = specification
-        page = 0
+        page = 1
         history.clear()
         canFetchMore = true
     }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DirectMessagesPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DirectMessagesPaginationManager.kt
@@ -1,0 +1,11 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.DirectMessageModel
+
+interface DirectMessagesPaginationManager {
+    val canFetchMore: Boolean
+
+    suspend fun reset(specification: DirectMessagesPaginationSpecification)
+
+    suspend fun loadNextPage(): List<DirectMessageModel>
+}

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DirectMessagesPaginationSpecification.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DirectMessagesPaginationSpecification.kt
@@ -1,0 +1,9 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
+
+sealed interface DirectMessagesPaginationSpecification {
+    data object All : DirectMessagesPaginationSpecification
+
+    data class Replies(
+        val parentUri: String,
+    ) : DirectMessagesPaginationSpecification
+}

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
@@ -1,5 +1,6 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.di
 
+import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultDirectMessagesPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultExplorePaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultFavoritesPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultFollowRequestPaginationManager
@@ -8,6 +9,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.Defau
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultSearchPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultTimelinePaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultUserPaginationManager
+import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DirectMessagesPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.ExplorePaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.FavoritesPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.FollowRequestPaginationManager
@@ -69,6 +71,11 @@ val domainContentPaginationModule =
         factory<FollowRequestPaginationManager> {
             DefaultFollowRequestPaginationManager(
                 userRepository = get(),
+            )
+        }
+        factory<DirectMessagesPaginationManager> {
+            DefaultDirectMessagesPaginationManager(
+                directMessageRepository = get(),
             )
         }
     }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultDirectMessageRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultDirectMessageRepository.kt
@@ -5,6 +5,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.DirectMessa
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.http.Parameters
+import io.ktor.http.append
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
@@ -50,6 +51,14 @@ internal class DefaultDirectMessageRepository(
                     FormDataContent(
                         formData =
                             Parameters.build {
+                                if (title != null) {
+                                    append("title", title)
+                                }
+                                append("text", text)
+                                if (inReplyTo != null) {
+                                    append("replyto", inReplyTo)
+                                }
+                                append("user_id", recipientId)
                             },
                     )
                 val res = provider.directMessage.create(data)

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
@@ -28,6 +28,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Tag
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.TrendsLink
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.UserList
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.UserListReplyPolicy
+import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.parseDate
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.AttachmentModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.CircleModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.CircleReplyPolicy
@@ -357,8 +358,16 @@ internal fun FriendicaContact.toModel() =
 internal fun FriendicaPrivateMessage.toModel() =
     DirectMessageModel(
         id = id.toString(),
+        created =
+            createdAt?.let { date ->
+                parseDate(
+                    value = date,
+                    format = "EEE MMM dd HH:mm:ss ZZZZ yyyy",
+                )
+            },
         text = text,
         title = title,
         sender = sender?.toModel(),
         recipient = recipient?.toModel(),
+        parentUri = parentUri,
     )

--- a/feature/directmessages/build.gradle.kts
+++ b/feature/directmessages/build.gradle.kts
@@ -1,0 +1,75 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.jetbrains.compose)
+    alias(libs.plugins.compose.compiler)
+}
+
+@OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
+kotlin {
+    applyDefaultHierarchyTemplate()
+    androidTarget {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_1_8)
+        }
+    }
+    listOf(
+        iosX64(),
+        iosArm64(),
+        iosSimulatorArm64(),
+    ).forEach {
+        it.binaries.framework {
+            baseName = "feature.directmessages"
+            isStatic = true
+        }
+    }
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(compose.runtime)
+                implementation(compose.foundation)
+                implementation(compose.material)
+                implementation(compose.material3)
+                implementation(compose.materialIconsExtended)
+
+                implementation(libs.koin.core)
+                implementation(libs.voyager.navigator)
+                implementation(libs.voyager.screenmodel)
+                implementation(libs.voyager.koin)
+
+                implementation(projects.core.appearance)
+                implementation(projects.core.architecture)
+                implementation(projects.core.commonui.components)
+                implementation(projects.core.commonui.content)
+                implementation(projects.core.l10n)
+                implementation(projects.core.navigation)
+                implementation(projects.core.notifications)
+                implementation(projects.core.utils)
+
+                implementation(projects.domain.content.data)
+                implementation(projects.domain.content.pagination)
+                implementation(projects.domain.content.repository)
+                implementation(projects.domain.identity.data)
+                implementation(projects.domain.identity.repository)
+                implementation(projects.domain.identity.usecase)
+            }
+        }
+    }
+}
+
+android {
+    namespace = "com.livefast.eattrash.raccoonforfriendica.feature.directmessages"
+    compileSdk =
+        libs.versions.android.targetSdk
+            .get()
+            .toInt()
+    defaultConfig {
+        minSdk =
+            libs.versions.android.minSdk
+                .get()
+                .toInt()
+    }
+}

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/components/ConversationItem.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/components/ConversationItem.kt
@@ -1,0 +1,139 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.directmessages.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.FilterQuality
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomImage
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.PlaceholderImage
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ContentBody
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ContentTitle
+import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
+import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.prettifyDate
+import com.livefast.eattrash.raccoonforfriendica.core.utils.ellipsize
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.ConversationModel
+
+@Composable
+internal fun ConversationItem(
+    conversation: ConversationModel,
+    modifier: Modifier = Modifier,
+    onClick: ((String) -> Unit)? = null,
+) {
+    val user = conversation.otherUser
+    val avatar = user.avatar.orEmpty()
+    val message = conversation.lastMessage
+    val avatarSize = IconSize.l
+    val fullColor = MaterialTheme.colorScheme.onBackground
+    val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha)
+
+    Column(
+        modifier =
+            modifier.clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+            ) {
+                message.parentUri?.also {
+                    onClick?.invoke(it)
+                }
+            },
+        verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+    ) {
+        Row(
+            modifier = Modifier.padding(Spacing.s),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+        ) {
+            if (avatar.isNotEmpty()) {
+                CustomImage(
+                    modifier =
+                        Modifier
+                            .size(avatarSize)
+                            .clip(RoundedCornerShape(avatarSize / 2)),
+                    url = avatar,
+                    quality = FilterQuality.Low,
+                    contentScale = ContentScale.FillBounds,
+                )
+            } else {
+                PlaceholderImage(
+                    size = avatarSize,
+                    title = user.displayName ?: user.handle ?: "?",
+                )
+            }
+
+            Column(
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(
+                    text = (user.displayName ?: user.username ?: "").ellipsize(30),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = fullColor,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = (user.handle ?: user.username ?: "").ellipsize(25),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = ancillaryColor,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+
+        val contentPadding = 10.dp
+        message.title?.also { title ->
+            ContentTitle(
+                modifier = Modifier.padding(horizontal = contentPadding),
+                content = title,
+            )
+        }
+
+        message.text?.also { text ->
+            ContentBody(
+                modifier = Modifier.padding(horizontal = contentPadding),
+                content = text,
+            )
+        }
+
+        Text(
+            modifier =
+                Modifier.padding(
+                    top = Spacing.xs,
+                    start = contentPadding,
+                    end = contentPadding,
+                    bottom = Spacing.xs,
+                ),
+            text =
+                buildString {
+                    append(conversation.messageCount)
+                    append(" ")
+                    append(LocalStrings.current.messages(conversation.messageCount))
+                    val date = message.created
+                    if (!date.isNullOrEmpty()) {
+                        append(" • ")
+                        append(date.prettifyDate())
+                    }
+                },
+            style = MaterialTheme.typography.titleSmall,
+            color = ancillaryColor,
+        )
+    }
+}

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/di/DirectMessagesModule.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/di/DirectMessagesModule.kt
@@ -1,0 +1,15 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.directmessages.di
+
+import com.livefast.eattrash.raccoonforfriendica.feature.directmessages.list.DirectMessageListMviModel
+import com.livefast.eattrash.raccoonforfriendica.feature.directmessages.list.DirectMessageListViewModel
+import org.koin.dsl.module
+
+val featureDirectMessagesModule =
+    module {
+        factory<DirectMessageListMviModel> {
+            DirectMessageListViewModel(
+                paginationManager = get(),
+                identityRepository = get(),
+            )
+        }
+    }

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/list/DirectMessageListMviModel.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/list/DirectMessageListMviModel.kt
@@ -1,0 +1,28 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.directmessages.list
+
+import cafe.adriel.voyager.core.model.ScreenModel
+import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.ConversationModel
+
+interface DirectMessageListMviModel :
+    ScreenModel,
+    MviModel<DirectMessageListMviModel.Intent, DirectMessageListMviModel.State, DirectMessageListMviModel.Effect> {
+    sealed interface Intent {
+        data object Refresh : Intent
+
+        data object LoadNextPage : Intent
+    }
+
+    data class State(
+        val currentUserId: String? = null,
+        val refreshing: Boolean = false,
+        val loading: Boolean = false,
+        val initial: Boolean = true,
+        val canFetchMore: Boolean = true,
+        val items: List<ConversationModel> = emptyList(),
+    )
+
+    sealed interface Effect {
+        data object BackToTop : Effect
+    }
+}

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/list/DirectMessageListScreen.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/list/DirectMessageListScreen.kt
@@ -1,0 +1,186 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.directmessages.list
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.koin.getScreenModel
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.GenericPlaceholder
+import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
+import com.livefast.eattrash.raccoonforfriendica.feature.directmessages.components.ConversationItem
+import kotlinx.coroutines.launch
+
+class DirectMessageListScreen : Screen {
+    @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
+    @Composable
+    override fun Content() {
+        val model = getScreenModel<DirectMessageListMviModel>()
+        val uiState by model.uiState.collectAsState()
+        val navigationCoordinator = remember { getNavigationCoordinator() }
+        val topAppBarState = rememberTopAppBarState()
+        val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
+        val lazyListState = rememberLazyListState()
+        val scope = rememberCoroutineScope()
+
+        fun goBackToTop() {
+            runCatching {
+                scope.launch {
+                    lazyListState.scrollToItem(0)
+                    topAppBarState.heightOffset = 0f
+                    topAppBarState.contentOffset = 0f
+                }
+            }
+        }
+
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    modifier = Modifier.clickable { scope.launch { goBackToTop() } },
+                    windowInsets = topAppBarState.toWindowInsets(),
+                    scrollBehavior = scrollBehavior,
+                    title = {
+                        Text(
+                            modifier = Modifier.padding(horizontal = Spacing.s),
+                            text = LocalStrings.current.directMessagesTitle,
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                    },
+                    navigationIcon = {
+                        if (navigationCoordinator.canPop.value) {
+                            Image(
+                                modifier =
+                                    Modifier.clickable {
+                                        navigationCoordinator.pop()
+                                    },
+                                imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                                contentDescription = null,
+                                colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground),
+                            )
+                        }
+                    },
+                )
+            },
+        ) { padding ->
+            val pullRefreshState =
+                rememberPullRefreshState(
+                    refreshing = uiState.refreshing,
+                    onRefresh = {
+                        model.reduce(DirectMessageListMviModel.Intent.Refresh)
+                    },
+                )
+            Box(
+                modifier =
+                    Modifier
+                        .padding(padding)
+                        .fillMaxWidth()
+                        .nestedScroll(scrollBehavior.nestedScrollConnection)
+                        .pullRefresh(pullRefreshState),
+            ) {
+                LazyColumn(
+                    state = lazyListState,
+                ) {
+                    if (uiState.initial) {
+                        items(10) {
+                            GenericPlaceholder(height = 120.dp)
+                            HorizontalDivider(
+                                modifier = Modifier.padding(vertical = Spacing.s),
+                            )
+                        }
+                    }
+
+                    if (!uiState.initial && !uiState.refreshing && !uiState.loading && uiState.items.isEmpty()) {
+                        item {
+                            Text(
+                                modifier = Modifier.fillMaxWidth().padding(top = Spacing.m),
+                                text = LocalStrings.current.messageEmptyList,
+                                textAlign = TextAlign.Center,
+                                style = MaterialTheme.typography.bodyLarge,
+                            )
+                        }
+                    }
+
+                    itemsIndexed(
+                        items = uiState.items,
+                        key = { _, e -> e.lastMessage.id },
+                    ) { idx, message ->
+
+                        ConversationItem(
+                            conversation = message,
+                            onClick = {},
+                        )
+                        HorizontalDivider(
+                            modifier = Modifier.padding(vertical = Spacing.s),
+                        )
+
+                        val canFetchMore =
+                            !uiState.initial && !uiState.loading && uiState.canFetchMore
+                        val isNearTheEnd =
+                            idx == uiState.items.lastIndex - 5 || uiState.items.size < 5
+                        if (isNearTheEnd && canFetchMore) {
+                            model.reduce(DirectMessageListMviModel.Intent.LoadNextPage)
+                        }
+                    }
+
+                    item {
+                        if (uiState.loading && !uiState.refreshing && uiState.canFetchMore) {
+                            Box(
+                                modifier = Modifier.fillMaxWidth(),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                ListLoadingIndicator()
+                            }
+                        }
+                    }
+
+                    item {
+                        Spacer(modifier = Modifier.height(Spacing.xxxl))
+                    }
+                }
+
+                PullRefreshIndicator(
+                    refreshing = uiState.refreshing,
+                    state = pullRefreshState,
+                    modifier = Modifier.align(Alignment.TopCenter),
+                    backgroundColor = MaterialTheme.colorScheme.background,
+                    contentColor = MaterialTheme.colorScheme.onBackground,
+                )
+            }
+        }
+    }
+}

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/list/DirectMessageListViewModel.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/list/DirectMessageListViewModel.kt
@@ -1,0 +1,96 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.directmessages.list
+
+import cafe.adriel.voyager.core.model.screenModelScope
+import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.ConversationModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DirectMessagesPaginationManager
+import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DirectMessagesPaginationSpecification
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+
+class DirectMessageListViewModel(
+    private val paginationManager: DirectMessagesPaginationManager,
+    private val identityRepository: IdentityRepository,
+) : DefaultMviModel<DirectMessageListMviModel.Intent, DirectMessageListMviModel.State, DirectMessageListMviModel.Effect>(
+        initialState = DirectMessageListMviModel.State(),
+    ),
+    DirectMessageListMviModel {
+    init {
+        screenModelScope.launch {
+            identityRepository.currentUser
+                .onEach { currentUser ->
+                    updateState { it.copy(currentUserId = currentUser?.id) }
+                    refresh(initial = true)
+                }.launchIn(this)
+        }
+    }
+
+    override fun reduce(intent: DirectMessageListMviModel.Intent) {
+        when (intent) {
+            DirectMessageListMviModel.Intent.Refresh ->
+                screenModelScope.launch {
+                    refresh()
+                }
+
+            DirectMessageListMviModel.Intent.LoadNextPage ->
+                screenModelScope.launch {
+                    loadNextPage()
+                }
+        }
+    }
+
+    private suspend fun refresh(initial: Boolean = false) {
+        updateState {
+            it.copy(initial = initial, refreshing = !initial)
+        }
+        paginationManager.reset(
+            DirectMessagesPaginationSpecification.All,
+        )
+        loadNextPage()
+    }
+
+    private suspend fun loadNextPage() {
+        if (uiState.value.loading) {
+            return
+        }
+
+        updateState { it.copy(loading = true) }
+        val currentUserId = uiState.value.currentUserId
+        val wasRefreshing = uiState.value.refreshing
+        val items =
+            paginationManager
+                .loadNextPage()
+                .groupBy {
+                    it.parentUri
+                }.mapNotNull { (_, messages) ->
+                    val lastMessage =
+                        messages.takeIf { it.isNotEmpty() }?.maxBy { it.created.orEmpty() }
+                    val user =
+                        lastMessage?.sender?.takeIf { it.id != currentUserId }
+                            ?: lastMessage?.recipient
+                    if (user == null || lastMessage == null) {
+                        null
+                    } else {
+                        ConversationModel(
+                            otherUser = user,
+                            lastMessage = lastMessage,
+                            messageCount = messages.size,
+                        )
+                    }
+                }
+        updateState {
+            it.copy(
+                items = items,
+                canFetchMore = paginationManager.canFetchMore,
+                loading = false,
+                initial = false,
+                refreshing = false,
+            )
+        }
+        if (wasRefreshing) {
+            emitEffect(DirectMessageListMviModel.Effect.BackToTop)
+        }
+    }
+}

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerContent.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerContent.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.feature.drawer
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Flaky
@@ -100,6 +101,16 @@ class DrawerContent : Screen {
                         handleOpen { detailOpener.openCircles() }
                     },
                 )
+
+                if (uiState.hasDirectMessages) {
+                    DrawerShortcut(
+                        title = LocalStrings.current.directMessagesTitle,
+                        icon = Icons.AutoMirrored.Default.Chat,
+                        onSelected = {
+                            handleOpen { detailOpener.openDirectMessages() }
+                        },
+                    )
+                }
             }
 
             DrawerShortcut(

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerMviModel.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerMviModel.kt
@@ -14,6 +14,7 @@ interface DrawerMviModel :
     data class State(
         val user: UserModel? = null,
         val node: String? = null,
+        val hasDirectMessages: Boolean = false,
     )
 
     sealed interface Effect

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerViewModel.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerViewModel.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.feature.drawer
 
 import cafe.adriel.voyager.core.model.screenModelScope
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.NodeInfoRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 import kotlinx.coroutines.flow.launchIn
@@ -11,6 +12,7 @@ import kotlinx.coroutines.launch
 class DrawerViewModel(
     private val apiConfigurationRepository: ApiConfigurationRepository,
     private val identityRepository: IdentityRepository,
+    private val nodeInfoRepository: NodeInfoRepository,
 ) : DefaultMviModel<DrawerMviModel.Intent, DrawerMviModel.State, DrawerMviModel.Effect>(
         initialState = DrawerMviModel.State(),
     ),
@@ -19,9 +21,11 @@ class DrawerViewModel(
         screenModelScope.launch {
             apiConfigurationRepository.node
                 .onEach { node ->
+                    val isFriendica = nodeInfoRepository.isFriendica()
                     updateState {
                         it.copy(
                             node = node,
+                            hasDirectMessages = isFriendica,
                         )
                     }
                 }.launchIn(this)

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/di/DrawerModule.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/di/DrawerModule.kt
@@ -10,6 +10,7 @@ val featureDrawerModule =
             DrawerViewModel(
                 apiConfigurationRepository = get(),
                 identityRepository = get(),
+                nodeInfoRepository = get(),
             )
         }
     }

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
@@ -79,7 +79,6 @@ class FavoritesScreen(
         val navigationCoordinator = remember { getNavigationCoordinator() }
         val topAppBarState = rememberTopAppBarState()
         val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
-        val connection = navigationCoordinator.getBottomBarScrollConnection()
         val uriHandler = LocalUriHandler.current
         val detailOpener = remember { getDetailOpener() }
         val lazyListState = rememberLazyListState()
@@ -164,13 +163,7 @@ class FavoritesScreen(
                     Modifier
                         .padding(padding)
                         .fillMaxWidth()
-                        .then(
-                            if (connection != null) {
-                                Modifier.nestedScroll(connection)
-                            } else {
-                                Modifier
-                            },
-                        ).nestedScroll(scrollBehavior.nestedScrollConnection)
+                        .nestedScroll(scrollBehavior.nestedScrollConnection)
                         .pullRefresh(pullRefreshState),
             ) {
                 LazyColumn(

--- a/feature/followrequests/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/followrequests/FollowRequestsScreen.kt
+++ b/feature/followrequests/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/followrequests/FollowRequestsScreen.kt
@@ -55,7 +55,6 @@ class FollowRequestsScreen : Screen {
         val navigationCoordinator = remember { getNavigationCoordinator() }
         val topAppBarState = rememberTopAppBarState()
         val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
-        val connection = navigationCoordinator.getBottomBarScrollConnection()
         val detailOpener = remember { getDetailOpener() }
         val lazyListState = rememberLazyListState()
         val scope = rememberCoroutineScope()
@@ -111,13 +110,7 @@ class FollowRequestsScreen : Screen {
                     Modifier
                         .padding(padding)
                         .fillMaxWidth()
-                        .then(
-                            if (connection != null) {
-                                Modifier.nestedScroll(connection)
-                            } else {
-                                Modifier
-                            },
-                        ).nestedScroll(scrollBehavior.nestedScrollConnection)
+                        .nestedScroll(scrollBehavior.nestedScrollConnection)
                         .pullRefresh(pullRefreshState),
             ) {
                 LazyColumn(

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/followed/FollowedHashtagsScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/followed/FollowedHashtagsScreen.kt
@@ -57,7 +57,6 @@ class FollowedHashtagsScreen : Screen {
         val navigationCoordinator = remember { getNavigationCoordinator() }
         val topAppBarState = rememberTopAppBarState()
         val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
-        val connection = navigationCoordinator.getBottomBarScrollConnection()
         val detailOpener = remember { getDetailOpener() }
         val lazyListState = rememberLazyListState()
         val scope = rememberCoroutineScope()
@@ -114,13 +113,7 @@ class FollowedHashtagsScreen : Screen {
                     Modifier
                         .padding(padding)
                         .fillMaxWidth()
-                        .then(
-                            if (connection != null) {
-                                Modifier.nestedScroll(connection)
-                            } else {
-                                Modifier
-                            },
-                        ).nestedScroll(scrollBehavior.nestedScrollConnection)
+                        .nestedScroll(scrollBehavior.nestedScrollConnection)
                         .pullRefresh(pullRefreshState),
             ) {
                 LazyColumn(

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
@@ -82,7 +82,6 @@ class HashtagScreen(
         val navigationCoordinator = remember { getNavigationCoordinator() }
         val topAppBarState = rememberTopAppBarState()
         val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
-        val connection = navigationCoordinator.getBottomBarScrollConnection()
         val uriHandler = LocalUriHandler.current
         val detailOpener = remember { getDetailOpener() }
         val lazyListState = rememberLazyListState()
@@ -186,13 +185,7 @@ class HashtagScreen(
                     Modifier
                         .padding(padding)
                         .fillMaxWidth()
-                        .then(
-                            if (connection != null) {
-                                Modifier.nestedScroll(connection)
-                            } else {
-                                Modifier
-                            },
-                        ).nestedScroll(scrollBehavior.nestedScrollConnection)
+                        .nestedScroll(scrollBehavior.nestedScrollConnection)
                         .pullRefresh(pullRefreshState),
             ) {
                 LazyColumn(

--- a/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/ManageBlocksScreen.kt
+++ b/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/ManageBlocksScreen.kt
@@ -77,7 +77,6 @@ class ManageBlocksScreen : Screen {
         val navigationCoordinator = remember { getNavigationCoordinator() }
         val topAppBarState = rememberTopAppBarState()
         val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
-        val connection = navigationCoordinator.getBottomBarScrollConnection()
         val detailOpener = remember { getDetailOpener() }
         val lazyListState = rememberLazyListState()
         val scope = rememberCoroutineScope()
@@ -156,13 +155,7 @@ class ManageBlocksScreen : Screen {
                     Modifier
                         .padding(padding)
                         .fillMaxWidth()
-                        .then(
-                            if (connection != null) {
-                                Modifier.nestedScroll(connection)
-                            } else {
-                                Modifier
-                            },
-                        ).nestedScroll(scrollBehavior.nestedScrollConnection)
+                        .nestedScroll(scrollBehavior.nestedScrollConnection)
                         .pullRefresh(pullRefreshState),
             ) {
                 LazyColumn(

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
@@ -81,6 +81,7 @@ class MyAccountScreen : Screen {
         val model = getScreenModel<MyAccountMviModel>()
         val uiState by model.uiState.collectAsState()
         val navigationCoordinator = remember { getNavigationCoordinator() }
+        val connection = navigationCoordinator.getBottomBarScrollConnection()
         val uriHandler = LocalUriHandler.current
         val detailOpener = remember { getDetailOpener() }
         val lazyListState = rememberLazyListState()
@@ -149,7 +150,13 @@ class MyAccountScreen : Screen {
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .nestedScroll(scrollBehavior.nestedScrollConnection)
+                    .then(
+                        if (connection != null) {
+                            Modifier.nestedScroll(connection)
+                        } else {
+                            Modifier
+                        },
+                    ).nestedScroll(scrollBehavior.nestedScrollConnection)
                     .pullRefresh(pullRefreshState),
         ) {
             LazyColumn(

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -52,6 +52,7 @@ include(":domain:identity:usecase")
 
 include(":feature:circles")
 include(":feature:composer")
+include(":feature:directmessages")
 include(":feature:drawer")
 include(":feature:entrydetail")
 include(":feature:explore")


### PR DESCRIPTION
This PR adds the conversation list screen, which can be accessed (on instances supporting it) from the navigation drawer.