### PR TITLE
enhancement: improve DM experience

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/SearchService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/SearchService.kt
@@ -11,6 +11,7 @@ interface SearchService {
         @Query("type") type: String,
         @Query("max_id") maxId: String? = null,
         @Query("min_id") minId: String? = null,
+        @Query("following") following: Boolean = false,
         @Query("limit") limit: Int = 20,
     ): Search
 }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SelectUserDialog.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SelectUserDialog.kt
@@ -23,7 +23,10 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -44,8 +47,12 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.Search
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.utils.compose.getAnimatedDots
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.map
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, FlowPreview::class)
 @Composable
 fun SelectUserDialog(
     query: String,
@@ -56,6 +63,13 @@ fun SelectUserDialog(
     onSearchChanged: ((String) -> Unit)? = null,
     onClose: ((UserModel?) -> Unit)? = null,
 ) {
+    val noUsersDebounced by
+        snapshotFlow { users }
+            .drop(1)
+            .map { it.isEmpty() }
+            .debounce(250)
+            .collectAsState(false)
+
     BasicAlertDialog(
         modifier = Modifier.clip(RoundedCornerShape(CornerSize.xxl)),
         onDismissRequest = {
@@ -112,7 +126,7 @@ fun SelectUserDialog(
                                 style = MaterialTheme.typography.bodyLarge,
                                 color = MaterialTheme.colorScheme.onBackground,
                             )
-                        } else {
+                        } else if (noUsersDebounced) {
                             Text(
                                 modifier = Modifier.fillMaxWidth().padding(top = Spacing.s),
                                 text = LocalStrings.current.messageEmptyList,

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -145,7 +145,7 @@ internal open class DefaultStrings : Strings {
     override val selectUserSearchPlaceholder = "username or handle"
     override val searchSectionUsers = "Users"
     override val searchPlaceholder = "Search the Fediverse"
-    override val messageSearchInitialEmpty = "Start typing something to search"
+    override val messageSearchInitialEmpty = "Start typing something"
     override val topicTitle = "Topic"
     override val threadTitle = "Thread"
     override val buttonLoadMoreReplies = "Load more replies"
@@ -276,4 +276,8 @@ internal open class DefaultStrings : Strings {
             1 -> "message"
             else -> "messages"
         }
+
+    override val messageEmptyConversation = "This is the beginning of your epic conversation with"
+    override val followRequiredMessage =
+        "You need to follow the other user in order to be able to send a direct message!"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -150,7 +150,7 @@ internal val ItStrings =
         override val selectUserSearchPlaceholder = "nome utente or identificativo"
         override val searchSectionUsers = "Utenti"
         override val searchPlaceholder = "Cerca nel Fediverso"
-        override val messageSearchInitialEmpty = "Inizia a digitare qualcosa da cercare"
+        override val messageSearchInitialEmpty = "Inizia a digitare qualcosa"
         override val topicTitle = "Argomento"
         override val threadTitle = "Conversazione"
         override val buttonLoadMoreReplies = "Carica altre risposte"
@@ -282,4 +282,9 @@ internal val ItStrings =
                 1 -> "messaggio"
                 else -> "messaggi"
             }
+
+        override val messageEmptyConversation =
+            "Questo è l'inizio della tua epica conversazione con"
+        override val followRequiredMessage =
+            "È necessario seguire l'altro utente per poter inviare un messaggio diretto!"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -255,6 +255,9 @@ interface Strings {
     val directMessagesTitle: String
 
     fun messages(count: Int): String
+
+    val messageEmptyConversation: String
+    val followRequiredMessage: String
 }
 
 object Locales {

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultDirectMessagesPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultDirectMessagesPaginationManager.kt
@@ -25,7 +25,10 @@ internal class DefaultDirectMessagesPaginationManager(
             when (specification) {
                 DirectMessagesPaginationSpecification.All ->
                     directMessageRepository
-                        .getAll(page = page)
+                        .getAll(
+                            page = page,
+                            limit = 40,
+                        )
                         .deduplicate()
                         .updatePaginationData()
 

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultDirectMessageRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultDirectMessageRepository.kt
@@ -12,13 +12,16 @@ import kotlinx.coroutines.withContext
 internal class DefaultDirectMessageRepository(
     private val provider: ServiceProvider,
 ) : DirectMessageRepository {
-    override suspend fun getAll(page: Int): List<DirectMessageModel> =
+    override suspend fun getAll(
+        page: Int,
+        limit: Int?,
+    ): List<DirectMessageModel> =
         withContext(Dispatchers.IO) {
             runCatching {
                 provider.directMessage
                     .getAll(
                         page = page,
-                        count = DEFAULT_PAGE_SIZE,
+                        count = limit ?: DEFAULT_PAGE_SIZE,
                     ).map { it.toModel() }
             }.getOrElse { emptyList() }
         }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepository.kt
@@ -141,6 +141,7 @@ internal class DefaultUserRepository(
                             query = query,
                             maxId = pageCursor,
                             type = "accounts",
+                            following = true,
                             limit = DEFAULT_PAGE_SIZE,
                         ).accounts
                         .map { it.toModel() }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DirectMessageRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DirectMessageRepository.kt
@@ -3,7 +3,10 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.DirectMessageModel
 
 interface DirectMessageRepository {
-    suspend fun getAll(page: Int = 0): List<DirectMessageModel>
+    suspend fun getAll(
+        page: Int = 0,
+        limit: Int? = null,
+    ): List<DirectMessageModel>
 
     suspend fun getReplies(
         parentUri: String,

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/components/CircleAddUsersDialog.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/components/CircleAddUsersDialog.kt
@@ -22,8 +22,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -43,6 +46,9 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.Search
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.utils.compose.getAnimatedDots
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.map
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -56,6 +62,13 @@ internal fun CircleAddUserDialog(
     onClose: ((List<UserModel>?) -> Unit)? = null,
 ) {
     val selectedUsers = remember { mutableStateListOf<UserModel>() }
+    val noUsersDebounced by
+        snapshotFlow { users }
+            .drop(1)
+            .map { it.isEmpty() }
+            .debounce(250)
+            .collectAsState(false)
+
     BasicAlertDialog(
         modifier = Modifier.clip(RoundedCornerShape(CornerSize.xxl)),
         onDismissRequest = {
@@ -111,7 +124,7 @@ internal fun CircleAddUserDialog(
                                 style = MaterialTheme.typography.bodyLarge,
                                 color = MaterialTheme.colorScheme.onBackground,
                             )
-                        } else {
+                        } else if (noUsersDebounced) {
                             Text(
                                 modifier = Modifier.fillMaxWidth().padding(top = Spacing.s),
                                 text = LocalStrings.current.messageEmptyList,

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationMviModel.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationMviModel.kt
@@ -37,5 +37,7 @@ interface ConversationMviModel :
         data object BackToTop : Effect
 
         data object Failure : Effect
+
+        data object FollowUserRequired : Effect
     }
 }

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationScreen.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationScreen.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.feature.directmessages.detail
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -38,6 +39,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -55,6 +57,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
@@ -91,6 +94,7 @@ class ConversationScreen(
         val snackbarHostState = remember { SnackbarHostState() }
         val lazyListState = rememberLazyListState()
         val scope = rememberCoroutineScope()
+        val otherUserName = uiState.otherUser?.let { it.displayName ?: it.username }
         val genericError = LocalStrings.current.messageGenericError
 
         fun goBackToTop() {
@@ -132,7 +136,6 @@ class ConversationScreen(
                         ) {
                             val avatar = uiState.otherUser?.avatar.orEmpty()
                             val avatarSize = IconSize.l
-                            val name = uiState.otherUser?.let { it.displayName ?: it.username }
                             if (avatar.isNotEmpty()) {
                                 CustomImage(
                                     modifier =
@@ -146,12 +149,12 @@ class ConversationScreen(
                             } else {
                                 PlaceholderImage(
                                     size = avatarSize,
-                                    title = name ?: "?",
+                                    title = otherUserName ?: "?",
                                 )
                             }
                             Text(
                                 modifier = Modifier.padding(horizontal = Spacing.s),
-                                text = name.orEmpty(),
+                                text = otherUserName.orEmpty(),
                                 style = MaterialTheme.typography.titleMedium,
                             )
                         }
@@ -261,12 +264,42 @@ class ConversationScreen(
 
                     if (!uiState.initial && !uiState.refreshing && !uiState.loading && uiState.items.isEmpty()) {
                         item {
-                            Text(
-                                modifier = Modifier.fillMaxWidth().padding(top = Spacing.m),
-                                text = LocalStrings.current.messageEmptyList,
-                                textAlign = TextAlign.Center,
-                                style = MaterialTheme.typography.bodyLarge,
-                            )
+                            if (!otherUserName.isNullOrEmpty()) {
+                                Box(
+                                    modifier =
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .padding(
+                                                top = Spacing.m,
+                                                start = Spacing.s,
+                                                end = Spacing.s,
+                                            ).border(
+                                                width = 1.dp,
+                                                color = MaterialTheme.colorScheme.onBackground,
+                                                shape = RoundedCornerShape(CornerSize.xl),
+                                            ).background(
+                                                color =
+                                                    MaterialTheme.colorScheme.surfaceColorAtElevation(
+                                                        5.dp,
+                                                    ),
+                                                shape = RoundedCornerShape(CornerSize.xl),
+                                            ).padding(
+                                                vertical = Spacing.s,
+                                                horizontal = Spacing.s,
+                                            ),
+                                ) {
+                                    Text(
+                                        text =
+                                            buildString {
+                                                append(LocalStrings.current.messageEmptyConversation)
+                                                append(" ")
+                                                append(otherUserName)
+                                            },
+                                        textAlign = TextAlign.Center,
+                                        style = MaterialTheme.typography.bodyLarge,
+                                    )
+                                }
+                            }
                         }
                     }
 

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationScreen.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationScreen.kt
@@ -96,6 +96,7 @@ class ConversationScreen(
         val scope = rememberCoroutineScope()
         val otherUserName = uiState.otherUser?.let { it.displayName ?: it.username }
         val genericError = LocalStrings.current.messageGenericError
+        val followRequiredMessage = LocalStrings.current.followRequiredMessage
 
         fun goBackToTop() {
             runCatching {
@@ -114,6 +115,9 @@ class ConversationScreen(
                         ConversationMviModel.Effect.BackToTop -> goBackToTop()
                         ConversationMviModel.Effect.Failure ->
                             snackbarHostState.showSnackbar(genericError)
+
+                        ConversationMviModel.Effect.FollowUserRequired ->
+                            snackbarHostState.showSnackbar(followRequiredMessage)
                     }
                 }.launchIn(this)
         }

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/list/DirectMessageListScreen.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/list/DirectMessageListScreen.kt
@@ -260,9 +260,11 @@ class DirectMessageListScreen : Screen {
                     selectUserToCreateConversationDialogOpen = false
                     val userId = user?.id
                     if (userId != null) {
+                        val existingConversation =
+                            uiState.items.firstOrNull { it.otherUser.id == userId }
                         detailOpener.openConversation(
                             otherUserId = userId,
-                            parentUri = "",
+                            parentUri = existingConversation?.lastMessage?.parentUri.orEmpty(),
                         )
                     }
                 },

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/list/DirectMessageListViewModel.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/list/DirectMessageListViewModel.kt
@@ -126,7 +126,7 @@ class DirectMessageListViewModel(
 
     private suspend fun refreshUsers(query: String) {
         userPaginationManager.reset(
-            UserPaginationSpecification.Search(
+            UserPaginationSpecification.SearchFollowing(
                 query = query,
                 withRelationship = false,
             ),


### PR DESCRIPTION
This PR improves the direct message feature introduced recently:
- avoid starting conversations with users you don't follow (and check before sending messages)
- improve empty conversation list
- better initial loading for conversation list
- avoid showing empty message list when not necessary in user selection dialogs
- reuse existing conversations instead of always opening a new one