### PR TITLE
enhancement: remove useless dividers; update font scale; back to top in favorites/bookmarks; placeholders

### DIFF
--- a/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/data/UiFontScale.kt
+++ b/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/data/UiFontScale.kt
@@ -18,10 +18,10 @@ sealed interface UiFontScale {
 fun UiFontScale.toScaleFactor(): Float =
     when (this) {
         UiFontScale.Largest -> 1.25f
-        UiFontScale.Larger -> 1.15f
-        UiFontScale.Normal -> 1.1f
-        UiFontScale.Smaller -> 1.05f
-        UiFontScale.Smallest -> 0.95f
+        UiFontScale.Larger -> 1.2f
+        UiFontScale.Normal -> 1.15f
+        UiFontScale.Smaller -> 1.1f
+        UiFontScale.Smallest -> 1f
     }
 
 fun UiFontScale.toInt(): Int =

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/PlaceholderImage.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/PlaceholderImage.kt
@@ -10,10 +10,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 
 @Composable
@@ -33,12 +31,7 @@ fun PlaceholderImage(
                 ),
         contentAlignment = Alignment.Center,
     ) {
-        val translationAmount = with(LocalDensity.current) { 1.dp.toPx() }
         Text(
-            modifier =
-                Modifier.graphicsLayer {
-                    translationY = -translationAmount
-                },
             text =
                 title
                     .firstOrNull()
@@ -47,6 +40,7 @@ fun PlaceholderImage(
                     .uppercase(),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onPrimary,
+            fontWeight = FontWeight.SemiBold,
         )
     }
 }

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/ProgressHud.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/ProgressHud.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.graphics.Color
 
 @Composable
 fun ProgressHud(
-    overlayColor: Color = MaterialTheme.colorScheme.surface.copy(alpha = 0.5f),
+    overlayColor: Color = MaterialTheme.colorScheme.scrim,
     color: Color = MaterialTheme.colorScheme.primary,
 ) {
     Surface(

--- a/feature/directmessages/build.gradle.kts
+++ b/feature/directmessages/build.gradle.kts
@@ -54,7 +54,6 @@ kotlin {
                 implementation(projects.domain.content.repository)
                 implementation(projects.domain.identity.data)
                 implementation(projects.domain.identity.repository)
-                implementation(projects.domain.identity.usecase)
             }
         }
     }

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/list/DirectMessageListScreen.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/list/DirectMessageListScreen.kt
@@ -167,11 +167,14 @@ class DirectMessageListScreen : Screen {
                     state = lazyListState,
                 ) {
                     if (uiState.initial) {
-                        items(10) {
+                        val placeholderCount = 10
+                        items(placeholderCount) { idx ->
                             GenericPlaceholder(height = 120.dp)
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = Spacing.s),
-                            )
+                            if (idx < placeholderCount - 1) {
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(vertical = Spacing.s),
+                                )
+                            }
                         }
                     }
 
@@ -203,9 +206,11 @@ class DirectMessageListScreen : Screen {
                                 }
                             },
                         )
-                        HorizontalDivider(
-                            modifier = Modifier.padding(vertical = Spacing.s),
-                        )
+                        if (idx < uiState.items.lastIndex) {
+                            HorizontalDivider(
+                                modifier = Modifier.padding(vertical = Spacing.s),
+                            )
+                        }
 
                         val canFetchMore =
                             !uiState.initial && !uiState.loading && uiState.canFetchMore

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
@@ -228,18 +229,21 @@ class EntryDetailScreen(
                     state = lazyListState,
                 ) {
                     if (uiState.initial) {
-                        items(5) {
+                        val placeholderCount = 5
+                        items(placeholderCount) { idx ->
                             TimelineItemPlaceholder(modifier = Modifier.fillMaxWidth())
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = Spacing.s),
-                            )
+                            if (idx < placeholderCount - 1) {
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(vertical = Spacing.s),
+                                )
+                            }
                         }
                     }
 
-                    items(
+                    itemsIndexed(
                         items = uiState.entries,
-                        key = { it.safeKey },
-                    ) { entry ->
+                        key = { _, e -> e.safeKey },
+                    ) { idx, entry ->
                         TimelineItem(
                             entry = entry,
                             extendedSocialInfoEnabled = (entry.id == id),
@@ -367,9 +371,11 @@ class EntryDetailScreen(
                                 }
                             },
                         )
-                        HorizontalDivider(
-                            modifier = Modifier.padding(vertical = Spacing.s),
-                        )
+                        if (idx < uiState.entries.lastIndex) {
+                            HorizontalDivider(
+                                modifier = Modifier.padding(vertical = Spacing.s),
+                            )
+                        }
                     }
                     item {
                         Spacer(modifier = Modifier.height(Spacing.xxxl))

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
@@ -240,7 +240,8 @@ class ExploreScreen : Screen {
                     }
 
                     if (uiState.initial) {
-                        items(20) {
+                        val placeholderCount = 20
+                        items(placeholderCount) { idx ->
                             val modifier = Modifier.fillMaxWidth()
                             when (uiState.section) {
                                 ExploreSection.Hashtags -> {
@@ -255,9 +256,11 @@ class ExploreScreen : Screen {
 
                                 ExploreSection.Posts -> {
                                     TimelineItemPlaceholder(modifier = modifier)
-                                    HorizontalDivider(
-                                        modifier = Modifier.padding(vertical = Spacing.s),
-                                    )
+                                    if (idx < placeholderCount - 1) {
+                                        HorizontalDivider(
+                                            modifier = Modifier.padding(vertical = Spacing.s),
+                                        )
+                                    }
                                 }
 
                                 ExploreSection.Suggestions -> {
@@ -428,9 +431,11 @@ class ExploreScreen : Screen {
                                         }
                                     },
                                 )
-                                HorizontalDivider(
-                                    modifier = Modifier.padding(vertical = Spacing.s),
-                                )
+                                if (idx < uiState.items.lastIndex) {
+                                    HorizontalDivider(
+                                        modifier = Modifier.padding(vertical = Spacing.s),
+                                    )
+                                }
                             }
 
                             is ExploreItemModel.HashTag -> {

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesMviModel.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesMviModel.kt
@@ -68,6 +68,8 @@ interface FavoritesMviModel :
     )
 
     sealed interface Effect {
+        data object BackToTop : Effect
+
         data object PollVoteFailure : Effect
     }
 }

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
@@ -106,6 +106,7 @@ class FavoritesScreen(
             model.effects
                 .onEach { event ->
                     when (event) {
+                        FavoritesMviModel.Effect.BackToTop -> goBackToTop()
                         FavoritesMviModel.Effect.PollVoteFailure -> pollErrorDialogOpened = true
                     }
                 }.launchIn(this)
@@ -170,11 +171,14 @@ class FavoritesScreen(
                     state = lazyListState,
                 ) {
                     if (uiState.initial) {
-                        items(5) {
+                        val placeholderCount = 5
+                        items(placeholderCount) { idx ->
                             TimelineItemPlaceholder(modifier = Modifier.fillMaxWidth())
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = Spacing.s),
-                            )
+                            if (idx < placeholderCount - 1) {
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(vertical = Spacing.s),
+                                )
+                            }
                         }
                     }
 
@@ -305,9 +309,11 @@ class FavoritesScreen(
                                 }
                             },
                         )
-                        HorizontalDivider(
-                            modifier = Modifier.padding(vertical = Spacing.s),
-                        )
+                        if (idx < uiState.entries.lastIndex) {
+                            HorizontalDivider(
+                                modifier = Modifier.padding(vertical = Spacing.s),
+                            )
+                        }
 
                         val canFetchMore =
                             !uiState.initial && !uiState.loading && uiState.canFetchMore

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesViewModel.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesViewModel.kt
@@ -113,6 +113,7 @@ class FavoritesViewModel(
 
         updateState { it.copy(loading = true) }
         val entries = paginationManager.loadNextPage()
+        val wasRefreshing = uiState.value.refreshing
         updateState {
             it.copy(
                 entries = entries,
@@ -121,6 +122,9 @@ class FavoritesViewModel(
                 initial = false,
                 refreshing = false,
             )
+        }
+        if (wasRefreshing) {
+            emitEffect(FavoritesMviModel.Effect.BackToTop)
         }
     }
 

--- a/feature/followrequests/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/followrequests/FollowRequestsScreen.kt
+++ b/feature/followrequests/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/followrequests/FollowRequestsScreen.kt
@@ -117,11 +117,14 @@ class FollowRequestsScreen : Screen {
                     state = lazyListState,
                 ) {
                     if (uiState.initial) {
-                        items(5) {
+                        val placeholderCount = 5
+                        items(placeholderCount) { idx ->
                             GenericPlaceholder(modifier = Modifier.fillMaxWidth())
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = Spacing.s),
-                            )
+                            if (idx < placeholderCount - 1) {
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(vertical = Spacing.s),
+                                )
+                            }
                         }
                     }
 

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/followed/FollowedHashtagsScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/followed/FollowedHashtagsScreen.kt
@@ -120,11 +120,14 @@ class FollowedHashtagsScreen : Screen {
                     state = lazyListState,
                 ) {
                     if (uiState.initial) {
-                        items(5) {
+                        val placeholderCount = 5
+                        items(placeholderCount) { idx ->
                             GenericPlaceholder(modifier = Modifier.fillMaxWidth())
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = Spacing.s),
-                            )
+                            if (idx < placeholderCount - 1) {
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(vertical = Spacing.s),
+                                )
+                            }
                         }
                     }
                     itemsIndexed(

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
@@ -192,11 +192,14 @@ class HashtagScreen(
                     state = lazyListState,
                 ) {
                     if (uiState.initial) {
-                        items(5) {
+                        val placeholderCount = 5
+                        items(placeholderCount) { idx ->
                             TimelineItemPlaceholder(modifier = Modifier.fillMaxWidth())
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = Spacing.s),
-                            )
+                            if (idx < placeholderCount - 1) {
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(vertical = Spacing.s),
+                                )
+                            }
                         }
                     }
 
@@ -327,9 +330,11 @@ class HashtagScreen(
                                 }
                             },
                         )
-                        HorizontalDivider(
-                            modifier = Modifier.padding(vertical = Spacing.s),
-                        )
+                        if (idx < uiState.entries.lastIndex) {
+                            HorizontalDivider(
+                                modifier = Modifier.padding(vertical = Spacing.s),
+                            )
+                        }
 
                         val canFetchMore =
                             !uiState.initial && !uiState.loading && uiState.canFetchMore

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
@@ -170,11 +170,14 @@ class InboxScreen : Screen {
                     state = lazyListState,
                 ) {
                     if (uiState.initial) {
-                        items(5) {
+                        val placeholderCount = 5
+                        items(placeholderCount) { idx ->
                             NotificationItemPlaceholder(modifier = Modifier.fillMaxWidth())
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = Spacing.interItem),
-                            )
+                            if (idx < placeholderCount - 1) {
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(vertical = Spacing.interItem),
+                                )
+                            }
                         }
                     }
 
@@ -224,9 +227,11 @@ class InboxScreen : Screen {
                                 model.reduce(InboxMviModel.Intent.ToggleSpoilerActive(e))
                             },
                         )
-                        HorizontalDivider(
-                            modifier = Modifier.padding(vertical = Spacing.interItem),
-                        )
+                        if (idx < uiState.notifications.lastIndex) {
+                            HorizontalDivider(
+                                modifier = Modifier.padding(vertical = Spacing.interItem),
+                            )
+                        }
 
                         val canFetchMore =
                             !uiState.initial && !uiState.loading && uiState.canFetchMore

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
@@ -244,11 +244,14 @@ class MyAccountScreen : Screen {
                 }
 
                 if (uiState.initial) {
-                    items(5) {
+                    val placeholderCount = 5
+                    items(placeholderCount) { idx ->
                         TimelineItemPlaceholder(modifier = Modifier.fillMaxWidth())
-                        HorizontalDivider(
-                            modifier = Modifier.padding(vertical = Spacing.s),
-                        )
+                        if (idx < placeholderCount - 1) {
+                            HorizontalDivider(
+                                modifier = Modifier.padding(vertical = Spacing.s),
+                            )
+                        }
                     }
                 }
 
@@ -349,9 +352,11 @@ class MyAccountScreen : Screen {
                             }
                         },
                     )
-                    HorizontalDivider(
-                        modifier = Modifier.padding(vertical = Spacing.s),
-                    )
+                    if (idx < uiState.entries.lastIndex) {
+                        HorizontalDivider(
+                            modifier = Modifier.padding(vertical = Spacing.s),
+                        )
+                    }
 
                     val canFetchMore =
                         !uiState.initial && !uiState.loading && uiState.canFetchMore

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
@@ -223,7 +223,8 @@ class SearchScreen : Screen {
                     }
 
                     if (uiState.initial) {
-                        items(20) {
+                        val placeholderCount = 20
+                        items(placeholderCount) { idx ->
                             val modifier = Modifier.fillMaxWidth()
                             when (uiState.section) {
                                 SearchSection.Hashtags -> {
@@ -233,9 +234,11 @@ class SearchScreen : Screen {
 
                                 SearchSection.Posts -> {
                                     TimelineItemPlaceholder(modifier = modifier)
-                                    HorizontalDivider(
-                                        modifier = Modifier.padding(vertical = Spacing.s),
-                                    )
+                                    if (idx < placeholderCount - 1) {
+                                        HorizontalDivider(
+                                            modifier = Modifier.padding(vertical = Spacing.s),
+                                        )
+                                    }
                                 }
 
                                 SearchSection.Users -> {
@@ -410,9 +413,11 @@ class SearchScreen : Screen {
                                         }
                                     },
                                 )
-                                HorizontalDivider(
-                                    modifier = Modifier.padding(vertical = Spacing.s),
-                                )
+                                if (idx < uiState.items.lastIndex) {
+                                    HorizontalDivider(
+                                        modifier = Modifier.padding(vertical = Spacing.s),
+                                    )
+                                }
                             }
 
                             is ExploreItemModel.HashTag -> {

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ExperimentalMaterialApi
@@ -217,11 +218,14 @@ class ThreadScreen(
                     state = lazyListState,
                 ) {
                     if (uiState.initial) {
-                        items(5) {
+                        val placeholderCount = 5
+                        items(placeholderCount) { idx ->
                             TimelineItemPlaceholder(modifier = Modifier.fillMaxWidth())
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = Spacing.s),
-                            )
+                            if (idx < placeholderCount - 1) {
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(vertical = Spacing.s),
+                                )
+                            }
                         }
                     }
 
@@ -332,10 +336,10 @@ class ThreadScreen(
                     }
 
                     // replies
-                    items(
+                    itemsIndexed(
                         items = uiState.replies,
-                        key = { it.safeKey },
-                    ) { entry ->
+                        key = { _, e -> e.safeKey },
+                    ) { idx, entry ->
                         TimelineReplyItem(
                             entry = entry,
                             onOpenUrl = { url ->
@@ -441,10 +445,11 @@ class ThreadScreen(
                                 }
                             }
                         }
-
-                        HorizontalDivider(
-                            modifier = Modifier.padding(vertical = Spacing.s),
-                        )
+                        if (idx < uiState.replies.lastIndex) {
+                            HorizontalDivider(
+                                modifier = Modifier.padding(vertical = Spacing.s),
+                            )
+                        }
                     }
                     item {
                         Spacer(modifier = Modifier.height(Spacing.xxxl))

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
@@ -242,11 +242,14 @@ class TimelineScreen : Screen {
                     state = lazyListState,
                 ) {
                     if (uiState.initial) {
-                        items(5) {
+                        val placeholderCount = 5
+                        items(placeholderCount) { idx ->
                             TimelineItemPlaceholder(modifier = Modifier.fillMaxWidth())
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = Spacing.s),
-                            )
+                            if (idx < placeholderCount - 1) {
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(vertical = Spacing.s),
+                                )
+                            }
                         }
                     }
 
@@ -379,9 +382,11 @@ class TimelineScreen : Screen {
                                 }
                             },
                         )
-                        HorizontalDivider(
-                            modifier = Modifier.padding(vertical = Spacing.s),
-                        )
+                        if (idx < uiState.entries.lastIndex) {
+                            HorizontalDivider(
+                                modifier = Modifier.padding(vertical = Spacing.s),
+                            )
+                        }
 
                         val canFetchMore =
                             !uiState.initial && !uiState.loading && uiState.canFetchMore

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -431,11 +431,14 @@ class UserDetailScreen(
                         }
 
                         if (uiState.initial) {
-                            items(5) {
+                            val placeholderCount = 5
+                            items(placeholderCount) { idx ->
                                 TimelineItemPlaceholder(modifier = Modifier.fillMaxWidth())
-                                HorizontalDivider(
-                                    modifier = Modifier.padding(vertical = Spacing.s),
-                                )
+                                if (idx < placeholderCount - 1) {
+                                    HorizontalDivider(
+                                        modifier = Modifier.padding(vertical = Spacing.s),
+                                    )
+                                }
                             }
                         }
 
@@ -533,9 +536,11 @@ class UserDetailScreen(
                                     }
                                 },
                             )
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = Spacing.s),
-                            )
+                            if (idx < uiState.entries.lastIndex) {
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(vertical = Spacing.s),
+                                )
+                            }
 
                             val canFetchMore =
                                 !uiState.initial && !uiState.loading && uiState.canFetchMore

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
@@ -225,11 +225,14 @@ class ForumListScreen(
                     state = lazyListState,
                 ) {
                     if (uiState.initial) {
-                        items(5) {
+                        val placeholderCount = 5
+                        items(placeholderCount) { idx ->
                             TimelineItemPlaceholder(modifier = Modifier.fillMaxWidth())
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = Spacing.s),
-                            )
+                            if (idx < placeholderCount - 1) {
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(vertical = Spacing.s),
+                                )
+                            }
                         }
                     }
 
@@ -336,9 +339,11 @@ class ForumListScreen(
                                 }
                             },
                         )
-                        HorizontalDivider(
-                            modifier = Modifier.padding(vertical = Spacing.s),
-                        )
+                        if (idx < uiState.entries.lastIndex) {
+                            HorizontalDivider(
+                                modifier = Modifier.padding(vertical = Spacing.s),
+                            )
+                        }
 
                         val canFetchMore =
                             !uiState.initial && !uiState.loading && uiState.canFetchMore


### PR DESCRIPTION
This PR contains a series of layout improvements
- inter item dividers are not shown after the last item
- font scale is increased
- back to top after refresh in favorites/bookmarks
- fix layout of placeholder images
- scrim color in progress overlays