### PR TITLE
fix: avoid opening user detail multiple times

### DIFF
--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -455,8 +455,10 @@ class UserDetailScreen(
                                 onOpenUrl = { url ->
                                     uriHandler.openUri(url)
                                 },
-                                onOpenUser = {
-                                    detailOpener.openUserDetail(it.id)
+                                onOpenUser = { user ->
+                                    if (user.id != uiState.user?.id) {
+                                        detailOpener.openUserDetail(user.id)
+                                    }
                                 },
                                 onOpenImage = { imageUrl ->
                                     detailOpener.openImageDetail(imageUrl)


### PR DESCRIPTION
This avoids opening the user detail from the screen itself (due to navigation issues).