### PR TITLE
fix: state restoration for favorites and user list

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
@@ -60,12 +60,20 @@ class DefaultDetailOpener(
     }
 
     override fun openFollowers(userId: String) {
-        val screen = UserListScreen(UserListType.Follower(userId))
+        val screen =
+            UserListScreen(
+                type = UserListType.Follower.toInt(),
+                userId = userId,
+            )
         navigationCoordinator.push(screen)
     }
 
     override fun openFollowing(userId: String) {
-        val screen = UserListScreen(UserListType.Following(userId))
+        val screen =
+            UserListScreen(
+                type = UserListType.Following.toInt(),
+                userId = userId,
+            )
         navigationCoordinator.push(screen)
     }
 
@@ -97,7 +105,12 @@ class DefaultDetailOpener(
         entryId: String,
         count: Int,
     ) {
-        val screen = UserListScreen(UserListType.UsersFavorite(entryId, count))
+        val screen =
+            UserListScreen(
+                type = UserListType.UsersFavorite.toInt(),
+                entryId = entryId,
+                infoCount = count,
+            )
         navigationCoordinator.push(screen)
     }
 
@@ -105,7 +118,12 @@ class DefaultDetailOpener(
         entryId: String,
         count: Int,
     ) {
-        val screen = UserListScreen(UserListType.UsersReblog(entryId, count))
+        val screen =
+            UserListScreen(
+                type = UserListType.UsersReblog.toInt(),
+                entryId = entryId,
+                infoCount = count,
+            )
         navigationCoordinator.push(screen)
     }
 

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
@@ -6,6 +6,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.NavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.FavoritesType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserListType
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toInt
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.feature.circles.detail.CircleDetailScreen
 import com.livefast.eattrash.raccoonforfriendica.feature.circles.list.CirclesScreen
@@ -72,7 +73,7 @@ class DefaultDetailOpener(
         if (!isLogged) {
             return
         }
-        val screen = FavoritesScreen(type = FavoritesType.Favorites)
+        val screen = FavoritesScreen(type = FavoritesType.Favorites.toInt())
         navigationCoordinator.push(screen)
     }
 
@@ -80,7 +81,7 @@ class DefaultDetailOpener(
         if (!isLogged) {
             return
         }
-        val screen = FavoritesScreen(type = FavoritesType.Bookmarks)
+        val screen = FavoritesScreen(type = FavoritesType.Bookmarks.toInt())
         navigationCoordinator.push(screen)
     }
 
@@ -190,7 +191,11 @@ class DefaultDetailOpener(
         otherUserId: String,
         parentUri: String,
     ) {
-        val screen = ConversationScreen(otherUserId = otherUserId, parentUri = parentUri)
+        val screen =
+            ConversationScreen(
+                otherUserId = otherUserId,
+                parentUri = parentUri,
+            )
         navigationCoordinator.push(screen)
     }
 
@@ -203,7 +208,11 @@ class DefaultDetailOpener(
         name: String,
         createMode: Boolean,
     ) {
-        val screen = AlbumDetailScreen(name = name, createMode = createMode)
+        val screen =
+            AlbumDetailScreen(
+                name = name,
+                createMode = createMode
+        )
         navigationCoordinator.push(screen)
     }
 }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentExtendedSocialInfo.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentExtendedSocialInfo.kt
@@ -3,7 +3,9 @@ package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FavoriteBorder
@@ -13,6 +15,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
@@ -34,11 +38,13 @@ fun ContentExtendedSocialInfo(
     ) {
         Row(
             modifier =
-                Modifier.clickable {
-                    if (reblogCount > 0) {
-                        onOpenUsersReblog?.invoke()
-                    }
-                },
+                Modifier
+                    .clip(RoundedCornerShape(CornerSize.xl))
+                    .clickable {
+                        if (reblogCount > 0) {
+                            onOpenUsersReblog?.invoke()
+                        }
+                    }.padding(horizontal = Spacing.s),
             horizontalArrangement = Arrangement.spacedBy(Spacing.s),
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -60,17 +66,19 @@ fun ContentExtendedSocialInfo(
             )
         }
         Text(
-            text = " • ",
+            text = "•",
             style = MaterialTheme.typography.labelMedium,
             color = ancillaryColor,
         )
         Row(
             modifier =
-                Modifier.clickable {
-                    if (favoriteCount > 0) {
-                        onOpenUsersFavorite?.invoke()
-                    }
-                },
+                Modifier
+                    .clip(RoundedCornerShape(CornerSize.xl))
+                    .clickable {
+                        if (favoriteCount > 0) {
+                            onOpenUsersFavorite?.invoke()
+                        }
+                    }.padding(horizontal = Spacing.s),
             horizontalArrangement = Arrangement.spacedBy(Spacing.s),
             verticalAlignment = Alignment.CenterVertically,
         ) {

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/InReplyToInfo.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/InReplyToInfo.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
@@ -94,6 +95,8 @@ internal fun InReplyToInfo(
             text = creatorName,
             style = MaterialTheme.typography.bodyMedium,
             color = fullColor,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
         )
     }
 }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ReblogInfo.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ReblogInfo.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
@@ -94,6 +95,8 @@ internal fun ReblogInfo(
             text = creatorName,
             style = MaterialTheme.typography.bodyMedium,
             color = fullColor,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
         )
     }
 }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserHeader.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserHeader.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
@@ -122,11 +123,13 @@ fun UserHeader(
                         val following = user?.following ?: 0
                         Text(
                             modifier =
-                                Modifier.clickable {
-                                    if (followers > 0) {
-                                        onOpenFollowers?.invoke()
-                                    }
-                                },
+                                Modifier
+                                    .clip(RoundedCornerShape(CornerSize.xl))
+                                    .clickable {
+                                        if (followers > 0) {
+                                            onOpenFollowers?.invoke()
+                                        }
+                                    }.padding(horizontal = Spacing.s),
                             text =
                                 buildString {
                                     append(followers)
@@ -137,17 +140,19 @@ fun UserHeader(
                             color = ancillaryColor,
                         )
                         Text(
-                            text = " • ",
+                            text = "•",
                             style = MaterialTheme.typography.labelMedium,
                             color = ancillaryColor,
                         )
                         Text(
                             modifier =
-                                Modifier.clickable {
-                                    if (following > 0) {
-                                        onOpenFollowing?.invoke()
-                                    }
-                                },
+                                Modifier
+                                    .clip(RoundedCornerShape(CornerSize.xl))
+                                    .clickable {
+                                        if (following > 0) {
+                                            onOpenFollowing?.invoke()
+                                        }
+                                    }.padding(horizontal = Spacing.s),
                             text =
                                 buildString {
                                     append(following)

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserHeader.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserHeader.kt
@@ -121,7 +121,12 @@ fun UserHeader(
                         val followers = user?.followers ?: 0
                         val following = user?.following ?: 0
                         Text(
-                            modifier = Modifier.clickable { onOpenFollowers?.invoke() },
+                            modifier =
+                                Modifier.clickable {
+                                    if (followers > 0) {
+                                        onOpenFollowers?.invoke()
+                                    }
+                                },
                             text =
                                 buildString {
                                     append(followers)
@@ -137,7 +142,12 @@ fun UserHeader(
                             color = ancillaryColor,
                         )
                         Text(
-                            modifier = Modifier.clickable { onOpenFollowing?.invoke() },
+                            modifier =
+                                Modifier.clickable {
+                                    if (following > 0) {
+                                        onOpenFollowing?.invoke()
+                                    }
+                                },
                             text =
                                 buildString {
                                     append(following)

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/FavoritesType.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/FavoritesType.kt
@@ -15,3 +15,15 @@ fun FavoritesType.toReadableName() =
         FavoritesType.Bookmarks -> LocalStrings.current.bookmarksTitle
         FavoritesType.Favorites -> LocalStrings.current.favoritesTitle
     }
+
+fun FavoritesType.toInt(): Int =
+    when (this) {
+        FavoritesType.Bookmarks -> 1
+        FavoritesType.Favorites -> 0
+    }
+
+fun Int.toFavoritesType(): FavoritesType =
+    when (this) {
+        1 -> FavoritesType.Bookmarks
+        else -> FavoritesType.Favorites
+}

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/UserListType.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/UserListType.kt
@@ -1,21 +1,27 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.data
 
 sealed interface UserListType {
-    data class Follower(
-        val userId: String,
-    ) : UserListType
+    data object Follower : UserListType
 
-    data class Following(
-        val userId: String,
-    ) : UserListType
+    data object Following : UserListType
 
-    data class UsersReblog(
-        val entryId: String,
-        val count: Int,
-    ) : UserListType
+    data object UsersReblog : UserListType
 
-    data class UsersFavorite(
-        val entryId: String,
-        val count: Int,
-    ) : UserListType
+    data object UsersFavorite : UserListType
+}
+
+fun UserListType.toInt(): Int =
+    when (this) {
+        UserListType.Follower -> 0
+        UserListType.Following -> 1
+        UserListType.UsersFavorite -> 2
+        UserListType.UsersReblog -> 3
+    }
+
+fun Int.toUserListType(): UserListType =
+    when (this) {
+        3 -> UserListType.UsersReblog
+        2 -> UserListType.UsersFavorite
+        1 -> UserListType.Following
+    else -> UserListType.Follower
 }

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
@@ -59,9 +59,9 @@ import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDetailOpener
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getShareHelper
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.FavoritesType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toFavoritesType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toReadableName
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -69,12 +69,13 @@ import kotlinx.coroutines.launch
 import org.koin.core.parameter.parametersOf
 
 class FavoritesScreen(
-    private val type: FavoritesType,
+    private val type: Int,
 ) : Screen {
     @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
     @Composable
     override fun Content() {
-        val model = getScreenModel<FavoritesMviModel>(parameters = { parametersOf(type) })
+        val model =
+            getScreenModel<FavoritesMviModel>(parameters = { parametersOf(type.toFavoritesType()) })
         val uiState by model.uiState.collectAsState()
         val navigationCoordinator = remember { getNavigationCoordinator() }
         val topAppBarState = rememberTopAppBarState()
@@ -121,7 +122,7 @@ class FavoritesScreen(
                     title = {
                         Text(
                             modifier = Modifier.padding(horizontal = Spacing.s),
-                            text = type.toReadableName(),
+                            text = type.toFavoritesType().toReadableName(),
                             style = MaterialTheme.typography.titleMedium,
                         )
                     },

--- a/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListViewModel.kt
+++ b/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListViewModel.kt
@@ -18,6 +18,8 @@ import kotlinx.coroutines.launch
 
 internal class UserListViewModel(
     private val type: UserListType,
+    private val userId: String? = null,
+    private val entryId: String? = null,
     private val paginationManager: UserPaginationManager,
     private val userRepository: UserRepository,
     private val hapticFeedback: HapticFeedback,
@@ -44,8 +46,8 @@ internal class UserListViewModel(
     private suspend fun loadUser() {
         val userId =
             when (type) {
-                is UserListType.Follower -> type.userId
-                is UserListType.Following -> type.userId
+                is UserListType.Follower -> userId
+                is UserListType.Following -> userId
                 else -> null
             }
         if (userId != null) {
@@ -78,10 +80,12 @@ internal class UserListViewModel(
         }
         paginationManager.reset(
             when (type) {
-                is UserListType.Follower -> UserPaginationSpecification.Follower(type.userId)
-                is UserListType.Following -> UserPaginationSpecification.Following(type.userId)
-                is UserListType.UsersFavorite -> UserPaginationSpecification.EntryUsersFavorite(type.entryId)
-                is UserListType.UsersReblog -> UserPaginationSpecification.EntryUsersReblog(type.entryId)
+                is UserListType.Follower -> UserPaginationSpecification.Follower(userId.orEmpty())
+                is UserListType.Following -> UserPaginationSpecification.Following(userId.orEmpty())
+                is UserListType.UsersFavorite ->
+                    UserPaginationSpecification.EntryUsersFavorite(entryId.orEmpty())
+
+                is UserListType.UsersReblog -> UserPaginationSpecification.EntryUsersReblog(entryId.orEmpty())
             },
         )
         loadNextPage()

--- a/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/di/UserListModule.kt
+++ b/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/di/UserListModule.kt
@@ -9,6 +9,8 @@ val featureUserListModule =
         factory<UserListMviModel> { params ->
             UserListViewModel(
                 type = params[0],
+                userId = params[1],
+                entryId = params[2],
                 paginationManager = get(),
                 userRepository = get(),
                 hapticFeedback = get(),


### PR DESCRIPTION
Due to a limitation of Voyager, it is not possible to pass non-primitive types in Screen constructors. I knew this from Raccon for Lemmy but I forgot about it for no reason here somewhere.