### PR TITLE
feat: show unread messages and mark messages as read

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DirectMessageService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DirectMessageService.kt
@@ -39,7 +39,7 @@ interface DirectMessageService {
         @Query("id") id: Long,
     ): FriendicaApiResult
 
-    @GET("friendica/direct_messages_setseen")
+    @POST("friendica/direct_messages_setseen")
     suspend fun markAsRead(
         @Query("id") id: Long,
     ): FriendicaApiResult

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -293,4 +293,6 @@ internal open class DefaultStrings : Strings {
         "It looks like this album is still empty… ✨"
     override val actionMove = "Move"
     override val pickFromGalleryDialogTitle = "Select from gallery"
+
+    override fun unreadMessages(count: Int): String = "unread"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -300,4 +300,10 @@ internal val ItStrings =
             "Sembra che questo album sia ancora vuoto… ✨"
         override val actionMove = "Sposta"
         override val pickFromGalleryDialogTitle = "Seleziona dalla galleria"
+
+        override fun unreadMessages(count: Int): String =
+            when (count) {
+                1 -> "non letto"
+                else -> "non letti"
+        }
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -266,6 +266,8 @@ interface Strings {
     val messageEmptyAlbum: String
     val actionMove: String
     val pickFromGalleryDialogTitle: String
+
+    fun unreadMessages(count: Int): String
 }
 
 object Locales {

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/ConversationModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/ConversationModel.kt
@@ -4,4 +4,5 @@ data class ConversationModel(
     val otherUser: UserModel,
     val lastMessage: DirectMessageModel,
     val messageCount: Int = 0,
+    val unreadCount: Int = 0,
 )

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
@@ -373,6 +373,7 @@ internal fun FriendicaPrivateMessage.toModel() =
         sender = sender?.toModel(),
         recipient = recipient?.toModel(),
         parentUri = parentUri,
+        read = seen ?: true,
     )
 
 internal fun FriendicaPhotoAlbum.toModel() =

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/components/ConversationItem.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/components/ConversationItem.kt
@@ -17,7 +17,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
@@ -127,10 +131,23 @@ internal fun ConversationItem(
                     bottom = Spacing.xs,
                 ),
             text =
-                buildString {
-                    append(conversation.messageCount)
+                buildAnnotatedString {
+                    append(conversation.messageCount.toString())
                     append(" ")
                     append(LocalStrings.current.messages(conversation.messageCount))
+
+                    if (conversation.unreadCount > 0) {
+                        append(" (")
+                        withStyle(SpanStyle(color = fullColor)) {
+                            withStyle(SpanStyle(fontWeight = FontWeight.SemiBold)) {
+                                append((conversation.unreadCount.toString()))
+                            }
+                            append(" ")
+                            append(LocalStrings.current.unreadMessages(conversation.unreadCount))
+                        }
+                        append(")")
+                    }
+
                     val date = message.created
                     if (!date.isNullOrEmpty()) {
                         append(" • ")

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationViewModel.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationViewModel.kt
@@ -102,6 +102,7 @@ class ConversationViewModel(
 
         updateState { it.copy(loading = true) }
         val items = paginationManager.loadNextPage()
+            .onEach { markAsRead(it) }
         val wasRefreshing = uiState.value.refreshing
         updateState {
             it.copy(
@@ -138,6 +139,12 @@ class ConversationViewModel(
             updateParentUriIfNeeded(newMessages.lastOrNull()?.parentUri)
             updateState { it.copy(items = newMessages + originalItems) }
             emitEffect(ConversationMviModel.Effect.BackToTop)
+        }
+    }
+
+    private suspend fun markAsRead(message: DirectMessageModel) {
+        if (!message.read) {
+            messageRepository.markAsRead(message.id)
         }
     }
 

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/list/DirectMessageListMviModel.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/list/DirectMessageListMviModel.kt
@@ -20,6 +20,10 @@ interface DirectMessageListMviModel :
         ) : Intent
 
         data object UserSearchClear : Intent
+
+        data class MarkConversationAsRead(
+            val index: Int,
+        ) : Intent
     }
 
     data class State(

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/list/DirectMessageListScreen.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/list/DirectMessageListScreen.kt
@@ -199,6 +199,9 @@ class DirectMessageListScreen : Screen {
                                 val otherUserId = conversation.otherUser.id
                                 val parentUri = conversation.lastMessage.parentUri
                                 if (parentUri != null) {
+                                    model.reduce(
+                                        DirectMessageListMviModel.Intent.MarkConversationAsRead(idx),
+                                    )
                                     detailOpener.openConversation(
                                         otherUserId = otherUserId,
                                         parentUri = parentUri,


### PR DESCRIPTION
This PR contains a significant improvement in the DM sections:
- show number of unread items in conversation list
- mark messages as read when opening the conversation and downloading messages