### PR TITLE
enhancement: load post source for editing

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/StatusSource.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/StatusSource.kt
@@ -1,0 +1,11 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class StatusSource(
+    @SerialName("id") val id: String,
+    @SerialName("text") val text: String? = null,
+    @SerialName("spoiler_text") val spoilerText: String? = null,
+)

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/StatusService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/StatusService.kt
@@ -3,6 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica.core.api.service
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Account
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Status
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.StatusContext
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.StatusSource
 import com.livefast.eattrash.raccoonforfriendica.core.api.form.CreateStatusForm
 import com.livefast.eattrash.raccoonforfriendica.core.api.form.ReblogPostForm
 import de.jensklingenberg.ktorfit.http.Body
@@ -25,6 +26,11 @@ interface StatusService {
     suspend fun getContext(
         @Path("id") id: String,
     ): StatusContext
+
+    @GET("v1/statuses/{id}/source")
+    suspend fun getSource(
+        @Path("id") id: String,
+    ): StatusSource
 
     @POST("v1/statuses/{id}/reblog")
     @Headers("Content-Type: application/json")

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTimelineEntryRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTimelineEntryRepository.kt
@@ -50,6 +50,13 @@ internal class DefaultTimelineEntryRepository(
             }.getOrNull()
         }
 
+    override suspend fun getSource(id: String): TimelineEntryModel? =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                provider.statuses.getSource(id = id).toModel()
+            }.getOrNull()
+        }
+
     override suspend fun getContext(id: String): TimelineContextModel? =
         withContext(Dispatchers.IO) {
             runCatching {

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/TimelineEntryRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/TimelineEntryRepository.kt
@@ -18,6 +18,8 @@ interface TimelineEntryRepository {
 
     suspend fun getById(id: String): TimelineEntryModel?
 
+    suspend fun getSource(id: String): TimelineEntryModel?
+
     suspend fun getContext(id: String): TimelineContextModel?
 
     suspend fun reblog(id: String): TimelineEntryModel?

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
@@ -25,6 +25,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.dto.PreviewCardType
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Relationship
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Status
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.StatusContext
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.StatusSource
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Tag
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.TrendsLink
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.UserList
@@ -88,6 +89,13 @@ internal fun Status.toModel() =
         visibility = visibility.toVisibility(),
         title = addons?.title?.takeIf { it.isNotBlank() },
         poll = poll?.toModel(),
+    )
+
+internal fun StatusSource.toModel() =
+    TimelineEntryModel(
+        content = text.orEmpty(),
+        id = id,
+        spoiler = spoilerText,
     )
 
 internal fun PreviewCard.toModel() =

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
@@ -497,7 +497,9 @@ class ComposerViewModel(
     private fun loadEditedPost() {
         val id = editedPostId ?: return
         screenModelScope.launch {
+            updateState { it.copy(loading = true) }
             val entry = timelineEntryRepository.getById(id)
+            val sourceEntry = timelineEntryRepository.getSource(id)
             val visibility =
                 entry?.visibility.let { visibility ->
                     when (visibility) {
@@ -516,10 +518,15 @@ class ComposerViewModel(
 
             updateState {
                 it.copy(
-                    bodyValue = TextFieldValue(text = entry?.content.orEmpty()),
+                    bodyValue = TextFieldValue(text = sourceEntry?.content.orEmpty()),
                     sensitive = entry?.sensitive ?: false,
                     attachments = entry?.attachments.orEmpty(),
                     visibility = visibility,
+                    spoilerValue = TextFieldValue(text = sourceEntry?.spoiler.orEmpty()),
+                    hasSpoiler = !sourceEntry?.spoiler.isNullOrEmpty(),
+                    titleValue = TextFieldValue(text = entry?.title.orEmpty()),
+                    hasTitle = !entry?.title.isNullOrEmpty(),
+                    loading = false,
                 )
             }
         }


### PR DESCRIPTION
This PR adds the GET `/api/v1/statuses/:id/source` call to retrieve the source text of the post body and spoiler, to allow editing without additional back-end generated formatting