### PR TITLE
feat: show multiple images

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentImage.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentImage.kt
@@ -63,6 +63,7 @@ fun ContentImage(
     originalHeight: Int = 0,
     minHeight: Dp = 50.dp,
     maxHeight: Dp = Dp.Unspecified,
+    contentScale: ContentScale = ContentScale.FillWidth,
     onClick: (() -> Unit)? = null,
 ) {
     var revealing by remember { mutableStateOf(!sensitive) }
@@ -73,9 +74,7 @@ fun ContentImage(
 
     Box(
         modifier =
-            modifier
-                .fillMaxWidth()
-                .heightIn(min = minHeight, max = maxHeight),
+            modifier.heightIn(min = minHeight, max = maxHeight),
     ) {
         if (!hasFinishedLoadingSuccessfully) {
             BlurredPreview(
@@ -89,6 +88,7 @@ fun ContentImage(
                 originalWidth = originalWidth,
                 originalHeight = originalHeight,
                 blurHash = blurHash,
+                contentScale = contentScale,
             )
         }
 
@@ -102,7 +102,7 @@ fun ContentImage(
             url = url,
             quality = FilterQuality.Low,
             blurred = !revealing,
-            contentScale = ContentScale.FillWidth,
+            contentScale = contentScale,
             onSuccess = {
                 hasFinishedLoadingSuccessfully = true
             },
@@ -210,6 +210,7 @@ private fun BlurredPreview(
     originalHeight: Int,
     blurHash: String?,
     modifier: Modifier = Modifier,
+    contentScale: ContentScale = ContentScale.FillWidth,
 ) {
     if (originalWidth > 0 && originalHeight > 0) {
         var imageBitmap by remember { mutableStateOf<ImageBitmap?>(null) }
@@ -234,7 +235,7 @@ private fun BlurredPreview(
                     modifier = Modifier.fillMaxSize(),
                     bitmap = bmp,
                     contentDescription = null,
-                    contentScale = ContentScale.FillWidth,
+                    contentScale = contentScale,
                 )
             }
         }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
@@ -32,7 +32,6 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomDropDown
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 
@@ -82,6 +81,7 @@ fun TimelineItem(
         Column(
             verticalArrangement = Arrangement.spacedBy(Spacing.xs),
         ) {
+            // reshare and reply info
             if (reshareAndReplyVisible) {
                 Column(
                     modifier = Modifier.padding(horizontal = contentHorizontalPadding),
@@ -105,6 +105,7 @@ fun TimelineItem(
                 }
             }
 
+            // header and options
             Row(
                 modifier = Modifier.padding(horizontal = contentHorizontalPadding),
                 verticalAlignment = Alignment.CenterVertically,
@@ -164,6 +165,7 @@ fun TimelineItem(
                 }
             }
 
+            // post spoiler
             if (spoiler.isNotEmpty()) {
                 SpoilerCard(
                     modifier =
@@ -182,7 +184,9 @@ fun TimelineItem(
                     },
                 )
             }
+
             if (entryToDisplay.isSpoilerActive || spoiler.isEmpty()) {
+                // post title
                 val title = entryToDisplay.title
                 if (!title.isNullOrBlank()) {
                     ContentTitle(
@@ -197,6 +201,7 @@ fun TimelineItem(
                     )
                 }
 
+                // post body
                 val body = entryToDisplay.content
                 if (body.isNotBlank()) {
                     ContentBody(
@@ -221,28 +226,22 @@ fun TimelineItem(
                     )
                 }
 
-                val firstImageAttachment =
-                    entryToDisplay.attachments
-                        .firstOrNull { attachment -> attachment.type == MediaType.Image }
-                val imageUrl = firstImageAttachment?.url?.takeIf { it.isNotBlank() }
-                if (imageUrl != null) {
-                    ContentImage(
-                        modifier =
-                            Modifier.fillMaxWidth().padding(
-                                top = Spacing.s,
-                                bottom = Spacing.xxxs,
-                                start = contentHorizontalPadding,
-                                end = contentHorizontalPadding,
-                            ),
-                        url = imageUrl,
-                        altText = firstImageAttachment.description,
-                        blurHash = firstImageAttachment.blurHash,
-                        originalWidth = firstImageAttachment.originalWidth ?: 0,
-                        originalHeight = firstImageAttachment.originalHeight ?: 0,
-                        sensitive = blurNsfw && entryToDisplay.sensitive,
-                        onClick = { onOpenImage?.invoke(imageUrl) },
-                    )
-                }
+                // attachment (single or grid)
+                TimelineItemAttachments(
+                    modifier =
+                        Modifier.fillMaxWidth().padding(
+                            top = Spacing.s,
+                            bottom = Spacing.xxxs,
+                            start = contentHorizontalPadding,
+                            end = contentHorizontalPadding,
+                        ),
+                    attachments = entryToDisplay.attachments,
+                    blurNsfw = blurNsfw,
+                    sensitive = entryToDisplay.sensitive,
+                    onOpenImage = onOpenImage,
+                )
+
+                // poll
                 entryToDisplay.poll?.also { poll ->
                     PollCard(
                         modifier =
@@ -257,7 +256,10 @@ fun TimelineItem(
                         },
                     )
                 }
+
+                // preview
                 entryToDisplay.card?.also { preview ->
+                    val attachmentUrls = entryToDisplay.attachments.map { it.url }
                     ContentPreview(
                         modifier =
                             Modifier
@@ -267,13 +269,14 @@ fun TimelineItem(
                                     start = contentHorizontalPadding,
                                     end = contentHorizontalPadding,
                                 ),
-                        card = preview.copy(image = preview.image.takeIf { it != imageUrl }),
+                        card = preview.copy(image = preview.image.takeIf { it !in attachmentUrls }),
                         onOpen = onOpenUrl,
                         onOpenImage = onOpenImage,
                     )
                 }
             }
 
+            // reblog and favorite info
             if (extendedSocialInfoEnabled) {
                 ContentExtendedSocialInfo(
                     modifier =

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItemAttachments.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItemAttachments.kt
@@ -1,0 +1,186 @@
+package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.toSize
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.AttachmentModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
+
+@Composable
+internal fun TimelineItemAttachments(
+    attachments: List<AttachmentModel>,
+    modifier: Modifier = Modifier,
+    blurNsfw: Boolean = true,
+    sensitive: Boolean = false,
+    onOpenImage: ((String) -> Unit)? = null,
+) {
+    val images =
+        attachments.filter { it.type == MediaType.Image }.takeIf { it.isNotEmpty() } ?: return
+    val firstAttachment = images.first()
+    val firstAttachmentWidth = firstAttachment.originalWidth ?: 0
+    val firstAttachmentHeight = firstAttachment.originalHeight ?: 0
+    val interItemSpacing = Spacing.xxs
+
+    if (attachments.size == 1) {
+        if (firstAttachment.url.isNotBlank()) {
+            ContentImage(
+                modifier = modifier,
+                url = firstAttachment.url,
+                altText = firstAttachment.description,
+                blurHash = firstAttachment.blurHash,
+                originalWidth = firstAttachment.originalWidth ?: 0,
+                originalHeight = firstAttachment.originalHeight ?: 0,
+                sensitive = blurNsfw && sensitive,
+                onClick = { onOpenImage?.invoke(firstAttachment.url) },
+            )
+        }
+    } else if (attachments.size == 2) {
+        Row(
+            modifier = modifier,
+            horizontalArrangement = Arrangement.spacedBy(interItemSpacing),
+        ) {
+            for (attachment in attachments) {
+                val attachmentWidth = attachment.originalWidth ?: 0
+                val attachmentHeight = attachment.originalHeight ?: 0
+                ContentImage(
+                    modifier = Modifier.weight(1f),
+                    url = attachment.url,
+                    altText = attachment.description,
+                    blurHash = attachment.blurHash,
+                    originalWidth = attachmentWidth,
+                    originalHeight = attachmentHeight,
+                    maxHeight = 200.dp,
+                    sensitive = blurNsfw && sensitive,
+                    onClick = { onOpenImage?.invoke(attachment.url) },
+                    contentScale =
+                        if (attachmentHeight < attachmentWidth) {
+                            ContentScale.FillHeight
+                        } else {
+                            ContentScale.FillWidth
+                        },
+                )
+            }
+        }
+    } else {
+        if (firstAttachmentWidth < firstAttachmentHeight) {
+            Row(
+                modifier = modifier,
+                horizontalArrangement = Arrangement.spacedBy(interItemSpacing),
+            ) {
+                // first image
+                var firstHeight by remember { mutableStateOf(0f) }
+                ContentImage(
+                    modifier =
+                        Modifier.weight(0.75f).onGloballyPositioned {
+                            firstHeight = it.size.toSize().height
+                        },
+                    url = firstAttachment.url,
+                    altText = firstAttachment.description,
+                    blurHash = firstAttachment.blurHash,
+                    originalWidth = firstAttachment.originalWidth ?: 0,
+                    originalHeight = firstAttachment.originalHeight ?: 0,
+                    sensitive = blurNsfw && sensitive,
+                    onClick = { onOpenImage?.invoke(firstAttachment.url) },
+                )
+
+                // rest of images arranged vertically in chunks
+                val chunks = attachments.drop(1).chunked(4)
+                for (chunk in chunks) {
+                    Column(
+                        modifier =
+                            Modifier
+                                .weight(0.25f)
+                                .height(with(LocalDensity.current) { firstHeight.toDp() }),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(interItemSpacing),
+                    ) {
+                        for (attachment in chunk) {
+                            val attachmentWidth = attachment.originalWidth ?: 0
+                            val attachmentHeight = attachment.originalHeight ?: 0
+                            ContentImage(
+                                modifier = Modifier.weight(1f),
+                                url = attachment.url,
+                                altText = attachment.description,
+                                blurHash = attachment.blurHash,
+                                originalWidth = attachmentWidth,
+                                originalHeight = attachmentHeight,
+                                sensitive = blurNsfw && sensitive,
+                                onClick = { onOpenImage?.invoke(attachment.url) },
+                                contentScale =
+                                    if (attachmentHeight < attachmentWidth) {
+                                        ContentScale.FillHeight
+                                    } else {
+                                        ContentScale.FillWidth
+                                    },
+                            )
+                        }
+                    }
+                }
+            }
+        } else {
+            Column(
+                modifier = modifier,
+                verticalArrangement = Arrangement.spacedBy(interItemSpacing),
+            ) {
+                // first image
+                ContentImage(
+                    modifier = Modifier.fillMaxWidth(),
+                    url = firstAttachment.url,
+                    altText = firstAttachment.description,
+                    blurHash = firstAttachment.blurHash,
+                    originalWidth = firstAttachment.originalWidth ?: 0,
+                    originalHeight = firstAttachment.originalHeight ?: 0,
+                    sensitive = blurNsfw && sensitive,
+                    onClick = { onOpenImage?.invoke(firstAttachment.url) },
+                )
+
+                // rest of images arranged vertically in chunks
+                val chunks = attachments.drop(1).chunked(4)
+                for (chunk in chunks) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(interItemSpacing),
+                    ) {
+                        for (attachment in chunk) {
+                            val attachmentWidth = attachment.originalWidth ?: 0
+                            val attachmentHeight = attachment.originalHeight ?: 0
+                            ContentImage(
+                                modifier = Modifier.weight(1f),
+                                url = attachment.url,
+                                altText = attachment.description,
+                                blurHash = attachment.blurHash,
+                                originalWidth = attachmentWidth,
+                                originalHeight = attachmentHeight,
+                                sensitive = blurNsfw && sensitive,
+                                maxHeight = 180.dp,
+                                onClick = { onOpenImage?.invoke(attachment.url) },
+                                contentScale =
+                                    if (attachmentHeight < attachmentWidth) {
+                                        ContentScale.FillHeight
+                                    } else {
+                                        ContentScale.FillWidth
+                                    },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
@@ -106,11 +106,12 @@ actual fun getPrettyDate(
     }
 }
 
-actual fun getDurationSinceDate(iso8601Timestamp: String): Duration? {
-    val date = getDateFromIso8601Timestamp(iso8601Timestamp).toOffsetDateTime()
+actual fun getDurationSinceDate(iso8601Timestamp: String): Duration? =
+    runCatching {
+        val date = getDateFromIso8601Timestamp(iso8601Timestamp).toOffsetDateTime()
     val now = LocalDateTime.now()
     val duration = JavaDuration.between(date, now)
-    return duration.toKotlinDuration()
-}
+        duration.toKotlinDuration()
+    }.getOrNull()
 
 private fun getDateFromIso8601Timestamp(string: String): ZonedDateTime = ZonedDateTime.parse(string)


### PR DESCRIPTION
One of the greatest limitation of this app so far was the way post attachments were displayed, i.e. truncating the list to the first image and discarding all the rest.

This PR contains the first step moving towards are more dynamic layout which displays one, two or more images in a grid, allowing to open each one individually.

<div align="center">
<img src="https://github.com/user-attachments/assets/49fea960-fe73-4c7d-b067-aed5ecb9d6a7" width="310" />
</div>
<div align="center">
<img src="https://github.com/user-attachments/assets/ddfe3d2e-f3ad-4299-b8fe-c4c5532500b0" width="310" />
</div>
<div align="center">
<img src="https://github.com/user-attachments/assets/db74170d-0b34-49ef-82f0-0125d48ec17b" width="310" />
</div>

Future PR will allow to navigate between pictures in the full-screen image detail and add support for other media types (GIFs and videos), considering the constraints imposed by the multiplatform technology this project is built upon.