### PR TITLE
enhancement: avoid self-follow

### DIFF
--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
@@ -167,15 +167,18 @@ class ExploreScreen : Screen {
                         )
                     },
                     actions = {
-                        IconButton(
-                            onClick = {
-                                detailOpener.openSearch()
-                            },
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.Search,
-                                contentDescription = null,
-                            )
+                        if (uiState.currentUserId != null) {
+                            // only logged users can call the v2/search API
+                            IconButton(
+                                onClick = {
+                                    detailOpener.openSearch()
+                                },
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Search,
+                                    contentDescription = null,
+                                )
+                            }
                         }
                     },
                 )

--- a/feature/userlist/build.gradle.kts
+++ b/feature/userlist/build.gradle.kts
@@ -51,6 +51,7 @@ kotlin {
                 implementation(projects.domain.content.data)
                 implementation(projects.domain.content.pagination)
                 implementation(projects.domain.content.repository)
+                implementation(projects.domain.identity.repository)
             }
         }
     }

--- a/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListMviModel.kt
+++ b/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListMviModel.kt
@@ -24,6 +24,7 @@ interface UserListMviModel :
     }
 
     data class State(
+        val currentUserId: String? = null,
         val refreshing: Boolean = false,
         val loading: Boolean = false,
         val initial: Boolean = true,
@@ -32,5 +33,7 @@ interface UserListMviModel :
         val users: List<UserModel> = emptyList(),
     )
 
-    sealed interface Effect
+    sealed interface Effect {
+        data object BackToTop : Effect
+    }
 }

--- a/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListScreen.kt
+++ b/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -49,6 +50,8 @@ import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigatio
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.RelationshipStatusNextAction
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserListType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toUserListType
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.koin.core.parameter.parametersOf
 
@@ -116,6 +119,15 @@ class UserListScreen(
                     topAppBarState.contentOffset = 0f
                 }
             }
+        }
+
+        LaunchedEffect(model) {
+            model.effects
+                .onEach { event ->
+                    when (event) {
+                        UserListMviModel.Effect.BackToTop -> goBackToTop()
+                    }
+                }.launchIn(this)
         }
 
         Scaffold(

--- a/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/di/UserListModule.kt
+++ b/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/di/UserListModule.kt
@@ -13,6 +13,7 @@ val featureUserListModule =
                 entryId = params[2],
                 paginationManager = get(),
                 userRepository = get(),
+                identityRepository = get(),
                 hapticFeedback = get(),
                 notificationCenter = get(),
             )


### PR DESCRIPTION
This PR hides the follow/send request button for anonymous users and, if logged, when the item corresponds to the current user.

Moreover, since the search API is available only for logged users, the magnifier button is hidden for anonymous users in the explore screen.