### PR TITLE
feat: open multiple images with pager

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
@@ -166,7 +166,21 @@ class DefaultDetailOpener(
     }
 
     override fun openImageDetail(url: String) {
-        val screen = ImageDetailScreen(url)
+        openImageDetail(
+            urls = listOf(url),
+            initialIndex = 0,
+        )
+    }
+
+    override fun openImageDetail(
+        urls: List<String>,
+        initialIndex: Int,
+    ) {
+        val screen =
+            ImageDetailScreen(
+                urls = urls,
+                initialIndex = initialIndex,
+            )
         navigationCoordinator.push(screen)
     }
 

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/ZoomableImage.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/ZoomableImage.kt
@@ -54,6 +54,8 @@ fun ZoomableImage(
         visible = true
     }
 
+    val gesturesEnabled = scale > 1
+
     BoxWithConstraints(
         modifier =
             modifier
@@ -75,27 +77,38 @@ fun ZoomableImage(
                                     scale *= 2.5f
                                 }
                             },
-                        ).pointerInput(Unit) {
-                            detectTransformGestures(
-                                onGesture = { _, pan, gestureZoom, _ ->
-                                    val extraWidth = (scale - 1) * constraints.maxWidth
-                                    val extraHeight = (scale - 1) * constraints.maxHeight
-                                    val maxX = extraWidth / 2
-                                    val maxY = extraHeight / 2
+                        ).pointerInput(gesturesEnabled) {
+                            // otherwise detectTransformGestures consumes the gesture and the pager does not intercept it
+                            if (gesturesEnabled) {
+                                detectTransformGestures(
+                                    onGesture = { _, pan, gestureZoom, _ ->
+                                        val extraWidth = (scale - 1) * constraints.maxWidth
+                                        val extraHeight = (scale - 1) * constraints.maxHeight
+                                        val maxX = extraWidth / 2
+                                        val maxY = extraHeight / 2
 
-                                    scale = (scale * gestureZoom).coerceIn(1f, 16f)
+                                        scale = (scale * gestureZoom).coerceIn(1f, 16f)
 
-                                    offset =
-                                        if (scale > 1) {
-                                            Offset(
-                                                x = (offset.x + pan.x * scale).coerceIn(-maxX, maxX),
-                                                y = (offset.y + pan.y * scale).coerceIn(-maxY, maxY),
-                                            )
-                                        } else {
-                                            Offset.Zero
-                                        }
-                                },
-                            )
+                                        offset =
+                                            if (scale > 1) {
+                                                Offset(
+                                                    x =
+                                                        (offset.x + pan.x * scale).coerceIn(
+                                                            minimumValue = -maxX,
+                                                            maximumValue = maxX,
+                                                        ),
+                                                    y =
+                                                        (offset.y + pan.y * scale).coerceIn(
+                                                            minimumValue = -maxY,
+                                                            maximumValue = maxY,
+                                                        ),
+                                                )
+                                            } else {
+                                                Offset.Zero
+                                            }
+                                    },
+                                )
+                            }
                         }.graphicsLayer(
                             scaleX = scale,
                             scaleY = scale,

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
@@ -54,7 +54,7 @@ fun TimelineItem(
     onBookmark: ((TimelineEntryModel) -> Unit)? = null,
     onOpenUsersFavorite: ((TimelineEntryModel) -> Unit)? = null,
     onOpenUsersReblog: ((TimelineEntryModel) -> Unit)? = null,
-    onOpenImage: ((String) -> Unit)? = null,
+    onOpenImage: ((List<String>, Int) -> Unit)? = null,
     onOptionSelected: ((OptionId) -> Unit)? = null,
     onPollVote: ((TimelineEntryModel, List<Int>) -> Unit)? = null,
     onToggleSpoilerActive: ((TimelineEntryModel) -> Unit)? = null,
@@ -271,7 +271,9 @@ fun TimelineItem(
                                 ),
                         card = preview.copy(image = preview.image.takeIf { it !in attachmentUrls }),
                         onOpen = onOpenUrl,
-                        onOpenImage = onOpenImage,
+                        onOpenImage = { url ->
+                            onOpenImage?.invoke(listOf(url), 0)
+                        },
                     )
                 }
             }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItemAttachments.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItemAttachments.kt
@@ -27,7 +27,7 @@ internal fun TimelineItemAttachments(
     modifier: Modifier = Modifier,
     blurNsfw: Boolean = true,
     sensitive: Boolean = false,
-    onOpenImage: ((String) -> Unit)? = null,
+    onOpenImage: ((List<String>, Int) -> Unit)? = null,
 ) {
     val images =
         attachments.filter { it.type == MediaType.Image }.takeIf { it.isNotEmpty() } ?: return
@@ -36,7 +36,7 @@ internal fun TimelineItemAttachments(
     val firstAttachmentHeight = firstAttachment.originalHeight ?: 0
     val interItemSpacing = Spacing.xxs
 
-    if (attachments.size == 1) {
+    if (images.size == 1) {
         if (firstAttachment.url.isNotBlank()) {
             ContentImage(
                 modifier = modifier,
@@ -46,15 +46,21 @@ internal fun TimelineItemAttachments(
                 originalWidth = firstAttachment.originalWidth ?: 0,
                 originalHeight = firstAttachment.originalHeight ?: 0,
                 sensitive = blurNsfw && sensitive,
-                onClick = { onOpenImage?.invoke(firstAttachment.url) },
+                onClick = {
+                    onOpenImage?.invoke(
+                        listOf(firstAttachment.url),
+                        0,
+                    )
+                },
             )
         }
-    } else if (attachments.size == 2) {
+    } else if (images.size == 2) {
+        val urls = images.map { it.url }
         Row(
             modifier = modifier,
             horizontalArrangement = Arrangement.spacedBy(interItemSpacing),
         ) {
-            for (attachment in attachments) {
+            images.forEachIndexed { idx, attachment ->
                 val attachmentWidth = attachment.originalWidth ?: 0
                 val attachmentHeight = attachment.originalHeight ?: 0
                 ContentImage(
@@ -66,7 +72,7 @@ internal fun TimelineItemAttachments(
                     originalHeight = attachmentHeight,
                     maxHeight = 200.dp,
                     sensitive = blurNsfw && sensitive,
-                    onClick = { onOpenImage?.invoke(attachment.url) },
+                    onClick = { onOpenImage?.invoke(urls, idx) },
                     contentScale =
                         if (attachmentHeight < attachmentWidth) {
                             ContentScale.FillHeight
@@ -77,6 +83,8 @@ internal fun TimelineItemAttachments(
             }
         }
     } else {
+        val urls = images.map { it.url }
+        val chunkSize = 4
         if (firstAttachmentWidth < firstAttachmentHeight) {
             Row(
                 modifier = modifier,
@@ -95,12 +103,12 @@ internal fun TimelineItemAttachments(
                     originalWidth = firstAttachment.originalWidth ?: 0,
                     originalHeight = firstAttachment.originalHeight ?: 0,
                     sensitive = blurNsfw && sensitive,
-                    onClick = { onOpenImage?.invoke(firstAttachment.url) },
+                    onClick = { onOpenImage?.invoke(urls, 0) },
                 )
 
                 // rest of images arranged vertically in chunks
-                val chunks = attachments.drop(1).chunked(4)
-                for (chunk in chunks) {
+                val chunks = images.drop(1).chunked(chunkSize)
+                chunks.forEachIndexed { chunkIndex, chunk ->
                     Column(
                         modifier =
                             Modifier
@@ -109,7 +117,8 @@ internal fun TimelineItemAttachments(
                         horizontalAlignment = Alignment.CenterHorizontally,
                         verticalArrangement = Arrangement.spacedBy(interItemSpacing),
                     ) {
-                        for (attachment in chunk) {
+                        chunk.forEachIndexed { imageIndex, attachment ->
+                            val index = imageIndex + chunkIndex * chunkSize + 1
                             val attachmentWidth = attachment.originalWidth ?: 0
                             val attachmentHeight = attachment.originalHeight ?: 0
                             ContentImage(
@@ -120,7 +129,9 @@ internal fun TimelineItemAttachments(
                                 originalWidth = attachmentWidth,
                                 originalHeight = attachmentHeight,
                                 sensitive = blurNsfw && sensitive,
-                                onClick = { onOpenImage?.invoke(attachment.url) },
+                                onClick = {
+                                    onOpenImage?.invoke(urls, index)
+                                },
                                 contentScale =
                                     if (attachmentHeight < attachmentWidth) {
                                         ContentScale.FillHeight
@@ -146,18 +157,19 @@ internal fun TimelineItemAttachments(
                     originalWidth = firstAttachment.originalWidth ?: 0,
                     originalHeight = firstAttachment.originalHeight ?: 0,
                     sensitive = blurNsfw && sensitive,
-                    onClick = { onOpenImage?.invoke(firstAttachment.url) },
+                    onClick = { onOpenImage?.invoke(urls, 0) },
                 )
 
                 // rest of images arranged vertically in chunks
-                val chunks = attachments.drop(1).chunked(4)
-                for (chunk in chunks) {
+                val chunks = images.drop(1).chunked(chunkSize)
+                chunks.forEachIndexed { chunkIndex, chunk ->
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(interItemSpacing),
                     ) {
-                        for (attachment in chunk) {
+                        chunk.forEachIndexed { imageIndex, attachment ->
+                            val index = imageIndex + chunkIndex * chunkSize + 1
                             val attachmentWidth = attachment.originalWidth ?: 0
                             val attachmentHeight = attachment.originalHeight ?: 0
                             ContentImage(
@@ -169,7 +181,7 @@ internal fun TimelineItemAttachments(
                                 originalHeight = attachmentHeight,
                                 sensitive = blurNsfw && sensitive,
                                 maxHeight = 180.dp,
-                                onClick = { onOpenImage?.invoke(attachment.url) },
+                                onClick = { onOpenImage?.invoke(urls, index) },
                                 contentScale =
                                     if (attachmentHeight < attachmentWidth) {
                                         ContentScale.FillHeight

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DetailOpener.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DetailOpener.kt
@@ -49,6 +49,11 @@ interface DetailOpener {
 
     fun openImageDetail(url: String)
 
+    fun openImageDetail(
+        urls: List<String>,
+        initialIndex: Int,
+    )
+
     fun openBlockedAndMuted()
 
     fun openCircles()

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.ExperimentalMaterialApi
@@ -259,8 +258,8 @@ class EntryDetailScreen(
                             onOpenUser = {
                                 detailOpener.openUserDetail(it.id)
                             },
-                            onOpenImage = { imageUrl ->
-                                detailOpener.openImageDetail(imageUrl)
+                            onOpenImage = { urls, imageIdx ->
+                                detailOpener.openImageDetail(urls = urls, initialIndex = imageIdx)
                             },
                             onReblog =
                                 uiState.currentUserId?.let {

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
@@ -308,8 +308,11 @@ class ExploreScreen : Screen {
                                     onOpenUser = {
                                         detailOpener.openUserDetail(it.id)
                                     },
-                                    onOpenImage = { imageUrl ->
-                                        detailOpener.openImageDetail(imageUrl)
+                                    onOpenImage = { urls, imageIdx ->
+                                        detailOpener.openImageDetail(
+                                            urls = urls,
+                                            initialIndex = imageIdx,
+                                        )
                                     },
                                     onReblog =
                                         uiState.currentUserId?.let {

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
@@ -210,8 +210,8 @@ class FavoritesScreen(
                             onOpenUser = {
                                 detailOpener.openUserDetail(it.id)
                             },
-                            onOpenImage = { imageUrl ->
-                                detailOpener.openImageDetail(imageUrl)
+                            onOpenImage = { urls, imageIdx ->
+                                detailOpener.openImageDetail(urls = urls, initialIndex = imageIdx)
                             },
                             onReblog =
                                 uiState.currentUserId?.let {

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
@@ -230,8 +230,8 @@ class HashtagScreen(
                             onOpenUser = {
                                 detailOpener.openUserDetail(it.id)
                             },
-                            onOpenImage = { imageUrl ->
-                                detailOpener.openImageDetail(imageUrl)
+                            onOpenImage = { urls, imageIdx ->
+                                detailOpener.openImageDetail(urls = urls, initialIndex = imageIdx)
                             },
                             onReblog =
                                 uiState.currentUserId?.let {

--- a/feature/imagedetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/imagedetail/ImageDetailMviModel.kt
+++ b/feature/imagedetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/imagedetail/ImageDetailMviModel.kt
@@ -10,6 +10,10 @@ interface ImageDetailMviModel :
     ScreenModel,
     MviModel<ImageDetailMviModel.Intent, ImageDetailMviModel.UiState, ImageDetailMviModel.Effect> {
     sealed interface Intent {
+        data class ChangeIndex(
+            val index: Int,
+        ) : Intent
+
         data object SaveToGallery : Intent
 
         data class ChangeContentScale(
@@ -22,6 +26,7 @@ interface ImageDetailMviModel :
     }
 
     data class UiState(
+        val currentIndex: Int = 0,
         val loading: Boolean = false,
         val contentScale: ContentScale = ContentScale.FillWidth,
     )

--- a/feature/imagedetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/imagedetail/di/ImageDetailModule.kt
+++ b/feature/imagedetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/imagedetail/di/ImageDetailModule.kt
@@ -8,7 +8,8 @@ val featureImageDetailModule =
     module {
         factory<ImageDetailMviModel> { params ->
             ImageDetailViewModel(
-                url = params[0],
+                urls = params[0],
+                initialIndex = params[1],
                 shareHelper = get(),
                 galleryHelper = get(),
                 imagePreloadManager = get(),

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
@@ -272,8 +272,8 @@ class MyAccountScreen : Screen {
                         onOpenUser = {
                             detailOpener.openUserDetail(it.id)
                         },
-                        onOpenImage = { imageUrl ->
-                            detailOpener.openImageDetail(imageUrl)
+                        onOpenImage = { urls, imageIdx ->
+                            detailOpener.openImageDetail(urls = urls, initialIndex = imageIdx)
                         },
                         onReblog = { e ->
                             model.reduce(MyAccountMviModel.Intent.ToggleReblog(e))

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
@@ -304,8 +304,11 @@ class SearchScreen : Screen {
                                     onOpenUser = {
                                         detailOpener.openUserDetail(it.id)
                                     },
-                                    onOpenImage = { imageUrl ->
-                                        detailOpener.openImageDetail(imageUrl)
+                                    onOpenImage = { urls, imageIdx ->
+                                        detailOpener.openImageDetail(
+                                            urls = urls,
+                                            initialIndex = imageIdx,
+                                        )
                                     },
                                     onReblog =
                                         uiState.currentUserId?.let {

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -253,8 +252,8 @@ class ThreadScreen(
                                 onOpenUser = {
                                     detailOpener.openUserDetail(it.id)
                                 },
-                                onOpenImage = { imageUrl ->
-                                    detailOpener.openImageDetail(imageUrl)
+                                onOpenImage = { urls, idx ->
+                                    detailOpener.openImageDetail(urls = urls, initialIndex = idx)
                                 },
                                 onReblog =
                                     uiState.currentUserId?.let {

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
@@ -280,8 +280,8 @@ class TimelineScreen : Screen {
                             onOpenUser = {
                                 detailOpener.openUserDetail(it.id)
                             },
-                            onOpenImage = { imageUrl ->
-                                detailOpener.openImageDetail(imageUrl)
+                            onOpenImage = { urls, imageIdx ->
+                                detailOpener.openImageDetail(urls = urls, initialIndex = imageIdx)
                             },
                             onReblog =
                                 uiState.currentUserId?.let {

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -508,8 +508,11 @@ class UserDetailScreen(
                                         detailOpener.openUserDetail(user.id)
                                     }
                                 },
-                                onOpenImage = { imageUrl ->
-                                    detailOpener.openImageDetail(imageUrl)
+                                onOpenImage = { urls, imageIdx ->
+                                    detailOpener.openImageDetail(
+                                        urls = urls,
+                                        initialIndex = imageIdx,
+                                    )
                                 },
                                 onReblog =
                                     uiState.currentUserId?.let {

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
@@ -253,8 +253,8 @@ class ForumListScreen(
                             onOpenUser = {
                                 detailOpener.openUserDetail(it.id)
                             },
-                            onOpenImage = { imageUrl ->
-                                detailOpener.openImageDetail(imageUrl)
+                            onOpenImage = { urls, imageIdx ->
+                                detailOpener.openImageDetail(urls = urls, initialIndex = imageIdx)
                             },
                             onReblog =
                                 uiState.currentUserId?.let {


### PR DESCRIPTION
This PR allows opening multiple images in a horizontal pager when, in a feed, an image is opened from the new attachment grid.

Since pager gestures interfere with pan/zoom gesture detection, the latter has been disabled when the scale factor is 1, and a double tap can be used to trigger a zoom (disabling the pager).