### PR TITLE
fix: DM loading and screen titles

### DIFF
--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
@@ -5,6 +5,7 @@ import java.time.Period
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 import java.util.TimeZone
 import kotlin.math.abs
 import kotlin.time.Duration
@@ -16,6 +17,7 @@ actual fun epochMillis(): Long = System.currentTimeMillis()
 private fun getDateTimeFormatter(pattern: String) =
     DateTimeFormatter
         .ofPattern(pattern)
+        .withLocale(Locale.US)
         .withZone(TimeZone.getTimeZone("UTC").toZoneId())
 
 private val safeFormatter = getDateTimeFormatter("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'")
@@ -109,8 +111,8 @@ actual fun getPrettyDate(
 actual fun getDurationSinceDate(iso8601Timestamp: String): Duration? =
     runCatching {
         val date = getDateFromIso8601Timestamp(iso8601Timestamp).toOffsetDateTime()
-    val now = LocalDateTime.now()
-    val duration = JavaDuration.between(date, now)
+        val now = LocalDateTime.now()
+        val duration = JavaDuration.between(date, now)
         duration.toKotlinDuration()
     }.getOrNull()
 

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/detail/CircleDetailScreen.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/detail/CircleDetailScreen.kt
@@ -116,7 +116,6 @@ class CircleDetailScreen(
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
-                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = uiState.circle?.name.orEmpty(),
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/list/CirclesScreen.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/list/CirclesScreen.kt
@@ -109,7 +109,6 @@ class CirclesScreen : Screen {
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
-                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = LocalStrings.current.manageCirclesTitle,
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
@@ -155,7 +155,6 @@ class ComposerScreen(
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
-                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = LocalStrings.current.createPostTitle,
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationScreen.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationScreen.kt
@@ -135,7 +135,7 @@ class ConversationScreen(
                     title = {
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+                            horizontalArrangement = Arrangement.spacedBy(Spacing.s),
                         ) {
                             val avatar = uiState.otherUser?.avatar.orEmpty()
                             val avatarSize = IconSize.l
@@ -156,7 +156,6 @@ class ConversationScreen(
                                 )
                             }
                             Text(
-                                modifier = Modifier.padding(horizontal = Spacing.s),
                                 text = otherUserName.orEmpty(),
                                 style = MaterialTheme.typography.titleMedium,
                             )

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/list/DirectMessageListScreen.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/list/DirectMessageListScreen.kt
@@ -102,7 +102,6 @@ class DirectMessageListScreen : Screen {
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
-                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = LocalStrings.current.directMessagesTitle,
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -131,7 +131,6 @@ class EntryDetailScreen(
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
-                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text =
                                 buildString {
                                     append(LocalStrings.current.postTitle)

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
@@ -145,7 +145,6 @@ class ExploreScreen : Screen {
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
-                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = LocalStrings.current.sectionTitleExplore,
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
@@ -121,7 +121,6 @@ class FavoritesScreen(
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
-                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = type.toFavoritesType().toReadableName(),
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/followrequests/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/followrequests/FollowRequestsScreen.kt
+++ b/feature/followrequests/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/followrequests/FollowRequestsScreen.kt
@@ -77,7 +77,6 @@ class FollowRequestsScreen : Screen {
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
-                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = LocalStrings.current.followRequestsTitle,
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/gallery/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/gallery/detail/AlbumDetailScreen.kt
+++ b/feature/gallery/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/gallery/detail/AlbumDetailScreen.kt
@@ -136,7 +136,6 @@ class AlbumDetailScreen(
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
-                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = name,
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/gallery/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/gallery/list/GalleryScreen.kt
+++ b/feature/gallery/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/gallery/list/GalleryScreen.kt
@@ -114,7 +114,6 @@ class GalleryScreen : Screen {
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
-                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = LocalStrings.current.galleryTitle,
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/followed/FollowedHashtagsScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/followed/FollowedHashtagsScreen.kt
@@ -80,7 +80,6 @@ class FollowedHashtagsScreen : Screen {
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
-                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = LocalStrings.current.followedHashtagsTitle,
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
@@ -123,7 +123,6 @@ class HashtagScreen(
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
-                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = "#$tag",
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/imagedetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/imagedetail/ImageDetailScreen.kt
+++ b/feature/imagedetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/imagedetail/ImageDetailScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.ui.layout.ContentScale
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.core.screen.ScreenKey
 import cafe.adriel.voyager.koin.getScreenModel
-import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomModalBottomSheet
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomModalBottomSheetItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ProgressHud
@@ -120,7 +119,6 @@ class ImageDetailScreen(
                 TopAppBar(
                     title = {
                         Text(
-                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text =
                                 buildString {
                                     if (urls.size > 1) {

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
@@ -109,7 +109,6 @@ class InboxScreen : Screen {
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
-                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = LocalStrings.current.sectionTitleInbox,
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/legacy/LegacyLoginScreen.kt
+++ b/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/legacy/LegacyLoginScreen.kt
@@ -113,7 +113,6 @@ class LegacyLoginScreen : Screen {
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
-                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = LocalStrings.current.loginTitle,
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/oauth/LoginScreen.kt
+++ b/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/oauth/LoginScreen.kt
@@ -97,7 +97,6 @@ class LoginScreen : Screen {
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
-                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = LocalStrings.current.loginTitle,
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/ManageBlocksScreen.kt
+++ b/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/ManageBlocksScreen.kt
@@ -111,7 +111,6 @@ class ManageBlocksScreen : Screen {
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
-                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = LocalStrings.current.settingsItemBlockedAndMuted,
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/nodeinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/NodeInfoScreen.kt
+++ b/feature/nodeinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/NodeInfoScreen.kt
@@ -96,7 +96,6 @@ class NodeInfoScreen : Screen {
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
-                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = LocalStrings.current.nodeInfoTitle,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
@@ -38,7 +38,6 @@ import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
 import cafe.adriel.voyager.navigator.Navigator
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
-import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomImage
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomModalBottomSheet
@@ -80,7 +79,6 @@ class ProfileScreen : Screen {
                         scrollBehavior = scrollBehavior,
                         title = {
                             Text(
-                                modifier = Modifier.padding(horizontal = Spacing.s),
                                 text = LocalStrings.current.sectionTitleProfile,
                                 style = MaterialTheme.typography.titleMedium,
                             )

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileScreen.kt
@@ -120,7 +120,6 @@ class EditProfileScreen : Screen {
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
-                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = LocalStrings.current.editProfileTitle,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
@@ -92,7 +92,6 @@ class SettingsScreen : Screen {
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
-                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = LocalStrings.current.settingsTitle,
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
@@ -131,7 +131,6 @@ class ThreadScreen(
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
-                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = LocalStrings.current.threadTitle,
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
@@ -153,7 +153,6 @@ class TimelineScreen : Screen {
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
-                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = uiState.timelineType?.toReadableName().orEmpty(),
                             style = MaterialTheme.typography.titleMedium,
                         )

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -177,7 +177,6 @@ class UserDetailScreen(
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
-                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text = uiState.user?.handle.orEmpty(),
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
@@ -133,7 +133,6 @@ class ForumListScreen(
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
-                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text =
                                 buildString {
                                     append(LocalStrings.current.topicTitle)

--- a/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListScreen.kt
+++ b/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListScreen.kt
@@ -138,7 +138,6 @@ class UserListScreen(
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
-                            modifier = Modifier.padding(horizontal = Spacing.s),
                             text =
                                 buildString {
                                     when (type.toUserListType()) {


### PR DESCRIPTION
This PR fixes the date parsing of DMs (again) as well as the horizontal margins for screen titles.