### PR TITLE
feat: support GIFs (Android only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The app is under ongoing development, here is a list of the features that are be
 - [x] edit one's own profile (custom fields and images not supported yet by the back-end)
 - [x] direct messages
 - [x] photo gallery
-- [ ] advanced media visualization (videos & GIFs)
+- [ ] advanced media visualization (videos, ~GIFs~, ~multiple images~)
 - [ ] scheduled posts
 - [ ] custom emojis
 

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItemAttachments.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItemAttachments.kt
@@ -22,7 +22,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.AttachmentM
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
 
 @Composable
-internal fun TimelineItemAttachments(
+fun TimelineItemAttachments(
     attachments: List<AttachmentModel>,
     modifier: Modifier = Modifier,
     blurNsfw: Boolean = true,

--- a/core/utils/build.gradle.kts
+++ b/core/utils/build.gradle.kts
@@ -49,6 +49,7 @@ kotlin {
                 implementation(libs.androidx.activity)
                 implementation(libs.androidx.browser)
                 implementation(libs.ktor.android)
+                implementation(libs.coil.gif)
             }
         }
         val iosMain by getting {

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/ImageUtils.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/ImageUtils.kt
@@ -2,8 +2,12 @@ package com.livefast.eattrash.raccoonforfriendica.core.utils.imageload
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.os.Build
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
+import coil3.decode.Decoder
+import coil3.gif.AnimatedImageDecoder
+import coil3.gif.GifDecoder
 
 actual fun ByteArray.toComposeImageBitmap(): ImageBitmap = BitmapFactory.decodeByteArray(this, 0, size).asImageBitmap()
 
@@ -11,3 +15,12 @@ actual fun IntArray.toComposeImageBitmap(
     width: Int,
     height: Int,
 ): ImageBitmap = Bitmap.createBitmap(this, width, height, Bitmap.Config.ARGB_8888).asImageBitmap()
+
+actual fun getNativeDecoders(): List<Decoder.Factory> =
+    buildList {
+        if (Build.VERSION.SDK_INT >= 28) {
+            AnimatedImageDecoder.Factory()
+        } else {
+            GifDecoder.Factory()
+        }
+    }

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/DefaultImageLoaderProvider.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/DefaultImageLoaderProvider.kt
@@ -14,7 +14,12 @@ internal class DefaultImageLoaderProvider(
     private val imageLoader by lazy {
         ImageLoader
             .Builder(context)
-            .memoryCache {
+            .components {
+                val decoders = getNativeDecoders()
+                for (decoder in decoders) {
+                    add(decoder)
+                }
+            }.memoryCache {
                 MemoryCache
                     .Builder()
                     .maxSizePercent(context, 0.25)

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/ImageUtils.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/ImageUtils.kt
@@ -1,6 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.core.utils.imageload
 
 import androidx.compose.ui.graphics.ImageBitmap
+import coil3.decode.Decoder
 
 expect fun ByteArray.toComposeImageBitmap(): ImageBitmap
 
@@ -8,3 +9,5 @@ expect fun IntArray.toComposeImageBitmap(
     width: Int,
     height: Int,
 ): ImageBitmap
+
+expect fun getNativeDecoders(): List<Decoder.Factory>

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/ImageUtils.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/ImageUtils.kt
@@ -3,6 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica.core.utils.imageload
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asComposeImageBitmap
 import androidx.compose.ui.graphics.toComposeImageBitmap
+import coil3.decode.Decoder
 import org.jetbrains.skia.Bitmap
 import org.jetbrains.skia.ColorAlphaType
 import org.jetbrains.skia.ColorType
@@ -20,3 +21,5 @@ actual fun IntArray.toComposeImageBitmap(
     bmp.installPixels(info, map { it.toByte() }.toByteArray(), info.minRowBytes)
     return bmp.asComposeImageBitmap()
 }
+
+actual fun getNativeDecoders(): List<Decoder.Factory> = emptyList()

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/composable/TimelineReplyItem.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/composable/TimelineReplyItem.kt
@@ -38,11 +38,10 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.Custom
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ContentBody
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ContentFooter
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ContentHeader
-import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ContentImage
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ContentTitle
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.Option
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItemAttachments
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 
@@ -60,7 +59,7 @@ fun TimelineReplyItem(
     onReblog: ((TimelineEntryModel) -> Unit)? = null,
     onFavorite: ((TimelineEntryModel) -> Unit)? = null,
     onBookmark: ((TimelineEntryModel) -> Unit)? = null,
-    onOpenImage: ((String) -> Unit)? = null,
+    onOpenImage: ((List<String>, Int) -> Unit)? = null,
     onOptionSelected: ((OptionId) -> Unit)? = null,
 ) {
     val entryToDisplay = entry.reblog ?: entry
@@ -168,7 +167,8 @@ fun TimelineReplyItem(
                     }
                 }
 
-                entryToDisplay.title?.let { title ->
+                val title = entryToDisplay.title
+                if (!title.isNullOrBlank()) {
                     ContentTitle(
                         modifier = Modifier.fillMaxWidth(),
                         content = title,
@@ -177,26 +177,30 @@ fun TimelineReplyItem(
                     )
                 }
 
-                ContentBody(
-                    modifier = Modifier.fillMaxWidth(),
-                    content = entryToDisplay.content,
-                    onClick = { onClick?.invoke(entryToDisplay) },
-                    onOpenUrl = onOpenUrl,
-                )
-
-                val firstImageAttachment =
-                    entryToDisplay.attachments
-                        .firstOrNull { attachment -> attachment.type == MediaType.Image }
-                val imageUrl = firstImageAttachment?.url?.takeIf { it.isNotBlank() }
-                if (imageUrl != null) {
-                    ContentImage(
+                val body = entryToDisplay.content
+                if (body.isNotBlank()) {
+                    ContentBody(
                         modifier = Modifier.fillMaxWidth(),
-                        url = imageUrl,
-                        altText = firstImageAttachment.description,
-                        sensitive = blurNsfw && entryToDisplay.sensitive,
-                        onClick = { onOpenImage?.invoke(imageUrl) },
+                        content = entryToDisplay.content,
+                        onClick = { onClick?.invoke(entryToDisplay) },
+                        onOpenUrl = onOpenUrl,
                     )
                 }
+
+                // attachment (single or grid)
+                TimelineItemAttachments(
+                    modifier =
+                        Modifier.fillMaxWidth().padding(
+                            top = Spacing.s,
+                            bottom = Spacing.xxxs,
+                            start = Spacing.s,
+                            end = Spacing.s,
+                        ),
+                    attachments = entryToDisplay.attachments,
+                    blurNsfw = blurNsfw,
+                    sensitive = entryToDisplay.sensitive,
+                    onOpenImage = onOpenImage,
+                )
 
                 if (actionsEnabled) {
                     ContentFooter(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,6 +49,7 @@ androidx-test-junit = { group = "androidx.test.ext", name = "junit", version.ref
 coil = { module = "io.coil-kt.coil3:coil", version.ref = "coil" }
 coil-network-ktor = { module = "io.coil-kt.coil3:coil-network-ktor2", version.ref = "coil" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose-core", version.ref = "coil" }
+coil-gif = { module = "io.coil-kt.coil3:coil-gif", version.ref = "coil" }
 
 multiplatform-settings = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatform-settings" }
 


### PR DESCRIPTION
This PR adds the support for GIFs with coil3. Moreover, since thread replies had not been migrated yet to support image grids, their appearance is unified with feed posts.