### PR TITLE
feat: add possibility to create direct (only mentions) posts

### DIFF
--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -133,7 +133,7 @@ internal open class DefaultStrings : Strings {
     override val visibilityPublic = "Public"
     override val visibilityUnlisted = "Unlisted"
     override val visibilityPrivate = "Private"
-    override val visibilityDirect = "Only mentioned"
+    override val visibilityDirect = "Only mentions"
     override val createPostBodyPlaceholder = "Your awesome new post… 🪄"
     override val createPostAttachmentsSection = "Attachments"
     override val actionEdit = "Edit"

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/Visibility.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/Visibility.kt
@@ -1,10 +1,10 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.data
 
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.Message
+import androidx.compose.material.icons.filled.AlternateEmail
 import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.LockOpen
 import androidx.compose.material.icons.filled.Public
-import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.filled.Workspaces
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -28,10 +28,10 @@ sealed interface Visibility {
 @Composable
 fun Visibility.toIcon(): ImageVector =
     when (this) {
-        Visibility.Direct -> Icons.AutoMirrored.Default.Message
-        Visibility.Private -> Icons.Default.VisibilityOff
+        Visibility.Direct -> Icons.Default.AlternateEmail
+        Visibility.Private -> Icons.Default.Lock
         Visibility.Public -> Icons.Default.Public
-        Visibility.Unlisted -> Icons.Default.Lock
+        Visibility.Unlisted -> Icons.Default.LockOpen
         is Visibility.Circle -> Icons.Default.Workspaces
     }
 

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
@@ -125,6 +125,7 @@ interface ComposerMviModel :
                 Visibility.Public,
                 Visibility.Unlisted,
                 Visibility.Private,
+                Visibility.Direct,
                 Visibility.Circle(),
             ),
         val sensitive: Boolean = false,

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
@@ -594,7 +594,7 @@ class ComposerViewModel(
                             inReplyTo = inReplyToId,
                             spoilerText = spoiler,
                             sensitive = currentState.sensitive,
-                            visibility = currentState.visibility,
+                            visibility = visibility,
                             lang = currentState.lang,
                             mediaIds = attachmentIds,
                         )


### PR DESCRIPTION
This allows to create posts with the `direct` visibility, i.e. only mentioned users can access them or just you if you do not mention anyone.