### PR TITLE
enhancement: preview cards

### DIFF
--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/CustomColorPickerDialog.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/CustomColorPickerDialog.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.github.skydoves.colorpicker.compose.ColorEnvelope
 import com.github.skydoves.colorpicker.compose.HsvColorPicker
@@ -88,7 +89,7 @@ fun CustomColorPickerDialog(
                     Modifier
                         .border(
                             color = selectedColor,
-                            width = 1.dp,
+                            width = Dp.Hairline,
                             shape = RoundedCornerShape(CornerSize.xxl),
                         ).padding(
                             horizontal = Spacing.m,

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/AlbumImageItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/AlbumImageItem.kt
@@ -69,7 +69,7 @@ fun AlbumImageItem(
     val iconModifier =
         Modifier
             .border(
-                width = 1.dp,
+                width = Dp.Hairline,
                 color = MaterialTheme.colorScheme.onBackground,
                 shape = CircleShape,
             ).padding(2.5.dp)

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentImage.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentImage.kt
@@ -109,7 +109,7 @@ fun ContentImage(
             val iconModifier =
                 Modifier
                     .border(
-                        width = 1.dp,
+                        width = Dp.Hairline,
                         color = MaterialTheme.colorScheme.onBackground,
                         shape = CircleShape,
                     ).padding(2.5.dp)

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentPreview.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentPreview.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -15,11 +17,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomImage
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.VideoPlayer
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.PreviewCardModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.PreviewType
 
@@ -34,75 +38,84 @@ fun ContentPreview(
     val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha)
     val url = card.url
     val image = card.image
+    val cornerSize = CornerSize.xl
 
-    when (card.type) {
-        PreviewType.Link -> {
-            if (card.type == PreviewType.Link && url.isNotEmpty()) {
-                LinkBanner(
-                    modifier =
-                        modifier.clickable {
-                            onOpen?.invoke(card.url)
+    Column(
+        modifier =
+            modifier
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                ) {
+                    if (url.isNotEmpty()) {
+                        onOpen?.invoke(url)
+                    }
+                }.border(
+                    width = Dp.Hairline,
+                    color = ancillaryColor,
+                    shape = RoundedCornerShape(cornerSize),
+                ).padding(
+                    bottom = 12.dp,
+                ),
+        verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+    ) {
+        if (!image.isNullOrBlank()) {
+            CustomImage(
+                modifier =
+                    Modifier
+                        .clip(
+                            RoundedCornerShape(
+                                topStart = cornerSize,
+                                topEnd = cornerSize,
+                            ),
+                        ).clickable {
+                            onOpenImage?.invoke(image)
                         },
-                    url = card.url,
+                url = image,
+                quality = FilterQuality.Low,
+                contentScale = ContentScale.FillWidth,
+            )
+        } else if (card.type == PreviewType.Video) {
+            VideoPlayer(
+                modifier =
+                    Modifier.fillMaxWidth().aspectRatio(16 / 9f),
+                url = url,
+            )
+        }
+
+        Column(
+            modifier =
+                Modifier.padding(
+                    top = Spacing.s,
+                    end = 10.dp,
+                    start = 10.dp,
+                ),
+            verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+        ) {
+            if (card.title.isNotEmpty()) {
+                Text(
+                    text = card.title,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = fullColor,
+                )
+            }
+            if (card.description.isNotEmpty()) {
+                Text(
+                    text = card.description,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = ancillaryColor,
                 )
             }
         }
+    }
 
-        PreviewType.Photo,
-        PreviewType.Video,
-        -> {
-            Column(
-                modifier =
-                    modifier
-                        .clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = null,
-                        ) {
-                            if (url.isNotEmpty()) {
-                                onOpen?.invoke(url)
-                            }
-                        }.border(
-                            width = 1.dp,
-                            color = MaterialTheme.colorScheme.onBackground,
-                            shape = RoundedCornerShape(CornerSize.l),
-                        ).padding(
-                            top = Spacing.s,
-                            bottom = 10.dp,
-                            start = 10.dp,
-                            end = 10.dp,
-                        ),
-                verticalArrangement = Arrangement.spacedBy(Spacing.s),
-            ) {
-                if (card.title.isNotEmpty()) {
-                    Text(
-                        text = card.title,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = fullColor,
-                    )
-                }
-                if (card.description.isNotEmpty()) {
-                    Text(
-                        text = card.description,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = ancillaryColor,
-                    )
-                }
-                if (!image.isNullOrBlank()) {
-                    CustomImage(
-                        modifier =
-                            Modifier
-                                .clip(RoundedCornerShape(CornerSize.xl))
-                                .clickable {
-                                    onOpenImage?.invoke(image)
-                                },
-                        url = image,
-                        quality = FilterQuality.Low,
-                        contentScale = ContentScale.FillWidth,
-                    )
-                }
-            }
-        }
-
-        else -> Unit
+    if (card.type == PreviewType.Link && url.isNotEmpty()) {
+        LinkBanner(
+            modifier =
+                modifier.clickable {
+                    onOpen?.invoke(url)
+                },
+            url = card.url,
+        )
     }
 }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/LinkItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/LinkItem.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
@@ -47,7 +48,7 @@ fun LinkItem(
                         onOpen?.invoke(url)
                     }
                 }.border(
-                    width = 1.dp,
+                    width = Dp.Hairline,
                     color = MaterialTheme.colorScheme.onBackground,
                     shape = RoundedCornerShape(CornerSize.l),
                 ).padding(Spacing.s),

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/PollCard.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/PollCard.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
@@ -159,7 +160,7 @@ private fun PollCardOption(
             modifier
                 .padding(vertical = Spacing.xxxs)
                 .border(
-                    width = 1.dp,
+                    width = Dp.Hairline,
                     color = MaterialTheme.colorScheme.onBackground,
                     shape = RoundedCornerShape(CornerSize.xl),
                 ).then(

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
@@ -259,7 +259,7 @@ fun TimelineItem(
 
                 // preview
                 entryToDisplay.card?.also { preview ->
-                    val attachmentUrls = entryToDisplay.attachments.map { it.url }
+                    val attachments = entryToDisplay.attachments
                     ContentPreview(
                         modifier =
                             Modifier
@@ -269,7 +269,7 @@ fun TimelineItem(
                                     start = contentHorizontalPadding,
                                     end = contentHorizontalPadding,
                                 ),
-                        card = preview.copy(image = preview.image.takeIf { it !in attachmentUrls }),
+                        card = preview.copy(image = preview.image.takeIf { attachments.isEmpty() }),
                         onOpen = onOpenUrl,
                         onOpenImage = { url ->
                             onOpenImage?.invoke(listOf(url), 0)

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationScreen.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
@@ -278,7 +279,7 @@ class ConversationScreen(
                                                 start = Spacing.s,
                                                 end = Spacing.s,
                                             ).border(
-                                                width = 1.dp,
+                                                width = Dp.Hairline,
                                                 color = MaterialTheme.colorScheme.onBackground,
                                                 shape = RoundedCornerShape(CornerSize.xl),
                                             ).background(

--- a/feature/followrequests/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/followrequests/components/FollowRequestItem.kt
+++ b/feature/followrequests/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/followrequests/components/FollowRequestItem.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.Dp
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
@@ -103,7 +103,7 @@ fun FollowRequestItem(
         ) {
             OutlinedButton(
                 modifier = Modifier.weight(1f),
-                border = BorderStroke(1.dp, rejectColor),
+                border = BorderStroke(Dp.Hairline, rejectColor),
                 onClick = {
                     onReject?.invoke()
                 },
@@ -121,7 +121,7 @@ fun FollowRequestItem(
             }
             OutlinedButton(
                 modifier = Modifier.weight(1f),
-                border = BorderStroke(1.dp, acceptColor),
+                border = BorderStroke(Dp.Hairline, acceptColor),
                 onClick = {
                     onAccept?.invoke()
                 },

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
@@ -52,11 +52,12 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.Dp
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.getFabNestedScrollConnection
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ConfirmMuteUserBottomSheet
@@ -221,9 +222,12 @@ class ThreadScreen(
                                 modifier =
                                     Modifier
                                         .border(
-                                            width = 1.dp,
-                                            color = MaterialTheme.colorScheme.onBackground,
-                                            shape = RoundedCornerShape(CornerSize.l),
+                                            width = Dp.Hairline,
+                                            color =
+                                                MaterialTheme.colorScheme.onBackground.copy(
+                                                    ancillaryTextAlpha,
+                                                ),
+                                                shape = RoundedCornerShape(CornerSize.l),
                                         ).padding(
                                             vertical = Spacing.s,
                                             horizontal = Spacing.xxxs,


### PR DESCRIPTION
This PR makes preview cards visible even when they are links (showing title and description). Moreover, all `1.dp` borders have been migrated to `Dp.Hairline`.