### PR TITLE
feat: scheduled posts • part 3

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentHeader.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentHeader.kt
@@ -102,7 +102,12 @@ fun ContentHeader(
                             if (isNotEmpty()) {
                                 append(" • ")
                             }
-                            append(getFormattedDate(scheduleDate, "dd/MM/yy HH:mm:ss"))
+                            append(
+                                getFormattedDate(
+                                    iso8601Timestamp = scheduleDate,
+                                    format = "dd/MM/yy HH:mm:ss",
+                                ),
+                            )
                         } else if (!date.isNullOrBlank()) {
                             if (isNotEmpty()) {
                                 append(" • ")

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/Options.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/Options.kt
@@ -25,6 +25,12 @@ sealed interface OptionId {
     data object Unpin : OptionId
 
     data object Move : OptionId
+
+    data object SetSchedule : OptionId
+
+    data object ChangeSchedule : OptionId
+
+    data object PublishDefault : OptionId
 }
 
 @Composable
@@ -41,6 +47,9 @@ private fun OptionId.toReadableName(): String =
         OptionId.Pin -> LocalStrings.current.actionPin
         OptionId.Unpin -> LocalStrings.current.actionUnpin
         OptionId.Move -> LocalStrings.current.actionMove
+        OptionId.SetSchedule -> LocalStrings.current.actionSetScheduleDate
+        OptionId.ChangeSchedule -> LocalStrings.current.actionUpdateScheduleDate
+        OptionId.PublishDefault -> LocalStrings.current.actionPublishDefault
     }
 
 @Composable

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -308,4 +308,9 @@ internal open class DefaultStrings : Strings {
     override val unpublishedTitle = "Unpublished items"
     override val unpublishedSectionScheduled = "Scheduled"
     override val unpublishedSectionDrafts = "Drafts"
+    override val actionSetScheduleDate = "Set schedule"
+    override val actionUpdateScheduleDate = "Change schedule"
+    override val actionPublishDefault = "Publish now"
+    override val scheduleDateIndication = "Scheduled for:"
+    override val messageScheduleDateInThePast = "Please select a schedule date in the future"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -319,4 +319,9 @@ internal val ItStrings =
         override val unpublishedTitle = "Non pubblicati"
         override val unpublishedSectionScheduled = "Schedulati"
         override val unpublishedSectionDrafts = "Bozze"
+        override val actionSetScheduleDate = "Imposta schedulazione"
+        override val actionUpdateScheduleDate = "Modifica schedulazione"
+        override val actionPublishDefault = "Pubblica ora"
+        override val scheduleDateIndication = "Schedulato per il:"
+        override val messageScheduleDateInThePast = "Selezionare una data di schedulazione futura"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -279,6 +279,11 @@ interface Strings {
     val unpublishedTitle: String
     val unpublishedSectionScheduled: String
     val unpublishedSectionDrafts: String
+    val actionSetScheduleDate: String
+    val actionUpdateScheduleDate: String
+    val actionPublishDefault: String
+    val scheduleDateIndication: String
+    val messageScheduleDateInThePast: String
 }
 
 object Locales {

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
@@ -10,7 +10,21 @@ expect fun epochMillis(): Long
 /**
  * Convert from a timestamp (in milliseconds) to an ISO-8601 string date.
  */
-expect fun Long.toIso8601Timestamp(): String?
+expect fun Long.toIso8601Timestamp(withLocalTimezone: Boolean = true): String?
+
+/**
+ * Convert from an ISO-8601 string date to a timestamp (in milliseconds).
+ */
+expect fun String.toEpochMillis(): Long
+
+/**
+ * Updates the time part of a timestamp (in milliseconds).
+ */
+expect fun Long.concatDateWithTime(
+    hours: Int,
+    minutes: Int,
+    seconds: Int,
+): Long
 
 /**
  * Converts a date (in the ISO 8601 format) to another given format.
@@ -18,6 +32,7 @@ expect fun Long.toIso8601Timestamp(): String?
 expect fun getFormattedDate(
     iso8601Timestamp: String,
     format: String,
+    withLocalTimezone: Boolean = true,
 ): String
 
 /**
@@ -50,3 +65,8 @@ expect fun getDurationFromNowToDate(iso8601Timestamp: String): Duration?
  * Get the time from now a past date to now.
  */
 expect fun getDurationFromDateToNow(iso8601Timestamp: String): Duration?
+
+/**
+ * Determines whether the date represented in the ISO-8601 string belongs to the current day
+ */
+expect fun isToday(iso8601Timestamp: String): Boolean

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
@@ -23,25 +23,80 @@ import kotlin.time.toDuration
 
 actual fun epochMillis(): Long = (NSDate().timeIntervalSince1970 * 1000).toLong()
 
-actual fun Long.toIso8601Timestamp(): String? {
-    val dateFormatter = NSDateFormatter()
-    dateFormatter.locale = NSLocale.autoupdatingCurrentLocale
-    dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'"
-    dateFormatter.calendar = NSCalendar(calendarIdentifier = NSCalendarIdentifierGregorian)
+private fun getDateFormatter(format: String) =
+    NSDateFormatter().apply {
+        locale = NSLocale.autoupdatingCurrentLocale
+        dateFormat = format
+        calendar = NSCalendar(calendarIdentifier = NSCalendarIdentifierGregorian)
+    }
+
+private val defaultFormatter = getDateFormatter("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'")
+private val backupFormatter = getDateFormatter("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+
+private fun String.tryParse(): NSDate? {
+    var res = runCatching { defaultFormatter.dateFromString(this) }.getOrNull()
+    if (res == null) {
+        res = runCatching { backupFormatter.dateFromString(this) }.getOrNull()
+    }
+    return res
+}
+
+private fun getDateFromIso8601Timestamp(string: String): NSDate? = NSISO8601DateFormatter().dateFromString(string)
+
+actual fun Long.toIso8601Timestamp(withLocalTimezone: Boolean): String? {
     val date = NSDate(timeIntervalSinceReferenceDate = (this.toDouble() / 1000))
-    return dateFormatter.stringFromDate(date)
+    return defaultFormatter
+        .apply {
+            if (withLocalTimezone) {
+                timeZone = NSTimeZone.localTimeZone
+            }
+        }.stringFromDate(date)
+}
+
+actual fun String.toEpochMillis(): Long {
+    val date = tryParse() ?: return 0
+    return (date.timeIntervalSince1970 * 1000).toLong()
+}
+
+actual fun Long.concatDateWithTime(
+    hours: Int,
+    minutes: Int,
+    seconds: Int,
+): Long {
+    val date = NSDate(timeIntervalSinceReferenceDate = (this.toDouble() / 1000))
+    val calendar = NSCalendar(calendarIdentifier = NSCalendarIdentifierGregorian)
+    val dateComponents =
+        calendar.components(
+            unitFlags =
+                NSCalendarUnitSecond
+                    .or(NSCalendarUnitMinute)
+                    .or(NSCalendarUnitHour)
+                    .or(NSCalendarUnitDay)
+                    .or(NSCalendarUnitMonth)
+                    .or(NSCalendarUnitYear),
+            fromDate = date,
+        )
+    dateComponents.hour = hours.toLong()
+    dateComponents.minute = minutes.toLong()
+    dateComponents.second = seconds.toLong()
+
+    val result = calendar.dateFromComponents(dateComponents) ?: return 0
+    return (result.timeIntervalSince1970 * 1000).toLong()
 }
 
 actual fun getFormattedDate(
     iso8601Timestamp: String,
     format: String,
+    withLocalTimezone: Boolean,
 ): String {
     val date = getDateFromIso8601Timestamp(iso8601Timestamp) ?: return ""
-
-    val dateFormatter = NSDateFormatter()
-    dateFormatter.timeZone = NSTimeZone.localTimeZone
-    dateFormatter.locale = NSLocale.autoupdatingCurrentLocale
-    dateFormatter.dateFormat = format
+    val dateFormatter =
+        getDateFormatter(format).run {
+            if (withLocalTimezone) {
+                timeZone = NSTimeZone.localTimeZone
+            }
+            this
+        }
     return dateFormatter.stringFromDate(date)
 }
 
@@ -49,12 +104,11 @@ actual fun parseDate(
     value: String,
     format: String,
 ): String {
-    val dateFormatter = NSDateFormatter()
-    dateFormatter.timeZone = NSTimeZone.localTimeZone
-    dateFormatter.locale = NSLocale.autoupdatingCurrentLocale
-    dateFormatter.dateFormat = format
-
-    val date = dateFormatter.dateFromString(value) ?: return ""
+    val dateFormatter = getDateFormatter(format)
+    val date =
+        runCatching {
+            dateFormatter.dateFromString(value)
+        }.getOrNull() ?: return ""
     return NSISO8601DateFormatter().stringFromDate(date)
 }
 
@@ -137,4 +191,32 @@ actual fun getDurationFromDateToNow(iso8601Timestamp: String): Duration? {
     return interval.toDuration(DurationUnit.SECONDS)
 }
 
-private fun getDateFromIso8601Timestamp(string: String): NSDate? = NSISO8601DateFormatter().dateFromString(string)
+actual fun isToday(iso8601Timestamp: String): Boolean {
+    val date = iso8601Timestamp.tryParse() ?: return false
+    val calendar = NSCalendar(calendarIdentifier = NSCalendarIdentifierGregorian)
+    val dateComponents =
+        calendar.components(
+            unitFlags =
+                NSCalendarUnitDay
+                    .or(NSCalendarUnitMonth)
+                    .or(NSCalendarUnitYear),
+            fromDate = date,
+        )
+    val year = dateComponents.year
+    val month = dateComponents.month
+    val day = dateComponents.day
+
+    val componentsNow =
+        calendar.components(
+            unitFlags =
+                NSCalendarUnitDay
+                    .or(NSCalendarUnitMonth)
+                    .or(NSCalendarUnitYear),
+            fromDate = NSDate(),
+        )
+    val yearNow = componentsNow.year
+    val monthNow = componentsNow.month
+    val dayNow = componentsNow.day
+
+    return year == yearNow && month == monthNow && day == dayNow
+}

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/TimelineEntryModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/TimelineEntryModel.kt
@@ -75,4 +75,4 @@ val TimelineEntryModel.safeKey: String
 val TimelineEntryModel.isNsfw: Boolean get() = reblog?.sensitive ?: sensitive
 
 val Duration.isOldEntry: Boolean
-    get() = this < (-30).days
+    get() = this > 30.days

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
@@ -17,6 +17,16 @@ sealed interface ComposerFieldType {
     data object Body : ComposerFieldType
 }
 
+sealed interface PublicationType {
+    data object Default : PublicationType
+
+    data class Scheduled(
+        val date: String,
+    ) : PublicationType
+
+    data object Draft : PublicationType
+}
+
 interface ComposerMviModel :
     ScreenModel,
     MviModel<ComposerMviModel.Intent, ComposerMviModel.State, ComposerMviModel.Effect> {
@@ -115,6 +125,10 @@ interface ComposerMviModel :
         data class GalleryAlbumSelected(
             val album: String,
         ) : Intent
+
+        data class ChangePublicationType(
+            val type: PublicationType,
+        ) : Intent
     }
 
     data class State(
@@ -150,16 +164,15 @@ interface ComposerMviModel :
         val galleryCurrentAlbumPhotos: List<AttachmentModel> = emptyList(),
         val characterLimit: Int? = null,
         val attachmentLimit: Int? = null,
-        val scheduleDate: String? = null,
+        val publicationType: PublicationType = PublicationType.Default,
     )
 
     sealed interface Effect {
         sealed interface ValidationError : Effect {
             data object TextOrImagesMandatory : ValidationError
-
             data object InvalidVisibility : ValidationError
-
             data object CharacterLimitExceeded : ValidationError
+            data object ScheduleDateInThePast : ValidationError
         }
 
         data object Success : Effect

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/components/MessageItem.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/components/MessageItem.kt
@@ -26,8 +26,8 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSiz
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ContentBody
-import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.getDurationFromDateToNow
 import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.getFormattedDate
+import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.isToday
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.DirectMessageModel
 
 @Composable
@@ -124,13 +124,12 @@ fun MessageItem(
                         )
                         val date = message.created
                         if (withDate && date != null) {
-                            val moreThanOneDay =
-                                (getDurationFromDateToNow(date)?.inWholeDays ?: 0) < -1
+                            val isDayDifferent = !isToday(date)
                             val dateString =
                                 getFormattedDate(
                                     iso8601Timestamp = date,
                                     format =
-                                        if (moreThanOneDay) {
+                                        if (isDayDifferent) {
                                             "dd/MM/yy • HH:mm"
                                         } else {
                                             "HH:mm"

--- a/feature/gallery/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/gallery/components/MediaAlbumItem.kt
+++ b/feature/gallery/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/gallery/components/MediaAlbumItem.kt
@@ -85,7 +85,10 @@ internal fun MediaAlbumItem(
                         val creationDate = album.created
                         if (creationDate != null) {
                             val formattedDate =
-                                getFormattedDate(iso8601Timestamp = creationDate, format = "dd/MM/yy")
+                                getFormattedDate(
+                                    iso8601Timestamp = creationDate,
+                                    format = "dd/MM/yy",
+                                )
                             append(formattedDate)
                         }
                         if (isNotEmpty()) {

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -239,10 +239,10 @@ class UserDetailScreen(
                                         )
                                 }
                             }
-                        var optionsOffset by remember { mutableStateOf(Offset.Zero) }
-                        var optionsMenuOpen by remember { mutableStateOf(false) }
                         if (options.isNotEmpty()) {
                             Box {
+                                var optionsOffset by remember { mutableStateOf(Offset.Zero) }
+                                var optionsMenuOpen by remember { mutableStateOf(false) }
                                 IconButton(
                                     modifier =
                                         Modifier.onGloballyPositioned {


### PR DESCRIPTION
This PR updates the composer screen to manage scheduled posts (and prepares the ground for supporting drafts). When a post is scheduled, it is needed to set the date and time from a picker. When editing a scheduled post, its content and date should be restored.

> [!WARNING]
> Friendica does not currently support (back-end side) the editing of scheduled posts, so it is only possible to delete them.