### PR TITLE
fix: insert media from gallery and drafts with attachments

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/DefaultServiceProvider.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/DefaultServiceProvider.kt
@@ -5,6 +5,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.service.DirectMessageS
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.FollowRequestService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.InstanceService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.ListService
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.MediaService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.NotificationService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.PhotoAlbumService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.PhotoService
@@ -20,6 +21,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.service.createDirectMe
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.createFollowRequestService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.createInstanceService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.createListService
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.createMediaService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.createNotificationService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.createPhotoAlbumService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.createPhotoService
@@ -65,6 +67,7 @@ internal class DefaultServiceProvider(
     override lateinit var followRequests: FollowRequestService
     override lateinit var instance: InstanceService
     override lateinit var lists: ListService
+    override lateinit var media: MediaService
     override lateinit var notifications: NotificationService
     override lateinit var photo: PhotoService
     override lateinit var photoAlbum: PhotoAlbumService
@@ -159,6 +162,7 @@ internal class DefaultServiceProvider(
         followRequests = ktorfit.createFollowRequestService()
         instance = ktorfit.createInstanceService()
         lists = ktorfit.createListService()
+        media = ktorfit.createMediaService()
         notifications = ktorfit.createNotificationService()
         photo = ktorfit.createPhotoService()
         photoAlbum = ktorfit.createPhotoAlbumService()

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/ServiceProvider.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/ServiceProvider.kt
@@ -5,6 +5,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.service.DirectMessageS
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.FollowRequestService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.InstanceService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.ListService
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.MediaService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.NotificationService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.PhotoAlbumService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.PhotoService
@@ -22,6 +23,7 @@ interface ServiceProvider {
     val followRequests: FollowRequestService
     val instance: InstanceService
     val lists: ListService
+    val media: MediaService
     val notifications: NotificationService
     val photo: PhotoService
     val photoAlbum: PhotoAlbumService

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/MediaService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/MediaService.kt
@@ -1,0 +1,12 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.service
+
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.MediaAttachment
+import de.jensklingenberg.ktorfit.http.GET
+import de.jensklingenberg.ktorfit.http.Path
+
+interface MediaService {
+    @GET("v1/media/{id}")
+    suspend fun getBy(
+        @Path("id") id: String,
+    ): MediaAttachment?
+}

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/PhotoAlbumService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/PhotoAlbumService.kt
@@ -16,7 +16,7 @@ interface PhotoAlbumService {
     @GET("friendica/photoalbum")
     suspend fun getPhotos(
         @Query("album") album: String,
-        @Query("maxId") maxId: Long? = null,
+        @Query("maxId") maxId: String? = null,
         @Query("latest_first") latestFirst: Boolean = false,
         @Query("limit") limit: Int = 20,
     ): List<FriendicaPhoto>

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/PhotoService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/PhotoService.kt
@@ -3,9 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica.core.api.service
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaApiResult
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaPhoto
 import de.jensklingenberg.ktorfit.http.Body
-import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.POST
-import de.jensklingenberg.ktorfit.http.Query
 import io.ktor.client.request.forms.MultiPartFormDataContent
 
 interface PhotoService {
@@ -13,11 +11,6 @@ interface PhotoService {
     suspend fun create(
         @Body content: MultiPartFormDataContent,
     ): FriendicaPhoto
-
-    @GET("friendica/photo")
-    suspend fun getBy(
-        @Query("photo_id") id: String,
-    ): FriendicaPhoto?
 
     @POST("friendica/photo/update")
     suspend fun update(

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultDraftRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultDraftRepository.kt
@@ -70,7 +70,7 @@ internal class DefaultDraftRepository(
                 mediaIds
                     ?.split(",")
                     ?.mapNotNull { id ->
-                        provider.photo.getBy(id)?.toModel()
+                        provider.media.getBy(id)?.toModel()
                     }.orEmpty(),
             parentId = inReplyToId,
             lang = lang,

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoAlbumRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoAlbumRepository.kt
@@ -62,7 +62,7 @@ internal class DefaultPhotoAlbumRepository(
                 provider.photoAlbum
                     .getPhotos(
                         album = album,
-                        maxId = pageCursor?.toLong(),
+                        maxId = pageCursor,
                         latestFirst = latestFirst,
                         limit = DEFAULT_PAGE_SIZE,
                     ).map { it.toModel() }


### PR DESCRIPTION
This PR fixes the selection of attachments from gallery in post creation and makes it possible to correctly retrieve draft posts even when the post contained attachments.