### PR TITLE
enhancement: Mastodon compatibility for attachment uploads

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/MediaAttachment.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/MediaAttachment.kt
@@ -10,6 +10,6 @@ data class MediaAttachment(
     @SerialName("meta") val meta: MediaMetadata? = null,
     @SerialName("preview_url") val previewUrl: String? = null,
     @SerialName("type") val type: MediaType,
-    @SerialName("url") val url: String,
+    @SerialName("url") val url: String = "",
     @SerialName("blurhash") val blurHash: String? = null,
 )

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/MediaService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/MediaService.kt
@@ -1,12 +1,33 @@
 package com.livefast.eattrash.raccoonforfriendica.core.api.service
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.MediaAttachment
+import de.jensklingenberg.ktorfit.http.Body
+import de.jensklingenberg.ktorfit.http.DELETE
 import de.jensklingenberg.ktorfit.http.GET
+import de.jensklingenberg.ktorfit.http.POST
+import de.jensklingenberg.ktorfit.http.PUT
 import de.jensklingenberg.ktorfit.http.Path
+import io.ktor.client.request.forms.MultiPartFormDataContent
 
 interface MediaService {
     @GET("v1/media/{id}")
     suspend fun getBy(
         @Path("id") id: String,
     ): MediaAttachment?
+
+    @POST("v2/media")
+    suspend fun create(
+        @Body content: MultiPartFormDataContent,
+    ): MediaAttachment
+
+    @PUT("v1/media/{id}")
+    suspend fun update(
+        @Path("id") id: String,
+        @Body content: MultiPartFormDataContent,
+    ): MediaAttachment
+
+    @DELETE("v1/media/{id}")
+    suspend fun delete(
+        @Path("id") id: String,
+    )
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMediaRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMediaRepository.kt
@@ -1,0 +1,89 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.AttachmentModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
+import io.ktor.client.request.forms.MultiPartFormDataContent
+import io.ktor.client.request.forms.formData
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+
+internal class DefaultMediaRepository(
+    private val provider: ServiceProvider,
+) : MediaRepository {
+    override suspend fun getBy(id: String): AttachmentModel? =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                provider.media.getBy(id)?.toModel()
+            }.getOrNull()
+        }
+
+    override suspend fun create(
+        bytes: ByteArray,
+        album: String,
+        alt: String,
+    ): AttachmentModel? =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val content =
+                    MultiPartFormDataContent(
+                        formData {
+                            append(
+                                key = "file",
+                                value = bytes,
+                                headers =
+                                    Headers.build {
+                                        append(HttpHeaders.ContentType, "image/*")
+                                        append(HttpHeaders.ContentDisposition, "filename=image.jpeg")
+                                    },
+                            )
+                            append("description", alt)
+                        },
+                    )
+                val res = provider.media.create(content = content).toModel()
+                val id = res.id
+                val url =
+                    withTimeoutOrNull(5000) {
+                        var url = res.url
+                        while (url.isEmpty()) {
+                            delay(1000)
+                            val pollingRes = getBy(id)
+                            if (pollingRes != null) {
+                                url = pollingRes.url
+                            }
+                        }
+                        url
+                    }.orEmpty()
+                res.copy(url = url)
+            }
+        }.getOrNull()
+
+    override suspend fun update(
+        id: String,
+        alt: String,
+    ): Boolean =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val content =
+                    MultiPartFormDataContent(
+                        formData {
+                        },
+                    )
+                provider.media.update(id = id, content = content)
+                true
+            }
+        }.getOrElse { false }
+
+    override suspend fun delete(id: String): Boolean =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                provider.media.delete(id = id)
+                true
+            }
+        }.getOrElse { false }
+}

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/MediaRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/MediaRepository.kt
@@ -1,0 +1,20 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.AttachmentModel
+
+interface MediaRepository {
+    suspend fun getBy(id: String): AttachmentModel?
+
+    suspend fun create(
+        bytes: ByteArray,
+        album: String = "",
+        alt: String = "",
+    ): AttachmentModel?
+
+    suspend fun update(
+        id: String,
+        alt: String = "",
+    ): Boolean
+
+    suspend fun delete(id: String): Boolean
+}

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
@@ -8,6 +8,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Defau
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultDraftRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultInboxManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultLocalItemCache
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultMediaRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultNodeInfoRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultNotificationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultPhotoAlbumRepository
@@ -23,6 +24,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Direc
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DraftRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.InboxManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.LocalItemCache
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.MediaRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.NodeInfoRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.NotificationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.PhotoAlbumRepository
@@ -118,6 +120,11 @@ val domainContentRepositoryModule =
         single<DraftRepository> {
             DefaultDraftRepository(
                 draftDao = get(),
+                provider = get(named("default")),
+            )
+        }
+        single<MediaRepository> {
+            DefaultMediaRepository(
                 provider = get(named("default")),
             )
         }

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/di/ComposerModule.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/di/ComposerModule.kt
@@ -15,6 +15,7 @@ val featureComposerModule =
                 userPaginationManager = get(),
                 circlesRepository = get(),
                 nodeInfoRepository = get(),
+                mediaRepository = get(),
                 albumRepository = get(),
                 albumPhotoPaginationManager = get(),
                 entryCache = get(),


### PR DESCRIPTION
This PR adds the support for the GET/PUT `v1/media/:id` and POST `v2/media` endpoints to be able to support creation of posts with attachments on Mastodon instances.