### PR TITLE
fix: gallery helper

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
@@ -40,6 +41,20 @@
                 <data android:host="auth" />
             </intent-filter>
         </activity>
+
+        <!-- Trigger Google Play services to install the backported photo picker module. -->
+        <service
+            android:name="com.google.android.gms.metadata.ModuleDependencies"
+            android:enabled="false"
+            android:exported="false"
+            tools:ignore="MissingClass">
+            <intent-filter>
+                <action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES" />
+            </intent-filter>
+            <meta-data
+                android:name="photopicker_activity:0:required"
+                android:value="" />
+        </service>
     </application>
 
 </manifest>

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/gallery/DefaultGalleryHelper.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/gallery/DefaultGalleryHelper.kt
@@ -85,8 +85,14 @@ internal class DefaultGalleryHelper(
                     result(byteArrayOf())
                 }
             }
+
         SideEffect {
-            pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+            pickMedia.launch(
+                PickVisualMediaRequest
+                    .Builder()
+                    .setMediaType(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                    .build(),
+            )
         }
     }
 }

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
@@ -127,7 +127,9 @@ class ComposerScreen(
         if (openImagePicker) {
             galleryHelper.getImageFromGallery { bytes ->
                 openImagePicker = false
-                model.reduce(ComposerMviModel.Intent.AddAttachment(bytes))
+                if (bytes.isNotEmpty()) {
+                    model.reduce(ComposerMviModel.Intent.AddAttachment(bytes))
+                }
             }
         }
         var photoGalleryPickerOpen by remember { mutableStateOf(false) }

--- a/feature/gallery/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/gallery/detail/AlbumDetailScreen.kt
+++ b/feature/gallery/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/gallery/detail/AlbumDetailScreen.kt
@@ -100,7 +100,9 @@ class AlbumDetailScreen(
         if (openImagePicker) {
             galleryHelper.getImageFromGallery { bytes ->
                 openImagePicker = false
-                model.reduce(AlbumDetailMviModel.Intent.Create(bytes))
+                if (bytes.isNotEmpty()) {
+                    model.reduce(AlbumDetailMviModel.Intent.Create(bytes))
+                }
             }
         }
         var attachmentIdToDelete by remember { mutableStateOf<String?>(null) }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileScreen.kt
@@ -339,13 +339,17 @@ class EditProfileScreen : Screen {
         if (openAvatarPicker) {
             galleryHelper.getImageFromGallery { bytes ->
                 openAvatarPicker = false
-                model.reduce(EditProfileMviModel.Intent.AvatarSelected(bytes))
+                if (bytes.isNotEmpty()) {
+                    model.reduce(EditProfileMviModel.Intent.AvatarSelected(bytes))
+                }
             }
         }
         if (openHeaderPicker) {
             galleryHelper.getImageFromGallery { bytes ->
                 openHeaderPicker = false
-                model.reduce(EditProfileMviModel.Intent.HeaderSelected(bytes))
+                if (bytes.isNotEmpty()) {
+                    model.reduce(EditProfileMviModel.Intent.HeaderSelected(bytes))
+                }
             }
         }
 


### PR DESCRIPTION
This PR fixes a crash when using the photo picker on Android API level < 30. Moreover it avoids processing an empty byte array when the request is canceled by the user.