### PR TITLE
feat: default visibility for posts and replies

### DIFF
--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -314,4 +314,6 @@ internal open class DefaultStrings : Strings {
     override val scheduleDateIndication = "Scheduled for:"
     override val messageScheduleDateInThePast = "Please select a schedule date in the future"
     override val actionSaveDraft = "Save draft"
+    override val settingsItemDefaultPostVisibility = "Default visibility for posts"
+    override val settingsItemDefaultReplyVisibility = "Default visibility for replies"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -325,4 +325,6 @@ internal val ItStrings =
         override val scheduleDateIndication = "Schedulato per il:"
         override val messageScheduleDateInThePast = "Selezionare una data di schedulazione futura"
         override val actionSaveDraft = "Salva bozza"
+        override val settingsItemDefaultPostVisibility = "Visibilità predefinita post"
+        override val settingsItemDefaultReplyVisibility = "Visibilità predefinita risposte"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -285,6 +285,8 @@ interface Strings {
     val scheduleDateIndication: String
     val messageScheduleDateInThePast: String
     val actionSaveDraft: String
+    val settingsItemDefaultPostVisibility: String
+    val settingsItemDefaultReplyVisibility: String
 }
 
 object Locales {

--- a/core/persistence/schemas/com.livefast.eattrash.raccoonforfriendica.core.persistence.AppDatabase/6.json
+++ b/core/persistence/schemas/com.livefast.eattrash.raccoonforfriendica.core.persistence.AppDatabase/6.json
@@ -1,0 +1,255 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "01b964b1d5a72557cd3ee1d6c3351c0a",
+    "entities": [
+      {
+        "tableName": "AccountEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `handle` TEXT NOT NULL, `active` INTEGER NOT NULL DEFAULT 0, `remoteId` TEXT, `avatar` TEXT, `displayName` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "handle",
+            "columnName": "handle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "active",
+            "columnName": "active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "avatar",
+            "columnName": "avatar",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AccountEntity_handle",
+            "unique": false,
+            "columnNames": [
+              "handle"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AccountEntity_handle` ON `${TABLE_NAME}` (`handle`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SettingsEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `accountId` INTEGER NOT NULL DEFAULT 0, `lang` TEXT NOT NULL DEFAULT 'en', `theme` INTEGER NOT NULL DEFAULT 0, `fontFamily` INTEGER NOT NULL DEFAULT 0, `fontScale` INTEGER NOT NULL DEFAULT 0, `dynamicColors` INTEGER NOT NULL DEFAULT 0, `customSeedColor` INTEGER, `defaultTimelineType` INTEGER NOT NULL DEFAULT 0, `includeNsfw` INTEGER NOT NULL DEFAULT 0, `blurNsfw` INTEGER NOT NULL DEFAULT 0, `urlOpeningMode` INTEGER NOT NULL DEFAULT 0, `defaultPostVisibility` INTEGER NOT NULL DEFAULT 0, `defaultReplyVisibility` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lang",
+            "columnName": "lang",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'en'"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "fontScale",
+            "columnName": "fontScale",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "dynamicColors",
+            "columnName": "dynamicColors",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "customSeedColor",
+            "columnName": "customSeedColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "defaultTimelineType",
+            "columnName": "defaultTimelineType",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "includeNsfw",
+            "columnName": "includeNsfw",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "blurNsfw",
+            "columnName": "blurNsfw",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "urlOpeningMode",
+            "columnName": "urlOpeningMode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "defaultPostVisibility",
+            "columnName": "defaultPostVisibility",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "defaultReplyVisibility",
+            "columnName": "defaultReplyVisibility",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "DraftEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mediaIds` TEXT, `inReplyToId` TEXT, `lang` TEXT, `sensitive` INTEGER, `spoiler` TEXT, `title` TEXT, `text` TEXT, `created` TEXT, `visibility` TEXT, `pollExpiresAt` TEXT, `pollMultiple` INTEGER, `pollOptions` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaIds",
+            "columnName": "mediaIds",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "inReplyToId",
+            "columnName": "inReplyToId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lang",
+            "columnName": "lang",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sensitive",
+            "columnName": "sensitive",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "spoiler",
+            "columnName": "spoiler",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "visibility",
+            "columnName": "visibility",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pollExpiresAt",
+            "columnName": "pollExpiresAt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pollMultiple",
+            "columnName": "pollMultiple",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pollOptions",
+            "columnName": "pollOptions",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '01b964b1d5a72557cd3ee1d6c3351c0a')"
+    ]
+  }
+}

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/AppDatabase.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/AppDatabase.kt
@@ -16,12 +16,13 @@ import com.livefast.eattrash.raccoonforfriendica.core.persistence.entities.Setti
         SettingsEntity::class,
         DraftEntity::class,
     ],
-    version = 5,
+    version = 6,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
         AutoMigration(from = 3, to = 4),
         AutoMigration(from = 4, to = 5),
+        AutoMigration(from = 5, to = 6),
 
     ],
 )

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/entities/SettingsEntity.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/entities/SettingsEntity.kt
@@ -18,4 +18,6 @@ data class SettingsEntity(
     @ColumnInfo(defaultValue = "0") val includeNsfw: Boolean = false,
     @ColumnInfo(defaultValue = "0") val blurNsfw: Boolean = true,
     @ColumnInfo(defaultValue = "0") val urlOpeningMode: Int = 0,
+    @ColumnInfo(defaultValue = "0") val defaultPostVisibility: Int = 0,
+    @ColumnInfo(defaultValue = "0") val defaultReplyVisibility: Int = 0,
 )

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/Visibility.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/Visibility.kt
@@ -44,3 +44,21 @@ fun Visibility.toReadableName(): String =
         Visibility.Unlisted -> LocalStrings.current.visibilityUnlisted
         is Visibility.Circle -> name ?: LocalStrings.current.visibilityCircle
     }
+
+fun Visibility.toInt() =
+    when (this) {
+        is Visibility.Circle -> 4
+        Visibility.Private -> 3
+        Visibility.Direct -> 2
+        Visibility.Unlisted -> 1
+        Visibility.Public -> 0
+    }
+
+fun Int.toVisibility(): Visibility =
+    when (this) {
+        4 -> Visibility.Circle()
+        3 -> Visibility.Private
+        2 -> Visibility.Direct
+        1 -> Visibility.Unlisted
+    else -> Visibility.Public
+}

--- a/domain/identity/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/data/SettingsModel.kt
+++ b/domain/identity/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/data/SettingsModel.kt
@@ -17,4 +17,6 @@ data class SettingsModel(
     val includeNsfw: Boolean = false,
     val blurNsfw: Boolean = true,
     val urlOpeningMode: UrlOpeningMode = UrlOpeningMode.External,
+    val defaultPostVisibility: Int = 0,
+    val defaultReplyVisibility: Int = 0,
 )

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultSettingsRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultSettingsRepository.kt
@@ -50,6 +50,8 @@ private fun SettingsEntity.toModel() =
         blurNsfw = blurNsfw,
         includeNsfw = includeNsfw,
         urlOpeningMode = urlOpeningMode.toUrlOpeningMode(),
+        defaultPostVisibility = defaultPostVisibility,
+        defaultReplyVisibility = defaultReplyVisibility,
     )
 
 private fun SettingsModel.toEntity() =
@@ -66,4 +68,6 @@ private fun SettingsModel.toEntity() =
         includeNsfw = includeNsfw,
         blurNsfw = blurNsfw,
         urlOpeningMode = urlOpeningMode.toInt(),
+        defaultPostVisibility = defaultPostVisibility,
+        defaultReplyVisibility = defaultReplyVisibility,
     )

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/di/ComposerModule.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/di/ComposerModule.kt
@@ -21,6 +21,7 @@ val featureComposerModule =
                 entryCache = get(),
                 scheduledEntryRepository = get(),
                 draftRepository = get(),
+                settingsRepository = get(),
                 notificationCenter = get(),
             )
         }

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsMviModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsMviModel.kt
@@ -9,6 +9,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.UiFontScal
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.UiTheme
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineType
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.Visibility
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.UrlOpeningMode
 
 @Stable
@@ -55,6 +56,14 @@ interface SettingsMviModel :
         data class ChangeUrlOpeningMode(
             val mode: UrlOpeningMode,
         ) : Intent
+
+        data class ChangeDefaultPostVisibility(
+            val visibility: Visibility,
+        ) : Intent
+
+        data class ChangeDefaultReplyVisibility(
+            val visibility: Visibility,
+        ) : Intent
     }
 
     data class State(
@@ -72,6 +81,8 @@ interface SettingsMviModel :
         val includeNsfw: Boolean = true,
         val blurNsfw: Boolean = true,
         val urlOpeningMode: UrlOpeningMode = UrlOpeningMode.External,
+        val defaultPostVisibility: Visibility = Visibility.Public,
+        val defaultReplyVisibility: Visibility = Visibility.Public,
     )
 
     sealed interface Effect

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
@@ -59,6 +59,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.l10n.toLanguageFlag
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.toLanguageName
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDetailOpener
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.Visibility
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toIcon
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toReadableName
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.UrlOpeningMode
@@ -84,6 +85,8 @@ class SettingsScreen : Screen {
         var urlOpeningModeBottomSheetOpened by remember { mutableStateOf(false) }
         var aboutDialogOpened by remember { mutableStateOf(false) }
         var customColorPickerDialogOpened by remember { mutableStateOf(false) }
+        var defaultPostVisibilityBottomSheetOpened by remember { mutableStateOf(false) }
+        var defaultReplyVisibilityBottomSheetOpened by remember { mutableStateOf(false) }
 
         Scaffold(
             topBar = {
@@ -141,6 +144,20 @@ class SettingsScreen : Screen {
                             value = uiState.defaultTimelineType.toReadableName(),
                             onTap = {
                                 defaultTimelineTypeBottomSheetOpened = true
+                            },
+                        )
+                        SettingsRow(
+                            title = LocalStrings.current.settingsItemDefaultPostVisibility,
+                            value = uiState.defaultPostVisibility.toReadableName(),
+                            onTap = {
+                                defaultPostVisibilityBottomSheetOpened = true
+                            },
+                        )
+                        SettingsRow(
+                            title = LocalStrings.current.settingsItemDefaultReplyVisibility,
+                            value = uiState.defaultReplyVisibility.toReadableName(),
+                            onTap = {
+                                defaultReplyVisibilityBottomSheetOpened = true
                             },
                         )
                         SettingsRow(
@@ -476,6 +493,74 @@ class SettingsScreen : Screen {
                     if (index != null) {
                         val type = types[index]
                         model.reduce(SettingsMviModel.Intent.ChangeUrlOpeningMode(type))
+                    }
+                },
+            )
+        }
+
+        if (defaultPostVisibilityBottomSheetOpened) {
+            val types =
+                listOf(
+                    Visibility.Public,
+                    Visibility.Unlisted,
+                    Visibility.Direct,
+                    Visibility.Private,
+                )
+            CustomModalBottomSheet(
+                title = LocalStrings.current.settingsItemDefaultPostVisibility,
+                items =
+                    types.map {
+                        CustomModalBottomSheetItem(
+                            label = it.toReadableName(),
+                            trailingContent = {
+                                Icon(
+                                    modifier = Modifier.size(IconSize.m),
+                                    imageVector = it.toIcon(),
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onBackground,
+                                )
+                            },
+                        )
+                    },
+                onSelected = { index ->
+                    defaultPostVisibilityBottomSheetOpened = false
+                    if (index != null) {
+                        val type = types[index]
+                        model.reduce(SettingsMviModel.Intent.ChangeDefaultPostVisibility(type))
+                    }
+                },
+            )
+        }
+
+        if (defaultReplyVisibilityBottomSheetOpened) {
+            val types =
+                listOf(
+                    Visibility.Public,
+                    Visibility.Unlisted,
+                    Visibility.Direct,
+                    Visibility.Private,
+                )
+            CustomModalBottomSheet(
+                title = LocalStrings.current.settingsItemDefaultReplyVisibility,
+                items =
+                    types.map {
+                        CustomModalBottomSheetItem(
+                            label = it.toReadableName(),
+                            trailingContent = {
+                                Icon(
+                                    modifier = Modifier.size(IconSize.m),
+                                    imageVector = it.toIcon(),
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onBackground,
+                                )
+                            },
+                        )
+                    },
+                onSelected = { index ->
+                    defaultReplyVisibilityBottomSheetOpened = false
+                    if (index != null) {
+                        val type = types[index]
+                        model.reduce(SettingsMviModel.Intent.ChangeDefaultReplyVisibility(type))
                     }
                 },
             )

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsViewModel.kt
@@ -12,8 +12,10 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ColorSche
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.L10nManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineType
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.Visibility
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toInt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toTimelineType
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toVisibility
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.UrlOpeningMode
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
@@ -92,6 +94,8 @@ class SettingsViewModel(
                                 includeNsfw = settings.includeNsfw,
                                 blurNsfw = settings.blurNsfw,
                                 urlOpeningMode = settings.urlOpeningMode,
+                                defaultPostVisibility = settings.defaultPostVisibility.toVisibility(),
+                                defaultReplyVisibility = settings.defaultReplyVisibility.toVisibility(),
                             )
                         }
                     }
@@ -157,6 +161,16 @@ class SettingsViewModel(
                 screenModelScope.launch {
                     changeUrlOpeningMode(intent.mode)
                 }
+
+            is SettingsMviModel.Intent.ChangeDefaultPostVisibility ->
+                screenModelScope.launch {
+                    changeDefaultPostVisibility(intent.visibility)
+                }
+
+            is SettingsMviModel.Intent.ChangeDefaultReplyVisibility ->
+                screenModelScope.launch {
+                    changeDefaultReplyVisibility(intent.visibility)
+                }
         }
     }
 
@@ -199,6 +213,18 @@ class SettingsViewModel(
     private suspend fun changeDefaultTimelineType(type: TimelineType) {
         val currentSettings = settingsRepository.current.value ?: return
         val newSettings = currentSettings.copy(defaultTimelineType = type.toInt())
+        saveSettings(newSettings)
+    }
+
+    private suspend fun changeDefaultPostVisibility(visibility: Visibility) {
+        val currentSettings = settingsRepository.current.value ?: return
+        val newSettings = currentSettings.copy(defaultPostVisibility = visibility.toInt())
+        saveSettings(newSettings)
+    }
+
+    private suspend fun changeDefaultReplyVisibility(visibility: Visibility) {
+        val currentSettings = settingsRepository.current.value ?: return
+        val newSettings = currentSettings.copy(defaultReplyVisibility = visibility.toInt())
         saveSettings(newSettings)
     }
 


### PR DESCRIPTION
This PR makes it possible to configure (in the Settings screen) the default visibility for new posts and replies to posts.

<div align="center">
<img src="https://github.com/user-attachments/assets/daae51ed-bbaa-44f4-9320-ac47b3d18d69" width="310" />
</div>
