### PR TITLE
enhancement: preload image avatars in feeds

### DIFF
--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NotificationModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NotificationModel.kt
@@ -7,3 +7,32 @@ data class NotificationModel(
     val type: NotificationType = NotificationType.Unknown,
     val user: UserModel? = null,
 )
+
+val NotificationModel.urlsForPreload: List<String>
+    get() =
+        buildList {
+            entry
+                ?.attachments
+                ?.mapNotNull { attachment ->
+                    if (attachment.type != MediaType.Image) {
+                        null
+                    } else {
+                        attachment.url.takeUnless { it.isNotBlank() }
+                    }
+                }?.also { urls ->
+                    addAll(urls)
+                }
+            entry
+                ?.creator
+                ?.avatar
+                ?.takeUnless { it.isNotBlank() }
+                ?.also { add(it) }
+            entry
+                ?.card
+                ?.image
+                ?.takeUnless { it.isNotBlank() }
+                ?.also { add(it) }
+
+            user?.header?.takeUnless { it.isNotBlank() }?.also { add(it) }
+            user?.avatar?.takeUnless { it.isNotBlank() }?.also { add(it) }
+        }

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/TimelineEntryModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/TimelineEntryModel.kt
@@ -57,6 +57,23 @@ val TimelineEntryModel.safeKey: String
 
 val TimelineEntryModel.original: TimelineEntryModel get() = reblog ?: this
 
+val TimelineEntryModel.urlsForPreload: List<String>
+    get() =
+        buildList {
+            attachments
+                .mapNotNull { attachment ->
+                    if (attachment.type != MediaType.Image) {
+                        null
+                    } else {
+                        attachment.url.takeUnless { it.isNotBlank() }
+                    }
+                }.also { urls ->
+                    addAll(urls)
+                }
+            creator?.avatar?.takeUnless { it.isNotBlank() }?.also { add(it) }
+            card?.image?.takeUnless { it.isNotBlank() }?.also { add(it) }
+        }
+
 val TimelineEntryModel.isNsfw: Boolean get() = reblog?.sensitive ?: sensitive
 
 val Duration.isOldEntry: Boolean

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailViewModel.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailViewModel.kt
@@ -7,9 +7,9 @@ import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.Timel
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.TimelineEntryUpdatedEvent
 import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.ImagePreloadManager
 import com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate.HapticFeedback
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.LocalItemCache
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
@@ -123,25 +123,7 @@ class EntryDetailViewModel(
 
     private fun List<TimelineEntryModel>.preloadImages() {
         flatMap { entry ->
-            val entryToDisplay = entry.original
-            buildList {
-                entryToDisplay.attachments
-                    .mapNotNull { attachment ->
-                        if (attachment.type != MediaType.Image) {
-                            null
-                        } else {
-                            attachment.url.takeUnless { it.isNotBlank() }
-                        }
-                    }.also { urls ->
-                        addAll(urls)
-                    }
-                entryToDisplay.card
-                    ?.image
-                    ?.takeUnless { it.isNotBlank() }
-                    ?.also { url ->
-                        add(url)
-                    }
-            }
+            entry.original.urlsForPreload
         }.forEach { url ->
             imagePreloadManager.preload(url)
         }

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreViewModel.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreViewModel.kt
@@ -9,12 +9,12 @@ import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.UserU
 import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.ImagePreloadManager
 import com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate.HapticFeedback
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.ExploreItemModel
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toNotificationStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toStatus
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.ExplorePaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.ExplorePaginationSpecification
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
@@ -169,25 +169,7 @@ class ExploreViewModel(
 
     private fun List<TimelineEntryModel>.preloadImages() {
         flatMap { entry ->
-            val entryToDisplay = entry.original
-            buildList {
-                entryToDisplay.attachments
-                    .mapNotNull { attachment ->
-                        if (attachment.type != MediaType.Image) {
-                            null
-                        } else {
-                            attachment.url.takeUnless { it.isNotBlank() }
-                        }
-                    }.also { urls ->
-                        addAll(urls)
-                    }
-                entryToDisplay.card
-                    ?.image
-                    ?.takeUnless { it.isNotBlank() }
-                    ?.also { url ->
-                        add(url)
-                    }
-            }
+            entry.original.urlsForPreload
         }.forEach { url ->
             imagePreloadManager.preload(url)
         }

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesViewModel.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesViewModel.kt
@@ -8,9 +8,9 @@ import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.Timel
 import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.ImagePreloadManager
 import com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate.HapticFeedback
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.FavoritesType
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.FavoritesPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.FavoritesPaginationSpecification
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
@@ -136,25 +136,7 @@ class FavoritesViewModel(
 
     private fun List<TimelineEntryModel>.preloadImages() {
         flatMap { entry ->
-            val entryToDisplay = entry.original
-            buildList {
-                entryToDisplay.attachments
-                    .mapNotNull { attachment ->
-                        if (attachment.type != MediaType.Image) {
-                            null
-                        } else {
-                            attachment.url.takeUnless { it.isNotBlank() }
-                        }
-                    }.also { urls ->
-                        addAll(urls)
-                    }
-                entryToDisplay.card
-                    ?.image
-                    ?.takeUnless { it.isNotBlank() }
-                    ?.also { url ->
-                        add(url)
-                    }
-            }
+            entry.original.urlsForPreload
         }.forEach { url ->
             imagePreloadManager.preload(url)
         }

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagViewModel.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagViewModel.kt
@@ -8,9 +8,9 @@ import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.Timel
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.TimelineEntryUpdatedEvent
 import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.ImagePreloadManager
 import com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate.HapticFeedback
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationSpecification
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TagRepository
@@ -135,25 +135,7 @@ class HashtagViewModel(
 
     private fun List<TimelineEntryModel>.preloadImages() {
         flatMap { entry ->
-            val entryToDisplay = entry.original
-            buildList {
-                entryToDisplay.attachments
-                    .mapNotNull { attachment ->
-                        if (attachment.type != MediaType.Image) {
-                            null
-                        } else {
-                            attachment.url.takeUnless { it.isNotBlank() }
-                        }
-                    }.also { urls ->
-                        addAll(urls)
-                    }
-                entryToDisplay.card
-                    ?.image
-                    ?.takeUnless { it.isNotBlank() }
-                    ?.also { url ->
-                        add(url)
-                    }
-            }
+            entry.original.urlsForPreload
         }.forEach { url ->
             imagePreloadManager.preload(url)
         }

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
@@ -4,12 +4,12 @@ import cafe.adriel.voyager.core.model.screenModelScope
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
 import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.ImagePreloadManager
 import com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate.HapticFeedback
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toNotificationStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toStatus
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.NotificationsPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.NotificationsPaginationSpecification
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.InboxManager
@@ -118,34 +118,7 @@ class InboxViewModel(
 
     private fun List<NotificationModel>.preloadImages() {
         flatMap { notification ->
-            val entry = notification.entry
-            val user = notification.user
-            buildList {
-                entry
-                    ?.attachments
-                    ?.mapNotNull { attachment ->
-                        if (attachment.type != MediaType.Image) {
-                            null
-                        } else {
-                            attachment.url.takeUnless { it.isNotBlank() }
-                        }
-                    }?.also { urls ->
-                        addAll(urls)
-                    }
-                entry
-                    ?.card
-                    ?.image
-                    ?.takeUnless { it.isNotBlank() }
-                    ?.also { url ->
-                        add(url)
-                    }
-                user
-                    ?.header
-                    ?.takeUnless { it.isNotBlank() }
-                    ?.also { url ->
-                        add(url)
-                    }
-            }
+            notification.urlsForPreload
         }.forEach { url ->
             imagePreloadManager.preload(url)
         }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
@@ -8,9 +8,9 @@ import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.Timel
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.TimelineEntryUpdatedEvent
 import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.ImagePreloadManager
 import com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate.HapticFeedback
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationSpecification
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
@@ -170,25 +170,7 @@ class MyAccountViewModel(
 
     private fun List<TimelineEntryModel>.preloadImages() {
         flatMap { entry ->
-            val entryToDisplay = entry.original
-            buildList {
-                entryToDisplay.attachments
-                    .mapNotNull { attachment ->
-                        if (attachment.type != MediaType.Image) {
-                            null
-                        } else {
-                            attachment.url.takeUnless { it.isNotBlank() }
-                        }
-                    }.also { urls ->
-                        addAll(urls)
-                    }
-                entryToDisplay.card
-                    ?.image
-                    ?.takeUnless { it.isNotBlank() }
-                    ?.also { url ->
-                        add(url)
-                    }
-            }
+            entry.original.urlsForPreload
         }.forEach { url ->
             imagePreloadManager.preload(url)
         }

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchViewModel.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchViewModel.kt
@@ -9,12 +9,12 @@ import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.UserU
 import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.ImagePreloadManager
 import com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate.HapticFeedback
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.ExploreItemModel
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toNotificationStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toStatus
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.SearchPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.SearchPaginationSpecification
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
@@ -178,25 +178,7 @@ class SearchViewModel(
 
     private fun List<TimelineEntryModel>.preloadImages() {
         flatMap { entry ->
-            val entryToDisplay = entry.original
-            buildList {
-                entryToDisplay.attachments
-                    .mapNotNull { attachment ->
-                        if (attachment.type != MediaType.Image) {
-                            null
-                        } else {
-                            attachment.url.takeUnless { it.isNotBlank() }
-                        }
-                    }.also { urls ->
-                        addAll(urls)
-                    }
-                entryToDisplay.card
-                    ?.image
-                    ?.takeUnless { it.isNotBlank() }
-                    ?.also { url ->
-                        add(url)
-                    }
-            }
+            entry.original.urlsForPreload
         }.forEach { url ->
             imagePreloadManager.preload(url)
         }

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadViewModel.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadViewModel.kt
@@ -7,9 +7,9 @@ import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.Timel
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.TimelineEntryUpdatedEvent
 import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.ImagePreloadManager
 import com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate.HapticFeedback
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.LocalItemCache
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
@@ -136,25 +136,7 @@ class ThreadViewModel(
 
     private fun List<TimelineEntryModel>.preloadImages() {
         flatMap { entry ->
-            val entryToDisplay = entry.original
-            buildList {
-                entryToDisplay.attachments
-                    .mapNotNull { attachment ->
-                        if (attachment.type != MediaType.Image) {
-                            null
-                        } else {
-                            attachment.url.takeUnless { it.isNotBlank() }
-                        }
-                    }.also { urls ->
-                        addAll(urls)
-                    }
-                entryToDisplay.card
-                    ?.image
-                    ?.takeUnless { it.isNotBlank() }
-                    ?.also { url ->
-                        add(url)
-                    }
-            }
+            entry.original.urlsForPreload
         }.forEach { url ->
             imagePreloadManager.preload(url)
         }

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
@@ -7,11 +7,11 @@ import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.Timel
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.TimelineEntryUpdatedEvent
 import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.ImagePreloadManager
 import com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate.HapticFeedback
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toTimelineType
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationSpecification
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.CirclesRepository
@@ -203,25 +203,7 @@ class TimelineViewModel(
 
     private fun List<TimelineEntryModel>.preloadImages() {
         flatMap { entry ->
-            val entryToDisplay = entry.original
-            buildList {
-                entryToDisplay.attachments
-                    .mapNotNull { attachment ->
-                        if (attachment.type != MediaType.Image) {
-                            null
-                        } else {
-                            attachment.url.takeUnless { it.isNotBlank() }
-                        }
-                    }.also { urls ->
-                        addAll(urls)
-                    }
-                entryToDisplay.card
-                    ?.image
-                    ?.takeUnless { it.isNotBlank() }
-                    ?.also { url ->
-                        add(url)
-                    }
-            }
+            entry.original.urlsForPreload
         }.forEach { url ->
             imagePreloadManager.preload(url)
         }

--- a/feature/unpublished/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/unpublished/UnpublishedViewModel.kt
+++ b/feature/unpublished/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/unpublished/UnpublishedViewModel.kt
@@ -6,10 +6,10 @@ import com.livefast.eattrash.raccoonforfriendica.core.notifications.Notification
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.DraftDeletedEvent
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.TimelineEntryDeletedEvent
 import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.ImagePreloadManager
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UnpublishedType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.UnpublishedPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.UnpublishedPaginationSpecification
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DraftRepository
@@ -110,25 +110,7 @@ class UnpublishedViewModel(
 
     private fun List<TimelineEntryModel>.preloadImages() {
         flatMap { entry ->
-            val entryToDisplay = entry.original
-            buildList {
-                entryToDisplay.attachments
-                    .mapNotNull { attachment ->
-                        if (attachment.type != MediaType.Image) {
-                            null
-                        } else {
-                            attachment.url.takeUnless { it.isNotBlank() }
-                        }
-                    }.also { urls ->
-                        addAll(urls)
-                    }
-                entryToDisplay.card
-                    ?.image
-                    ?.takeUnless { it.isNotBlank() }
-                    ?.also { url ->
-                        add(url)
-                    }
-            }
+            entry.original.urlsForPreload
         }.forEach { url ->
             imagePreloadManager.preload(url)
         }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailViewModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailViewModel.kt
@@ -8,12 +8,12 @@ import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.Timel
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.UserUpdatedEvent
 import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.ImagePreloadManager
 import com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate.HapticFeedback
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toNotificationStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toStatus
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationSpecification
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.LocalItemCache
@@ -174,25 +174,7 @@ class UserDetailViewModel(
 
     private fun List<TimelineEntryModel>.preloadImages() {
         flatMap { entry ->
-            val entryToDisplay = entry.original
-            buildList {
-                entryToDisplay.attachments
-                    .mapNotNull { attachment ->
-                        if (attachment.type != MediaType.Image) {
-                            null
-                        } else {
-                            attachment.url.takeUnless { it.isNotBlank() }
-                        }
-                    }.also { urls ->
-                        addAll(urls)
-                    }
-                entryToDisplay.card
-                    ?.image
-                    ?.takeUnless { it.isNotBlank() }
-                    ?.also { url ->
-                        add(url)
-                    }
-            }
+            entry.original.urlsForPreload
         }.forEach { url ->
             imagePreloadManager.preload(url)
         }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListViewModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListViewModel.kt
@@ -7,10 +7,10 @@ import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.Timel
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.TimelineEntryUpdatedEvent
 import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.ImagePreloadManager
 import com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate.HapticFeedback
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationSpecification
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.LocalItemCache
@@ -136,25 +136,7 @@ class ForumListViewModel(
 
     private fun List<TimelineEntryModel>.preloadImages() {
         flatMap { entry ->
-            val entryToDisplay = entry.original
-            buildList {
-                entryToDisplay.attachments
-                    .mapNotNull { attachment ->
-                        if (attachment.type != MediaType.Image) {
-                            null
-                        } else {
-                            attachment.url.takeUnless { it.isNotBlank() }
-                        }
-                    }.also { urls ->
-                        addAll(urls)
-                    }
-                entryToDisplay.card
-                    ?.image
-                    ?.takeUnless { it.isNotBlank() }
-                    ?.also { url ->
-                        add(url)
-                    }
-            }
+            entry.original.urlsForPreload
         }.forEach { url ->
             imagePreloadManager.preload(url)
         }


### PR DESCRIPTION
This PR further increases images preload for posts and notifications, including user avatars and banners (where needed).

Moreover, it removes some duplicated code in determining the URL list.