### PR TITLE
enhancement: propagate post creation and update events

### DIFF
--- a/core/notifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/notifications/events/Events.kt
+++ b/core/notifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/notifications/events/Events.kt
@@ -8,6 +8,10 @@ data class UserUpdatedEvent(
     val user: UserModel,
 ) : NotificationCenterEvent
 
+data class TimelineEntryCreatedEvent(
+    val entry: TimelineEntryModel,
+) : NotificationCenterEvent
+
 data class TimelineEntryUpdatedEvent(
     val entry: TimelineEntryModel,
 ) : NotificationCenterEvent

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUnpublishedPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUnpublishedPaginationManager.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
 
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.NotificationCenter
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.TimelineEntryDeletedEvent
+import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.TimelineEntryUpdatedEvent
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DraftRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.ScheduledEntryRepository
@@ -37,6 +38,16 @@ internal class DefaultUnpublishedPaginationManager(
                     val idx = history.indexOfFirst { e -> e.id == event.id }
                     if (idx >= 0) {
                         history.removeAt(idx)
+                    }
+                }
+            }.launchIn(scope)
+        notificationCenter
+            .subscribe(TimelineEntryUpdatedEvent::class)
+            .onEach { event ->
+                mutex.withLock {
+                    val idx = history.indexOfFirst { e -> e.id == event.entry.id }
+                    if (idx >= 0) {
+                        history[idx] = event.entry
                     }
                 }
             }.launchIn(scope)

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
@@ -82,6 +82,11 @@ class MyAccountViewModel(
                 .onEach { event ->
                     updateEntryInState(event.entry.id) { event.entry }
                 }.launchIn(this)
+            notificationCenter
+                .subscribe(TimelineEntryDeletedEvent::class)
+                .onEach { event ->
+                    removeEntryFromState(event.id)
+                }.launchIn(this)
         }
     }
 

--- a/feature/unpublished/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/unpublished/UnpublishedViewModel.kt
+++ b/feature/unpublished/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/unpublished/UnpublishedViewModel.kt
@@ -4,7 +4,9 @@ import cafe.adriel.voyager.core.model.screenModelScope
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.NotificationCenter
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.DraftDeletedEvent
+import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.TimelineEntryCreatedEvent
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.TimelineEntryDeletedEvent
+import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.TimelineEntryUpdatedEvent
 import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.ImagePreloadManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UnpublishedType
@@ -36,6 +38,16 @@ class UnpublishedViewModel(
                 .subscribe(DraftDeletedEvent::class)
                 .onEach { event ->
                     removeEntryFromState(event.id)
+                }.launchIn(this)
+            notificationCenter
+                .subscribe(TimelineEntryUpdatedEvent::class)
+                .onEach { event ->
+                    updateEntryInState(event.entry.id) { event.entry }
+                }.launchIn(this)
+            notificationCenter
+                .subscribe(TimelineEntryCreatedEvent::class)
+                .onEach {
+                    refresh()
                 }.launchIn(this)
             identityRepository.currentUser
                 .onEach { currentUser ->


### PR DESCRIPTION
This PR makes it more "natural" to see post updates and creation after having created or edited a post in profile, post detail and scheduled/draft screen.