### PR TITLE
fix: loading of relationship status in user list

### DIFF
--- a/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListViewModel.kt
+++ b/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListViewModel.kt
@@ -39,17 +39,16 @@ internal class UserListViewModel(
                     updateState {
                         it.copy(currentUserId = currentUser?.id)
                     }
+                    if (uiState.value.initial) {
+                        loadUser()
+                        refresh(initial = true)
+                    }
                 }.launchIn(this)
             notificationCenter
                 .subscribe(UserUpdatedEvent::class)
                 .onEach { event ->
                     updateUserInState(event.user.id) { event.user }
                 }.launchIn(this)
-
-            if (uiState.value.initial) {
-                loadUser()
-                refresh(initial = true)
-            }
         }
     }
 
@@ -94,7 +93,6 @@ internal class UserListViewModel(
                 is UserListType.Following -> UserPaginationSpecification.Following(userId.orEmpty())
                 is UserListType.UsersFavorite ->
                     UserPaginationSpecification.EntryUsersFavorite(entryId.orEmpty())
-
                 is UserListType.UsersReblog -> UserPaginationSpecification.EntryUsersReblog(entryId.orEmpty())
             },
         )


### PR DESCRIPTION
This PR fixes a bug due to which relationship with other users in user lists (e.g. following/follower or people who liked/reshared a post) did not have the relationship populated even when there is a logged user.

Now it is (again) possible to follow/unfollow/send requests to people from user lists.