### PR TITLE
enhancement: preload user avatars in lists

### DIFF
--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/detail/CircleDetailViewModel.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/detail/CircleDetailViewModel.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.feature.circles.detail
 
 import cafe.adriel.voyager.core.model.screenModelScope
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
+import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.ImagePreloadManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.UserPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.UserPaginationSpecification
@@ -22,6 +23,7 @@ class CircleDetailViewModel(
     private val paginationManager: UserPaginationManager,
     private val circlesRepository: CirclesRepository,
     private val searchPaginationManager: UserPaginationManager,
+    private val imagePreloadManager: ImagePreloadManager,
 ) : DefaultMviModel<CircleDetailMviModel.Intent, CircleDetailMviModel.State, CircleDetailMviModel.Effect>(
         initialState = CircleDetailMviModel.State(),
     ),
@@ -93,6 +95,7 @@ class CircleDetailViewModel(
         updateState { it.copy(loading = true) }
         while (paginationManager.canFetchMore) {
             val users = paginationManager.loadNextPage()
+            users.preloadImages()
             updateState {
                 it.copy(
                     users = users,
@@ -104,6 +107,14 @@ class CircleDetailViewModel(
         }
         updateState {
             it.copy(loading = false)
+        }
+    }
+
+    private fun List<UserModel>.preloadImages() {
+        mapNotNull { user ->
+            user.avatar?.takeIf { it.isNotEmpty() }
+        }.onEach { url ->
+            imagePreloadManager.preload(url)
         }
     }
 

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/di/CirclesModule.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/di/CirclesModule.kt
@@ -20,6 +20,7 @@ val featureCirclesModule =
                 paginationManager = get(),
                 circlesRepository = get(),
                 searchPaginationManager = get(),
+                imagePreloadManager = get(),
             )
         }
     }

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreViewModel.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreViewModel.kt
@@ -156,6 +156,7 @@ class ExploreViewModel(
         updateState { it.copy(loading = true) }
         val entries = paginationManager.loadNextPage()
         entries.mapNotNull { (it as? ExploreItemModel.Entry)?.entry }.preloadImages()
+        entries.mapNotNull { (it as? ExploreItemModel.User)?.user }.preloadAvatars()
         updateState {
             it.copy(
                 items = entries,
@@ -171,6 +172,14 @@ class ExploreViewModel(
         flatMap { entry ->
             entry.original.urlsForPreload
         }.forEach { url ->
+            imagePreloadManager.preload(url)
+        }
+    }
+
+    private fun List<UserModel>.preloadAvatars() {
+        mapNotNull { user ->
+            user.avatar?.takeIf { it.isNotEmpty() }
+        }.onEach { url ->
             imagePreloadManager.preload(url)
         }
     }

--- a/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/ManageBlocksViewModel.kt
+++ b/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/ManageBlocksViewModel.kt
@@ -2,6 +2,8 @@ package com.livefast.eattrash.raccoonforfriendica.feature.manageblocks
 
 import cafe.adriel.voyager.core.model.screenModelScope
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
+import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.ImagePreloadManager
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.UserPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.UserPaginationSpecification
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
@@ -11,6 +13,7 @@ import kotlinx.coroutines.launch
 class ManageBlocksViewModel(
     private val paginationManager: UserPaginationManager,
     private val userRepository: UserRepository,
+    private val imagePreloadManager: ImagePreloadManager,
 ) : DefaultMviModel<ManageBlocksMviModel.Intent, ManageBlocksMviModel.State, ManageBlocksMviModel.Effect>(
         initialState = ManageBlocksMviModel.State(),
     ),
@@ -60,15 +63,24 @@ class ManageBlocksViewModel(
         }
 
         updateState { it.copy(loading = true) }
-        val entries = paginationManager.loadNextPage()
+        val users = paginationManager.loadNextPage()
+        users.preloadImages()
         updateState {
             it.copy(
-                items = entries,
+                items = users,
                 canFetchMore = paginationManager.canFetchMore,
                 loading = false,
                 initial = false,
                 refreshing = false,
             )
+        }
+    }
+
+    private fun List<UserModel>.preloadImages() {
+        mapNotNull { user ->
+            user.avatar?.takeIf { it.isNotEmpty() }
+        }.onEach { url ->
+            imagePreloadManager.preload(url)
         }
     }
 

--- a/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/di/ManageBlocksModule.kt
+++ b/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/di/ManageBlocksModule.kt
@@ -10,6 +10,7 @@ val featureManageBlocksModule =
             ManageBlocksViewModel(
                 paginationManager = get(),
                 userRepository = get(),
+                imagePreloadManager = get(),
             )
         }
     }

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchViewModel.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchViewModel.kt
@@ -164,6 +164,7 @@ class SearchViewModel(
         updateState { it.copy(loading = true) }
         val entries = paginationManager.loadNextPage()
         entries.mapNotNull { (it as? ExploreItemModel.Entry)?.entry }.preloadImages()
+        entries.mapNotNull { (it as? ExploreItemModel.User)?.user }.preloadAvatars()
         updateState {
             it.copy(
                 items = entries,
@@ -180,6 +181,14 @@ class SearchViewModel(
         flatMap { entry ->
             entry.original.urlsForPreload
         }.forEach { url ->
+            imagePreloadManager.preload(url)
+        }
+    }
+
+    private fun List<UserModel>.preloadAvatars() {
+        mapNotNull { user ->
+            user.avatar?.takeIf { it.isNotEmpty() }
+        }.onEach { url ->
             imagePreloadManager.preload(url)
         }
     }

--- a/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListViewModel.kt
+++ b/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListViewModel.kt
@@ -4,6 +4,7 @@ import cafe.adriel.voyager.core.model.screenModelScope
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.NotificationCenter
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.UserUpdatedEvent
+import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.ImagePreloadManager
 import com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate.HapticFeedback
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserListType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
@@ -26,6 +27,7 @@ internal class UserListViewModel(
     private val userRepository: UserRepository,
     private val identityRepository: IdentityRepository,
     private val hapticFeedback: HapticFeedback,
+    private val imagePreloadManager: ImagePreloadManager,
     private val notificationCenter: NotificationCenter,
     private val userCache: LocalItemCache<UserModel>,
 ) : DefaultMviModel<UserListMviModel.Intent, UserListMviModel.State, UserListMviModel.Effect>(
@@ -118,6 +120,7 @@ internal class UserListViewModel(
                         user
                     }
                 }
+        users.preloadImages()
         val wasRefreshing = currentState.refreshing
         updateState {
             it.copy(
@@ -130,6 +133,14 @@ internal class UserListViewModel(
         }
         if (wasRefreshing) {
             emitEffect(UserListMviModel.Effect.BackToTop)
+        }
+    }
+
+    private fun List<UserModel>.preloadImages() {
+        mapNotNull { user ->
+            user.avatar?.takeIf { it.isNotEmpty() }
+        }.onEach { url ->
+            imagePreloadManager.preload(url)
         }
     }
 

--- a/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/di/UserListModule.kt
+++ b/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/di/UserListModule.kt
@@ -15,6 +15,7 @@ val featureUserListModule =
                 userRepository = get(),
                 identityRepository = get(),
                 hapticFeedback = get(),
+                imagePreloadManager = get(),
                 notificationCenter = get(),
                 userCache = get(),
             )


### PR DESCRIPTION
As per title, impacted screens:
- user list (following/followers and users who liked/reshared a post)
- explore
- search
- manage blocks
- circle detail