### PR TITLE
refactor: centralize supported features

### DIFF
--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NodeFeatures.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NodeFeatures.kt
@@ -1,0 +1,10 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.data
+
+data class NodeFeatures(
+    val supportsPhotoGallery: Boolean = false,
+    val supportsDirectMessages: Boolean = false,
+    val supportsEntryTitles: Boolean = false,
+    val supportsPolls: Boolean = false,
+    val supportsCustomCircles: Boolean = false,
+    val supportReportCategoryRuleViolation: Boolean = false,
+)

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NodeInfoModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NodeInfoModel.kt
@@ -15,12 +15,3 @@ data class NodeInfoModel(
     val uri: String? = null,
     val version: String? = null,
 )
-
-private val FRIENDICA_REGEX =
-    Regex("\\(compatible; Friendica (?<version>[a-zA-Z0-9.-_]*)\\)")
-
-val NodeInfoModel.isFriendica: Boolean
-    get() =
-        version
-            .orEmpty()
-            .contains(FRIENDICA_REGEX)

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepository.kt
@@ -1,0 +1,35 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NodeFeatures
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NodeInfoModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+
+internal class DefaultSupportedFeatureRepository(
+    private val nodeInfoRepository: NodeInfoRepository,
+) : SupportedFeatureRepository {
+    override val features = MutableStateFlow(NodeFeatures())
+
+    override suspend fun refresh() {
+        val info = nodeInfoRepository.getInfo()
+        features.update {
+            it.copy(
+                supportsPhotoGallery = info?.isFriendica == true,
+                supportsDirectMessages = info?.isFriendica == true,
+                supportsEntryTitles = info?.isFriendica == true,
+                supportsCustomCircles = info?.isFriendica == true,
+                supportReportCategoryRuleViolation = info?.isFriendica == false,
+                supportsPolls = info?.isFriendica == false,
+            )
+        }
+    }
+}
+
+private val FRIENDICA_REGEX =
+    Regex("\\(compatible; Friendica (?<version>[a-zA-Z0-9.-_]*)\\)")
+
+private val NodeInfoModel.isFriendica: Boolean
+    get() =
+        version
+            .orEmpty()
+            .contains(FRIENDICA_REGEX)

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/SupportedFeatureRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/SupportedFeatureRepository.kt
@@ -1,0 +1,10 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NodeFeatures
+import kotlinx.coroutines.flow.StateFlow
+
+interface SupportedFeatureRepository {
+    val features: StateFlow<NodeFeatures>
+
+    suspend fun refresh()
+}

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
@@ -16,6 +16,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Defau
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultReportRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultScheduledEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultSearchRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultSupportedFeatureRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultTagRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultTimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultTimelineRepository
@@ -33,6 +34,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Photo
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.ReportRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.ScheduledEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SearchRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SupportedFeatureRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TagRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineRepository
@@ -133,6 +135,11 @@ val domainContentRepositoryModule =
         single<ReportRepository> {
             DefaultReportRepository(
                 provider = get(named("default")),
+            )
+        }
+        single<SupportedFeatureRepository> {
+            DefaultSupportedFeatureRepository(
+                nodeInfoRepository = get(),
             )
         }
     }

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitor.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitor.kt
@@ -1,5 +1,6 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
 
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SupportedFeatureRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountCredentialsCache
@@ -23,6 +24,7 @@ internal class DefaultActiveAccountMonitor(
     private val identityRepository: IdentityRepository,
     private val accountCredentialsCache: AccountCredentialsCache,
     private val settingsRepository: SettingsRepository,
+    private val supportedFeatureRepository: SupportedFeatureRepository,
     coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ActiveAccountMonitor {
     private val scope = CoroutineScope(SupervisorJob() + coroutineDispatcher)
@@ -53,8 +55,10 @@ internal class DefaultActiveAccountMonitor(
         if (account == null) {
             apiConfigurationRepository.setAuth(null)
             identityRepository.refreshCurrentUser(null)
+            supportedFeatureRepository.refresh()
             return
         }
+
         val node =
             account.handle.substringAfter("@").takeIf { it.isNotEmpty() }
                 ?: apiConfigurationRepository.defaultNode
@@ -63,6 +67,7 @@ internal class DefaultActiveAccountMonitor(
         apiConfigurationRepository.setAuth(credentials)
 
         identityRepository.refreshCurrentUser(account.remoteId)
+        supportedFeatureRepository.refresh()
 
         val defaultSettings = settingsRepository.get(account.id) ?: SettingsModel()
         settingsRepository.changeCurrent(defaultSettings)

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
@@ -70,6 +70,7 @@ val domainIdentityUseCaseModule =
                 identityRepository = get(),
                 settingsRepository = get(),
                 accountCredentialsCache = get(),
+                supportedFeatureRepository = get(),
             )
         }
     }

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/di/CirclesModule.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/di/CirclesModule.kt
@@ -11,7 +11,7 @@ val featureCirclesModule =
         factory<CirclesMviModel> {
             CirclesViewModel(
                 circlesRepository = get(),
-                nodeInfoRepository = get(),
+                supportedFeatureRepository = get(),
             )
         }
         factory<CircleDetailMviModel> { params ->

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/list/CirclesViewModel.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/list/CirclesViewModel.kt
@@ -5,25 +5,27 @@ import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviMod
 import com.livefast.eattrash.raccoonforfriendica.core.utils.validation.ValidationError
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.CircleModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.CircleReplyPolicy
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isFriendica
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.CirclesRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.NodeInfoRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SupportedFeatureRepository
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 class CirclesViewModel(
     private val circlesRepository: CirclesRepository,
-    private val nodeInfoRepository: NodeInfoRepository,
+    private val supportedFeatureRepository: SupportedFeatureRepository,
 ) : DefaultMviModel<CirclesMviModel.Intent, CirclesMviModel.State, CirclesMviModel.Effect>(
         initialState = CirclesMviModel.State(),
     ),
     CirclesMviModel {
     init {
         screenModelScope.launch {
-            if (uiState.value.initial) {
-                refresh(initial = true)
-            }
+            supportedFeatureRepository.features
+                .onEach {
+                    refresh(initial = true)
+                }.launchIn(this)
         }
     }
 
@@ -74,11 +76,14 @@ class CirclesViewModel(
                 async {
                     circlesRepository.getFriendicaCircles()
                 }.await().orEmpty()
-            val isFriendica = async { nodeInfoRepository.getInfo()?.isFriendica == true }.await()
+
             val items =
                 circles.map { circle ->
-                    // on Mastodon, all lists can be edited; on Friendica ony the user-created ones
-                    val canBeEdited = !isFriendica || friendicaCircles.any { c -> c.id == circle.id }
+                    // on Mastodon, all lists can be edited; on Friendica only the user-created ones
+                    val supportsCustomCircles =
+                        supportedFeatureRepository.features.value.supportsCustomCircles
+                    val canBeEdited =
+                        !supportsCustomCircles || friendicaCircles.any { c -> c.id == circle.id }
                     circle.copy(editable = canBeEdited)
                 }
 

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
@@ -166,14 +166,7 @@ interface ComposerMviModel :
         val bodyValue: TextFieldValue = TextFieldValue(),
         val spoilerValue: TextFieldValue = TextFieldValue(),
         val visibility: Visibility = Visibility.Public,
-        val availableVisibilities: List<Visibility> =
-            listOf(
-                Visibility.Public,
-                Visibility.Unlisted,
-                Visibility.Private,
-                Visibility.Direct,
-                Visibility.Circle(),
-            ),
+        val availableVisibilities: List<Visibility> = emptyList(),
         val sensitive: Boolean = false,
         val attachments: List<AttachmentModel> = emptyList(),
         val poll: PollModel? = null,

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/di/ComposerModule.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/di/ComposerModule.kt
@@ -15,6 +15,7 @@ val featureComposerModule =
                 userPaginationManager = get(),
                 circlesRepository = get(),
                 nodeInfoRepository = get(),
+                supportedFeatureRepository = get(),
                 mediaRepository = get(),
                 albumRepository = get(),
                 albumPhotoPaginationManager = get(),

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerViewModel.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerViewModel.kt
@@ -2,8 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.feature.drawer
 
 import cafe.adriel.voyager.core.model.screenModelScope
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isFriendica
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.NodeInfoRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SupportedFeatureRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 import kotlinx.coroutines.flow.launchIn
@@ -13,7 +12,7 @@ import kotlinx.coroutines.launch
 class DrawerViewModel(
     private val apiConfigurationRepository: ApiConfigurationRepository,
     private val identityRepository: IdentityRepository,
-    private val nodeInfoRepository: NodeInfoRepository,
+    private val supportedFeatureRepository: SupportedFeatureRepository,
 ) : DefaultMviModel<DrawerMviModel.Intent, DrawerMviModel.State, DrawerMviModel.Effect>(
         initialState = DrawerMviModel.State(),
     ),
@@ -23,13 +22,19 @@ class DrawerViewModel(
             identityRepository.currentUser
                 .onEach { currentUser ->
                     val node = apiConfigurationRepository.node.value
-                    val isFriendica = nodeInfoRepository.getInfo()?.isFriendica == true
                     updateState {
                         it.copy(
                             user = currentUser,
                             node = node,
-                            hasDirectMessages = isFriendica,
-                            hasGallery = isFriendica,
+                        )
+                    }
+                }.launchIn(this)
+            supportedFeatureRepository.features
+                .onEach { features ->
+                    updateState {
+                        it.copy(
+                            hasDirectMessages = features.supportsDirectMessages,
+                            hasGallery = features.supportsPhotoGallery,
                         )
                     }
                 }.launchIn(this)

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/di/DrawerModule.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/di/DrawerModule.kt
@@ -10,7 +10,7 @@ val featureDrawerModule =
             DrawerViewModel(
                 apiConfigurationRepository = get(),
                 identityRepository = get(),
-                nodeInfoRepository = get(),
+                supportedFeatureRepository = get(),
             )
         }
     }

--- a/feature/report/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/report/di/ReportModule.kt
+++ b/feature/report/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/report/di/ReportModule.kt
@@ -11,6 +11,7 @@ val featureReportModule =
                 userId = params[0],
                 entryId = params[1],
                 nodeInfoRepository = get(),
+                supportedFeatureRepository = get(),
                 reportRepository = get(),
                 userCache = get(),
                 entryCache = get(),


### PR DESCRIPTION
The check for the features (e.g. photo gallery, direct messages, custom circle post visibility, polls, post title, report categories) supported by the current instance was scattered in multiple places and was growing over time to an unmanageable situation because there were `isFriendica` queries in more and more places.

This PR centralizes the check for supported features in a single place, kept in sync when the user changes.