### PR TITLE
feat: change instance from navigation drawer in anonymous mode

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentVideo.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentVideo.kt
@@ -34,7 +34,7 @@ fun ContentVideo(
     contentScale: ContentScale = ContentScale.FillWidth,
     onClick: (() -> Unit)? = null,
 ) {
-    // TODO: add support for click ot open
+    // TODO: add support for click to open
     var revealing by remember { mutableStateOf(!sensitive) }
     var hasFinishedLoadingSuccessfully by remember { mutableStateOf(false) }
     val ratio =

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
@@ -361,4 +361,5 @@ internal val DeStrings =
         override val userFeedbackFieldComment = "Feedback"
         override val userFeedbackCommentPlaceholder =
             "Beschreiben Sie das aufgetretene Problem oder hinterlassen Sie einfach ein Feedback 🖋️"
+        override val changeNodeDialogTitle = "Instanz ändern"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -352,4 +352,5 @@ internal open class DefaultStrings : Strings {
     override val userFeedbackFieldComment = "Feedback"
     override val userFeedbackCommentPlaceholder =
         "Describe the issue you encountered or just leave a feedback 🖋️"
+    override val changeNodeDialogTitle = "Change instance"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -83,7 +83,7 @@ internal val ItStrings =
         override val fieldUsername = "Username"
         override val fieldPassword = "Password"
         override val actionLogout = "Logout"
-        override val relationshipStatusFollowing = "Stai seguendo"
+        override val relationshipStatusFollowing = "Segui già"
         override val relationshipStatusFollowsYou = "Ti segue"
         override val relationshipStatusMutual = "Reciproci"
         override val relationshipStatusRequestedToOther = "Richiesta inviata"
@@ -361,4 +361,5 @@ internal val ItStrings =
         override val userFeedbackFieldComment = "Feedback"
         override val userFeedbackCommentPlaceholder =
             "Descrivi il problema che hai riscontrato o lascia un feedback 🖋️"
+        override val changeNodeDialogTitle = "Cambia istanza"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -316,6 +316,7 @@ interface Strings {
     val userFeedbackFieldEmail: String
     val userFeedbackFieldComment: String
     val userFeedbackCommentPlaceholder: String
+    val changeNodeDialogTitle: String
 }
 
 object Locales {

--- a/feature/drawer/build.gradle.kts
+++ b/feature/drawer/build.gradle.kts
@@ -52,6 +52,7 @@ kotlin {
                 implementation(projects.domain.content.repository)
                 implementation(projects.domain.identity.data)
                 implementation(projects.domain.identity.repository)
+                implementation(projects.domain.identity.usecase)
             }
         }
     }

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerContent.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerContent.kt
@@ -1,6 +1,15 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.drawer
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.filled.Bookmarks
@@ -12,29 +21,57 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Tag
 import androidx.compose.material.icons.filled.Workspaces
+import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.FilterQuality
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomImage
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomModalBottomSheet
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomModalBottomSheetItem
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.PlaceholderImage
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDetailOpener
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDrawerCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
+import com.livefast.eattrash.raccoonforfriendica.core.utils.validation.toReadableMessage
 import com.livefast.eattrash.raccoonforfriendica.feature.drawer.components.DrawerHeader
 import com.livefast.eattrash.raccoonforfriendica.feature.drawer.components.DrawerShortcut
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 class DrawerContent : Screen {
+    @OptIn(ExperimentalMaterial3Api::class)
     @Composable
     override fun Content() {
         val model = getScreenModel<DrawerMviModel>()
@@ -43,6 +80,8 @@ class DrawerContent : Screen {
         val drawerCoordinator = remember { getDrawerCoordinator() }
         val detailOpener = remember { getDetailOpener() }
         val scope = rememberCoroutineScope()
+        var manageAccountsDialogOpened by remember { mutableStateOf(false) }
+        var changeInstanceDialogOpen by remember { mutableStateOf(false) }
 
         fun handleOpen(action: suspend () -> Unit) {
             scope.launch {
@@ -53,10 +92,29 @@ class DrawerContent : Screen {
             }
         }
 
+        LaunchedEffect(model) {
+            model.effects
+                .onEach { event ->
+                    when (event) {
+                        DrawerMviModel.Effect.AnonymousChangeNodeSuccess -> {
+                            changeInstanceDialogOpen = false
+                            drawerCoordinator.closeDrawer()
+                        }
+                    }
+                }.launchIn(this)
+        }
+
         ModalDrawerSheet {
             DrawerHeader(
                 user = uiState.user,
                 node = uiState.node,
+                canSwitchAccount = uiState.availableAccounts.size > 1,
+                onOpenChangeInstance = {
+                    changeInstanceDialogOpen = true
+                },
+                onOpenSwitchAccount = {
+                    manageAccountsDialogOpened = true
+                },
             )
 
             HorizontalDivider()
@@ -150,6 +208,129 @@ class DrawerContent : Screen {
                     handleOpen { detailOpener.openSettings() }
                 },
             )
+        }
+
+        if (manageAccountsDialogOpened) {
+            val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+            val items =
+                uiState.availableAccounts.map { account ->
+                    CustomModalBottomSheetItem(
+                        label = account.displayName.orEmpty(),
+                        subtitle = account.handle,
+                        leadingContent = {
+                            val avatar = account.avatar.orEmpty()
+                            val avatarSize = IconSize.xl
+                            if (avatar.isNotEmpty()) {
+                                CustomImage(
+                                    modifier =
+                                        Modifier
+                                            .size(avatarSize)
+                                            .clip(RoundedCornerShape(avatarSize / 2)),
+                                    url = avatar,
+                                    quality = FilterQuality.Low,
+                                    contentScale = ContentScale.FillBounds,
+                                )
+                            } else {
+                                PlaceholderImage(
+                                    size = avatarSize,
+                                    title = account.displayName ?: account.handle,
+                                )
+                            }
+                        },
+                        trailingContent = {
+                            RadioButton(
+                                selected = account.active,
+                                onClick = {},
+                            )
+                        },
+                    )
+                }
+            CustomModalBottomSheet(
+                title = LocalStrings.current.actionSwitchAccount,
+                sheetState = sheetState,
+                items = items,
+                onSelected = { index ->
+                    manageAccountsDialogOpened = false
+                    if (index != null) {
+                        val accounts = uiState.availableAccounts
+                        if (index in accounts.indices) {
+                            val selectedAccount = accounts[index]
+                            model.reduce(DrawerMviModel.Intent.SwitchAccount(selectedAccount))
+                        }
+                    }
+                },
+            )
+        }
+
+        if (changeInstanceDialogOpen) {
+            BasicAlertDialog(
+                modifier = Modifier.clip(RoundedCornerShape(CornerSize.xxl)),
+                onDismissRequest = {
+                    changeInstanceDialogOpen = false
+                },
+            ) {
+                Column(
+                    modifier =
+                        Modifier
+                            .background(color = MaterialTheme.colorScheme.surfaceColorAtElevation(5.dp))
+                            .padding(Spacing.m),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
+                ) {
+                    Text(
+                        text = LocalStrings.current.changeNodeDialogTitle,
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onBackground,
+                    )
+                    Spacer(modifier = Modifier.height(Spacing.s))
+
+                    TextField(
+                        modifier = Modifier.fillMaxWidth(),
+                        maxLines = 1,
+                        colors =
+                            TextFieldDefaults.colors(
+                                focusedContainerColor = Color.Transparent,
+                                unfocusedContainerColor = Color.Transparent,
+                                disabledContainerColor = Color.Transparent,
+                            ),
+                        label = {
+                            Text(
+                                text = LocalStrings.current.fieldNodeName,
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
+                        },
+                        isError = uiState.anonymousChangeNodeNameError != null,
+                        supportingText = {
+                            val error = uiState.anonymousChangeNodeNameError
+                            if (error != null) {
+                                Text(
+                                    text = error.toReadableMessage(),
+                                    color = MaterialTheme.colorScheme.error,
+                                )
+                            }
+                        },
+                        textStyle = MaterialTheme.typography.bodyMedium,
+                        value = uiState.anonymousChangeNodeName,
+                        keyboardOptions =
+                            KeyboardOptions(
+                                keyboardType = KeyboardType.Text,
+                                autoCorrect = true,
+                            ),
+                        onValueChange = { value ->
+                            model.reduce(DrawerMviModel.Intent.SetAnonymousChangeNode(value))
+                        },
+                    )
+
+                    Spacer(modifier = Modifier.height(Spacing.xs))
+                    Button(
+                        onClick = {
+                            model.reduce(DrawerMviModel.Intent.SubmitAnonymousChangeNode)
+                        },
+                    ) {
+                        Text(text = LocalStrings.current.buttonConfirm)
+                    }
+                }
+            }
         }
     }
 }

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerMviModel.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerMviModel.kt
@@ -3,20 +3,37 @@ package com.livefast.eattrash.raccoonforfriendica.feature.drawer
 import androidx.compose.runtime.Stable
 import cafe.adriel.voyager.core.model.ScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
+import com.livefast.eattrash.raccoonforfriendica.core.utils.validation.ValidationError
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
 
 @Stable
 interface DrawerMviModel :
     ScreenModel,
     MviModel<DrawerMviModel.Intent, DrawerMviModel.State, DrawerMviModel.Effect> {
-    sealed interface Intent
+    sealed interface Intent {
+        data class SetAnonymousChangeNode(
+            val nodeName: String,
+        ) : Intent
+
+        data object SubmitAnonymousChangeNode : Intent
+
+        data class SwitchAccount(
+            val account: AccountModel,
+        ) : Intent
+    }
 
     data class State(
         val user: UserModel? = null,
         val node: String? = null,
         val hasDirectMessages: Boolean = false,
         val hasGallery: Boolean = false,
+        val anonymousChangeNodeName: String = "",
+        val anonymousChangeNodeNameError: ValidationError? = null,
+        val availableAccounts: List<AccountModel> = emptyList(),
     )
 
-    sealed interface Effect
+    sealed interface Effect {
+        data object AnonymousChangeNodeSuccess : Effect
+    }
 }

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerViewModel.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerViewModel.kt
@@ -2,9 +2,14 @@ package com.livefast.eattrash.raccoonforfriendica.feature.drawer
 
 import cafe.adriel.voyager.core.model.screenModelScope
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
+import com.livefast.eattrash.raccoonforfriendica.core.utils.validation.ValidationError
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SupportedFeatureRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.CredentialsRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.SwitchAccountUseCase
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -13,6 +18,9 @@ class DrawerViewModel(
     private val apiConfigurationRepository: ApiConfigurationRepository,
     private val identityRepository: IdentityRepository,
     private val supportedFeatureRepository: SupportedFeatureRepository,
+    private val credentialsRepository: CredentialsRepository,
+    private val switchAccountUseCase: SwitchAccountUseCase,
+    accountRepository: AccountRepository,
 ) : DefaultMviModel<DrawerMviModel.Intent, DrawerMviModel.State, DrawerMviModel.Effect>(
         initialState = DrawerMviModel.State(),
     ),
@@ -21,12 +29,14 @@ class DrawerViewModel(
         screenModelScope.launch {
             identityRepository.currentUser
                 .onEach { currentUser ->
-                    val node = apiConfigurationRepository.node.value
                     updateState {
-                        it.copy(
-                            user = currentUser,
-                            node = node,
-                        )
+                        it.copy(user = currentUser)
+                    }
+                }.launchIn(this)
+            apiConfigurationRepository.node
+                .onEach { node ->
+                    updateState {
+                        it.copy(node = node)
                     }
                 }.launchIn(this)
             supportedFeatureRepository.features
@@ -38,6 +48,73 @@ class DrawerViewModel(
                         )
                     }
                 }.launchIn(this)
+            accountRepository
+                .getAllAsFlow()
+                .onEach { accounts ->
+                    val nonAnonymousAccounts = accounts.filter { it.remoteId != null }
+                    updateState {
+                        it.copy(availableAccounts = nonAnonymousAccounts)
+                    }
+                }.launchIn(this)
+        }
+    }
+
+    override fun reduce(intent: DrawerMviModel.Intent) {
+        when (intent) {
+            is DrawerMviModel.Intent.SetAnonymousChangeNode ->
+                screenModelScope.launch {
+                    updateState { it.copy(anonymousChangeNodeName = intent.nodeName) }
+                }
+
+            DrawerMviModel.Intent.SubmitAnonymousChangeNode -> submitChangeNode()
+            is DrawerMviModel.Intent.SwitchAccount -> switchAccount(intent.account)
+        }
+    }
+
+    private fun switchAccount(account: AccountModel) {
+        if (account.remoteId == uiState.value.user?.id) {
+            return
+        }
+        screenModelScope.launch {
+            switchAccountUseCase(account)
+        }
+    }
+
+    private fun submitChangeNode() {
+        val isLogged = apiConfigurationRepository.isLogged.value
+        if (isLogged) {
+            return
+        }
+
+        screenModelScope.launch {
+            val newNode = uiState.value.anonymousChangeNodeName
+
+            // validate fields
+            val nodeNameError =
+                if (newNode.isBlank()) {
+                    ValidationError.MissingField
+                } else {
+                    val isNodeValid = credentialsRepository.validateNode(newNode)
+                    if (!isNodeValid) {
+                        ValidationError.InvalidField
+                    } else {
+                        null
+                    }
+                }
+            updateState {
+                it.copy(
+                    anonymousChangeNodeNameError = nodeNameError,
+                )
+            }
+
+            val isValid = nodeNameError == null
+            if (!isValid) {
+                return@launch
+            }
+
+            apiConfigurationRepository.changeNode(newNode)
+            supportedFeatureRepository.refresh()
+            emitEffect(DrawerMviModel.Effect.AnonymousChangeNodeSuccess)
         }
     }
 }

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/components/DrawerHeader.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/components/DrawerHeader.kt
@@ -34,6 +34,7 @@ internal fun DrawerHeader(
     modifier: Modifier = Modifier,
     user: UserModel? = null,
     node: String? = null,
+    canSwitchAccount: Boolean = false,
     onOpenChangeInstance: (() -> Unit)? = null,
     onOpenSwitchAccount: (() -> Unit)? = null,
 ) {
@@ -72,9 +73,11 @@ internal fun DrawerHeader(
                 )
             }
 
-            Row {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
                 Column(
-                    verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
+                    verticalArrangement = Arrangement.spacedBy(Spacing.xxxs),
                 ) {
                     Text(
                         text = username,
@@ -97,15 +100,17 @@ internal fun DrawerHeader(
                     )
                 }
                 Spacer(modifier = Modifier.weight(1f))
-                IconButton(
-                    onClick = {
-                        onOpenSwitchAccount?.invoke()
-                    },
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.ArrowDropDown,
-                        contentDescription = null,
-                    )
+                if (canSwitchAccount) {
+                    IconButton(
+                        onClick = {
+                            onOpenSwitchAccount?.invoke()
+                        },
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.ArrowDropDown,
+                            contentDescription = null,
+                        )
+                    }
                 }
             }
         } else {
@@ -115,16 +120,25 @@ internal fun DrawerHeader(
                 title = anonymousTitle,
             )
             Column(
-                verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
+                verticalArrangement = Arrangement.spacedBy(Spacing.xxxs),
             ) {
                 Text(
                     text = anonymousTitle,
                     style = MaterialTheme.typography.titleMedium,
                     color = fullColor,
                 )
-                Row {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
                     Text(
-                        text = node.orEmpty(),
+                        text =
+                            buildString {
+                                append(LocalStrings.current.nodeVia)
+                                append(" ")
+                                append(node)
+                            },
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
                         style = MaterialTheme.typography.titleMedium,
                         color = ancillaryColor,
                     )

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/di/DrawerModule.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/di/DrawerModule.kt
@@ -11,6 +11,9 @@ val featureDrawerModule =
                 apiConfigurationRepository = get(),
                 identityRepository = get(),
                 supportedFeatureRepository = get(),
+                credentialsRepository = get(),
+                accountRepository = get(),
+                switchAccountUseCase = get(),
             )
         }
     }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
@@ -98,17 +98,17 @@ class ProfileScreen : Screen {
                             }
                         },
                         actions = {
+                            IconButton(
+                                onClick = {
+                                    manageAccountsDialogOpened = true
+                                },
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.ManageAccounts,
+                                    contentDescription = null,
+                                )
+                            }
                             if (uiState.currentUserId != null) {
-                                IconButton(
-                                    onClick = {
-                                        manageAccountsDialogOpened = true
-                                    },
-                                ) {
-                                    Icon(
-                                        imageVector = Icons.Default.ManageAccounts,
-                                        contentDescription = null,
-                                    )
-                                }
                                 IconButton(
                                     onClick = {
                                         confirmLogoutDialogOpened = true

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
@@ -70,8 +70,9 @@ class TimelineViewModel(
 
             combine(
                 settingsRepository.current,
+                apiConfigurationRepository.node,
                 identityRepository.currentUser,
-            ) { _, user ->
+            ) { _, _, user ->
                 // wait until either there is a logged user if there are valid credentials stored
                 if (user != null || !apiConfigurationRepository.hasCachedAuthCredentials()) {
                     refresh(initial = true)


### PR DESCRIPTION
This PR implements the possibility to quickly switch from an instance to another in anonymous mode. Moreover, the same button allows logged users to switch between account whenever there is more than one saved.

The possibility to open the account switch bottom sheet from the profile screen has been added to anonymous mode as well, in oder to get back to a previous account (if there is one) or to create a new one, starting the login flow.