### PR TITLE
fix: allow replying to own posts

### DIFF
--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultEntryActionRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultEntryActionRepository.kt
@@ -10,7 +10,7 @@ internal class DefaultEntryActionRepository(
 
     override fun canShare(entry: TimelineEntryModel): Boolean = !entry.url.isNullOrBlank()
 
-    override fun canReply(entry: TimelineEntryModel): Boolean = entry.isFromOtherUser
+    override fun canReply(entry: TimelineEntryModel): Boolean = isLogged
 
     override fun canReact(entry: TimelineEntryModel): Boolean = isLogged
 


### PR DESCRIPTION
I thought it was a good idea to check whether the original post is authored by the current user before allowing to reply (in order avoiding self-replies), but it turned out it wasn't. I definitely want to reply to my own posts too!