### PR TITLE
ehnancement: native video aspect ratio

### DIFF
--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/VideoPlayer.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/VideoPlayer.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.core.commonui.components
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.IntSize
 
 /*
  * CREDITS:
@@ -12,4 +13,5 @@ expect fun VideoPlayer(
     url: String,
     modifier: Modifier = Modifier,
     onPlaybackStarted: (() -> Unit)? = null,
+    onResize: ((IntSize) -> Unit)? = null,
 )


### PR DESCRIPTION
This PR removes video mute and autoplay (you manually have to start videos so when you do, the volume is on) and makes them appear, at least on Android, with their native aspect ratio.

This was a long-waited-for feature which bugged me a lot but I never had time to put some effort to improve the VideoPlayer component.