### PR TITLE
feat: add ability to quote posts

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
@@ -144,6 +144,7 @@ class DefaultDetailOpener(
         inReplyToId: String?,
         inReplyToUser: UserModel?,
         editedPostId: String?,
+        urlToShare: String?,
         inGroup: Boolean,
     ) {
         if (!isLogged) {
@@ -161,6 +162,7 @@ class DefaultDetailOpener(
                 groupUsername = inReplyToUser?.username.takeIf { isGroup },
                 groupHandle = inReplyToUser?.handle.takeIf { isGroup },
                 editedPostId = editedPostId,
+                urlToShare = urlToShare,
             )
         navigationCoordinator.push(screen)
     }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/Options.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/Options.kt
@@ -40,6 +40,8 @@ sealed interface OptionId {
 
     data object ViewDetails : OptionId
 
+    data object Quote : OptionId
+
     interface Custom : OptionId
 }
 
@@ -64,6 +66,7 @@ private fun OptionId.toReadableName(): String =
         OptionId.ReportUser -> LocalStrings.current.actionReportUser
         OptionId.ReportEntry -> LocalStrings.current.actionReportEntry
         OptionId.ViewDetails -> LocalStrings.current.actionViewDetails
+        OptionId.Quote -> LocalStrings.current.actionQuote
         else -> ""
     }
 

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
@@ -362,4 +362,5 @@ internal val DeStrings =
         override val userFeedbackCommentPlaceholder =
             "Beschreiben Sie das aufgetretene Problem oder hinterlassen Sie einfach ein Feedback 🖋️"
         override val changeNodeDialogTitle = "Instanz ändern"
+        override val actionQuote = "Zitieren"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -353,4 +353,5 @@ internal open class DefaultStrings : Strings {
     override val userFeedbackCommentPlaceholder =
         "Describe the issue you encountered or just leave a feedback 🖋️"
     override val changeNodeDialogTitle = "Change instance"
+    override val actionQuote = "Quote"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -362,4 +362,5 @@ internal val ItStrings =
         override val userFeedbackCommentPlaceholder =
             "Descrivi il problema che hai riscontrato o lascia un feedback 🖋️"
         override val changeNodeDialogTitle = "Cambia istanza"
+        override val actionQuote = "Cita"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -317,6 +317,7 @@ interface Strings {
     val userFeedbackFieldComment: String
     val userFeedbackCommentPlaceholder: String
     val changeNodeDialogTitle: String
+    val actionQuote: String
 }
 
 object Locales {

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DetailOpener.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DetailOpener.kt
@@ -39,6 +39,7 @@ interface DetailOpener {
         inReplyToId: String? = null,
         inReplyToUser: UserModel? = null,
         editedPostId: String? = null,
+        urlToShare: String? = null,
         inGroup: Boolean = false,
     )
 

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NodeFeatures.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NodeFeatures.kt
@@ -7,4 +7,6 @@ data class NodeFeatures(
     val supportsPolls: Boolean = false,
     val supportsCustomCircles: Boolean = false,
     val supportReportCategoryRuleViolation: Boolean = false,
+    val supportsBBCode: Boolean = false,
+    val supportsEntryShare: Boolean = false,
 )

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepository.kt
@@ -20,6 +20,8 @@ internal class DefaultSupportedFeatureRepository(
                 supportsCustomCircles = info?.isFriendica == true,
                 supportReportCategoryRuleViolation = info?.isFriendica == false,
                 supportsPolls = info?.isFriendica == false,
+                supportsBBCode = info?.isFriendica == true,
+                supportsEntryShare = info?.isFriendica == true,
             )
         }
     }

--- a/domain/identity/repository/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/di/Utils.kt
+++ b/domain/identity/repository/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/di/Utils.kt
@@ -2,7 +2,6 @@ package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di
 
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AuthManager
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.EntryActionRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
 import org.koin.java.KoinJavaComponent
 
@@ -18,10 +17,5 @@ actual fun getSettingsRepository(): SettingsRepository {
 
 actual fun getAuthManager(): AuthManager {
     val res by KoinJavaComponent.inject<AuthManager>(AuthManager::class.java)
-    return res
-}
-
-actual fun getEntryActionRepository(): EntryActionRepository {
-    val res by KoinJavaComponent.inject<EntryActionRepository>(EntryActionRepository::class.java)
     return res
 }

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/di/IdentityRepositoryModule.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/di/IdentityRepositoryModule.kt
@@ -8,10 +8,8 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Defa
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultAccountRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultApiConfigurationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultCredentialsRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultEntryActionRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultIdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultSettingsRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.EntryActionRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
 import org.koin.core.qualifier.named
@@ -53,11 +51,6 @@ val domainIdentityRepositoryModule =
         single<AccountCredentialsCache> {
             DefaultAccountCredentialsCache(
                 keyStore = get(),
-            )
-        }
-        single<EntryActionRepository> {
-            DefaultEntryActionRepository(
-                identityRepository = get(),
             )
         }
     }

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/di/Utils.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/di/Utils.kt
@@ -2,7 +2,6 @@ package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di
 
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AuthManager
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.EntryActionRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
 
 expect fun getApiConfigurationRepository(): ApiConfigurationRepository
@@ -10,5 +9,3 @@ expect fun getApiConfigurationRepository(): ApiConfigurationRepository
 expect fun getSettingsRepository(): SettingsRepository
 
 expect fun getAuthManager(): AuthManager
-
-expect fun getEntryActionRepository(): EntryActionRepository

--- a/domain/identity/repository/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/di/Utils.kt
+++ b/domain/identity/repository/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/di/Utils.kt
@@ -2,7 +2,6 @@ package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di
 
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AuthManager
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.EntryActionRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -13,11 +12,8 @@ actual fun getSettingsRepository(): SettingsRepository = DomainIdentityRepositor
 
 actual fun getAuthManager(): AuthManager = DomainIdentityRepositoryDiHelper.authManager
 
-actual fun getEntryActionRepository(): EntryActionRepository = DomainIdentityRepositoryDiHelper.entryActionRepository
-
 internal object DomainIdentityRepositoryDiHelper : KoinComponent {
     val settingsRepository: SettingsRepository by inject()
     val authManager: AuthManager by inject()
     val apiConfigurationRepository: ApiConfigurationRepository by inject()
-    val entryActionRepository: EntryActionRepository by inject()
 }

--- a/domain/identity/usecase/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/Utils.kt
+++ b/domain/identity/usecase/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/Utils.kt
@@ -3,6 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di
 import androidx.compose.ui.platform.UriHandler
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.ActiveAccountMonitor
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.CustomUriHandler
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.EntryActionRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.SetupAccountUseCase
 import org.koin.core.parameter.parametersOf
 import org.koin.java.KoinJavaComponent
@@ -26,5 +27,10 @@ actual fun getCustomUriHandler(fallback: UriHandler): CustomUriHandler {
             },
         )
     val res by inject
+    return res
+}
+
+actual fun getEntryActionRepository(): EntryActionRepository {
+    val res by KoinJavaComponent.inject<EntryActionRepository>(EntryActionRepository::class.java)
     return res
 }

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultEntryActionRepository.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultEntryActionRepository.kt
@@ -1,9 +1,12 @@
-package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
 
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SupportedFeatureRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 
 internal class DefaultEntryActionRepository(
     private val identityRepository: IdentityRepository,
+    private val supportedFeatureRepository: SupportedFeatureRepository,
 ) : EntryActionRepository {
     private val currentUserId: String? get() = identityRepository.currentUser.value?.id
     private val isLogged: Boolean get() = currentUserId != null
@@ -29,6 +32,8 @@ internal class DefaultEntryActionRepository(
     override fun canTogglePin(entry: TimelineEntryModel): Boolean = entry.isFromCurrentUser
 
     override fun canBlock(entry: TimelineEntryModel): Boolean = entry.isFromOtherUser
+
+    override fun canQuote(entry: TimelineEntryModel): Boolean = supportedFeatureRepository.features.value.supportsEntryShare
 
     private val TimelineEntryModel.isFromCurrentUser: Boolean
         get() = isLogged && creator?.id == currentUserId

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/EntryActionRepository.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/EntryActionRepository.kt
@@ -1,4 +1,4 @@
-package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
 
 import androidx.compose.runtime.Stable
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
@@ -26,4 +26,6 @@ interface EntryActionRepository {
     fun canTogglePin(entry: TimelineEntryModel): Boolean
 
     fun canBlock(entry: TimelineEntryModel): Boolean
+
+    fun canQuote(entry: TimelineEntryModel): Boolean
 }

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
@@ -5,11 +5,13 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.CustomU
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultActiveAccountMonitor
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultCustomUriHandler
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultDeleteAccountUseCase
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultEntryActionRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultLoginUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultLogoutUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultSetupAccountUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultSwitchAccountUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DeleteAccountUseCase
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.EntryActionRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.LoginUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.LogoutUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.SetupAccountUseCase
@@ -70,6 +72,12 @@ val domainIdentityUseCaseModule =
                 identityRepository = get(),
                 settingsRepository = get(),
                 accountCredentialsCache = get(),
+                supportedFeatureRepository = get(),
+            )
+        }
+        single<EntryActionRepository> {
+            DefaultEntryActionRepository(
+                identityRepository = get(),
                 supportedFeatureRepository = get(),
             )
         }

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/Utils.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/Utils.kt
@@ -3,6 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di
 import androidx.compose.ui.platform.UriHandler
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.ActiveAccountMonitor
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.CustomUriHandler
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.EntryActionRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.SetupAccountUseCase
 
 expect fun getActiveAccountMonitor(): ActiveAccountMonitor
@@ -10,3 +11,5 @@ expect fun getActiveAccountMonitor(): ActiveAccountMonitor
 expect fun getSetupAccountUseCase(): SetupAccountUseCase
 
 expect fun getCustomUriHandler(fallback: UriHandler): CustomUriHandler
+
+expect fun getEntryActionRepository(): EntryActionRepository

--- a/domain/identity/usecase/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/Utils.kt
+++ b/domain/identity/usecase/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/Utils.kt
@@ -3,6 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di
 import androidx.compose.ui.platform.UriHandler
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.ActiveAccountMonitor
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.CustomUriHandler
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.EntryActionRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.SetupAccountUseCase
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -14,9 +15,12 @@ actual fun getSetupAccountUseCase(): SetupAccountUseCase = DomainIdentityUseCase
 
 actual fun getCustomUriHandler(fallback: UriHandler): CustomUriHandler = DomainIdentityUseCaseDiHelper.getCustomUriHandler(fallback)
 
+actual fun getEntryActionRepository(): EntryActionRepository = DomainIdentityUseCaseDiHelper.entryActionRepository
+
 internal object DomainIdentityUseCaseDiHelper : KoinComponent {
     val activeAccountMonitor: ActiveAccountMonitor by inject()
     val setupAccountUseCase: SetupAccountUseCase by inject()
+    val entryActionRepository: EntryActionRepository by inject()
 
     fun getCustomUriHandler(default: UriHandler): CustomUriHandler {
         val res by inject<CustomUriHandler>(

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
@@ -44,6 +44,10 @@ interface ComposerMviModel :
             val id: String,
         ) : Intent
 
+        data class AddShareUrl(
+            val url: String,
+        ) : Intent
+
         data class SetFieldValue(
             val value: TextFieldValue,
             val fieldType: ComposerFieldType,

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
@@ -99,6 +99,7 @@ class ComposerScreen(
     private val editedPostId: String? = null,
     private val scheduledPostId: String? = null,
     private val draftId: String? = null,
+    private val urlToShare: String? = null,
 ) : Screen {
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
@@ -154,6 +155,9 @@ class ComposerScreen(
 
                 !groupHandle.isNullOrEmpty() ->
                     model.reduce(ComposerMviModel.Intent.AddGroupReference(groupHandle))
+
+                !urlToShare.isNullOrEmpty() ->
+                    model.reduce(ComposerMviModel.Intent.AddShareUrl(urlToShare))
 
                 else -> Unit
             }

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -338,9 +338,12 @@ class EntryDetailScreen(
                                     if (actionRepository.canBlock(entry)) {
                                         this += OptionId.Block.toOption()
                                     }
-                                    if (actionRepository.canReport(entry)) {
+                                    if (actionRepository.canReport(entry.original)) {
                                         this += OptionId.ReportUser.toOption()
                                         this += OptionId.ReportEntry.toOption()
+                                    }
+                                    if (actionRepository.canQuote(entry.original)) {
+                                        this += OptionId.Quote.toOption()
                                     }
                                     this += OptionId.ViewDetails.toOption()
                                 },
@@ -389,6 +392,13 @@ class EntryDetailScreen(
                                             }
                                         }
                                     OptionId.ViewDetails -> seeDetailsEntry = entry.original
+                                    OptionId.Quote -> {
+                                        entry.original.also { entryToShare ->
+                                            detailOpener.openComposer(
+                                                urlToShare = entryToShare.url,
+                                            )
+                                        }
+                                    }
                                     else -> Unit
                                 }
                             },

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -71,7 +71,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEnt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isOldEntry
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di.getEntryActionRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getEntryActionRepository
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
@@ -391,9 +391,12 @@ class ExploreScreen : Screen {
                                             if (actionRepository.canBlock(entry)) {
                                                 this += OptionId.Block.toOption()
                                             }
-                                            if (actionRepository.canReport(entry)) {
+                                            if (actionRepository.canReport(entry.original)) {
                                                 this += OptionId.ReportUser.toOption()
                                                 this += OptionId.ReportEntry.toOption()
+                                            }
+                                            if (actionRepository.canQuote(entry.original)) {
+                                                this += OptionId.Quote.toOption()
                                             }
                                             this += OptionId.ViewDetails.toOption()
                                         },
@@ -445,6 +448,13 @@ class ExploreScreen : Screen {
                                                     }
                                                 }
                                             OptionId.ViewDetails -> seeDetailsEntry = item.entry.original
+                                            OptionId.Quote -> {
+                                                item.entry.original.also { entryToShare ->
+                                                    detailOpener.openComposer(
+                                                        urlToShare = entryToShare.url,
+                                                    )
+                                                }
+                                            }
                                             else -> Unit
                                         }
                                     },

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
@@ -78,7 +78,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEnt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isOldEntry
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di.getEntryActionRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getEntryActionRepository
 import com.livefast.eattrash.raccoonforfriendica.feature.explore.data.ExploreSection
 import com.livefast.eattrash.raccoonforfriendica.feature.explore.data.toExploreSection
 import com.livefast.eattrash.raccoonforfriendica.feature.explore.data.toInt

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
@@ -67,7 +67,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toFavoritesType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toReadableName
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di.getEntryActionRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getEntryActionRepository
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
@@ -292,9 +292,12 @@ class FavoritesScreen(
                                     if (actionRepository.canBlock(entry)) {
                                         this += OptionId.Block.toOption()
                                     }
-                                    if (actionRepository.canReport(entry)) {
+                                    if (actionRepository.canReport(entry.original)) {
                                         this += OptionId.ReportUser.toOption()
                                         this += OptionId.ReportEntry.toOption()
+                                    }
+                                    if (actionRepository.canQuote(entry.original)) {
+                                        this += OptionId.Quote.toOption()
                                     }
                                     this += OptionId.ViewDetails.toOption()
                                 },
@@ -343,6 +346,13 @@ class FavoritesScreen(
                                             }
                                         }
                                     OptionId.ViewDetails -> seeDetailsEntry = entry.original
+                                    OptionId.Quote -> {
+                                        entry.original.also { entryToShare ->
+                                            detailOpener.openComposer(
+                                                urlToShare = entryToShare.url,
+                                            )
+                                        }
+                                    }
                                     else -> Unit
                                 }
                             },

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
@@ -67,7 +67,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEnt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isOldEntry
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di.getEntryActionRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getEntryActionRepository
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
@@ -312,9 +312,12 @@ class HashtagScreen(
                                     if (actionRepository.canBlock(entry)) {
                                         this += OptionId.Block.toOption()
                                     }
-                                    if (actionRepository.canReport(entry)) {
+                                    if (actionRepository.canReport(entry.original)) {
                                         this += OptionId.ReportUser.toOption()
                                         this += OptionId.ReportEntry.toOption()
+                                    }
+                                    if (actionRepository.canQuote(entry.original)) {
+                                        this += OptionId.Quote.toOption()
                                     }
                                     this += OptionId.ViewDetails.toOption()
                                 },
@@ -363,6 +366,13 @@ class HashtagScreen(
                                             }
                                         }
                                     OptionId.ViewDetails -> seeDetailsEntry = entry.original
+                                    OptionId.Quote -> {
+                                        entry.original.also { entryToShare ->
+                                            detailOpener.openComposer(
+                                                urlToShare = entryToShare.url,
+                                            )
+                                        }
+                                    }
                                     else -> Unit
                                 }
                             },

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
@@ -312,6 +312,9 @@ class MyAccountScreen : Screen {
                                         this += OptionId.Pin.toOption()
                                     }
                                 }
+                                if (actionRepository.canQuote(entry.original)) {
+                                    this += OptionId.Quote.toOption()
+                                }
                                 this += OptionId.ViewDetails.toOption()
                             },
                         onOptionSelected = { optionId ->
@@ -351,6 +354,13 @@ class MyAccountScreen : Screen {
                                         MyAccountMviModel.Intent.TogglePin(entry),
                                     )
                                 OptionId.ViewDetails -> seeDetailsEntry = entry.original
+                                OptionId.Quote -> {
+                                    entry.original.also { entryToShare ->
+                                        detailOpener.openComposer(
+                                            urlToShare = entryToShare.url,
+                                        )
+                                    }
+                                }
                                 else -> Unit
                             }
                         },

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
@@ -68,7 +68,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.FieldModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di.getEntryActionRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getEntryActionRepository
 import com.livefast.eattrash.raccoonforfriendica.feature.profile.LocalProfileTopAppBarStateWrapper
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
@@ -391,9 +391,12 @@ class SearchScreen : Screen {
                                             if (actionRepository.canBlock(entry)) {
                                                 this += OptionId.Block.toOption()
                                             }
-                                            if (actionRepository.canReport(entry)) {
+                                            if (actionRepository.canReport(entry.original)) {
                                                 this += OptionId.ReportUser.toOption()
                                                 this += OptionId.ReportEntry.toOption()
+                                            }
+                                            if (actionRepository.canQuote(entry.original)) {
+                                                this += OptionId.Quote.toOption()
                                             }
                                             this += OptionId.ViewDetails.toOption()
                                         },
@@ -446,6 +449,13 @@ class SearchScreen : Screen {
                                                     }
                                                 }
                                             OptionId.ViewDetails -> seeDetailsEntry = item.entry.original
+                                            OptionId.Quote -> {
+                                                item.entry.original.also { entryToShare ->
+                                                    detailOpener.openComposer(
+                                                        urlToShare = entryToShare.url,
+                                                    )
+                                                }
+                                            }
                                             else -> Unit
                                         }
                                     },

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
@@ -79,7 +79,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEnt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isOldEntry
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di.getEntryActionRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getEntryActionRepository
 import com.livefast.eattrash.raccoonforfriendica.feaure.search.data.SearchSection
 import com.livefast.eattrash.raccoonforfriendica.feaure.search.data.toInt
 import com.livefast.eattrash.raccoonforfriendica.feaure.search.data.toReadableName

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
@@ -322,6 +322,9 @@ class ThreadScreen(
                                             this += OptionId.Share.toOption()
                                             this += OptionId.CopyUrl.toOption()
                                         }
+                                        if (actionRepository.canQuote(entry.original)) {
+                                            this += OptionId.Quote.toOption()
+                                        }
                                         this += OptionId.ViewDetails.toOption()
                                     },
                                 onOptionSelected = { optionId ->
@@ -339,6 +342,13 @@ class ThreadScreen(
                                             }
                                         }
                                         OptionId.ViewDetails -> seeDetailsEntry = uiState.entry?.original
+                                        OptionId.Quote -> {
+                                            uiState.entry?.original?.also { entryToShare ->
+                                                detailOpener.openComposer(
+                                                    urlToShare = entryToShare.url,
+                                                )
+                                            }
+                                        }
                                         else -> Unit
                                     }
                                 },
@@ -425,9 +435,12 @@ class ThreadScreen(
                                     if (actionRepository.canBlock(entry)) {
                                         this += OptionId.Block.toOption()
                                     }
-                                    if (actionRepository.canReport(entry)) {
+                                    if (actionRepository.canReport(entry.original)) {
                                         this += OptionId.ReportUser.toOption()
                                         this += OptionId.ReportEntry.toOption()
+                                    }
+                                    if (actionRepository.canQuote(entry.original)) {
+                                        this += OptionId.Quote.toOption()
                                     }
                                     this += OptionId.ViewDetails.toOption()
                                 },
@@ -472,6 +485,13 @@ class ThreadScreen(
                                             }
                                         }
                                     OptionId.ViewDetails -> seeDetailsEntry = entry.original
+                                    OptionId.Quote -> {
+                                        entry.original.also { entryToShare ->
+                                            detailOpener.openComposer(
+                                                urlToShare = entryToShare.url,
+                                            )
+                                        }
+                                    }
                                     else -> Unit
                                 }
                             },

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
@@ -77,7 +77,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEnt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isOldEntry
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di.getEntryActionRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getEntryActionRepository
 import com.livefast.eattrash.raccoonforfriendica.feature.thread.composable.TimelineReplyItem
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
@@ -83,7 +83,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toIcon
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toReadableName
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di.getEntryActionRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getEntryActionRepository
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -334,7 +334,7 @@ class TimelineScreen : Screen {
                                                 choices = choices,
                                             ),
                                         )
-                                }
+                                    }
                                 },
                             options =
                                 buildList {

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
@@ -361,9 +361,12 @@ class TimelineScreen : Screen {
                                     if (actionRepository.canBlock(entry)) {
                                         this += OptionId.Block.toOption()
                                     }
-                                    if (actionRepository.canReport(entry)) {
+                                    if (actionRepository.canReport(entry.original)) {
                                         this += OptionId.ReportUser.toOption()
                                         this += OptionId.ReportEntry.toOption()
+                                    }
+                                    if (actionRepository.canQuote(entry.original)) {
+                                        this += OptionId.Quote.toOption()
                                     }
                                     this += OptionId.ViewDetails.toOption()
                                 },
@@ -412,6 +415,14 @@ class TimelineScreen : Screen {
                                                 )
                                             }
                                         }
+
+                                    OptionId.Quote -> {
+                                        entry.original.also { entryToShare ->
+                                            detailOpener.openComposer(
+                                                urlToShare = entryToShare.url,
+                                            )
+                                        }
+                                    }
                                     OptionId.ViewDetails -> seeDetailsEntry = entry.original
                                     else -> Unit
                                 }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -104,7 +104,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEnt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isOldEntry
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di.getEntryActionRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getEntryActionRepository
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -618,8 +618,11 @@ class UserDetailScreen(
                                         this += OptionId.Share.toOption()
                                         this += OptionId.CopyUrl.toOption()
                                     }
-                                    if (actionRepository.canReport(entry)) {
+                                    if (actionRepository.canReport(entry.original)) {
                                         this += OptionId.ReportEntry.toOption()
+                                    }
+                                    if (actionRepository.canQuote(entry.original)) {
+                                        this += OptionId.Quote.toOption()
                                     }
                                     this += OptionId.ViewDetails.toOption()
                                 },
@@ -649,6 +652,13 @@ class UserDetailScreen(
                                             }
                                         }
                                     OptionId.ViewDetails -> seeDetailsEntry = entry.original
+                                    OptionId.Quote -> {
+                                        entry.original.also { entryToShare ->
+                                            detailOpener.openComposer(
+                                                urlToShare = entryToShare.url,
+                                            )
+                                        }
+                                    }
                                     else -> Unit
                                 }
                             },

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
@@ -73,7 +73,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEnt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isOldEntry
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di.getEntryActionRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getEntryActionRepository
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
@@ -58,6 +58,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLo
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.getFabNestedScrollConnection
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ConfirmMuteUserBottomSheet
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.EntryDetailDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.PollVoteErrorDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
@@ -113,6 +114,7 @@ class ForumListScreen(
         var confirmBlockEntry by remember { mutableStateOf<TimelineEntryModel?>(null) }
         var confirmReblogEntry by remember { mutableStateOf<TimelineEntryModel?>(null) }
         var pollErrorDialogOpened by remember { mutableStateOf(false) }
+        var seeDetailsEntry by remember { mutableStateOf<TimelineEntryModel?>(null) }
 
         fun goBackToTop() {
             runCatching {
@@ -326,10 +328,14 @@ class ForumListScreen(
                                     if (actionRepository.canBlock(entry)) {
                                         this += OptionId.Block.toOption()
                                     }
-                                    if (actionRepository.canReport(entry)) {
+                                    if (actionRepository.canReport(entry.original)) {
                                         this += OptionId.ReportUser.toOption()
                                         this += OptionId.ReportEntry.toOption()
                                     }
+                                    if (actionRepository.canQuote(entry.original)) {
+                                        this += OptionId.Quote.toOption()
+                                    }
+                                    this += OptionId.ViewDetails.toOption()
                                 },
                             onOptionSelected = { optionId ->
                                 when (optionId) {
@@ -371,6 +377,14 @@ class ForumListScreen(
                                                 )
                                             }
                                         }
+                                    OptionId.Quote -> {
+                                        entry.original.also { entryToShare ->
+                                            detailOpener.openComposer(
+                                                urlToShare = entryToShare.url,
+                                            )
+                                        }
+                                    }
+                                    OptionId.ViewDetails -> seeDetailsEntry = entry.original
                                     else -> Unit
                                 }
                             },
@@ -510,6 +524,15 @@ class ForumListScreen(
                     if (confirm && e != null) {
                         model.reduce(ForumListMviModel.Intent.ToggleReblog(e))
                     }
+                },
+            )
+        }
+
+        seeDetailsEntry?.let { entry ->
+            EntryDetailDialog(
+                entry = entry,
+                onClose = {
+                    seeDetailsEntry = null
                 },
             )
         }


### PR DESCRIPTION
It turns out that Friendica, unlike Mastodon, supports post quotations (i.e. cross posts). This PR adds the ability to quote an existing post which will be referenced in the new one.

Since this feature is only available if the BBCode syntax is used in the editor, this PR introduces BBCode by default on Friendica instances, defaulting to HTML on other platforms.