### PR TITLE
feat: basic support for custom emojis

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The app is under ongoing development, here is a list of the features that are be
 - [x] advanced media visualization (videos, GIFs, multiple images)
 - [x] scheduled posts and drafts
 - [x] report posts and users
-- [ ] custom emojis
+- [x] custom emojis (in posts, for user accounts they do not seem to be returned by the back-end)
 
 ## Technologies used
 
@@ -133,6 +133,8 @@ The app is under ongoing development, here is a list of the features that are be
   preferences
 - [MaterialKolor](https://github.com/jordond/MaterialKolor) for custom theme generation
 - [Ksoup](https://github.com/MohamedRejeb/Ksoup) for HTML parsing
+- [Colorpicker-compose](https://github.com/skydoves/colorpicker-compose) for custom color selection
+- [Sentry](https://sentry.io) for crash reporting and user feedback collection
 
 ## Disclaimer
 

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Account.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Account.kt
@@ -11,6 +11,7 @@ data class Account(
     @SerialName("created_at") val createdAt: String? = null,
     @SerialName("discoverable") val discoverable: Boolean? = null,
     @SerialName("display_name") val displayName: String? = null,
+    @SerialName("emojis") val emojis: List<CustomEmoji>? = null,
     @SerialName("fields") val fields: List<Field> = emptyList(),
     @SerialName("followers_count") val followersCount: Int = 0,
     @SerialName("following_count") val followingCount: Int = 0,

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/CustomEmoji.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/CustomEmoji.kt
@@ -1,0 +1,13 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CustomEmoji(
+    @SerialName("shortcode") val shortCode: String,
+    @SerialName("url") val url: String,
+    @SerialName("static_url") val staticUrl: String,
+    @SerialName("visible_in_picker") val visibleInPicker: Boolean = false,
+    @SerialName("category") val category: String? = null,
+)

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Status.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Status.kt
@@ -11,6 +11,7 @@ data class Status(
     @SerialName("content") val content: String = "",
     @SerialName("created_at") val createdAt: String? = null,
     @SerialName("edited_at") val editedAt: String? = null,
+    @SerialName("emojis") val emojis: List<CustomEmoji>? = null,
     @SerialName("favourited") val favourited: Boolean = false,
     @SerialName("favourites_count") val favoritesCount: Int = 0,
     @SerialName("friendica") val addons: StatusAddons? = null,

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentBody.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentBody.kt
@@ -1,18 +1,19 @@
 package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
 
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import com.livefast.eattrash.raccoonforfriendica.core.htmlparse.parseHtml
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EmojiModel
 
 @Composable
 fun ContentBody(
     content: String = "",
     color: Color = MaterialTheme.colorScheme.onBackground,
     modifier: Modifier = Modifier,
+    emojis: List<EmojiModel> = emptyList(),
     onClick: (() -> Unit)? = null,
     onOpenUrl: ((String) -> Unit)? = null,
 ) {
@@ -21,9 +22,10 @@ fun ContentBody(
             content.parseHtml(
                 linkColor = MaterialTheme.colorScheme.primary,
             )
-        ClickableText(
+        TextWithCustomEmojis(
             style = MaterialTheme.typography.bodyMedium.copy(color = color),
             text = annotatedContent,
+            emojis = emojis,
             onClick = { offset ->
                 val url =
                     annotatedContent

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentHeader.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentHeader.kt
@@ -86,8 +86,9 @@ fun ContentHeader(
         Column(
             modifier = Modifier.weight(1f),
         ) {
-            Text(
+            TextWithCustomEmojis(
                 text = creatorName,
+                emojis = user?.emojis.orEmpty(),
                 style = MaterialTheme.typography.bodyMedium,
                 color = fullColor,
             )

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentTitle.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentTitle.kt
@@ -1,17 +1,18 @@
 package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
 
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import com.livefast.eattrash.raccoonforfriendica.core.htmlparse.parseHtml
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EmojiModel
 
 @Composable
 fun ContentTitle(
     content: String = "",
     modifier: Modifier = Modifier,
+    emojis: List<EmojiModel> = emptyList(),
     color: Color = MaterialTheme.colorScheme.onBackground,
     onClick: (() -> Unit)? = null,
     onOpenUrl: ((String) -> Unit)? = null,
@@ -21,9 +22,10 @@ fun ContentTitle(
             content.parseHtml(
                 linkColor = MaterialTheme.colorScheme.primary,
             )
-        ClickableText(
+        TextWithCustomEmojis(
             style = MaterialTheme.typography.titleMedium.copy(color = color),
             text = annotatedContent,
+            emojis = emojis,
             onClick = { offset ->
                 val url =
                     annotatedContent

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TextWithCustomEmojis.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TextWithCustomEmojis.kt
@@ -1,0 +1,143 @@
+package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
+
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.foundation.text.appendInlineContent
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.Placeholder
+import androidx.compose.ui.text.PlaceholderVerticalAlign
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.em
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomImage
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EmojiModel
+
+private val EMOJI_REGEX = Regex(":(\\w+):")
+
+@Composable
+fun TextWithCustomEmojis(
+    text: AnnotatedString,
+    modifier: Modifier = Modifier,
+    emojis: List<EmojiModel> = emptyList(),
+    style: TextStyle = LocalTextStyle.current,
+    color: Color = Color.Unspecified,
+    softWrap: Boolean = true,
+    overflow: TextOverflow = TextOverflow.Clip,
+    maxLines: Int = Int.MAX_VALUE,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+    onClick: ((Int) -> Unit) = {},
+) {
+    var index = 0
+    val occurrences = EMOJI_REGEX.findAll(text)
+    val foundEmojis = mutableListOf<EmojiModel>()
+    val processedText =
+        buildAnnotatedString {
+            for (occurrence in occurrences) {
+                val (start, end) = occurrence.range.first to occurrence.range.last
+                if (start > index) {
+                    append(text.subSequence(startIndex = index, endIndex = start))
+                }
+                val emojiCode =
+                    occurrence.groups
+                        .first()
+                        ?.value
+                        .orEmpty()
+                        .trim(':')
+                val foundEmoji = emojis.firstOrNull { it.code == emojiCode }
+                if (foundEmoji != null) {
+                    appendInlineContent(
+                        id = emojiCode,
+                        alternateText = occurrence.value,
+                    )
+                    foundEmojis += foundEmoji
+                } else {
+                    append(occurrence.value)
+                }
+                index = end + 1
+            }
+            if (index < text.length) {
+                append(text.subSequence(startIndex = index, endIndex = text.length))
+            }
+        }
+    val inlineContent =
+        foundEmojis.associate { emoji ->
+            emoji.code to
+                InlineTextContent(
+                    placeholder =
+                        Placeholder(
+                            width = 1.5.em,
+                            height = 1.5.em,
+                            placeholderVerticalAlign = PlaceholderVerticalAlign.TextCenter,
+                        ),
+                ) {
+                    CustomImage(
+                        modifier = Modifier.fillMaxSize(),
+                        url = emoji.url,
+                        contentScale = ContentScale.FillWidth,
+                    )
+                }
+        }
+
+    val layoutResult = remember { mutableStateOf<TextLayoutResult?>(null) }
+    val pressIndicator =
+        Modifier.pointerInput(onClick) {
+            detectTapGestures { pos ->
+                layoutResult.value?.let { layoutResult ->
+                    onClick(layoutResult.getOffsetForPosition(pos))
+                }
+            }
+        }
+    BasicText(
+        modifier = modifier.then(pressIndicator),
+        text = processedText,
+        inlineContent = inlineContent,
+        style = style,
+        color = { color },
+        softWrap = softWrap,
+        overflow = overflow,
+        maxLines = maxLines,
+        onTextLayout = {
+            layoutResult.value = it
+            onTextLayout(it)
+        },
+    )
+}
+
+@Composable
+fun TextWithCustomEmojis(
+    text: String,
+    modifier: Modifier = Modifier,
+    emojis: List<EmojiModel> = emptyList(),
+    style: TextStyle = LocalTextStyle.current,
+    color: Color = Color.Unspecified,
+    softWrap: Boolean = true,
+    overflow: TextOverflow = TextOverflow.Clip,
+    maxLines: Int = Int.MAX_VALUE,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+    onClick: ((Int) -> Unit) = {},
+) {
+    TextWithCustomEmojis(
+        text = AnnotatedString(text),
+        modifier = modifier,
+        emojis = emojis,
+        style = style,
+        color = color,
+        softWrap = softWrap,
+        overflow = overflow,
+        maxLines = maxLines,
+        onTextLayout = onTextLayout,
+        onClick = onClick,
+    )
+}

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
@@ -198,6 +198,7 @@ fun TimelineItem(
                                 end = contentHorizontalPadding,
                             ),
                         content = title,
+                        emojis = entryToDisplay.emojis,
                         onClick = { onClick?.invoke(entryToDisplay) },
                         onOpenUrl = onOpenUrl,
                     )
@@ -223,6 +224,7 @@ fun TimelineItem(
                                 },
                             ),
                         content = body,
+                        emojis = entryToDisplay.emojis,
                         onClick = { onClick?.invoke(entryToDisplay) },
                         onOpenUrl = onOpenUrl,
                     )

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserHeader.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserHeader.kt
@@ -31,7 +31,6 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillary
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomImage
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.PlaceholderImage
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
-import com.livefast.eattrash.raccoonforfriendica.core.utils.ellipsize
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationStatusNextAction
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.RelationshipStatusNextAction
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
@@ -216,13 +215,14 @@ fun UserHeader(
                 Column(
                     verticalArrangement = Arrangement.spacedBy(Spacing.xs),
                 ) {
-                    Text(
-                        text = (user?.displayName ?: user?.username ?: "").ellipsize(30),
+                    TextWithCustomEmojis(
+                        text = user?.displayName ?: user?.username ?: "",
+                        emojis = user?.emojis.orEmpty(),
                         style = MaterialTheme.typography.titleMedium,
                         color = fullColor,
                     )
                     Text(
-                        text = (user?.handle ?: user?.username ?: "").ellipsize(25),
+                        text = user?.handle ?: user?.username ?: "",
                         style = MaterialTheme.typography.titleMedium,
                         color = ancillaryColor,
                     )
@@ -231,6 +231,7 @@ fun UserHeader(
             user?.bio?.takeIf { it.isNotEmpty() }?.let { bio ->
                 ContentBody(
                     content = bio,
+                    emojis = user.emojis,
                     onOpenUrl = onOpenUrl,
                 )
             }

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/EmojiModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/EmojiModel.kt
@@ -1,0 +1,9 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.data
+
+data class EmojiModel(
+    val code: String,
+    val url: String,
+    val staticUrl: String,
+    val visibleInPicker: Boolean = false,
+    val category: String? = null,
+)

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/TimelineEntryModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/TimelineEntryModel.kt
@@ -15,6 +15,7 @@ data class TimelineEntryModel(
     val creator: UserModel? = null,
     @Transient val depth: Int = 0,
     val dislikesCount: Int = 0,
+    val emojis: List<EmojiModel> = emptyList(),
     val favorite: Boolean = false,
     val favoriteCount: Int = 0,
     @Transient val favoriteLoading: Boolean = false,

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/UserModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/UserModel.kt
@@ -10,6 +10,7 @@ data class UserModel(
     val created: String? = null,
     val discoverable: Boolean = true,
     val displayName: String? = null,
+    val emojis: List<EmojiModel> = emptyList(),
     val entryCount: Int = 0,
     val fields: List<FieldModel> = emptyList(),
     val followers: Int = 0,

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
@@ -3,6 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.repository.util
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Account
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.ContentVisibility
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.CredentialAccount
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.CustomEmoji
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Field
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaCircle
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaContact
@@ -37,6 +38,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.AttachmentM
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.CircleModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.CircleReplyPolicy
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.DirectMessageModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EmojiModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.FieldModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.HashtagHistoryItem
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.LinkModel
@@ -76,6 +78,7 @@ internal fun Status.toModel() =
         created = createdAt,
         creator = account?.toModel(),
         dislikesCount = addons?.dislikesCount ?: 0,
+        emojis = emojis?.map { it.toModel() }.orEmpty(),
         favorite = favourited,
         favoriteCount = favoritesCount,
         id = id,
@@ -174,6 +177,7 @@ internal fun Account.toModel() =
         created = createdAt,
         discoverable = discoverable ?: true,
         displayName = displayName,
+        emojis = emojis?.map { it.toModel() }.orEmpty(),
         entryCount = statusesCount,
         fields = fields.map { it.toModel() },
         followers = followersCount,
@@ -439,6 +443,15 @@ internal fun ReportCategory.toDto(): String =
         ReportCategory.Spam -> "spam"
         ReportCategory.Violation -> "violation"
     }
+
+internal fun CustomEmoji.toModel() =
+    EmojiModel(
+        url = url,
+        code = shortCode,
+        staticUrl = staticUrl,
+        category = category,
+        visibleInPicker = visibleInPicker,
+    )
 
 private object FriendicaDateFormats {
     const val PRIVATE_MESSAGES = "EEE MMM dd HH:mm:ss xxxx yyyy"


### PR DESCRIPTION
This PR adds the support for custom emojis returned with posts and users in the `emojis` field. These are rendered as inline elements in the text Composables.