### PR TITLE
enhancement: retrieve missing custom emojis for users

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/InstanceService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/InstanceService.kt
@@ -1,5 +1,6 @@
 package com.livefast.eattrash.raccoonforfriendica.core.api.service
 
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.CustomEmoji
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Instance
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.InstanceRule
 import de.jensklingenberg.ktorfit.http.GET
@@ -10,4 +11,7 @@ interface InstanceService {
 
     @GET("v1/instance/rules")
     suspend fun getRules(): List<InstanceRule>
+
+    @GET("v1/custom_emojis")
+    suspend fun getCustomEmojis(): List<CustomEmoji>
 }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/InReplyToInfo.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/InReplyToInfo.kt
@@ -27,7 +27,6 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillary
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomImage
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.PlaceholderImage
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
-import com.livefast.eattrash.raccoonforfriendica.core.utils.ellipsize
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 
 @Composable
@@ -37,7 +36,7 @@ internal fun InReplyToInfo(
     iconSize: Dp = IconSize.s,
     onOpenUser: ((UserModel) -> Unit)? = null,
 ) {
-    val creatorName = user?.let { it.displayName ?: it.handle }.orEmpty().ellipsize(30)
+    val creatorName = user?.let { it.displayName ?: it.handle }.orEmpty()
     val creatorAvatar = user?.avatar.orEmpty()
     val fullColor = MaterialTheme.colorScheme.onBackground
     val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha)
@@ -92,8 +91,9 @@ internal fun InReplyToInfo(
             )
         }
 
-        Text(
+        TextWithCustomEmojis(
             text = creatorName,
+            emojis = user?.emojis.orEmpty(),
             style = MaterialTheme.typography.bodyMedium,
             color = fullColor,
             maxLines = 1,

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ReblogInfo.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ReblogInfo.kt
@@ -27,7 +27,6 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillary
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomImage
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.PlaceholderImage
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
-import com.livefast.eattrash.raccoonforfriendica.core.utils.ellipsize
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 
 @Composable
@@ -37,7 +36,7 @@ internal fun ReblogInfo(
     iconSize: Dp = IconSize.s,
     onOpenUser: ((UserModel) -> Unit)? = null,
 ) {
-    val creatorName = user?.let { it.displayName ?: it.handle }.orEmpty().ellipsize(30)
+    val creatorName = user?.let { it.displayName ?: it.handle }.orEmpty()
     val creatorAvatar = user?.avatar.orEmpty()
     val fullColor = MaterialTheme.colorScheme.onBackground
     val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha)
@@ -92,8 +91,9 @@ internal fun ReblogInfo(
             )
         }
 
-        Text(
+        TextWithCustomEmojis(
             text = creatorName,
+            emojis = user?.emojis.orEmpty(),
             style = MaterialTheme.typography.bodyMedium,
             color = fullColor,
             maxLines = 1,

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/Extensions.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/Extensions.kt
@@ -12,3 +12,5 @@ fun String?.ellipsize(
     }
     return take(length - 1) + ellipsis
 }
+
+val String?.nodeName: String? get() = orEmpty().substringAfter('@').takeIf { it.isNotEmpty() }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
@@ -30,12 +30,14 @@ val domainContentPaginationModule =
             DefaultTimelinePaginationManager(
                 timelineRepository = get(),
                 timelineEntryRepository = get(),
+                emojiRepository = get(),
                 notificationCenter = get(),
             )
         }
         factory<NotificationsPaginationManager> {
             DefaultNotificationsPaginationManager(
                 notificationRepository = get(),
+                emojiRepository = get(),
                 userRepository = get(),
             )
         }
@@ -43,6 +45,7 @@ val domainContentPaginationModule =
             DefaultExplorePaginationManager(
                 trendingRepository = get(),
                 userRepository = get(),
+                emojiRepository = get(),
                 notificationCenter = get(),
             )
         }
@@ -51,12 +54,14 @@ val domainContentPaginationModule =
                 userRepository = get(),
                 timelineEntryRepository = get(),
                 circlesRepository = get(),
+                emojiRepository = get(),
                 notificationCenter = get(),
             )
         }
         factory<FavoritesPaginationManager> {
             DefaultFavoritesPaginationManager(
                 timelineEntryRepository = get(),
+                emojiRepository = get(),
                 notificationCenter = get(),
             )
         }
@@ -69,17 +74,20 @@ val domainContentPaginationModule =
             DefaultSearchPaginationManager(
                 searchRepository = get(),
                 userRepository = get(),
+                emojiRepository = get(),
                 notificationCenter = get(),
             )
         }
         factory<FollowRequestPaginationManager> {
             DefaultFollowRequestPaginationManager(
                 userRepository = get(),
+                emojiRepository = get(),
             )
         }
         factory<DirectMessagesPaginationManager> {
             DefaultDirectMessagesPaginationManager(
                 directMessageRepository = get(),
+                emojiRepository = get(),
             )
         }
         factory<AlbumPhotoPaginationManager> {

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEmojiRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEmojiRepository.kt
@@ -1,0 +1,85 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
+import com.livefast.eattrash.raccoonforfriendica.core.utils.cache.LruCache
+import com.livefast.eattrash.raccoonforfriendica.core.utils.nodeName
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EmojiModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
+
+internal class DefaultEmojiRepository(
+    private val provider: ServiceProvider,
+    private val otherProvider: ServiceProvider,
+) : EmojiRepository {
+    private val cache = LruCache<String, List<EmojiModel>>(20)
+
+    override suspend fun getAll(node: String?): List<EmojiModel>? {
+        val key = node.orEmpty()
+        return if (cache.containsKey(key)) {
+            cache.get(key)
+        } else {
+            retrieve(node).orEmpty().also {
+                cache.put(key, it)
+            }
+        }
+    }
+
+    override suspend fun UserModel.withEmojisIfMissing(): UserModel {
+        if (emojis.isNotEmpty()) {
+            return this
+        }
+        val texts =
+            arrayOf(
+                displayName.orEmpty(),
+                bio.orEmpty(),
+            )
+        if (texts.none { it.contains(EMOJI_REGEX) }) {
+            return this
+        }
+
+        val node = handle.nodeName
+        val emojis = getAll(node)?.filterContainedIn(*texts).orEmpty()
+        return copy(emojis = emojis)
+    }
+
+    override suspend fun TimelineEntryModel.withEmojisIfMissing(): TimelineEntryModel =
+        copy(
+            creator = creator?.withEmojisIfMissing(),
+            inReplyTo =
+                inReplyTo?.copy(
+                    creator = reblog?.creator?.withEmojisIfMissing(),
+                ),
+            reblog =
+                reblog?.copy(
+                    creator = reblog?.creator?.withEmojisIfMissing(),
+                ),
+        )
+
+    private suspend fun retrieve(node: String?): List<EmojiModel>? =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val res =
+                    if (node == null) {
+                        provider.instance.getCustomEmojis()
+                    } else {
+                        otherProvider.changeNode(node)
+                        otherProvider.instance.getCustomEmojis()
+                    }
+                res.map { it.toModel() }
+            }.getOrElse { null }
+        }
+
+    companion object {
+        private val EMOJI_REGEX = Regex(":\\w+:")
+    }
+}
+
+private fun List<EmojiModel>.filterContainedIn(vararg texts: String): List<EmojiModel> =
+    filter { emoji ->
+        val occurrence = ":${emoji.code}:"
+        texts.any { it.contains(occurrence) }
+    }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/EmojiRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/EmojiRepository.kt
@@ -1,0 +1,21 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EmojiModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+
+interface EmojiRepository {
+    suspend fun getAll(node: String? = null): List<EmojiModel>?
+
+    /*
+     * Due to a bug in Friendica, custom emojis are never returned for users (neither as single
+     * entities nor as post creators).
+     *
+     * These two functions are a client-side workaround that retrieves the emojis if (and only if)
+     * needed with an aggressive caching mechanism to avoid flooding the servers with unneeded calls.
+     */
+    suspend fun UserModel.withEmojisIfMissing(): UserModel
+
+    // see comment above
+    suspend fun TimelineEntryModel.withEmojisIfMissing(): TimelineEntryModel
+}

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
@@ -6,6 +6,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Circl
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultCirclesRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultDirectMessageRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultDraftRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultEmojiRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultInboxManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultLocalItemCache
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultMediaRepository
@@ -24,6 +25,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Defau
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultUserRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DirectMessageRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DraftRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.InboxManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.LocalItemCache
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.MediaRepository
@@ -140,6 +142,12 @@ val domainContentRepositoryModule =
         single<SupportedFeatureRepository> {
             DefaultSupportedFeatureRepository(
                 nodeInfoRepository = get(),
+            )
+        }
+        single<EmojiRepository> {
+            DefaultEmojiRepository(
+                provider = get(named("default")),
+                otherProvider = get(named("other")),
             )
         }
     }

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitor.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitor.kt
@@ -1,5 +1,6 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
 
+import com.livefast.eattrash.raccoonforfriendica.core.utils.nodeName
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SupportedFeatureRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
@@ -59,9 +60,7 @@ internal class DefaultActiveAccountMonitor(
             return
         }
 
-        val node =
-            account.handle.substringAfter("@").takeIf { it.isNotEmpty() }
-                ?: apiConfigurationRepository.defaultNode
+        val node = account.handle.nodeName ?: apiConfigurationRepository.defaultNode
         apiConfigurationRepository.changeNode(node)
         val credentials = accountCredentialsCache.get(account.id)
         apiConfigurationRepository.setAuth(credentials)

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationViewModel.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationViewModel.kt
@@ -226,7 +226,7 @@ class ConversationViewModel(
                 updateMessageInState(localId) {
                     remoteMessage.copy(
                         // the title is appended in a newline before the body
-                        text = remoteMessage.text?.substringAfter("\n"),
+                        text = remoteMessage.text?.substringAfter('\n'),
                     )
                 }
                 updateState {

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailViewModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailViewModel.kt
@@ -18,6 +18,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationSpecification
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.LocalItemCache
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
@@ -40,6 +41,7 @@ class UserDetailViewModel(
     private val notificationCenter: NotificationCenter,
     private val imagePreloadManager: ImagePreloadManager,
     private val blurHashRepository: BlurHashRepository,
+    private val emojiRepository: EmojiRepository,
 ) : DefaultMviModel<UserDetailMviModel.Intent, UserDetailMviModel.State, UserDetailMviModel.Effect>(
         initialState = UserDetailMviModel.State(),
     ),
@@ -118,7 +120,10 @@ class UserDetailViewModel(
     }
 
     private suspend fun loadUser() {
-        val user = userCache.get(id)
+        val user =
+            with(emojiRepository) {
+                userCache.get(id)?.withEmojisIfMissing()
+            }
         updateState { it.copy(user = user) }
         val relationship =
             if (id != uiState.value.currentUserId) {

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/di/UserDetailModule.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/di/UserDetailModule.kt
@@ -21,6 +21,7 @@ val featureUserDetailModule =
                 notificationCenter = get(),
                 imagePreloadManager = get(),
                 blurHashRepository = get(),
+                emojiRepository = get(),
             )
         }
         factory<ForumListMviModel> { params ->


### PR DESCRIPTION
This PR adds a workaround for custom emojis for users on Friendica instances, where they are not returned for accounts but only for statuses.

The idea is to retrieve them from the source instance and cache them based on the node name in order to avoid multiple requests.