### PR TITLE
feat: add strikethrough and code format options

### DIFF
--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
@@ -363,4 +363,8 @@ internal val DeStrings =
             "Beschreiben Sie das aufgetretene Problem oder hinterlassen Sie einfach ein Feedback 🖋️"
         override val changeNodeDialogTitle = "Instanz ändern"
         override val actionQuote = "Zitieren"
+        override val actionAddTitle = "Titel hinzufügen"
+        override val actionRemoveTitle = "Titel entfernen"
+        override val actionAddSpoiler = "Spoiler hinzufügen"
+        override val actionRemoveSpoiler = "Spoiler entfernen"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -354,4 +354,8 @@ internal open class DefaultStrings : Strings {
         "Describe the issue you encountered or just leave a feedback 🖋️"
     override val changeNodeDialogTitle = "Change instance"
     override val actionQuote = "Quote"
+    override val actionAddTitle = "Add title"
+    override val actionRemoveTitle = "Remove title"
+    override val actionAddSpoiler = "Add spoiler"
+    override val actionRemoveSpoiler = "Remove spoiler"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -363,4 +363,8 @@ internal val ItStrings =
             "Descrivi il problema che hai riscontrato o lascia un feedback 🖋️"
         override val changeNodeDialogTitle = "Cambia istanza"
         override val actionQuote = "Cita"
+        override val actionAddTitle = "Aggiungi titolo"
+        override val actionRemoveTitle = "Rimuovi titolo"
+        override val actionAddSpoiler = "Aggiungi spoiler"
+        override val actionRemoveSpoiler = "Rimuovi spoiler"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -318,6 +318,10 @@ interface Strings {
     val userFeedbackCommentPlaceholder: String
     val changeNodeDialogTitle: String
     val actionQuote: String
+    val actionAddTitle: String
+    val actionRemoveTitle: String
+    val actionAddSpoiler: String
+    val actionRemoveSpoiler: String
 }
 
 object Locales {

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
@@ -121,6 +121,14 @@ interface ComposerMviModel :
             val fieldType: ComposerFieldType,
         ) : Intent
 
+        data class AddStrikethroughFormat(
+            val fieldType: ComposerFieldType,
+        ) : Intent
+
+        data class AddCodeFormat(
+            val fieldType: ComposerFieldType,
+        ) : Intent
+
         data object ToggleHasSpoiler : Intent
 
         data object ToggleHasTitle : Intent

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
@@ -248,12 +248,35 @@ class ComposerScreen(
                                     }
                                 }
 
+                                this +=
+                                    CustomOptions.ToggleSpoiler.toOption(
+                                        label =
+                                            if (uiState.hasSpoiler) {
+                                                LocalStrings.current.actionRemoveSpoiler
+                                            } else {
+                                                LocalStrings.current.actionAddSpoiler
+                                            },
+                                    )
+
+                                if (uiState.titleFeatureSupported) {
+                                    this +=
+                                        CustomOptions.ToggleTitle.toOption(
+                                            label =
+                                                if (uiState.hasTitle) {
+                                                    LocalStrings.current.actionRemoveTitle
+                                                } else {
+                                                    LocalStrings.current.actionAddTitle
+                                                },
+                                        )
+                                }
+
                                 if (uiState.galleryFeatureSupported && uiState.poll == null) {
                                     this +=
                                         CustomOptions.SelectFromGallery.toOption(
                                             label = LocalStrings.current.actionAddImageFromGallery,
                                         )
                                 }
+
                                 if (uiState.pollFeatureSupported && uiState.attachments.isEmpty()) {
                                     this +=
                                         CustomOptions.TogglePoll.toOption(
@@ -348,6 +371,14 @@ class ComposerScreen(
                                                     }
                                                 }
 
+                                                CustomOptions.ToggleTitle -> {
+                                                    model.reduce(ComposerMviModel.Intent.ToggleHasTitle)
+                                                }
+
+                                                CustomOptions.ToggleSpoiler -> {
+                                                    model.reduce(ComposerMviModel.Intent.ToggleHasSpoiler)
+                                                }
+
                                                 else -> Unit
                                             }
                                         },
@@ -395,7 +426,6 @@ class ComposerScreen(
                             openImagePicker = true
                         }
                     },
-                    supportsTitleFeature = uiState.titleFeatureSupported,
                     hasPoll = uiState.poll != null,
                     onLinkClicked = {
                         linkDialogOpen = true
@@ -439,11 +469,29 @@ class ComposerScreen(
                             ),
                         )
                     },
-                    onSpoilerClicked = {
-                        model.reduce(ComposerMviModel.Intent.ToggleHasSpoiler)
+                    onStrikethroughClicked = {
+                        model.reduce(
+                            ComposerMviModel.Intent.AddStrikethroughFormat(
+                                fieldType =
+                                    when {
+                                        hasTitleFocus -> ComposerFieldType.Title
+                                        hasSpoilerFieldFocus -> ComposerFieldType.Spoiler
+                                        else -> ComposerFieldType.Body
+                                    },
+                            ),
+                        )
                     },
-                    onTitleClicked = {
-                        model.reduce(ComposerMviModel.Intent.ToggleHasTitle)
+                    onCodeClicked = {
+                        model.reduce(
+                            ComposerMviModel.Intent.AddCodeFormat(
+                                fieldType =
+                                    when {
+                                        hasTitleFocus -> ComposerFieldType.Title
+                                        hasSpoilerFieldFocus -> ComposerFieldType.Spoiler
+                                        else -> ComposerFieldType.Body
+                                    },
+                            ),
+                        )
                     },
                 )
             },
@@ -635,7 +683,7 @@ class ComposerScreen(
                                 onSend = {
                                     model.reduce(ComposerMviModel.Intent.Submit)
                                 },
-                        ),
+                            ),
                         onValueChange = { value ->
                             model.reduce(
                                 ComposerMviModel.Intent.SetFieldValue(
@@ -850,4 +898,8 @@ private sealed interface CustomOptions : OptionId.Custom {
     data object SelectFromGallery : CustomOptions
 
     data object TogglePoll : CustomOptions
+
+    data object ToggleTitle : CustomOptions
+
+    data object ToggleSpoiler : CustomOptions
 }

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
@@ -245,6 +245,8 @@ class ComposerViewModel(
             is ComposerMviModel.Intent.AddBoldFormat -> addBoldFormat(intent.fieldType)
             is ComposerMviModel.Intent.AddItalicFormat -> addItalicFormat(intent.fieldType)
             is ComposerMviModel.Intent.AddUnderlineFormat -> addUnderlineFormat(intent.fieldType)
+            is ComposerMviModel.Intent.AddStrikethroughFormat -> addStrikethroughFormat(intent.fieldType)
+            is ComposerMviModel.Intent.AddCodeFormat -> addCodeFormat(intent.fieldType)
             is ComposerMviModel.Intent.AddAttachmentsFromGallery ->
                 addAttachmentsFromGallery(intent.attachments)
 
@@ -571,6 +573,100 @@ class ComposerViewModel(
                     "[/u]"
                 } else {
                     "</u>"
+                }
+            val newValue =
+                getNewTextFieldValue(
+                    value = value,
+                    additionalPart =
+                        buildString {
+                            append(before)
+                            append(selectedText)
+                            append(after)
+                        },
+                    offsetAfter = before.length,
+                )
+            updateState {
+                when (fieldType) {
+                    ComposerFieldType.Body -> it.copy(bodyValue = newValue)
+                    ComposerFieldType.Spoiler -> it.copy(spoilerValue = newValue)
+                    ComposerFieldType.Title -> it.copy(titleValue = newValue)
+                }
+            }
+        }
+    }
+
+    private fun addStrikethroughFormat(fieldType: ComposerFieldType) {
+        screenModelScope.launch {
+            val value =
+                when (fieldType) {
+                    ComposerFieldType.Body ->
+                        uiState.value.bodyValue
+
+                    ComposerFieldType.Spoiler ->
+                        uiState.value.spoilerValue
+
+                    ComposerFieldType.Title ->
+                        uiState.value.titleValue
+                }
+            val selectedText = value.getSelectedText().text
+            val before =
+                if (useBBCode) {
+                    "[s]"
+                } else {
+                    "<s>"
+                }
+            val after =
+                if (useBBCode) {
+                    "[/s]"
+                } else {
+                    "</s>"
+                }
+            val newValue =
+                getNewTextFieldValue(
+                    value = value,
+                    additionalPart =
+                        buildString {
+                            append(before)
+                            append(selectedText)
+                            append(after)
+                        },
+                    offsetAfter = before.length,
+                )
+            updateState {
+                when (fieldType) {
+                    ComposerFieldType.Body -> it.copy(bodyValue = newValue)
+                    ComposerFieldType.Spoiler -> it.copy(spoilerValue = newValue)
+                    ComposerFieldType.Title -> it.copy(titleValue = newValue)
+                }
+            }
+        }
+    }
+
+    private fun addCodeFormat(fieldType: ComposerFieldType) {
+        screenModelScope.launch {
+            val value =
+                when (fieldType) {
+                    ComposerFieldType.Body ->
+                        uiState.value.bodyValue
+
+                    ComposerFieldType.Spoiler ->
+                        uiState.value.spoilerValue
+
+                    ComposerFieldType.Title ->
+                        uiState.value.titleValue
+                }
+            val selectedText = value.getSelectedText().text
+            val before =
+                if (useBBCode) {
+                    "[code]"
+                } else {
+                    "<code>"
+                }
+            val after =
+                if (useBBCode) {
+                    "[/code]"
+                } else {
+                    "</code>"
                 }
             val newValue =
                 getNewTextFieldValue(

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/components/UtilsBar.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/components/UtilsBar.kt
@@ -8,13 +8,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AlternateEmail
-import androidx.compose.material.icons.filled.Explicit
+import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.FormatBold
 import androidx.compose.material.icons.filled.FormatItalic
+import androidx.compose.material.icons.filled.FormatStrikethrough
 import androidx.compose.material.icons.filled.FormatUnderlined
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.PhotoCamera
-import androidx.compose.material.icons.filled.Title
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -26,7 +26,6 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 @Composable
 internal fun UtilsBar(
     modifier: Modifier = Modifier,
-    supportsTitleFeature: Boolean = false,
     hasPoll: Boolean = false,
     onLinkClicked: (() -> Unit)? = null,
     onMentionClicked: (() -> Unit)? = null,
@@ -34,8 +33,8 @@ internal fun UtilsBar(
     onBoldClicked: (() -> Unit)? = null,
     onItalicClicked: (() -> Unit)? = null,
     onUnderlineClicked: (() -> Unit)? = null,
-    onSpoilerClicked: (() -> Unit)? = null,
-    onTitleClicked: (() -> Unit)? = null,
+    onStrikethroughClicked: (() -> Unit)? = null,
+    onCodeClicked: (() -> Unit)? = null,
 ) {
     Row(
         modifier =
@@ -82,30 +81,6 @@ internal fun UtilsBar(
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
-        if (supportsTitleFeature) {
-            IconButton(
-                onClick = {
-                    onTitleClicked?.invoke()
-                },
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Title,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-        }
-        IconButton(
-            onClick = {
-                onSpoilerClicked?.invoke()
-            },
-        ) {
-            Icon(
-                imageVector = Icons.Default.Explicit,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
         IconButton(
             onClick = {
                 onBoldClicked?.invoke()
@@ -135,6 +110,28 @@ internal fun UtilsBar(
         ) {
             Icon(
                 imageVector = Icons.Default.FormatUnderlined,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        IconButton(
+            onClick = {
+                onStrikethroughClicked?.invoke()
+            },
+        ) {
+            Icon(
+                imageVector = Icons.Default.FormatStrikethrough,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        IconButton(
+            onClick = {
+                onCodeClicked?.invoke()
+            },
+        ) {
+            Icon(
+                imageVector = Icons.Default.Code,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,6 @@ androidx-appcompat = "1.7.0"
 androidx-browser = "1.8.0"
 androidx-core-ktx = "1.13.1"
 androidx-crypto = "1.0.0"
-androidx-material = "1.12.0"
 androidx-media3 = "1.4.1"
 androidx-splashscreen = "1.0.1"
 androidx-sqlite = "2.5.0-alpha08"
@@ -43,7 +42,6 @@ androidx-activity = { module = "androidx.activity:activity", version.ref = "andr
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidx-appcompat" }
 androidx-browser = { module = "androidx.browser:browser", version.ref = "androidx-browser" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidx-core-ktx" }
-androidx-material = { group = "com.google.android.material", name = "material", version.ref = "androidx-material" }
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "androidx-crypto" }
 androidx-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "androidx-splashscreen" }
 androidx-test-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-junit" }


### PR DESCRIPTION
This PR adds the strikethrough and code formatting options and moves the "spoiler" and "title" options to the drop-down menu in the top app bar.