### PR TITLE
feat: exclude replies from timelines

### DIFF
--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
@@ -368,4 +368,5 @@ internal val DeStrings =
         override val actionAddSpoiler = "Spoiler hinzufügen"
         override val actionRemoveSpoiler = "Spoiler entfernen"
         override val actionRevealContent = "Inhalt enthüllen"
+        override val settingsItemExcludeRepliesFromTimeline = "Antworten aus der Zeitleiste ausschließen"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -359,4 +359,5 @@ internal open class DefaultStrings : Strings {
     override val actionAddSpoiler = "Add spoiler"
     override val actionRemoveSpoiler = "Remove spoiler"
     override val actionRevealContent = "Reveal content"
+    override val settingsItemExcludeRepliesFromTimeline = "Exclude replies from timeline"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -368,4 +368,5 @@ internal val ItStrings =
         override val actionAddSpoiler = "Aggiungi spoiler"
         override val actionRemoveSpoiler = "Rimuovi spoiler"
         override val actionRevealContent = "Rivela contenuto"
+        override val settingsItemExcludeRepliesFromTimeline = "Escludi risposte dalla timeline"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -323,6 +323,7 @@ interface Strings {
     val actionAddSpoiler: String
     val actionRemoveSpoiler: String
     val actionRevealContent: String
+    val settingsItemExcludeRepliesFromTimeline: String
 }
 
 object Locales {

--- a/core/persistence/schemas/com.livefast.eattrash.raccoonforfriendica.core.persistence.AppDatabase/7.json
+++ b/core/persistence/schemas/com.livefast.eattrash.raccoonforfriendica.core.persistence.AppDatabase/7.json
@@ -1,0 +1,262 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 7,
+    "identityHash": "5e02b3929cd7f1f054ef5469dc185467",
+    "entities": [
+      {
+        "tableName": "AccountEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `handle` TEXT NOT NULL, `active` INTEGER NOT NULL DEFAULT 0, `remoteId` TEXT, `avatar` TEXT, `displayName` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "handle",
+            "columnName": "handle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "active",
+            "columnName": "active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "avatar",
+            "columnName": "avatar",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AccountEntity_handle",
+            "unique": false,
+            "columnNames": [
+              "handle"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AccountEntity_handle` ON `${TABLE_NAME}` (`handle`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SettingsEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `accountId` INTEGER NOT NULL DEFAULT 0, `lang` TEXT NOT NULL DEFAULT 'en', `theme` INTEGER NOT NULL DEFAULT 0, `fontFamily` INTEGER NOT NULL DEFAULT 0, `fontScale` INTEGER NOT NULL DEFAULT 0, `dynamicColors` INTEGER NOT NULL DEFAULT 0, `customSeedColor` INTEGER, `defaultTimelineType` INTEGER NOT NULL DEFAULT 0, `includeNsfw` INTEGER NOT NULL DEFAULT 0, `blurNsfw` INTEGER NOT NULL DEFAULT 0, `urlOpeningMode` INTEGER NOT NULL DEFAULT 0, `defaultPostVisibility` INTEGER NOT NULL DEFAULT 0, `defaultReplyVisibility` INTEGER NOT NULL DEFAULT 0, `excludeRepliesFromTimeline` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lang",
+            "columnName": "lang",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'en'"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "fontScale",
+            "columnName": "fontScale",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "dynamicColors",
+            "columnName": "dynamicColors",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "customSeedColor",
+            "columnName": "customSeedColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "defaultTimelineType",
+            "columnName": "defaultTimelineType",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "includeNsfw",
+            "columnName": "includeNsfw",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "blurNsfw",
+            "columnName": "blurNsfw",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "urlOpeningMode",
+            "columnName": "urlOpeningMode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "defaultPostVisibility",
+            "columnName": "defaultPostVisibility",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "defaultReplyVisibility",
+            "columnName": "defaultReplyVisibility",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "excludeRepliesFromTimeline",
+            "columnName": "excludeRepliesFromTimeline",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "DraftEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mediaIds` TEXT, `inReplyToId` TEXT, `lang` TEXT, `sensitive` INTEGER, `spoiler` TEXT, `title` TEXT, `text` TEXT, `created` TEXT, `visibility` TEXT, `pollExpiresAt` TEXT, `pollMultiple` INTEGER, `pollOptions` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaIds",
+            "columnName": "mediaIds",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "inReplyToId",
+            "columnName": "inReplyToId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lang",
+            "columnName": "lang",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sensitive",
+            "columnName": "sensitive",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "spoiler",
+            "columnName": "spoiler",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "visibility",
+            "columnName": "visibility",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pollExpiresAt",
+            "columnName": "pollExpiresAt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pollMultiple",
+            "columnName": "pollMultiple",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pollOptions",
+            "columnName": "pollOptions",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '5e02b3929cd7f1f054ef5469dc185467')"
+    ]
+  }
+}

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/AppDatabase.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/AppDatabase.kt
@@ -16,13 +16,14 @@ import com.livefast.eattrash.raccoonforfriendica.core.persistence.entities.Setti
         SettingsEntity::class,
         DraftEntity::class,
     ],
-    version = 6,
+    version = 7,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
         AutoMigration(from = 3, to = 4),
         AutoMigration(from = 4, to = 5),
         AutoMigration(from = 5, to = 6),
+        AutoMigration(from = 6, to = 7),
 
     ],
 )

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/entities/SettingsEntity.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/entities/SettingsEntity.kt
@@ -20,4 +20,5 @@ data class SettingsEntity(
     @ColumnInfo(defaultValue = "0") val urlOpeningMode: Int = 0,
     @ColumnInfo(defaultValue = "0") val defaultPostVisibility: Int = 0,
     @ColumnInfo(defaultValue = "0") val defaultReplyVisibility: Int = 0,
+    @ColumnInfo(defaultValue = "0") val excludeRepliesFromTimeline: Boolean = false,
 )

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
@@ -93,6 +93,7 @@ internal class DefaultTimelinePaginationManager(
                                 pageCursor = pageCursor,
                             )
                     }?.updatePaginationData()
+                        ?.filterReplies(included = !specification.excludeReplies)
                         ?.filterNsfw(specification.includeNsfw)
                         ?.deduplicate()
                         ?.fixupCreatorEmojis()
@@ -181,6 +182,11 @@ internal class DefaultTimelinePaginationManager(
         filter { e1 ->
             history.none { e2 -> e1.id == e2.id }
         }.distinctBy { it.id }
+
+    private fun List<TimelineEntryModel>.filterReplies(included: Boolean): List<TimelineEntryModel> =
+        filter {
+            included || it.inReplyTo == null
+        }
 
     private fun List<TimelineEntryModel>.filterNsfw(included: Boolean): List<TimelineEntryModel> = filter { included || !it.isNsfw }
 

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/TimelinePaginationSpecification.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/TimelinePaginationSpecification.kt
@@ -5,6 +5,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineTyp
 sealed interface TimelinePaginationSpecification {
     data class Feed(
         val timelineType: TimelineType,
+        val excludeReplies: Boolean = false,
         val includeNsfw: Boolean = true,
     ) : TimelinePaginationSpecification
 

--- a/domain/identity/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/data/SettingsModel.kt
+++ b/domain/identity/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/data/SettingsModel.kt
@@ -19,4 +19,5 @@ data class SettingsModel(
     val urlOpeningMode: UrlOpeningMode = UrlOpeningMode.External,
     val defaultPostVisibility: Int = 0,
     val defaultReplyVisibility: Int = 0,
+    val excludeRepliesFromTimeline: Boolean = false,
 )

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultSettingsRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultSettingsRepository.kt
@@ -52,6 +52,7 @@ private fun SettingsEntity.toModel() =
         urlOpeningMode = urlOpeningMode.toUrlOpeningMode(),
         defaultPostVisibility = defaultPostVisibility,
         defaultReplyVisibility = defaultReplyVisibility,
+        excludeRepliesFromTimeline = excludeRepliesFromTimeline,
     )
 
 private fun SettingsModel.toEntity() =
@@ -70,4 +71,5 @@ private fun SettingsModel.toEntity() =
         urlOpeningMode = urlOpeningMode.toInt(),
         defaultPostVisibility = defaultPostVisibility,
         defaultReplyVisibility = defaultReplyVisibility,
+        excludeRepliesFromTimeline = excludeRepliesFromTimeline,
     )

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsMviModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsMviModel.kt
@@ -64,6 +64,10 @@ interface SettingsMviModel :
         data class ChangeDefaultReplyVisibility(
             val visibility: Visibility,
         ) : Intent
+
+        data class ChangeExcludeRepliesFromTimeline(
+            val value: Boolean,
+        ) : Intent
     }
 
     data class State(
@@ -83,6 +87,7 @@ interface SettingsMviModel :
         val urlOpeningMode: UrlOpeningMode = UrlOpeningMode.External,
         val defaultPostVisibility: Visibility = Visibility.Public,
         val defaultReplyVisibility: Visibility = Visibility.Public,
+        val excludeRepliesFromTimeline: Boolean = false,
     )
 
     sealed interface Effect

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
@@ -167,6 +167,15 @@ class SettingsScreen : Screen {
                                 urlOpeningModeBottomSheetOpened = true
                             },
                         )
+                        SettingsSwitchRow(
+                            title = LocalStrings.current.settingsItemExcludeRepliesFromTimeline,
+                            value = uiState.excludeRepliesFromTimeline,
+                            onValueChanged = {
+                                model.reduce(
+                                    SettingsMviModel.Intent.ChangeExcludeRepliesFromTimeline(it),
+                                )
+                            },
+                        )
 
                         SettingsHeader(
                             title = LocalStrings.current.settingsHeaderLookAndFeel,

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsViewModel.kt
@@ -96,6 +96,7 @@ class SettingsViewModel(
                                 urlOpeningMode = settings.urlOpeningMode,
                                 defaultPostVisibility = settings.defaultPostVisibility.toVisibility(),
                                 defaultReplyVisibility = settings.defaultReplyVisibility.toVisibility(),
+                                excludeRepliesFromTimeline = settings.excludeRepliesFromTimeline,
                             )
                         }
                     }
@@ -171,6 +172,11 @@ class SettingsViewModel(
                 screenModelScope.launch {
                     changeDefaultReplyVisibility(intent.visibility)
                 }
+
+            is SettingsMviModel.Intent.ChangeExcludeRepliesFromTimeline ->
+                screenModelScope.launch {
+                    changeExcludeRepliesFromTimeline(intent.value)
+                }
         }
     }
 
@@ -243,6 +249,12 @@ class SettingsViewModel(
     private suspend fun changeUrlOpeningMode(value: UrlOpeningMode) {
         val currentSettings = settingsRepository.current.value ?: return
         val newSettings = currentSettings.copy(urlOpeningMode = value)
+        saveSettings(newSettings)
+    }
+
+    private suspend fun changeExcludeRepliesFromTimeline(value: Boolean) {
+        val currentSettings = settingsRepository.current.value ?: return
+        val newSettings = currentSettings.copy(excludeRepliesFromTimeline = value)
         saveSettings(newSettings)
     }
 

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
@@ -19,6 +19,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.Timel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.CirclesRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
@@ -178,10 +179,12 @@ class TimelineViewModel(
         updateState {
             it.copy(initial = initial, refreshing = !initial)
         }
+        val settings = settingsRepository.current.value ?: SettingsModel()
         paginationManager.reset(
             TimelinePaginationSpecification.Feed(
                 timelineType = uiState.value.timelineType ?: TimelineType.Local,
-                includeNsfw = settingsRepository.current.value?.includeNsfw ?: false,
+                includeNsfw = settings.includeNsfw,
+                excludeReplies = settings.excludeRepliesFromTimeline,
             ),
         )
         loadNextPage()


### PR DESCRIPTION
This adds an option in the settings screen to exclude replies from main feeds (subscriptions, all and local).

<div align="center">
<img width="321" alt="Screenshot 2024-09-27 at 20 19 19" src="https://github.com/user-attachments/assets/dc91add1-2d80-48b3-8f2b-5001a1acac35" />
</div>
