### PR TITLE
fix: edit post when it has been reblogged

### DIFF
--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTimelineEntryRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTimelineEntryRepository.kt
@@ -278,7 +278,7 @@ internal class DefaultTimelineEntryRepository(
                     .update(
                         id = id,
                         data = data,
-                    ).toModel()
+                    ).toModelWithReply()
             }.getOrNull()
         }
 


### PR DESCRIPTION
This PR fixes a bug happening when one edits one's own post which has been reblogged by another user. In this case, the `reblog` embedded object was lost, which lead to an empty post in the feed where the edited one was.