### PR TITLE
refactor: cleanup emoji repository

### DIFF
--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultDirectMessagesPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultDirectMessagesPaginationManager.kt
@@ -2,11 +2,11 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
 
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.DirectMessageModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DirectMessageRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
 
 internal class DefaultDirectMessagesPaginationManager(
     private val directMessageRepository: DirectMessageRepository,
-    private val emojiRepository: EmojiRepository,
+    private val emojiHelper: EmojiHelper,
 ) : DirectMessagesPaginationManager {
     private var specification: DirectMessagesPaginationSpecification? = null
     private var page = 1
@@ -64,7 +64,7 @@ internal class DefaultDirectMessagesPaginationManager(
         }.distinctBy { it.id }
 
     private suspend fun List<DirectMessageModel>.fixupCreatorEmojis(): List<DirectMessageModel> =
-        with(emojiRepository) {
+        with(emojiHelper) {
             map {
                 it.copy(
                     recipient = it.recipient?.withEmojisIfMissing(),

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultExplorePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultExplorePaginationManager.kt
@@ -8,7 +8,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.ExploreItem
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isNsfw
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toNotificationStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toStatus
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TrendingRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
 import kotlinx.coroutines.CoroutineDispatcher
@@ -25,7 +25,7 @@ import kotlinx.coroutines.sync.withLock
 internal class DefaultExplorePaginationManager(
     private val trendingRepository: TrendingRepository,
     private val userRepository: UserRepository,
-    private val emojiRepository: EmojiRepository,
+    private val emojiHelper: EmojiHelper,
     notificationCenter: NotificationCenter,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ExplorePaginationManager {
@@ -168,7 +168,7 @@ internal class DefaultExplorePaginationManager(
         }
 
     private suspend fun List<ExploreItemModel>.fixupCreatorEmojis(): List<ExploreItemModel> =
-        with(emojiRepository) {
+        with(emojiHelper) {
             map {
                 when (it) {
                     is ExploreItemModel.Entry -> it.copy(entry = it.entry.withEmojisIfMissing())

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFavoritesPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFavoritesPaginationManager.kt
@@ -5,7 +5,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.Timel
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.TimelineEntryUpdatedEvent
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isNsfw
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -19,7 +19,7 @@ import kotlinx.coroutines.sync.withLock
 
 internal class DefaultFavoritesPaginationManager(
     private val timelineEntryRepository: TimelineEntryRepository,
-    private val emojiRepository: EmojiRepository,
+    private val emojiHelper: EmojiHelper,
     notificationCenter: NotificationCenter,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : FavoritesPaginationManager {
@@ -103,7 +103,7 @@ internal class DefaultFavoritesPaginationManager(
     private fun List<TimelineEntryModel>.filterNsfw(included: Boolean): List<TimelineEntryModel> = filter { included || !it.isNsfw }
 
     private suspend fun List<TimelineEntryModel>.fixupCreatorEmojis(): List<TimelineEntryModel> =
-        with(emojiRepository) {
+        with(emojiHelper) {
             map {
                 it.withEmojisIfMissing()
             }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFollowRequestPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFollowRequestPaginationManager.kt
@@ -1,12 +1,12 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
 
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
 
 internal class DefaultFollowRequestPaginationManager(
     private val userRepository: UserRepository,
-    private val emojiRepository: EmojiRepository,
+    private val emojiHelper: EmojiHelper,
 ) : FollowRequestPaginationManager {
     private var pageCursor: String? = null
     override var canFetchMore: Boolean = true
@@ -45,7 +45,7 @@ internal class DefaultFollowRequestPaginationManager(
         }.distinctBy { it.id }
 
     private suspend fun List<UserModel>.fixupCreatorEmojis(): List<UserModel> =
-        with(emojiRepository) {
+        with(emojiHelper) {
             map {
                 it.withEmojisIfMissing()
             }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultNotificationsPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultNotificationsPaginationManager.kt
@@ -5,14 +5,14 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.Notificatio
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isNsfw
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toNotificationStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toStatus
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.NotificationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
 
 internal class DefaultNotificationsPaginationManager(
     private val notificationRepository: NotificationRepository,
     private val userRepository: UserRepository,
-    private val emojiRepository: EmojiRepository,
+    private val emojiHelper: EmojiHelper,
 ) : NotificationsPaginationManager {
     private var specification: NotificationsPaginationSpecification? = null
     private var pageCursor: String? = null
@@ -83,7 +83,7 @@ internal class DefaultNotificationsPaginationManager(
         filter { included || it.entry?.isNsfw != true }
 
     private suspend fun List<NotificationModel>.fixupCreatorEmojis(): List<NotificationModel> =
-        with(emojiRepository) {
+        with(emojiHelper) {
             map {
                 it.copy(
                     user = it.user?.withEmojisIfMissing(),

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultSearchPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultSearchPaginationManager.kt
@@ -9,7 +9,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.SearchResul
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isNsfw
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toNotificationStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toStatus
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SearchRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
 import kotlinx.coroutines.CoroutineDispatcher
@@ -26,7 +26,7 @@ import kotlinx.coroutines.sync.withLock
 internal class DefaultSearchPaginationManager(
     private val searchRepository: SearchRepository,
     private val userRepository: UserRepository,
-    private val emojiRepository: EmojiRepository,
+    private val emojiHelper: EmojiHelper,
     notificationCenter: NotificationCenter,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : SearchPaginationManager {
@@ -166,7 +166,7 @@ internal class DefaultSearchPaginationManager(
         }
 
     private suspend fun List<ExploreItemModel>.fixupCreatorEmojis(): List<ExploreItemModel> =
-        with(emojiRepository) {
+        with(emojiHelper) {
             map {
                 when (it) {
                     is ExploreItemModel.Entry -> it.copy(entry = it.entry.withEmojisIfMissing())

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
@@ -6,7 +6,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.Timel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isNsfw
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineRepository
 import kotlinx.coroutines.CoroutineDispatcher
@@ -22,7 +22,7 @@ import kotlinx.coroutines.sync.withLock
 internal class DefaultTimelinePaginationManager(
     private val timelineRepository: TimelineRepository,
     private val timelineEntryRepository: TimelineEntryRepository,
-    private val emojiRepository: EmojiRepository,
+    private val emojiHelper: EmojiHelper,
     notificationCenter: NotificationCenter,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : TimelinePaginationManager {
@@ -191,7 +191,7 @@ internal class DefaultTimelinePaginationManager(
     private fun List<TimelineEntryModel>.filterNsfw(included: Boolean): List<TimelineEntryModel> = filter { included || !it.isNsfw }
 
     private suspend fun List<TimelineEntryModel>.fixupCreatorEmojis(): List<TimelineEntryModel> =
-        with(emojiRepository) {
+        with(emojiHelper) {
             map {
                 it.withEmojisIfMissing()
             }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUserPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUserPaginationManager.kt
@@ -6,7 +6,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toNotificationStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.CirclesRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
 import kotlinx.coroutines.CoroutineDispatcher
@@ -23,7 +23,7 @@ internal class DefaultUserPaginationManager(
     private val userRepository: UserRepository,
     private val timelineEntryRepository: TimelineEntryRepository,
     private val circlesRepository: CirclesRepository,
-    private val emojiRepository: EmojiRepository,
+    private val emojiHelper: EmojiHelper,
     notificationCenter: NotificationCenter,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : UserPaginationManager {
@@ -213,7 +213,7 @@ internal class DefaultUserPaginationManager(
         }
 
     private suspend fun List<UserModel>.fixupCreatorEmojis(): List<UserModel> =
-        with(emojiRepository) {
+        with(emojiHelper) {
             map {
                 it.withEmojisIfMissing()
             }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
@@ -30,14 +30,14 @@ val domainContentPaginationModule =
             DefaultTimelinePaginationManager(
                 timelineRepository = get(),
                 timelineEntryRepository = get(),
-                emojiRepository = get(),
+                emojiHelper = get(),
                 notificationCenter = get(),
             )
         }
         factory<NotificationsPaginationManager> {
             DefaultNotificationsPaginationManager(
                 notificationRepository = get(),
-                emojiRepository = get(),
+                emojiHelper = get(),
                 userRepository = get(),
             )
         }
@@ -45,7 +45,7 @@ val domainContentPaginationModule =
             DefaultExplorePaginationManager(
                 trendingRepository = get(),
                 userRepository = get(),
-                emojiRepository = get(),
+                emojiHelper = get(),
                 notificationCenter = get(),
             )
         }
@@ -54,14 +54,14 @@ val domainContentPaginationModule =
                 userRepository = get(),
                 timelineEntryRepository = get(),
                 circlesRepository = get(),
-                emojiRepository = get(),
+                emojiHelper = get(),
                 notificationCenter = get(),
             )
         }
         factory<FavoritesPaginationManager> {
             DefaultFavoritesPaginationManager(
                 timelineEntryRepository = get(),
-                emojiRepository = get(),
+                emojiHelper = get(),
                 notificationCenter = get(),
             )
         }
@@ -74,20 +74,20 @@ val domainContentPaginationModule =
             DefaultSearchPaginationManager(
                 searchRepository = get(),
                 userRepository = get(),
-                emojiRepository = get(),
+                emojiHelper = get(),
                 notificationCenter = get(),
             )
         }
         factory<FollowRequestPaginationManager> {
             DefaultFollowRequestPaginationManager(
                 userRepository = get(),
-                emojiRepository = get(),
+                emojiHelper = get(),
             )
         }
         factory<DirectMessagesPaginationManager> {
             DefaultDirectMessagesPaginationManager(
                 directMessageRepository = get(),
-                emojiRepository = get(),
+                emojiHelper = get(),
             )
         }
         factory<AlbumPhotoPaginationManager> {

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEmojiHelper.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEmojiHelper.kt
@@ -1,0 +1,48 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.core.utils.nodeName
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EmojiModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+
+internal class DefaultEmojiHelper(
+    private val repository: EmojiRepository,
+) : EmojiHelper {
+    override suspend fun UserModel.withEmojisIfMissing(): UserModel {
+        if (emojis.isNotEmpty()) {
+            return this
+        }
+        val texts =
+            arrayOf(
+                displayName.orEmpty(),
+                bio.orEmpty(),
+            )
+        if (texts.none { it.contains(EMOJI_REGEX) }) {
+            return this
+        }
+
+        val node = handle.nodeName
+        val emojis = repository.getAll(node)?.filterContainedIn(*texts).orEmpty()
+        return copy(emojis = emojis)
+    }
+
+    override suspend fun TimelineEntryModel.withEmojisIfMissing(): TimelineEntryModel =
+        copy(
+            creator = creator?.withEmojisIfMissing(),
+            inReplyTo =
+                inReplyTo?.copy(
+                    creator = inReplyTo?.creator?.withEmojisIfMissing(),
+                ),
+            reblog = reblog?.copy(reblog = null)?.withEmojisIfMissing(),
+        )
+
+    companion object {
+        private val EMOJI_REGEX = Regex(":\\w+:")
+    }
+}
+
+private fun List<EmojiModel>.filterContainedIn(vararg texts: String): List<EmojiModel> =
+    filter { emoji ->
+        val occurrence = ":${emoji.code}:"
+        texts.any { it.contains(occurrence) }
+    }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEmojiRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEmojiRepository.kt
@@ -2,10 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
 import com.livefast.eattrash.raccoonforfriendica.core.utils.cache.LruCache
-import com.livefast.eattrash.raccoonforfriendica.core.utils.nodeName
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EmojiModel
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -17,9 +14,12 @@ internal class DefaultEmojiRepository(
 ) : EmojiRepository {
     private val cache = LruCache<String, List<EmojiModel>>(20)
 
-    override suspend fun getAll(node: String?): List<EmojiModel>? {
+    override suspend fun getAll(
+        node: String?,
+        refresh: Boolean,
+    ): List<EmojiModel>? {
         val key = node.orEmpty()
-        return if (cache.containsKey(key)) {
+        return if (cache.containsKey(key) && !refresh) {
             cache.get(key)
         } else {
             retrieve(node).orEmpty().also {
@@ -27,34 +27,6 @@ internal class DefaultEmojiRepository(
             }
         }
     }
-
-    override suspend fun UserModel.withEmojisIfMissing(): UserModel {
-        if (emojis.isNotEmpty()) {
-            return this
-        }
-        val texts =
-            arrayOf(
-                displayName.orEmpty(),
-                bio.orEmpty(),
-            )
-        if (texts.none { it.contains(EMOJI_REGEX) }) {
-            return this
-        }
-
-        val node = handle.nodeName
-        val emojis = getAll(node)?.filterContainedIn(*texts).orEmpty()
-        return copy(emojis = emojis)
-    }
-
-    override suspend fun TimelineEntryModel.withEmojisIfMissing(): TimelineEntryModel =
-        copy(
-            creator = creator?.withEmojisIfMissing(),
-            inReplyTo =
-                inReplyTo?.copy(
-                    creator = inReplyTo?.creator?.withEmojisIfMissing(),
-                ),
-            reblog = reblog?.copy(reblog = null)?.withEmojisIfMissing(),
-        )
 
     private suspend fun retrieve(node: String?): List<EmojiModel>? =
         withContext(Dispatchers.IO) {
@@ -69,14 +41,4 @@ internal class DefaultEmojiRepository(
                 res.map { it.toModel() }
             }.getOrElse { null }
         }
-
-    companion object {
-        private val EMOJI_REGEX = Regex(":\\w+:")
-    }
 }
-
-private fun List<EmojiModel>.filterContainedIn(vararg texts: String): List<EmojiModel> =
-    filter { emoji ->
-        val occurrence = ":${emoji.code}:"
-        texts.any { it.contains(occurrence) }
-    }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/EmojiHelper.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/EmojiHelper.kt
@@ -1,0 +1,16 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+
+/*
+ * Due to a bug in Friendica, custom emojis are never returned for users (neither as single
+ * entities nor as post creators).
+ *
+ * This helper is a client-side workaround that retrieves the emojis if (and only if) needed.
+ */
+interface EmojiHelper {
+    suspend fun UserModel.withEmojisIfMissing(): UserModel
+
+    suspend fun TimelineEntryModel.withEmojisIfMissing(): TimelineEntryModel
+}

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/EmojiRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/EmojiRepository.kt
@@ -1,21 +1,10 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EmojiModel
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 
 interface EmojiRepository {
-    suspend fun getAll(node: String? = null): List<EmojiModel>?
-
-    /*
-     * Due to a bug in Friendica, custom emojis are never returned for users (neither as single
-     * entities nor as post creators).
-     *
-     * These two functions are a client-side workaround that retrieves the emojis if (and only if)
-     * needed with an aggressive caching mechanism to avoid flooding the servers with unneeded calls.
-     */
-    suspend fun UserModel.withEmojisIfMissing(): UserModel
-
-    // see comment above
-    suspend fun TimelineEntryModel.withEmojisIfMissing(): TimelineEntryModel
+    suspend fun getAll(
+        node: String? = null,
+        refresh: Boolean = false,
+    ): List<EmojiModel>?
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
@@ -6,6 +6,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Circl
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultCirclesRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultDirectMessageRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultDraftRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultEmojiHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultEmojiRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultInboxManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultLocalItemCache
@@ -25,6 +26,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Defau
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultUserRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DirectMessageRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DraftRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.InboxManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.LocalItemCache
@@ -148,6 +150,11 @@ val domainContentRepositoryModule =
             DefaultEmojiRepository(
                 provider = get(named("default")),
                 otherProvider = get(named("other")),
+            )
+        }
+        single<EmojiHelper> {
+            DefaultEmojiHelper(
+                repository = get(),
             )
         }
     }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/di/ProfileModule.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/di/ProfileModule.kt
@@ -37,7 +37,7 @@ val featureProfileModule =
                 notificationCenter = get(),
                 imagePreloadManager = get(),
                 blurHashRepository = get(),
-                emojiRepository = get(),
+                emojiHelper = get(),
             )
         }
         factory<AnonymousMviModel> {

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
@@ -15,7 +15,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationSpecification
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
@@ -38,7 +38,7 @@ class MyAccountViewModel(
     private val notificationCenter: NotificationCenter,
     private val imagePreloadManager: ImagePreloadManager,
     private val blurHashRepository: BlurHashRepository,
-    private val emojiRepository: EmojiRepository,
+    private val emojiHelper: EmojiHelper,
 ) : DefaultMviModel<MyAccountMviModel.Intent, MyAccountMviModel.State, MyAccountMviModel.Effect>(
         initialState = MyAccountMviModel.State(),
     ),
@@ -55,14 +55,14 @@ class MyAccountViewModel(
                     if (cachedUser?.id != userId) {
                         delay(50)
                         val currentUser =
-                            with(emojiRepository) {
+                            with(emojiHelper) {
                                 userRepository.getById(userId)?.withEmojisIfMissing()
                             }
                         updateState { it.copy(user = currentUser) }
                         refresh(initial = true)
                     } else {
                         val currentUser =
-                            with(emojiRepository) {
+                            with(emojiHelper) {
                                 cachedUser.withEmojisIfMissing()
                             }
                         updateState {

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailViewModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailViewModel.kt
@@ -18,7 +18,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationSpecification
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.LocalItemCache
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
@@ -41,7 +41,7 @@ class UserDetailViewModel(
     private val notificationCenter: NotificationCenter,
     private val imagePreloadManager: ImagePreloadManager,
     private val blurHashRepository: BlurHashRepository,
-    private val emojiRepository: EmojiRepository,
+    private val emojiHelper: EmojiHelper,
 ) : DefaultMviModel<UserDetailMviModel.Intent, UserDetailMviModel.State, UserDetailMviModel.Effect>(
         initialState = UserDetailMviModel.State(),
     ),
@@ -121,7 +121,7 @@ class UserDetailViewModel(
 
     private suspend fun loadUser() {
         val user =
-            with(emojiRepository) {
+            with(emojiHelper) {
                 userCache.get(id)?.withEmojisIfMissing()
             }
         updateState { it.copy(user = user) }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/di/UserDetailModule.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/di/UserDetailModule.kt
@@ -21,7 +21,7 @@ val featureUserDetailModule =
                 notificationCenter = get(),
                 imagePreloadManager = get(),
                 blurHashRepository = get(),
-                emojiRepository = get(),
+                emojiHelper = get(),
             )
         }
         factory<ForumListMviModel> { params ->


### PR DESCRIPTION
This PR moves the helper functions from `EmojiRepository` to a dedicated class in order to better separate responsibilities. 

Moreover, a `refresh` parameter is added to the repository to force a reload instead of cache lookup; this will be extended to other repositories too as long as the adoption of local caching mechanism is extended to other contents.