### PR TITLE
fix: list scroll after navigation

### DIFF
--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
@@ -147,9 +147,6 @@ class ExploreScreen : Screen {
                     }
                 }.launchIn(this)
         }
-        LaunchedEffect(uiState.currentUserId) {
-            goBackToTop()
-        }
 
         Scaffold(
             topBar = {

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
@@ -102,9 +102,6 @@ class InboxScreen : Screen {
                     }
                 }.launchIn(this)
         }
-        LaunchedEffect(uiState.currentUserId) {
-            goBackToTop()
-        }
 
         Scaffold(
             topBar = {

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
@@ -146,9 +146,6 @@ class MyAccountScreen : Screen {
                     }
                 }.launchIn(this)
         }
-        LaunchedEffect(uiState.user?.id) {
-            goBackToTop()
-        }
 
         val pullRefreshState =
             rememberPullRefreshState(

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
@@ -149,9 +149,6 @@ class TimelineScreen : Screen {
                     }
                 }.launchIn(this)
         }
-        LaunchedEffect(uiState.currentUserId) {
-            goBackToTop()
-        }
 
         Scaffold(
             topBar = {


### PR DESCRIPTION
This PR fixes a bug introduced in #277 due to which lists were scrolled back to top after navigating back.