### PR TITLE
enhancement: confirm exit in post edit

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/MainActivity.kt
@@ -38,6 +38,12 @@ class MainActivity : ComponentActivity() {
                         return
                     }
 
+                    // back can be prevented by custom callback
+                    val canGoBackCallback = navigationCoordinator.getCanGoBackCallback()
+                    if (canGoBackCallback?.invoke() == false) {
+                        return
+                    }
+
                     // if in home, ask for confirmation
                     if (navigationCoordinator.currentSection.value == BottomNavigationSection.Home) {
                         // asks for confirmation
@@ -66,8 +72,10 @@ class MainActivity : ComponentActivity() {
                 backPressedCallback.isEnabled = !exitMessageVisible
                 finishBackPressedCallback.isEnabled = exitMessageVisible
             }.launchIn(lifecycleScope)
-        onBackPressedDispatcher.addCallback(backPressedCallback)
-        onBackPressedDispatcher.addCallback(finishBackPressedCallback)
+        with(onBackPressedDispatcher) {
+            addCallback(backPressedCallback)
+            addCallback(finishBackPressedCallback)
+        }
 
         setContent {
             App(

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/App.kt
@@ -148,23 +148,16 @@ fun App(onLoadingFinished: (() -> Unit)? = null) {
                                     return@Navigator false
                                 }
 
-                                true
+                                // otherwise use the screen-provided callback
+                                val callback = navigationCoordinator.getCanGoBackCallback()
+                                callback?.let { it() } ?: true
                             },
                         ) { navigator ->
                             LaunchedEffect(navigationCoordinator) {
                                 navigationCoordinator.setRootNavigator(navigator)
                             }
 
-                            ModalNavigationDrawer(
-                                modifier = Modifier.fillMaxSize(),
-                                drawerState = drawerState,
-                                gesturesEnabled = drawerGesturesEnabled,
-                                drawerContent = {
-                                    Navigator(DrawerContent())
-                                },
-                            ) {
-                                CurrentScreen()
-                            }
+                            CurrentScreen()
                         }
                     }
                 }

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationCoordinator.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationCoordinator.kt
@@ -23,6 +23,7 @@ internal class DefaultNavigationCoordinator(
 
     private var rootNavigator: Navigator? = null
     private var bottomBarScrollConnection: NestedScrollConnection? = null
+    private var canGoBackCallback: (() -> Boolean)? = null
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + dispatcher)
 
     override fun setCurrentSection(section: BottomNavigationSection) {
@@ -50,6 +51,12 @@ internal class DefaultNavigationCoordinator(
     }
 
     override fun getBottomBarScrollConnection() = bottomBarScrollConnection
+
+    override fun setCanGoBackCallback(value: (() -> Boolean)?) {
+        canGoBackCallback = value
+    }
+
+    override fun getCanGoBackCallback(): (() -> Boolean)? = canGoBackCallback
 
     override fun push(screen: Screen) {
         rootNavigator?.push(screen)

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/NavigationCoordinator.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/NavigationCoordinator.kt
@@ -20,6 +20,10 @@ interface NavigationCoordinator {
 
     fun setBottomBarScrollConnection(connection: NestedScrollConnection?)
 
+    fun setCanGoBackCallback(value: (() -> Boolean)?)
+
+    fun getCanGoBackCallback(): (() -> Boolean)?
+
     fun setExitMessageVisible(value: Boolean)
 
     fun setRootNavigator(navigator: Navigator)

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
@@ -209,6 +209,7 @@ interface ComposerMviModel :
         val pollOptionLimit: Int? = null,
         val publicationType: PublicationType = PublicationType.Default,
         val availableEmojis: List<EmojiModel> = emptyList(),
+        val hasUnsavedChanges: Boolean = false,
     )
 
     sealed interface Effect {

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
@@ -189,16 +189,35 @@ class ComposerViewModel(
                 screenModelScope.launch {
                     updateState {
                         when (intent.fieldType) {
-                            ComposerFieldType.Body -> it.copy(bodyValue = intent.value)
-                            ComposerFieldType.Spoiler -> it.copy(spoilerValue = intent.value)
-                            ComposerFieldType.Title -> it.copy(titleValue = intent.value)
+                            ComposerFieldType.Body ->
+                                it.copy(
+                                    bodyValue = intent.value,
+                                    hasUnsavedChanges = true,
+                                )
+
+                            ComposerFieldType.Spoiler ->
+                                it.copy(
+                                    spoilerValue = intent.value,
+                                    hasUnsavedChanges = true,
+                                )
+
+                            ComposerFieldType.Title ->
+                                it.copy(
+                                    titleValue = intent.value,
+                                    hasUnsavedChanges = true,
+                                )
                         }
                     }
                 }
 
             ComposerMviModel.Intent.ToggleHasSpoiler ->
                 screenModelScope.launch {
-                    updateState { it.copy(hasSpoiler = !it.hasSpoiler) }
+                    updateState {
+                        it.copy(
+                            hasSpoiler = !it.hasSpoiler,
+                            hasUnsavedChanges = true,
+                        )
+                    }
                 }
 
             ComposerMviModel.Intent.ToggleHasTitle ->
@@ -208,7 +227,12 @@ class ComposerViewModel(
 
             is ComposerMviModel.Intent.SetVisibility ->
                 screenModelScope.launch {
-                    updateState { it.copy(visibility = intent.visibility) }
+                    updateState {
+                        it.copy(
+                            visibility = intent.visibility,
+                            hasUnsavedChanges = true,
+                        )
+                    }
                 }
 
             is ComposerMviModel.Intent.AddAttachment -> uploadAttachment(intent.byteArray)
@@ -247,7 +271,12 @@ class ComposerViewModel(
 
             is ComposerMviModel.Intent.SetSensitive ->
                 screenModelScope.launch {
-                    updateState { it.copy(sensitive = intent.sensitive) }
+                    updateState {
+                        it.copy(
+                            sensitive = intent.sensitive,
+                            hasUnsavedChanges = true,
+                        )
+                    }
                 }
 
             is ComposerMviModel.Intent.AddBoldFormat -> addBoldFormat(intent.fieldType)
@@ -300,18 +329,29 @@ class ComposerViewModel(
                                             this += PollOptionModel(title = "")
                                         },
                                 ),
+                            hasUnsavedChanges = true,
                         )
                     }
                 }
 
             is ComposerMviModel.Intent.SetPollMultiple ->
                 screenModelScope.launch {
-                    updateState { it.copy(poll = it.poll?.copy(multiple = intent.multiple)) }
+                    updateState {
+                        it.copy(
+                            poll = it.poll?.copy(multiple = intent.multiple),
+                            hasUnsavedChanges = true,
+                        )
+                    }
                 }
 
             is ComposerMviModel.Intent.SetPollExpirationDate ->
                 screenModelScope.launch {
-                    updateState { it.copy(poll = it.poll?.copy(expiresAt = intent.date)) }
+                    updateState {
+                        it.copy(
+                            poll = it.poll?.copy(expiresAt = intent.date),
+                            hasUnsavedChanges = true,
+                        )
+                    }
                 }
 
             is ComposerMviModel.Intent.AddPollOption ->
@@ -328,6 +368,7 @@ class ComposerViewModel(
                                             },
                                     )
                                 },
+                            hasUnsavedChanges = true,
                         )
                     }
                 }
@@ -342,6 +383,7 @@ class ComposerViewModel(
                                         options = p.options.filterIndexed { idx, _ -> idx != intent.index },
                                     )
                                 },
+                            hasUnsavedChanges = true,
                         )
                     }
                 }
@@ -363,13 +405,19 @@ class ComposerViewModel(
                                             },
                                     )
                                 },
+                            hasUnsavedChanges = true,
                         )
                     }
                 }
 
             ComposerMviModel.Intent.RemovePoll ->
                 screenModelScope.launch {
-                    updateState { it.copy(poll = null) }
+                    updateState {
+                        it.copy(
+                            poll = null,
+                            hasUnsavedChanges = true,
+                        )
+                    }
                 }
 
             is ComposerMviModel.Intent.InsertCustomEmoji ->
@@ -420,7 +468,7 @@ class ComposerViewModel(
                         },
                     offsetAfter = before.length,
                 )
-            updateState { it.copy(bodyValue = newValue) }
+            updateState { it.copy(bodyValue = newValue, hasUnsavedChanges = true) }
         }
     }
 
@@ -444,7 +492,7 @@ class ComposerViewModel(
                     additionalPart = additionalPart,
                     offsetAfter = additionalPart.length,
                 )
-            updateState { it.copy(bodyValue = newValue) }
+            updateState { it.copy(bodyValue = newValue, hasUnsavedChanges = true) }
         }
     }
 
@@ -461,7 +509,7 @@ class ComposerViewModel(
                     additionalPart = additionalPart,
                     offsetAfter = additionalPart.length,
                 )
-            updateState { it.copy(bodyValue = newValue) }
+            updateState { it.copy(bodyValue = newValue, hasUnsavedChanges = true) }
         }
     }
 
@@ -504,9 +552,23 @@ class ComposerViewModel(
                 )
             updateState {
                 when (fieldType) {
-                    ComposerFieldType.Body -> it.copy(bodyValue = newValue)
-                    ComposerFieldType.Spoiler -> it.copy(spoilerValue = newValue)
-                    ComposerFieldType.Title -> it.copy(titleValue = newValue)
+                    ComposerFieldType.Body ->
+                        it.copy(
+                            bodyValue = newValue,
+                            hasUnsavedChanges = true,
+                        )
+
+                    ComposerFieldType.Spoiler ->
+                        it.copy(
+                            spoilerValue = newValue,
+                            hasUnsavedChanges = true,
+                        )
+
+                    ComposerFieldType.Title ->
+                        it.copy(
+                            titleValue = newValue,
+                            hasUnsavedChanges = true,
+                        )
                 }
             }
         }
@@ -551,9 +613,23 @@ class ComposerViewModel(
                 )
             updateState {
                 when (fieldType) {
-                    ComposerFieldType.Body -> it.copy(bodyValue = newValue)
-                    ComposerFieldType.Spoiler -> it.copy(spoilerValue = newValue)
-                    ComposerFieldType.Title -> it.copy(titleValue = newValue)
+                    ComposerFieldType.Body ->
+                        it.copy(
+                            bodyValue = newValue,
+                            hasUnsavedChanges = true,
+                        )
+
+                    ComposerFieldType.Spoiler ->
+                        it.copy(
+                            spoilerValue = newValue,
+                            hasUnsavedChanges = true,
+                        )
+
+                    ComposerFieldType.Title ->
+                        it.copy(
+                            titleValue = newValue,
+                        hasUnsavedChanges = true
+                    )
                 }
             }
         }
@@ -598,9 +674,22 @@ class ComposerViewModel(
                 )
             updateState {
                 when (fieldType) {
-                    ComposerFieldType.Body -> it.copy(bodyValue = newValue)
-                    ComposerFieldType.Spoiler -> it.copy(spoilerValue = newValue)
-                    ComposerFieldType.Title -> it.copy(titleValue = newValue)
+                    ComposerFieldType.Body ->
+                        it.copy(
+                            bodyValue = newValue,
+                            hasUnsavedChanges = true,
+                        )
+
+                    ComposerFieldType.Spoiler ->
+                        it.copy(
+                            spoilerValue = newValue,
+                            hasUnsavedChanges = true,
+                        )
+
+                    ComposerFieldType.Title -> it.copy(
+                        titleValue = newValue,
+                        hasUnsavedChanges = true
+                    )
                 }
             }
         }
@@ -645,9 +734,22 @@ class ComposerViewModel(
                 )
             updateState {
                 when (fieldType) {
-                    ComposerFieldType.Body -> it.copy(bodyValue = newValue)
-                    ComposerFieldType.Spoiler -> it.copy(spoilerValue = newValue)
-                    ComposerFieldType.Title -> it.copy(titleValue = newValue)
+                    ComposerFieldType.Body ->
+                        it.copy(
+                            bodyValue = newValue,
+                            hasUnsavedChanges = true,
+                        )
+
+                    ComposerFieldType.Spoiler ->
+                        it.copy(
+                            spoilerValue = newValue,
+                            hasUnsavedChanges = true
+                    )
+
+                    ComposerFieldType.Title -> it.copy(
+                        titleValue = newValue,
+                        hasUnsavedChanges = true
+                    )
                 }
             }
         }
@@ -692,9 +794,22 @@ class ComposerViewModel(
                 )
             updateState {
                 when (fieldType) {
-                    ComposerFieldType.Body -> it.copy(bodyValue = newValue)
-                    ComposerFieldType.Spoiler -> it.copy(spoilerValue = newValue)
-                    ComposerFieldType.Title -> it.copy(titleValue = newValue)
+                    ComposerFieldType.Body ->
+                        it.copy(
+                            bodyValue = newValue,
+                            hasUnsavedChanges = true,
+                        )
+
+                    ComposerFieldType.Spoiler ->
+                        it.copy(
+                            spoilerValue = newValue,
+                        hasUnsavedChanges = true
+                    )
+
+                    ComposerFieldType.Title -> it.copy(
+                        titleValue = newValue,
+                        hasUnsavedChanges = true
+                    )
                 }
             }
         }
@@ -730,9 +845,21 @@ class ComposerViewModel(
                 )
             updateState {
                 when (fieldType) {
-                    ComposerFieldType.Body -> it.copy(bodyValue = newValue)
-                    ComposerFieldType.Spoiler -> it.copy(spoilerValue = newValue)
-                    ComposerFieldType.Title -> it.copy(titleValue = newValue)
+                    ComposerFieldType.Body ->
+                        it.copy(
+                            bodyValue = newValue,
+                            hasUnsavedChanges = true,
+                        )
+
+                    ComposerFieldType.Spoiler -> it.copy(
+                        spoilerValue = newValue,
+                        hasUnsavedChanges = true
+                    )
+
+                    ComposerFieldType.Title -> it.copy(
+                        titleValue = newValue,
+                        hasUnsavedChanges = true
+                    )
                 }
             }
         }
@@ -761,6 +888,7 @@ class ComposerViewModel(
                 updateState {
                     it.copy(
                         attachments = it.attachments.filter { a -> a.id != PLACEHOLDER_ID } + attachment,
+                        hasUnsavedChanges = true
                     )
                 }
             } else {
@@ -783,13 +911,17 @@ class ComposerViewModel(
                             attachment
                         }
                     },
+                hasUnsavedChanges = true
             )
         }
     }
 
     private suspend fun removeAttachmentFromState(attachmentId: String) {
         updateState {
-            it.copy(attachments = it.attachments.filter { attachment -> attachment.id != attachmentId })
+            it.copy(
+                attachments = it.attachments.filter { attachment -> attachment.id != attachmentId },
+                hasUnsavedChanges = true
+            )
         }
     }
 

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -132,6 +133,18 @@ class EditProfileScreen : Screen {
                             )
                     }
                 }.launchIn(this)
+        }
+        DisposableEffect(key) {
+            navigationCoordinator.setCanGoBackCallback {
+                if (uiState.hasUnsavedChanges) {
+                    confirmBackWithUnsavedChangesDialog = true
+                    return@setCanGoBackCallback false
+                }
+                true
+            }
+            onDispose {
+                navigationCoordinator.setCanGoBackCallback(null)
+            }
         }
 
         Scaffold(


### PR DESCRIPTION
This PR introduces confirmation before exit with unsaved changes in post composer/editor.

Moreover, it fixes a bug due to which the system back (gesture or navigation) was not considered when exiting the profile editor.