### PR TITLE
chore: add build action

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,28 @@
+name: build
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 8.8
+
+      - name: Build
+        run: ./gradlew build

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -24,5 +24,11 @@ jobs:
         with:
           gradle-version: 8.8
 
+      - name: Create Sentry config file
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        run: |
+          echo 'sentry_dsn=$SENTRY_DSN\n' > core/utils/build.properties
+
       - name: Build
         run: ./gradlew build

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
   <img src="https://img.shields.io/badge/Android-26+-34A853?logo=android" />
   <img src="https://img.shields.io/badge/Compose-1.6.7-4285F4?logo=jetpackcompose" />
   <img src="https://img.shields.io/github/license/LiveFastEatTrashRaccoon/RaccoonForFriendica" />
+  <img src="https://github.com/LiveFastEatTrashRaccoon/RaccoonForFriendica/actions/workflows/android.yml/badge.svg" />
 </div>
 
 # RaccoonForFriendica

--- a/core/persistence/build.gradle.kts
+++ b/core/persistence/build.gradle.kts
@@ -1,4 +1,6 @@
+import com.google.devtools.ksp.gradle.KspTaskMetadata
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
@@ -63,9 +65,17 @@ room {
 }
 
 dependencies {
-    add("kspCommonMainMetadata", libs.room.ksp)
+    add("kspCommonMainMetadata", libs.ktorfit.ksp)
     add("kspAndroid", libs.room.ksp)
     add("kspIosX64", libs.room.ksp)
     add("kspIosArm64", libs.room.ksp)
     add("kspIosSimulatorArm64", libs.room.ksp)
+}
+
+kotlin.sourceSets.commonMain {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType<KotlinCompile> {
+    dependsOn(tasks.withType<KspTaskMetadata>())
 }

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/AppDatabase.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/AppDatabase.kt
@@ -1,6 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.core.persistence
 
 import androidx.room.AutoMigration
+import androidx.room.ConstructedBy
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.dao.AccountDao
@@ -27,6 +28,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.persistence.entities.Setti
 
     ],
 )
+@ConstructedBy(AppDatabaseConstructor::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun getAccountDao(): AccountDao
 

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/AppDatabaseConstructor.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/AppDatabaseConstructor.kt
@@ -1,0 +1,7 @@
+package com.livefast.eattrash.raccoonforfriendica.core.persistence
+
+import androidx.room.RoomDatabaseConstructor
+
+expect object AppDatabaseConstructor : RoomDatabaseConstructor<AppDatabase> {
+    override fun initialize(): AppDatabase
+}

--- a/core/utils/build.gradle.kts
+++ b/core/utils/build.gradle.kts
@@ -85,7 +85,7 @@ android {
 
     buildTypes {
         all {
-            val props = loadProperties("./build.properties")
+            val props = loadProperties("build.properties")
             resValue("string", "sentry_dsn", props.getProperty("sentry_dsn"))
         }
     }


### PR DESCRIPTION
Add basic CI configuration for builds.

This will be needed to make it easier to see at a glance whether dependabot's PRs are passing or not.