### PR TITLE
enhancement: insert all mentions in reply

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
@@ -141,7 +141,7 @@ class DefaultDetailOpener(
     }
 
     override fun openComposer(
-        inReplyToId: String?,
+        inReplyTo: TimelineEntryModel?,
         inReplyToUser: UserModel?,
         editedPostId: String?,
         urlToShare: String?,
@@ -150,13 +150,16 @@ class DefaultDetailOpener(
         if (!isLogged) {
             return
         }
+        if (inReplyTo != null) {
+            entryCache.put(inReplyTo.id, inReplyTo)
+        }
         if (inReplyToUser != null) {
             userCache.put(inReplyToUser.id, inReplyToUser)
         }
         val isGroup = inReplyToUser?.group == true && inGroup
         val screen =
             ComposerScreen(
-                inReplyToId = inReplyToId,
+                inReplyToId = inReplyTo?.id,
                 inReplyToUsername = inReplyToUser?.username.takeIf { !isGroup },
                 inReplyToHandle = inReplyToUser?.handle.takeIf { !isGroup },
                 groupUsername = inReplyToUser?.username.takeIf { isGroup },

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DetailOpener.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DetailOpener.kt
@@ -36,7 +36,7 @@ interface DetailOpener {
     )
 
     fun openComposer(
-        inReplyToId: String? = null,
+        inReplyTo: TimelineEntryModel? = null,
         inReplyToUser: UserModel? = null,
         editedPostId: String? = null,
         urlToShare: String? = null,

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/TimelineEntryModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/TimelineEntryModel.kt
@@ -24,6 +24,7 @@ data class TimelineEntryModel(
     @Transient val isSpoilerActive: Boolean = false,
     val lang: String? = null,
     @Transient val loadMoreButtonVisible: Boolean = false,
+    val mentions: List<UserModel> = emptyList(),
     val parentId: String? = null,
     val pinned: Boolean = false,
     val poll: PollModel? = null,

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
@@ -28,6 +28,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Relationship
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.ScheduledStatus
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Status
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.StatusContext
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.StatusMention
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.StatusSource
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Tag
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.TrendsLink
@@ -83,6 +84,7 @@ internal fun Status.toModel() =
         favoriteCount = favoritesCount,
         id = id,
         lang = lang,
+        mentions = mentions.map { it.toModel() },
         parentId = inReplyToId,
         pinned = pinned,
         poll = poll?.toModel(),
@@ -99,6 +101,14 @@ internal fun Status.toModel() =
         updated = editedAt,
         url = url,
         visibility = visibility.toVisibility(),
+    )
+
+private fun StatusMention.toModel() =
+    UserModel(
+        id = id,
+        username = username,
+        handle = acct,
+        url = url,
     )
 
 internal fun StatusSource.toModel() =

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
@@ -106,6 +106,10 @@ interface ComposerMviModel :
             val handle: String,
         ) : Intent
 
+        data class AddInitialMentions(
+            val initialHandle: String?,
+        ) : Intent
+
         data class AddGroupReference(
             val handle: String,
         ) : Intent

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
@@ -154,20 +154,26 @@ class ComposerScreen(
             when {
                 draftId != null ->
                     model.reduce(ComposerMviModel.Intent.LoadDraft(draftId))
+
                 scheduledPostId != null ->
                     model.reduce(ComposerMviModel.Intent.LoadScheduled(scheduledPostId))
 
                 editedPostId != null ->
                     model.reduce(ComposerMviModel.Intent.LoadEditedPost(editedPostId))
 
-                !inReplyToHandle.isNullOrEmpty() ->
-                    model.reduce(ComposerMviModel.Intent.AddMention(inReplyToHandle))
-
                 !groupHandle.isNullOrEmpty() ->
                     model.reduce(ComposerMviModel.Intent.AddGroupReference(groupHandle))
 
                 !urlToShare.isNullOrEmpty() ->
                     model.reduce(ComposerMviModel.Intent.AddShareUrl(urlToShare))
+
+                inReplyToId != null ->
+                    model.reduce(
+                        ComposerMviModel.Intent.AddInitialMentions(initialHandle = inReplyToHandle),
+                    )
+
+                !inReplyToHandle.isNullOrEmpty() ->
+                    model.reduce(ComposerMviModel.Intent.AddMention(inReplyToHandle))
 
                 else -> Unit
             }

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
@@ -248,6 +248,28 @@ class ComposerViewModel(
 
             is ComposerMviModel.Intent.AddMention -> addMention(handle = intent.handle)
 
+            is ComposerMviModel.Intent.AddInitialMentions -> {
+                val mentions =
+                    buildList {
+                        val initialValue = intent.initialHandle.orEmpty()
+                        if (initialValue.isNotEmpty()) {
+                            this += initialValue
+                        }
+                        val mentions =
+                            inReplyToId
+                                ?.let { entryCache.get(it) }
+                                ?.mentions
+                                .orEmpty()
+                                .mapNotNull { it.handle }
+                                .filterNot { it == initialValue }
+                        addAll(mentions)
+                    }
+
+                for (mention in mentions) {
+                    addMention(handle = mention)
+                }
+            }
+
             is ComposerMviModel.Intent.AddGroupReference ->
                 addMention(
                     handle = intent.handle,
@@ -485,6 +507,7 @@ class ComposerViewModel(
                         append("@")
                     }
                     append(handle)
+                    append(" ")
                 }
             val newValue =
                 getNewTextFieldValue(

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -189,7 +189,7 @@ class EntryDetailScreen(
                                 val entry = uiState.entries.firstOrNull { it.id == id }
                                 if (entry != null) {
                                     detailOpener.openComposer(
-                                        inReplyToId = id,
+                                        inReplyTo = entry,
                                         inReplyToUser = entry.creator,
                                     )
                                 }
@@ -299,7 +299,7 @@ class EntryDetailScreen(
                             onReply =
                                 { e: TimelineEntryModel ->
                                     detailOpener.openComposer(
-                                        inReplyToId = e.id,
+                                        inReplyTo = e,
                                         inReplyToUser = e.creator,
                                     )
                                 }.takeIf { actionRepository.canReply(entry.original) },
@@ -369,7 +369,7 @@ class EntryDetailScreen(
                                     OptionId.Edit -> {
                                         entry.original.also { entryToEdit ->
                                             detailOpener.openComposer(
-                                                inReplyToId = entryToEdit.inReplyTo?.id,
+                                                inReplyTo = entryToEdit.inReplyTo,
                                                 inReplyToUser = entryToEdit.inReplyTo?.creator,
                                                 editedPostId = entryToEdit.id,
                                             )

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
@@ -348,7 +348,7 @@ class ExploreScreen : Screen {
                                     onReply =
                                         { e: TimelineEntryModel ->
                                             detailOpener.openComposer(
-                                                inReplyToId = e.id,
+                                                inReplyTo = e,
                                                 inReplyToUser = e.creator,
                                             )
                                         }.takeIf { actionRepository.canReply(item.entry.original) },
@@ -421,7 +421,7 @@ class ExploreScreen : Screen {
                                             OptionId.Edit -> {
                                                 item.entry.original.also { entryToEdit ->
                                                     detailOpener.openComposer(
-                                                        inReplyToId = entryToEdit.inReplyTo?.id,
+                                                        inReplyTo = entryToEdit.inReplyTo,
                                                         inReplyToUser = entryToEdit.inReplyTo?.creator,
                                                         editedPostId = entryToEdit.id,
                                                     )

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
@@ -254,7 +254,7 @@ class FavoritesScreen(
                             onReply =
                                 { e: TimelineEntryModel ->
                                     detailOpener.openComposer(
-                                        inReplyToId = e.id,
+                                        inReplyTo = e,
                                         inReplyToUser = e.creator,
                                     )
                                 }.takeIf { actionRepository.canReply(entry.original) },
@@ -324,7 +324,7 @@ class FavoritesScreen(
                                     OptionId.Edit -> {
                                         entry.original.also { entryToEdit ->
                                             detailOpener.openComposer(
-                                                inReplyToId = entryToEdit.inReplyTo?.id,
+                                                inReplyTo = entryToEdit.inReplyTo,
                                                 inReplyToUser = entryToEdit.inReplyTo?.creator,
                                                 editedPostId = entryToEdit.id,
                                             )

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
@@ -274,7 +274,7 @@ class HashtagScreen(
                             onReply =
                                 { e: TimelineEntryModel ->
                                     detailOpener.openComposer(
-                                        inReplyToId = e.id,
+                                        inReplyTo = e,
                                         inReplyToUser = e.creator,
                                     )
                                 }.takeIf { actionRepository.canReply(entry.original) },
@@ -344,7 +344,7 @@ class HashtagScreen(
                                     OptionId.Edit -> {
                                         entry.original.also { entryToEdit ->
                                             detailOpener.openComposer(
-                                                inReplyToId = entryToEdit.inReplyTo?.id,
+                                                inReplyTo = entryToEdit.inReplyTo,
                                                 inReplyToUser = entryToEdit.inReplyTo?.creator,
                                                 editedPostId = entryToEdit.id,
                                             )

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
@@ -297,6 +297,13 @@ class MyAccountScreen : Screen {
                             { e: TimelineEntryModel ->
                                 model.reduce(MyAccountMviModel.Intent.ToggleFavorite(e))
                             }.takeIf { actionRepository.canReact(entry.original) },
+                        onReply =
+                            { e: TimelineEntryModel ->
+                                detailOpener.openComposer(
+                                    inReplyTo = e,
+                                    inReplyToUser = e.creator,
+                                )
+                            }.takeIf { actionRepository.canReply(entry.original) },
                         onToggleSpoilerActive = { e ->
                             model.reduce(MyAccountMviModel.Intent.ToggleSpoilerActive(e))
                         },
@@ -330,14 +337,14 @@ class MyAccountScreen : Screen {
                                     if (entry.creator?.group == true) {
                                         // edit the original post reblogged by the group
                                         detailOpener.openComposer(
-                                            inReplyToId = entry.inReplyTo?.id,
+                                            inReplyTo = entry.inReplyTo,
                                             inReplyToUser = entry.creator,
                                             editedPostId = entry.reblog?.id,
                                             inGroup = true,
                                         )
                                     } else {
                                         detailOpener.openComposer(
-                                            inReplyToId = entry.inReplyTo?.id,
+                                            inReplyTo = entry.inReplyTo,
                                             inReplyToUser = entry.inReplyTo?.creator,
                                             editedPostId = entry.id,
                                         )

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
@@ -349,7 +349,7 @@ class SearchScreen : Screen {
                                     onReply =
                                         { e: TimelineEntryModel ->
                                             detailOpener.openComposer(
-                                                inReplyToId = e.id,
+                                                inReplyTo = e,
                                                 inReplyToUser = e.creator,
                                             )
                                         }.takeIf { actionRepository.canReply(item.entry.original) },
@@ -423,7 +423,7 @@ class SearchScreen : Screen {
                                                         ?: item.entry
                                                 ).also { entryToEdit ->
                                                     detailOpener.openComposer(
-                                                        inReplyToId = entryToEdit.inReplyTo?.id,
+                                                        inReplyTo = entryToEdit.inReplyTo,
                                                         inReplyToUser = entryToEdit.inReplyTo?.creator,
                                                         editedPostId = entryToEdit.id,
                                                     )

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
@@ -179,7 +179,7 @@ class ThreadScreen(
                                 val entry = uiState.entry
                                 if (entry != null) {
                                     detailOpener.openComposer(
-                                        inReplyToId = entry.id,
+                                        inReplyTo = entry,
                                         inReplyToUser = entry.creator,
                                     )
                                 }
@@ -300,7 +300,7 @@ class ThreadScreen(
                                     uiState.currentUserId?.let {
                                         { e ->
                                             detailOpener.openComposer(
-                                                inReplyToId = e.id,
+                                                inReplyTo = e,
                                                 inReplyToUser = e.creator,
                                             )
                                         }
@@ -421,7 +421,7 @@ class ThreadScreen(
                             onReply =
                                 { e: TimelineEntryModel ->
                                     detailOpener.openComposer(
-                                        inReplyToId = e.id,
+                                        inReplyTo = e,
                                         inReplyToUser = e.creator,
                                     )
                                 }.takeIf { actionRepository.canReply(entry.original) },

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
@@ -323,7 +323,7 @@ class TimelineScreen : Screen {
                             onReply =
                                 { e: TimelineEntryModel ->
                                     detailOpener.openComposer(
-                                        inReplyToId = e.id,
+                                        inReplyTo = e,
                                         inReplyToUser = e.creator,
                                     )
                                 }.takeIf { actionRepository.canReply(entry.original) },
@@ -393,7 +393,7 @@ class TimelineScreen : Screen {
                                     OptionId.Edit -> {
                                         entry.original.also { entryToEdit ->
                                             detailOpener.openComposer(
-                                                inReplyToId = entryToEdit.inReplyTo?.id,
+                                                inReplyTo = entryToEdit.inReplyTo,
                                                 inReplyToUser = entryToEdit.inReplyTo?.creator,
                                                 editedPostId = entryToEdit.id,
                                             )

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -598,7 +598,7 @@ class UserDetailScreen(
                             onReply =
                                 { e: TimelineEntryModel ->
                                     detailOpener.openComposer(
-                                        inReplyToId = e.id,
+                                        inReplyTo = e,
                                         inReplyToUser = e.creator,
                                     )
                                 }.takeIf { actionRepository.canReply(entry.original) },

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
@@ -297,7 +297,7 @@ class ForumListScreen(
                             onReply =
                                 { e: TimelineEntryModel ->
                                     detailOpener.openComposer(
-                                        inReplyToId = e.id,
+                                        inReplyTo = e,
                                         inReplyToUser = e.creator,
                                     )
                                 }.takeIf { actionRepository.canReply(entry.original) },


### PR DESCRIPTION
This PR fixes a "bug" (or, rather, a misinterpretation of the _fediquette_ of mine) due to which only the original poster was mentioned in each reply instead of mentioning all the involved users.

This will make the app comply with the "lore of the Fediverse", according to which all participants of a conversation should be mentioned in each reply in order to receive a notification.