### PR TITLE
enhancement: suggestions for user mentions in bottom bar

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SpoilerTextField.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SpoilerTextField.kt
@@ -4,10 +4,12 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.surfaceColorAtElevation
@@ -32,23 +34,20 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillary
 @Composable
 fun SpoilerTextField(
     hint: String? = null,
-    hintTextStyle: TextStyle = MaterialTheme.typography.bodyMedium,
+    hintTextStyle: TextStyle = LocalTextStyle.current,
     value: TextFieldValue,
-    textStyle: TextStyle = MaterialTheme.typography.bodyMedium,
+    textStyle: TextStyle = LocalTextStyle.current,
     backgroundColor: Color = MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp),
     onValueChange: (TextFieldValue) -> Unit,
     modifier: Modifier = Modifier,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
 ) {
-    var height by remember { mutableStateOf(0f) }
-    val heightDp = with(LocalDensity.current) { height.toDp() }
+    var contentHeightPx by remember { mutableStateOf(0f) }
+    val contentHeightDp = with(LocalDensity.current) { contentHeightPx.toDp() }
 
     BasicTextField(
-        modifier =
-            modifier.onGloballyPositioned {
-                height = it.size.toSize().height
-            },
+        modifier = modifier,
         value = value,
         onValueChange = onValueChange,
         keyboardOptions = keyboardOptions,
@@ -64,10 +63,15 @@ fun SpoilerTextField(
                     horizontalArrangement = Arrangement.spacedBy(Spacing.s),
                 ) {
                     SpoilerBar(
-                        modifier = Modifier.size(width = 6.dp, height = heightDp),
+                        modifier = Modifier.size(width = 6.dp, height = contentHeightDp),
                     )
                     Box(
-                        modifier = Modifier.weight(1f),
+                        modifier =
+                            Modifier
+                                .weight(1f)
+                                .onGloballyPositioned {
+                                    contentHeightPx = it.size.toSize().height
+                                }.padding(Spacing.s),
                         contentAlignment = Alignment.CenterStart,
                     ) {
                         innerTextField()
@@ -84,7 +88,7 @@ fun SpoilerTextField(
                         }
                     }
                     SpoilerBar(
-                        modifier = Modifier.size(width = 6.dp, height = heightDp),
+                        modifier = Modifier.size(width = 6.dp, height = contentHeightDp),
                     )
                 }
             },

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
@@ -365,9 +365,8 @@ internal val DeStrings =
         override val actionQuote = "Zitieren"
         override val actionAddTitle = "Titel hinzufügen"
         override val actionRemoveTitle = "Titel entfernen"
-        override val actionAddSpoiler = "Spoiler hinzufügen"
-        override val actionRemoveSpoiler = "Spoiler entfernen"
         override val actionRevealContent = "Inhalt enthüllen"
         override val settingsItemExcludeRepliesFromTimeline = "Antworten aus der Zeitleiste ausschließen"
         override val insertEmojiTitle = "Emoji einfügen"
+        override val messageLoadingUsers = "Benutzer laden"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -356,9 +356,8 @@ internal open class DefaultStrings : Strings {
     override val actionQuote = "Quote"
     override val actionAddTitle = "Add title"
     override val actionRemoveTitle = "Remove title"
-    override val actionAddSpoiler = "Add spoiler"
-    override val actionRemoveSpoiler = "Remove spoiler"
     override val actionRevealContent = "Reveal content"
     override val settingsItemExcludeRepliesFromTimeline = "Exclude replies from timeline"
     override val insertEmojiTitle = "Insert emoji"
+    override val messageLoadingUsers = "Loading users"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -365,9 +365,8 @@ internal val ItStrings =
         override val actionQuote = "Cita"
         override val actionAddTitle = "Aggiungi titolo"
         override val actionRemoveTitle = "Rimuovi titolo"
-        override val actionAddSpoiler = "Aggiungi spoiler"
-        override val actionRemoveSpoiler = "Rimuovi spoiler"
         override val actionRevealContent = "Rivela contenuto"
         override val settingsItemExcludeRepliesFromTimeline = "Escludi risposte dalla timeline"
         override val insertEmojiTitle = "Inserisci emoji"
+        override val messageLoadingUsers = "Caricamento utenti"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -320,11 +320,10 @@ interface Strings {
     val actionQuote: String
     val actionAddTitle: String
     val actionRemoveTitle: String
-    val actionAddSpoiler: String
-    val actionRemoveSpoiler: String
     val actionRevealContent: String
     val settingsItemExcludeRepliesFromTimeline: String
     val insertEmojiTitle: String
+    val messageLoadingUsers: String
 }
 
 object Locales {

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/compose/AnimatedDots.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/compose/AnimatedDots.kt
@@ -11,7 +11,10 @@ import kotlinx.coroutines.yield
 import kotlin.math.roundToLong
 
 @Composable
-fun getAnimatedDots(durationMillis: Long = 2500): String {
+fun getAnimatedDots(
+    char: String = ".",
+    durationMillis: Long = 2500,
+): String {
     val maxStep = 4
     val interval = (durationMillis / maxStep.toFloat()).roundToLong()
     var step by remember { mutableStateOf(0) }
@@ -22,5 +25,5 @@ fun getAnimatedDots(durationMillis: Long = 2500): String {
             yield()
         }
     }
-    return ".".repeat(step)
+    return char.repeat(step)
 }

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
@@ -106,6 +106,10 @@ interface ComposerMviModel :
             val handle: String,
         ) : Intent
 
+        data class CompleteMention(
+            val handle: String,
+        ) : Intent
+
         data class AddInitialMentions(
             val initialHandle: String?,
         ) : Intent
@@ -214,6 +218,9 @@ interface ComposerMviModel :
         val publicationType: PublicationType = PublicationType.Default,
         val availableEmojis: List<EmojiModel> = emptyList(),
         val hasUnsavedChanges: Boolean = false,
+        val shouldShowMentionSuggestions: Boolean = false,
+        val mentionSuggestionsLoading: Boolean = false,
+        val mentionSuggestions: List<UserModel> = emptyList(),
     )
 
     sealed interface Effect {

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
@@ -3,7 +3,6 @@ package com.livefast.eattrash.raccoonforfriendica.feature.composer
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -78,7 +77,6 @@ import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.utils.compose.safeImePadding
 import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.epochMillis
-import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.getFormattedDate
 import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.toEpochMillis
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getGalleryHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.AttachmentModel
@@ -86,6 +84,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.Visibility
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.components.AttachmentsGrid
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.components.CreateInGroupInfo
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.components.CreatePostHeader
+import com.livefast.eattrash.raccoonforfriendica.feature.composer.components.CreatePostSubHeader
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.components.DateTimeSelectionFlow
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.components.GalleryPickerDialog
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.components.InReplyToInfo
@@ -149,6 +148,11 @@ class ComposerScreen(
         var pollExpirationDatePickerOpen by remember { mutableStateOf(false) }
         var insertEmojiModalOpen by remember { mutableStateOf(false) }
         var confirmBackWithUnsavedChangesDialog by remember { mutableStateOf(false) }
+        val scheduleDate =
+            when (val type = uiState.publicationType) {
+                is PublicationType.Scheduled -> type.date
+                else -> null
+            }
 
         LaunchedEffect(model) {
             when {
@@ -573,48 +577,12 @@ class ComposerScreen(
                         },
                     )
 
-                    // schedule date and character count
-                    if (uiState.characterLimit != null) {
-                        Row(
-                            modifier =
-                                Modifier.padding(
-                                    top = Spacing.s,
-                                    start = Spacing.s,
-                                    end = Spacing.s,
-                                ),
-                        ) {
-                            val date =
-                                when (val type = uiState.publicationType) {
-                                    is PublicationType.Scheduled -> type.date
-                                    else -> null
-                                }
-                            if (date != null) {
-                                Text(
-                                    text =
-                                        buildString {
-                                            append(LocalStrings.current.scheduleDateIndication)
-                                            append(" ")
-                                            append(
-                                                getFormattedDate(
-                                                    iso8601Timestamp = date,
-                                                    format = "dd/MM/yy HH:mm",
-                                                ),
-                                            )
-                                        },
-                                    style = MaterialTheme.typography.labelSmall,
-                                )
-                            }
-                            Spacer(modifier = Modifier.weight(1f))
-                            Text(
-                                text =
-                                    buildString {
-                                        append(uiState.bodyValue.text.length)
-                                        append("/")
-                                        append(uiState.characterLimit)
-                                    },
-                                style = MaterialTheme.typography.labelSmall,
-                            )
-                        }
+                    if (uiState.characterLimit != null || scheduleDate != null) {
+                        CreatePostSubHeader(
+                            date = scheduleDate,
+                            characters = uiState.bodyValue.text.length,
+                            characterLimit = uiState.characterLimit,
+                        )
                     }
 
                     // spoiler text

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
@@ -69,7 +69,6 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.Progre
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.InsertEmojiBottomSheet
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
-import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.SelectUserDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.SettingsSwitchRow
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.SpoilerTextField
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toOption
@@ -89,6 +88,7 @@ import com.livefast.eattrash.raccoonforfriendica.feature.composer.components.Dat
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.components.GalleryPickerDialog
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.components.InReplyToInfo
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.components.InsertLinkDialog
+import com.livefast.eattrash.raccoonforfriendica.feature.composer.components.MentionsBar
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.components.PollForm
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.components.SelectCircleDialog
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.components.UtilsBar
@@ -136,7 +136,6 @@ class ComposerScreen(
         }
         var photoGalleryPickerOpen by remember { mutableStateOf(false) }
         var linkDialogOpen by remember { mutableStateOf(false) }
-        var mentionDialogOpen by remember { mutableStateOf(false) }
         var selectCircleDialogOpen by remember { mutableStateOf(false) }
         var attachmentWithDescriptionBeingEdited by remember { mutableStateOf<AttachmentModel?>(null) }
         var hasSpoilerFieldFocus by remember { mutableStateOf(false) }
@@ -279,16 +278,6 @@ class ComposerScreen(
                                     }
                                 }
 
-                                this +=
-                                    CustomOptions.ToggleSpoiler.toOption(
-                                        label =
-                                            if (uiState.hasSpoiler) {
-                                                LocalStrings.current.actionRemoveSpoiler
-                                            } else {
-                                                LocalStrings.current.actionAddSpoiler
-                                            },
-                                    )
-
                                 if (uiState.availableEmojis.isNotEmpty()) {
                                     this +=
                                         CustomOptions.InsertCustomEmoji.toOption(
@@ -413,10 +402,6 @@ class ComposerScreen(
                                                     model.reduce(ComposerMviModel.Intent.ToggleHasTitle)
                                                 }
 
-                                                CustomOptions.ToggleSpoiler -> {
-                                                    model.reduce(ComposerMviModel.Intent.ToggleHasSpoiler)
-                                                }
-
                                                 CustomOptions.InsertCustomEmoji -> {
                                                     insertEmojiModalOpen = true
                                                 }
@@ -459,83 +444,101 @@ class ComposerScreen(
                 }
             },
             bottomBar = {
-                UtilsBar(
+                Column(
                     modifier =
-                        Modifier.fillMaxWidth(),
-                    onAttachmentClicked = {
-                        val limit = uiState.attachmentLimit ?: Int.MAX_VALUE
-                        if (uiState.attachments.size < limit) {
-                            openImagePicker = true
-                        }
-                    },
-                    hasPoll = uiState.poll != null,
-                    onLinkClicked = {
-                        linkDialogOpen = true
-                    },
-                    onMentionClicked = {
-                        mentionDialogOpen = true
-                    },
-                    onBoldClicked = {
-                        model.reduce(
-                            ComposerMviModel.Intent.AddBoldFormat(
-                                fieldType =
-                                    when {
-                                        hasTitleFocus -> ComposerFieldType.Title
-                                        hasSpoilerFieldFocus -> ComposerFieldType.Spoiler
-                                        else -> ComposerFieldType.Body
-                                    },
-                            ),
+                        Modifier
+                            .background(MaterialTheme.colorScheme.surfaceVariant)
+                            .padding(vertical = Spacing.xs),
+                ) {
+                    if (uiState.shouldShowMentionSuggestions) {
+                        MentionsBar(
+                            suggestions = uiState.mentionSuggestions,
+                            loading = uiState.mentionSuggestionsLoading,
+                            onSelected = { user ->
+                                user.handle?.also { handle ->
+                                    model.reduce(ComposerMviModel.Intent.CompleteMention(handle))
+                                }
+                            },
                         )
-                    },
-                    onItalicClicked = {
-                        model.reduce(
-                            ComposerMviModel.Intent.AddItalicFormat(
-                                fieldType =
-                                    when {
-                                        hasTitleFocus -> ComposerFieldType.Title
-                                        hasSpoilerFieldFocus -> ComposerFieldType.Spoiler
-                                        else -> ComposerFieldType.Body
-                                    },
-                            ),
-                        )
-                    },
-                    onUnderlineClicked = {
-                        model.reduce(
-                            ComposerMviModel.Intent.AddUnderlineFormat(
-                                fieldType =
-                                    when {
-                                        hasTitleFocus -> ComposerFieldType.Title
-                                        hasSpoilerFieldFocus -> ComposerFieldType.Spoiler
-                                        else -> ComposerFieldType.Body
-                                    },
-                            ),
-                        )
-                    },
-                    onStrikethroughClicked = {
-                        model.reduce(
-                            ComposerMviModel.Intent.AddStrikethroughFormat(
-                                fieldType =
-                                    when {
-                                        hasTitleFocus -> ComposerFieldType.Title
-                                        hasSpoilerFieldFocus -> ComposerFieldType.Spoiler
-                                        else -> ComposerFieldType.Body
-                                    },
-                            ),
-                        )
-                    },
-                    onCodeClicked = {
-                        model.reduce(
-                            ComposerMviModel.Intent.AddCodeFormat(
-                                fieldType =
-                                    when {
-                                        hasTitleFocus -> ComposerFieldType.Title
-                                        hasSpoilerFieldFocus -> ComposerFieldType.Spoiler
-                                        else -> ComposerFieldType.Body
-                                    },
-                            ),
-                        )
-                    },
-                )
+                    }
+                    UtilsBar(
+                        modifier = Modifier.fillMaxWidth(),
+                        onAttachmentClicked = {
+                            val limit = uiState.attachmentLimit ?: Int.MAX_VALUE
+                            if (uiState.attachments.size < limit) {
+                                openImagePicker = true
+                            }
+                        },
+                        hasPoll = uiState.poll != null,
+                        hasSpoiler = uiState.hasSpoiler,
+                        onLinkClicked = {
+                            linkDialogOpen = true
+                        },
+                        onBoldClicked = {
+                            model.reduce(
+                                ComposerMviModel.Intent.AddBoldFormat(
+                                    fieldType =
+                                        when {
+                                            hasTitleFocus -> ComposerFieldType.Title
+                                            hasSpoilerFieldFocus -> ComposerFieldType.Spoiler
+                                            else -> ComposerFieldType.Body
+                                        },
+                                ),
+                            )
+                        },
+                        onItalicClicked = {
+                            model.reduce(
+                                ComposerMviModel.Intent.AddItalicFormat(
+                                    fieldType =
+                                        when {
+                                            hasTitleFocus -> ComposerFieldType.Title
+                                            hasSpoilerFieldFocus -> ComposerFieldType.Spoiler
+                                            else -> ComposerFieldType.Body
+                                        },
+                                ),
+                            )
+                        },
+                        onUnderlineClicked = {
+                            model.reduce(
+                                ComposerMviModel.Intent.AddUnderlineFormat(
+                                    fieldType =
+                                        when {
+                                            hasTitleFocus -> ComposerFieldType.Title
+                                            hasSpoilerFieldFocus -> ComposerFieldType.Spoiler
+                                            else -> ComposerFieldType.Body
+                                        },
+                                ),
+                            )
+                        },
+                        onStrikethroughClicked = {
+                            model.reduce(
+                                ComposerMviModel.Intent.AddStrikethroughFormat(
+                                    fieldType =
+                                        when {
+                                            hasTitleFocus -> ComposerFieldType.Title
+                                            hasSpoilerFieldFocus -> ComposerFieldType.Spoiler
+                                            else -> ComposerFieldType.Body
+                                        },
+                                ),
+                            )
+                        },
+                        onCodeClicked = {
+                            model.reduce(
+                                ComposerMviModel.Intent.AddCodeFormat(
+                                    fieldType =
+                                        when {
+                                            hasTitleFocus -> ComposerFieldType.Title
+                                            hasSpoilerFieldFocus -> ComposerFieldType.Spoiler
+                                            else -> ComposerFieldType.Body
+                                        },
+                                ),
+                            )
+                        },
+                        onSpoilerClicked = {
+                            model.reduce(ComposerMviModel.Intent.ToggleHasSpoiler)
+                        },
+                    )
+                }
             },
             content = { padding ->
                 Column(
@@ -770,30 +773,6 @@ class ComposerScreen(
             )
         }
 
-        if (mentionDialogOpen) {
-            SelectUserDialog(
-                query = uiState.userSearchQuery,
-                users = uiState.userSearchUsers,
-                loading = uiState.userSearchLoading,
-                canFetchMore = uiState.userSearchCanFetchMore,
-                onSearchChanged = {
-                    model.reduce(ComposerMviModel.Intent.UserSearchSetQuery(it))
-                },
-                onLoadMoreUsers = {
-                    model.reduce(ComposerMviModel.Intent.UserSearchLoadNextPage)
-                },
-                onClose = { user ->
-                    model.reduce(ComposerMviModel.Intent.UserSearchSetQuery(""))
-                    model.reduce(ComposerMviModel.Intent.UserSearchClear)
-                    mentionDialogOpen = false
-                    val handle = user?.handle
-                    if (handle != null) {
-                        model.reduce(ComposerMviModel.Intent.AddMention(handle))
-                    }
-                },
-            )
-        }
-
         if (attachmentWithDescriptionBeingEdited != null) {
             EditTextualInfoDialog(
                 label = LocalStrings.current.pictureDescriptionPlaceholder,
@@ -934,8 +913,6 @@ private sealed interface CustomOptions : OptionId.Custom {
     data object TogglePoll : CustomOptions
 
     data object ToggleTitle : CustomOptions
-
-    data object ToggleSpoiler : CustomOptions
 
     data object InsertCustomEmoji : CustomOptions
 }

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/components/CreatePostSubHeader.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/components/CreatePostSubHeader.kt
@@ -1,0 +1,57 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.composer.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
+import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.getFormattedDate
+
+@Composable
+internal fun CreatePostSubHeader(
+    date: String? = null,
+    characters: Int = 0,
+    characterLimit: Int? = null,
+) {
+    Row(
+        modifier =
+            Modifier.padding(
+                top = Spacing.s,
+                start = Spacing.s,
+                end = Spacing.s,
+            ),
+    ) {
+        if (date != null) {
+            Text(
+                text =
+                    buildString {
+                        append(LocalStrings.current.scheduleDateIndication)
+                        append(" ")
+                        append(
+                            getFormattedDate(
+                                iso8601Timestamp = date,
+                                format = "dd/MM/yy HH:mm",
+                            ),
+                        )
+                    },
+                style = MaterialTheme.typography.labelSmall,
+            )
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        if (characterLimit != null) {
+            Text(
+                text =
+                    buildString {
+                        append(characters)
+                        append("/")
+                        append(characterLimit)
+                    },
+                style = MaterialTheme.typography.labelSmall,
+            )
+        }
+    }
+}

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/components/MentionsBar.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/components/MentionsBar.kt
@@ -1,0 +1,72 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.composer.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
+import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
+import com.livefast.eattrash.raccoonforfriendica.core.utils.compose.getAnimatedDots
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+
+@Composable
+internal fun MentionsBar(
+    modifier: Modifier = Modifier,
+    suggestions: List<UserModel> = emptyList(),
+    loading: Boolean = false,
+    onSelected: ((UserModel) -> Unit)? = null,
+) {
+    val fullColor = MaterialTheme.colorScheme.onSurfaceVariant
+    val ancillaryColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(ancillaryTextAlpha)
+    Row(
+        modifier = modifier.height(40.dp).horizontalScroll(rememberScrollState()),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        val users = suggestions.filter { !it.handle.isNullOrBlank() }
+        val animatingPart = getAnimatedDots()
+        if (users.isEmpty()) {
+            if (loading) {
+                Text(
+                    modifier = Modifier.padding(Spacing.s),
+                    text =
+                        buildString {
+                            append(LocalStrings.current.messageLoadingUsers)
+                            append(animatingPart)
+                        },
+                    style = MaterialTheme.typography.labelMedium,
+                    color = ancillaryColor,
+                )
+            }
+        } else {
+            for (user in users) {
+                Text(
+                    modifier =
+                        Modifier
+                            .clickable {
+                                onSelected?.invoke(user)
+                            }.padding(Spacing.s),
+                    text = user.handle.orEmpty(),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = fullColor,
+                )
+            }
+            if (loading) {
+                Text(
+                    modifier = Modifier.padding(Spacing.s),
+                    text = animatingPart,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = fullColor,
+                )
+            }
+        }
+    }
+}

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/components/UtilsBar.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/components/UtilsBar.kt
@@ -1,13 +1,10 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.composer.components
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AlternateEmail
 import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.FormatBold
 import androidx.compose.material.icons.filled.FormatItalic
@@ -15,35 +12,32 @@ import androidx.compose.material.icons.filled.FormatStrikethrough
 import androidx.compose.material.icons.filled.FormatUnderlined
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.PhotoCamera
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 
 @Composable
 internal fun UtilsBar(
     modifier: Modifier = Modifier,
     hasPoll: Boolean = false,
+    hasSpoiler: Boolean = false,
     onLinkClicked: (() -> Unit)? = null,
-    onMentionClicked: (() -> Unit)? = null,
     onAttachmentClicked: (() -> Unit)? = null,
     onBoldClicked: (() -> Unit)? = null,
     onItalicClicked: (() -> Unit)? = null,
     onUnderlineClicked: (() -> Unit)? = null,
     onStrikethroughClicked: (() -> Unit)? = null,
     onCodeClicked: (() -> Unit)? = null,
+    onSpoilerClicked: (() -> Unit)? = null,
 ) {
     Row(
-        modifier =
-            modifier
-                .background(MaterialTheme.colorScheme.surfaceVariant)
-                .horizontalScroll(rememberScrollState())
-                .padding(
-                    vertical = Spacing.xs,
-                ),
+        modifier = modifier.horizontalScroll(rememberScrollState()),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceAround,
     ) {
@@ -66,17 +60,6 @@ internal fun UtilsBar(
         ) {
             Icon(
                 imageVector = Icons.Default.Link,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-        IconButton(
-            onClick = {
-                onMentionClicked?.invoke()
-            },
-        ) {
-            Icon(
-                imageVector = Icons.Default.AlternateEmail,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -135,6 +118,35 @@ internal fun UtilsBar(
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+        }
+        if (hasSpoiler) {
+            FilledIconButton(
+                colors =
+                    IconButtonDefaults.filledIconButtonColors(
+                        containerColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    ),
+                onClick = {
+                    onSpoilerClicked?.invoke()
+                },
+            ) {
+                Icon(
+                    imageVector = Icons.Default.VisibilityOff,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.surfaceVariant,
+                )
+            }
+        } else {
+            IconButton(
+                onClick = {
+                    onSpoilerClicked?.invoke()
+                },
+            ) {
+                Icon(
+                    imageVector = Icons.Default.VisibilityOff,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
     }
 }

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/di/ComposerModule.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/di/ComposerModule.kt
@@ -24,6 +24,7 @@ val featureComposerModule =
                 draftRepository = get(),
                 settingsRepository = get(),
                 emojiRepository = get(),
+                userRepository = get(),
                 notificationCenter = get(),
             )
         }


### PR DESCRIPTION
This PR moves the user selection for mentions to a bottom bar (instead of using a dialog). This makes user selection easier for users and frees up some space in the formatting bar which can be dedicated to spoilers.

This is a first implementation which can be refined in the future, both for mention detection while typing and for the way search results are displayed.