### PR TITLE
fix: custom emojis in node info, notifications headers, user selection dialogs, etc.

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SelectUserDialog.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SelectUserDialog.kt
@@ -46,7 +46,6 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.Placeh
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.SearchField
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.utils.compose.getAnimatedDots
-import com.livefast.eattrash.raccoonforfriendica.core.utils.ellipsize
 import com.livefast.eattrash.raccoonforfriendica.core.utils.isNearTheEnd
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import kotlinx.coroutines.FlowPreview
@@ -222,7 +221,7 @@ private fun UserResultItem(
                 verticalArrangement = Arrangement.spacedBy(Spacing.xs),
             ) {
                 TextWithCustomEmojis(
-                    text = (user.displayName ?: user.username ?: "").ellipsize(30),
+                    text = user.displayName ?: user.username ?: "",
                     style = MaterialTheme.typography.bodyMedium,
                     color = fullColor,
                     maxLines = 1,
@@ -230,7 +229,7 @@ private fun UserResultItem(
                     emojis = user.emojis,
                 )
                 Text(
-                    text = (user.handle ?: "").ellipsize(25),
+                    text = user.handle ?: "",
                     style = MaterialTheme.typography.bodySmall,
                     color = ancillaryColor,
                     maxLines = 1,

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserItem.kt
@@ -38,7 +38,6 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillary
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomDropDown
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomImage
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.PlaceholderImage
-import com.livefast.eattrash.raccoonforfriendica.core.utils.ellipsize
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.RelationshipStatusNextAction
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 
@@ -92,7 +91,7 @@ fun UserItem(
             modifier = Modifier.weight(1f),
         ) {
             TextWithCustomEmojis(
-                text = (user.displayName ?: user.username ?: "").ellipsize(30),
+                text = user.displayName ?: user.username ?: "",
                 style = MaterialTheme.typography.titleMedium,
                 color = fullColor,
                 maxLines = 1,
@@ -100,7 +99,7 @@ fun UserItem(
                 emojis = user.emojis,
             )
             Text(
-                text = (user.handle ?: user.username ?: "").ellipsize(25),
+                text = user.handle ?: user.username ?: "",
                 style = MaterialTheme.typography.titleMedium,
                 color = ancillaryColor,
                 maxLines = 1,

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/components/CircleAddUsersDialog.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/components/CircleAddUsersDialog.kt
@@ -46,7 +46,6 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.Search
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TextWithCustomEmojis
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.utils.compose.getAnimatedDots
-import com.livefast.eattrash.raccoonforfriendica.core.utils.ellipsize
 import com.livefast.eattrash.raccoonforfriendica.core.utils.isNearTheEnd
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import kotlinx.coroutines.FlowPreview
@@ -248,7 +247,7 @@ private fun UserResultItem(
             verticalArrangement = Arrangement.spacedBy(Spacing.xs),
         ) {
             TextWithCustomEmojis(
-                text = (user.displayName ?: user.username ?: "").ellipsize(30),
+                text = user.displayName ?: user.username ?: "",
                 style = MaterialTheme.typography.bodyMedium,
                 color = fullColor,
                 maxLines = 1,
@@ -256,7 +255,7 @@ private fun UserResultItem(
                 emojis = user.emojis,
             )
             Text(
-                text = (user.handle ?: "").ellipsize(25),
+                text = user.handle ?: "",
                 style = MaterialTheme.typography.bodySmall,
                 color = ancillaryColor,
                 maxLines = 1,

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/components/CreatePostHeader.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/components/CreatePostHeader.kt
@@ -35,7 +35,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillary
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomDropDown
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomImage
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.PlaceholderImage
-import com.livefast.eattrash.raccoonforfriendica.core.utils.ellipsize
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TextWithCustomEmojis
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.Visibility
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toIcon
@@ -62,7 +62,7 @@ internal fun CreatePostHeader(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(Spacing.s),
     ) {
-        val creatorName = (author?.displayName ?: author?.username ?: "").ellipsize(30)
+        val creatorName = author?.displayName ?: author?.username ?: ""
         val creatorAvatar = author?.avatar.orEmpty()
         val iconSize = IconSize.l
         if (creatorAvatar.isNotEmpty()) {
@@ -86,8 +86,9 @@ internal fun CreatePostHeader(
         Column(
             modifier = Modifier.weight(1f),
         ) {
-            Text(
+            TextWithCustomEmojis(
                 text = creatorName,
+                emojis = author?.emojis.orEmpty(),
                 style = MaterialTheme.typography.bodyMedium,
                 color = fullColor,
             )

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/components/ConversationItem.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/components/ConversationItem.kt
@@ -30,9 +30,9 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.Custom
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.PlaceholderImage
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ContentBody
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ContentTitle
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TextWithCustomEmojis
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.prettifyDate
-import com.livefast.eattrash.raccoonforfriendica.core.utils.ellipsize
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.ConversationModel
 
 @Composable
@@ -84,15 +84,16 @@ internal fun ConversationItem(
             Column(
                 modifier = Modifier.weight(1f),
             ) {
-                Text(
-                    text = (user.displayName ?: user.username ?: "").ellipsize(30),
+                TextWithCustomEmojis(
+                    text = user.displayName ?: user.username ?: "",
+                    emojis = user.emojis,
                     style = MaterialTheme.typography.titleMedium,
                     color = fullColor,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
                 Text(
-                    text = (user.handle ?: user.username ?: "").ellipsize(25),
+                    text = user.handle ?: user.username ?: "",
                     style = MaterialTheme.typography.titleMedium,
                     color = ancillaryColor,
                     maxLines = 1,

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationScreen.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationScreen.kt
@@ -35,7 +35,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
@@ -52,7 +51,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
@@ -63,11 +61,11 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomImage
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.PlaceholderImage
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TextWithCustomEmojis
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.utils.compose.safeImePadding
 import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.getDurationFromDateToNow
-import com.livefast.eattrash.raccoonforfriendica.core.utils.ellipsize
 import com.livefast.eattrash.raccoonforfriendica.core.utils.isNearTheEnd
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.DirectMessageModel
 import com.livefast.eattrash.raccoonforfriendica.feature.directmessages.components.MessageItem
@@ -96,7 +94,7 @@ class ConversationScreen(
         val snackbarHostState = remember { SnackbarHostState() }
         val lazyListState = rememberLazyListState()
         val scope = rememberCoroutineScope()
-        val otherUserName = uiState.otherUser?.let { it.displayName ?: it.username }.ellipsize(30)
+        val otherUserName = uiState.otherUser?.let { it.displayName ?: it.username } ?: ""
         val genericError = LocalStrings.current.messageGenericError
         val followRequiredMessage = LocalStrings.current.followRequiredMessage
 
@@ -158,8 +156,9 @@ class ConversationScreen(
                                     title = otherUserName,
                                 )
                             }
-                            Text(
+                            TextWithCustomEmojis(
                                 text = otherUserName,
+                                emojis = uiState.otherUser?.emojis.orEmpty(),
                                 style = MaterialTheme.typography.titleMedium,
                             )
                         }
@@ -293,15 +292,16 @@ class ConversationScreen(
                                                 vertical = Spacing.s,
                                                 horizontal = Spacing.s,
                                             ),
+                                    contentAlignment = Alignment.Center,
                                 ) {
-                                    Text(
+                                    TextWithCustomEmojis(
                                         text =
                                             buildString {
                                                 append(LocalStrings.current.messageEmptyConversation)
                                                 append(" ")
                                                 append(otherUserName)
                                             },
-                                        textAlign = TextAlign.Center,
+                                        emojis = uiState.otherUser?.emojis.orEmpty(),
                                         style = MaterialTheme.typography.bodyLarge,
                                     )
                                 }

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerViewModel.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerViewModel.kt
@@ -3,6 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica.feature.drawer
 import cafe.adriel.voyager.core.model.screenModelScope
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
 import com.livefast.eattrash.raccoonforfriendica.core.utils.validation.ValidationError
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SupportedFeatureRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
@@ -20,6 +21,7 @@ class DrawerViewModel(
     private val supportedFeatureRepository: SupportedFeatureRepository,
     private val credentialsRepository: CredentialsRepository,
     private val switchAccountUseCase: SwitchAccountUseCase,
+    private val emojiHelper: EmojiHelper,
     accountRepository: AccountRepository,
 ) : DefaultMviModel<DrawerMviModel.Intent, DrawerMviModel.State, DrawerMviModel.Effect>(
         initialState = DrawerMviModel.State(),
@@ -29,8 +31,12 @@ class DrawerViewModel(
         screenModelScope.launch {
             identityRepository.currentUser
                 .onEach { currentUser ->
+                    val user =
+                        with(emojiHelper) {
+                            currentUser?.withEmojisIfMissing()
+                        }
                     updateState {
-                        it.copy(user = currentUser)
+                        it.copy(user = user)
                     }
                 }.launchIn(this)
             apiConfigurationRepository.node

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/components/DrawerHeader.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/components/DrawerHeader.kt
@@ -25,8 +25,8 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomImage
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.PlaceholderImage
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TextWithCustomEmojis
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
-import com.livefast.eattrash.raccoonforfriendica.core.utils.ellipsize
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 
 @Composable
@@ -53,7 +53,7 @@ internal fun DrawerHeader(
         horizontalArrangement = Arrangement.spacedBy(Spacing.m),
     ) {
         if (user != null) {
-            val username = (user.displayName ?: user.username ?: "").ellipsize(30)
+            val username = user.displayName ?: user.username ?: ""
             val userAvatar = user.avatar.orEmpty()
             if (userAvatar.isNotEmpty()) {
                 CustomImage(
@@ -79,8 +79,9 @@ internal fun DrawerHeader(
                 Column(
                     verticalArrangement = Arrangement.spacedBy(Spacing.xxxs),
                 ) {
-                    Text(
+                    TextWithCustomEmojis(
                         text = username,
+                        emojis = user.emojis,
                         style = MaterialTheme.typography.titleMedium,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/di/DrawerModule.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/di/DrawerModule.kt
@@ -14,6 +14,7 @@ val featureDrawerModule =
                 credentialsRepository = get(),
                 accountRepository = get(),
                 switchAccountUseCase = get(),
+                emojiHelper = get(),
             )
         }
     }

--- a/feature/followrequests/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/followrequests/components/FollowRequestItem.kt
+++ b/feature/followrequests/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/followrequests/components/FollowRequestItem.kt
@@ -28,8 +28,8 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomImage
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.PlaceholderImage
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TextWithCustomEmojis
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
-import com.livefast.eattrash.raccoonforfriendica.core.utils.ellipsize
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 
 @Composable
@@ -80,15 +80,16 @@ fun FollowRequestItem(
             Column(
                 modifier = Modifier.weight(1f),
             ) {
-                Text(
-                    text = (user.displayName ?: user.username ?: "").ellipsize(30),
+                TextWithCustomEmojis(
+                    text = user.displayName ?: user.username ?: "",
+                    emojis = user.emojis,
                     style = MaterialTheme.typography.titleMedium,
                     color = fullColor,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
                 Text(
-                    text = (user.handle ?: user.username ?: "").ellipsize(25),
+                    text = user.handle ?: user.username ?: "",
                     style = MaterialTheme.typography.titleMedium,
                     color = ancillaryColor,
                     maxLines = 1,

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationUserInfo.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationUserInfo.kt
@@ -28,9 +28,9 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillary
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomImage
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.PlaceholderImage
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ContentBody
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TextWithCustomEmojis
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.UserRelationshipButton
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
-import com.livefast.eattrash.raccoonforfriendica.core.utils.ellipsize
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.RelationshipStatusNextAction
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 
@@ -103,13 +103,14 @@ fun NotificationUserInfo(
                 Column(
                     verticalArrangement = Arrangement.spacedBy(Spacing.xs),
                 ) {
-                    Text(
-                        text = (user.displayName ?: user.username ?: "").ellipsize(30),
+                    TextWithCustomEmojis(
+                        text = user.displayName ?: user.username ?: "",
+                        emojis = user.emojis,
                         style = MaterialTheme.typography.titleMedium,
                         color = fullColor,
                     )
                     Text(
-                        text = (user.handle ?: user.username ?: "").ellipsize(25),
+                        text = user.handle ?: user.username ?: "",
                         style = MaterialTheme.typography.titleMedium,
                         color = ancillaryColor,
                     )

--- a/feature/nodeinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/NodeInfoScreen.kt
+++ b/feature/nodeinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/NodeInfoScreen.kt
@@ -59,11 +59,11 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ContentBo
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ContentTitle
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.GenericPlaceholder
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.SettingsHeader
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TextWithCustomEmojis
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.UserItemPlaceholder
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDetailOpener
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
-import com.livefast.eattrash.raccoonforfriendica.core.utils.ellipsize
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.RuleModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import kotlinx.coroutines.launch
@@ -351,12 +351,13 @@ private fun ContactUserItem(
                 modifier = Modifier.weight(1f).padding(vertical = Spacing.s),
                 verticalArrangement = Arrangement.spacedBy(Spacing.xs),
             ) {
-                val title = (user.displayName ?: user.username ?: "").ellipsize(30)
+                val title = user.displayName ?: user.username ?: ""
                 val subtitle = user.handle ?: ""
                 if (title.isNotBlank()) {
-                    Text(
+                    TextWithCustomEmojis(
                         text = title,
                         style = MaterialTheme.typography.bodyMedium,
+                        emojis = user.emojis,
                         color = fullColor,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
@@ -364,7 +365,7 @@ private fun ContactUserItem(
                 }
                 if (subtitle.isNotBlank()) {
                     Text(
-                        text = (user.handle ?: "").ellipsize(25),
+                        text = user.handle ?: "",
                         style = MaterialTheme.typography.bodySmall,
                         color = ancillaryColor,
                         maxLines = 1,

--- a/feature/nodeinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/NodeInfoViewModel.kt
+++ b/feature/nodeinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/NodeInfoViewModel.kt
@@ -2,19 +2,29 @@ package com.livefast.eattrash.raccoonforfriendica.feature.nodeinfo
 
 import cafe.adriel.voyager.core.model.screenModelScope
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.NodeInfoRepository
 import kotlinx.coroutines.launch
 
 class NodeInfoViewModel(
     private val nodeInfoRepository: NodeInfoRepository,
+    private val emojiHelper: EmojiHelper,
 ) : DefaultMviModel<NodeInfoMviModel.Intent, NodeInfoMviModel.State, NodeInfoMviModel.Effect>(
         initialState = NodeInfoMviModel.State(),
     ),
     NodeInfoMviModel {
     init {
         screenModelScope.launch {
-            val info = nodeInfoRepository.getInfo()
-            updateState { it.copy(info = info) }
+            val nodeInfo =
+                nodeInfoRepository.getInfo()?.let { info ->
+                    info.copy(
+                        contact =
+                            with(emojiHelper) {
+                                info.contact?.withEmojisIfMissing()
+                            },
+                    )
+                }
+            updateState { it.copy(info = nodeInfo) }
         }
     }
 }

--- a/feature/nodeinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/di/NodeInfoModule.kt
+++ b/feature/nodeinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/di/NodeInfoModule.kt
@@ -9,6 +9,7 @@ val featureNodeInfoModule =
         factory<NodeInfoMviModel> {
             NodeInfoViewModel(
                 nodeInfoRepository = get(),
+                emojiHelper = get(),
             )
         }
     }


### PR DESCRIPTION
Support for custom emojis had not been properly handled in all app screens, due to the fact that a specific UI component has to be used for them to be displayed.

This PR makes sure the correct component is called in:
- node info
- follow requests
- conversations
- navigation drawer
- notifications
- user selection dialogs.

In the navigation drawer and node info, moreover, the information was not retrieved if missing (e.g. on Friendica servers where the information does not come in piggyback along with user info).