### PR TITLE
chore: add test for DefaultIdentityRepository and DefaultSettingsRepository

### DIFF
--- a/domain/identity/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultIdentityRepositoryTest.kt
+++ b/domain/identity/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultIdentityRepositoryTest.kt
@@ -1,0 +1,63 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository
+
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Account
+import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.UserService
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import io.ktor.utils.io.errors.IOException
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class DefaultIdentityRepositoryTest {
+    private val userService = mock<UserService>(mode = MockMode.autoUnit)
+    private val provider =
+        mock<ServiceProvider> {
+            every { users } returns userService
+        }
+    private val sut = DefaultIdentityRepository(provider = provider)
+
+    @Test
+    fun `given valid user id when refresh then result is as expected`() =
+        runTest {
+            val userId = "user-id"
+            everySuspend {
+                userService.getById(any())
+            } returns Account(id = userId, acct = "fake-user-name", username = "fake-user-name")
+            sut.refreshCurrentUser(userId)
+
+            val res = sut.currentUser.value
+
+            assertNotNull(res)
+            assertEquals(userId, res.id)
+            verifySuspend {
+                userService.getById(userId)
+            }
+        }
+
+    @Test
+    fun `given invalid user id when refresh then result is as expected`() =
+        runTest {
+            val userId = "user-id"
+            everySuspend {
+                userService.getById(any())
+            } throws IOException("Not found")
+            sut.refreshCurrentUser(userId)
+
+            val res = sut.currentUser.value
+
+            assertNull(res)
+            verifySuspend {
+                userService.getById(userId)
+            }
+        }
+}

--- a/domain/identity/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultSettingsRepositoryTest.kt
+++ b/domain/identity/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultSettingsRepositoryTest.kt
@@ -1,0 +1,80 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository
+
+import com.livefast.eattrash.raccoonforfriendica.core.persistence.dao.SettingsDao
+import com.livefast.eattrash.raccoonforfriendica.core.persistence.entities.SettingsEntity
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DefaultSettingsRepositoryTest {
+    private val dao = mock<SettingsDao>(mode = MockMode.autoUnit)
+    private val sut = DefaultSettingsRepository(settingsDao = dao)
+
+    @Test
+    fun `when changeCurrent then value is updated`() =
+        runTest {
+            val settings = SettingsModel(lang = "it")
+            sut.changeCurrent(settings)
+
+            val res = sut.current.value
+            assertEquals(settings, res)
+        }
+
+    @Test
+    fun `when get then result is as expected`() =
+        runTest {
+            val accountId = 1L
+            everySuspend { dao.getBy(any()) } returns SettingsEntity(lang = "it")
+            val settings = SettingsModel(lang = "it")
+
+            val res = sut.get(accountId)
+
+            assertEquals(settings, res)
+            verifySuspend {
+                dao.getBy(accountId)
+            }
+        }
+
+    @Test
+    fun `when create then result is as expected`() =
+        runTest {
+            val settings = SettingsModel(lang = "it", accountId = 1L)
+
+            sut.create(settings)
+
+            verifySuspend {
+                dao.insert(SettingsEntity(lang = "it", accountId = 1L))
+            }
+        }
+
+    @Test
+    fun `when update then result is as expected`() =
+        runTest {
+            val settings = SettingsModel(lang = "it", accountId = 1L)
+
+            sut.update(settings)
+
+            verifySuspend {
+                dao.update(SettingsEntity(lang = "it", accountId = 1L))
+            }
+        }
+
+    @Test
+    fun `when delete then result is as expected`() =
+        runTest {
+            val settings = SettingsModel(lang = "it", accountId = 1L)
+
+            sut.delete(settings)
+
+            verifySuspend {
+                dao.delete(SettingsEntity(lang = "it", accountId = 1L))
+            }
+        }
+}


### PR DESCRIPTION
This completes the test on the `:domain:identity:repository` module.