### PR TITLE
fix: conditional private visibility in settings

### DIFF
--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -50,6 +50,7 @@ kotlin {
                 implementation(projects.core.utils)
 
                 implementation(projects.domain.content.data)
+                implementation(projects.domain.content.repository)
                 implementation(projects.domain.identity.data)
                 implementation(projects.domain.identity.repository)
                 implementation(projects.domain.identity.usecase)

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsMviModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsMviModel.kt
@@ -88,6 +88,7 @@ interface SettingsMviModel :
         val defaultPostVisibility: Visibility = Visibility.Public,
         val defaultReplyVisibility: Visibility = Visibility.Public,
         val excludeRepliesFromTimeline: Boolean = false,
+        val availableVisibilities: List<Visibility> = emptyList(),
     )
 
     sealed interface Effect

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
@@ -59,7 +59,6 @@ import com.livefast.eattrash.raccoonforfriendica.core.l10n.toLanguageFlag
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.toLanguageName
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDetailOpener
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.Visibility
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toIcon
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toReadableName
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.UrlOpeningMode
@@ -509,13 +508,7 @@ class SettingsScreen : Screen {
         }
 
         if (defaultPostVisibilityBottomSheetOpened) {
-            val types =
-                listOf(
-                    Visibility.Public,
-                    Visibility.Unlisted,
-                    Visibility.Direct,
-                    Visibility.Private,
-                )
+            val types = uiState.availableVisibilities
             CustomModalBottomSheet(
                 title = LocalStrings.current.settingsItemDefaultPostVisibility,
                 items =
@@ -543,13 +536,7 @@ class SettingsScreen : Screen {
         }
 
         if (defaultReplyVisibilityBottomSheetOpened) {
-            val types =
-                listOf(
-                    Visibility.Public,
-                    Visibility.Unlisted,
-                    Visibility.Direct,
-                    Visibility.Private,
-                )
+            val types = uiState.availableVisibilities
             CustomModalBottomSheet(
                 title = LocalStrings.current.settingsItemDefaultReplyVisibility,
                 items =

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsViewModel.kt
@@ -16,6 +16,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.Visibility
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toInt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toTimelineType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toVisibility
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SupportedFeatureRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.UrlOpeningMode
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
@@ -31,6 +32,7 @@ class SettingsViewModel(
     private val colorSchemeProvider: ColorSchemeProvider,
     private val themeColorRepository: ThemeColorRepository,
     private val identityRepository: IdentityRepository,
+    private val supportedFeatureRepository: SupportedFeatureRepository,
 ) : DefaultMviModel<SettingsMviModel.Intent, SettingsMviModel.State, SettingsMviModel.Effect>(
         initialState = SettingsMviModel.State(),
     ),
@@ -99,6 +101,22 @@ class SettingsViewModel(
                                 excludeRepliesFromTimeline = settings.excludeRepliesFromTimeline,
                             )
                         }
+                    }
+                }.launchIn(this)
+            supportedFeatureRepository.features
+                .onEach { features ->
+                    updateState {
+                        it.copy(
+                            availableVisibilities =
+                                buildList {
+                                    this += Visibility.Public
+                                    this += Visibility.Unlisted
+                                    if (features.supportsPrivateVisibility) {
+                                        this += Visibility.Private
+                                    }
+                                    this += Visibility.Direct
+                                },
+                        )
                     }
                 }.launchIn(this)
 

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/di/SettingsModule.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/di/SettingsModule.kt
@@ -16,6 +16,7 @@ val featureSettingsModule =
                 colorSchemeProvider = get(),
                 themeColorRepository = get(),
                 identityRepository = get(),
+                supportedFeatureRepository = get(),
             )
         }
         factory<UserFeedbackMviModel> {


### PR DESCRIPTION
In follow-up with #300, this PR excludes the "private" visibility option as default visibility for posts or replies in the settings screen.