### PR TITLE
enhancement: improve timeline attachment grid element content scale

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/AttachmentsGrid.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/AttachmentsGrid.kt
@@ -143,10 +143,10 @@ fun AttachmentsGrid(
                                 attachment = attachment,
                                 sensitive = blurNsfw && sensitive,
                                 contentScale =
-                                    if (attachment.aspectRatio >= 1) {
-                                        ContentScale.FillHeight
-                                    } else {
+                                    if (chunkSize == chunk.size) {
                                         ContentScale.FillWidth
+                                    } else {
+                                        ContentScale.Crop
                                     },
                                 onClick = {
                                     onOpenImage?.invoke(
@@ -196,10 +196,10 @@ fun AttachmentsGrid(
                                 sensitive = blurNsfw && sensitive,
                                 maxHeight = 180.dp,
                                 contentScale =
-                                    if (attachment.aspectRatio >= 1) {
+                                    if (chunkSize == chunk.size) {
                                         ContentScale.FillHeight
                                     } else {
-                                        ContentScale.FillWidth
+                                        ContentScale.Crop
                                     },
                                 onClick = {
                                     onOpenImage?.invoke(


### PR DESCRIPTION
There were cases in which the attachment grid in timelines contained some "gaps", especially when in multi-row layout (i.e. when the first attachment is wider than taller and subsequent images are disposed in rows of at most 4 elements.

When one of such elements had an aspect ratio > 1, there were vertical gaps that made the grid appearance suboptimal, like in the example below. This PR makes sure all the space is filled with no gaps.

<div align="center">
<img width="484" alt="image" src="https://github.com/user-attachments/assets/71c69076-a084-4085-8966-015d5a5f6329">
</div>