### PR TITLE
fix: visibility icon tint color in post detail dialog

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/EntryDetailDialog.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/EntryDetailDialog.kt
@@ -105,6 +105,7 @@ fun EntryDetailDialog(
                                 modifier = Modifier.size(IconSize.s),
                                 imageVector = entry.visibility.toIcon(),
                                 contentDescription = null,
+                                tint = fullColor,
                             )
                         }
                     }


### PR DESCRIPTION
This PR makes sure the visibility icon in the post detail dialog has the onBackground theme color.