### PR TITLE
fix: clear notification list after logout

### DIFF
--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
@@ -107,7 +107,11 @@ class InboxViewModel(
 
         val wasRefreshing = uiState.value.refreshing
         updateState { it.copy(loading = true) }
-        val notifications = paginationManager.loadNextPage()
+        val notifications =
+            paginationManager
+                .loadNextPage()
+                .takeIf { uiState.value.currentUserId != null }
+                .orEmpty()
         notifications.preloadImages()
         updateState {
             it.copy(


### PR DESCRIPTION
This fixes the notification list after logout: the inbox screen should be cleared instead of showing the items of the previous user.