### PR TITLE
enhancement: avoid unnecessary calls upon account switch

### DIFF
--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
@@ -65,6 +65,14 @@ internal class DefaultTimelinePaginationManager(
         canFetchMore = true
     }
 
+    override suspend fun restoreHistory(values: List<TimelineEntryModel>) {
+        mutex.withLock {
+            history.clear()
+            history.addAll(values)
+            canFetchMore = true
+        }
+    }
+
     override suspend fun loadNextPage(): List<TimelineEntryModel> {
         val specification = this.specification ?: return emptyList()
 

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/TimelinePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/TimelinePaginationManager.kt
@@ -9,4 +9,6 @@ interface TimelinePaginationManager {
     suspend fun reset(specification: TimelinePaginationSpecification)
 
     suspend fun loadNextPage(): List<TimelineEntryModel>
+
+    suspend fun restoreHistory(values: List<TimelineEntryModel>)
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTimelineEntryRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTimelineEntryRepository.kt
@@ -27,6 +27,8 @@ internal class DefaultTimelineEntryRepository(
 ) : TimelineEntryRepository {
     private val cachedValues: MutableList<TimelineEntryModel> = mutableListOf()
 
+    override fun getCachedByUser(): List<TimelineEntryModel> = cachedValues
+
     override suspend fun getByUser(
         userId: String,
         pageCursor: String?,

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/TimelineEntryRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/TimelineEntryRepository.kt
@@ -7,6 +7,8 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.Visibility
 
 interface TimelineEntryRepository {
+    fun getCachedByUser(): List<TimelineEntryModel>
+
     suspend fun getByUser(
         userId: String,
         pageCursor: String? = null,

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultContentPreloadManager.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultContentPreloadManager.kt
@@ -3,19 +3,15 @@ package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.NotificationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TrendingRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 
 internal class DefaultContentPreloadManager(
-    private val timelineRepository: TimelineRepository,
     private val timelineEntryRepository: TimelineEntryRepository,
     private val trendingRepository: TrendingRepository,
     private val notificationRepository: NotificationRepository,
-    private val userRepository: UserRepository,
 ) : ContentPreloadManager {
     override suspend fun preload(
         userRemoteId: String?,
@@ -25,30 +21,10 @@ internal class DefaultContentPreloadManager(
             buildList {
                 this +=
                     async {
-                        when (defaultTimelineType) {
-                            TimelineType.All ->
-                                timelineRepository.getPublic(refresh = true)
-
-                            TimelineType.Local ->
-                                timelineRepository.getLocal(refresh = true)
-
-                            TimelineType.Subscriptions ->
-                                timelineRepository.getHome(refresh = true)
-
-                            else -> Unit
-                        }
-                    }
-                this +=
-                    async {
                         trendingRepository.getHashtags(
                             offset = 0,
                             refresh = true,
                         )
-                    }
-
-                this +=
-                    async {
-                        userRepository.getCurrent(refresh = true)
                     }
 
                 if (userRemoteId != null) {

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
@@ -87,11 +87,9 @@ val domainIdentityUseCaseModule =
         }
         single<ContentPreloadManager> {
             DefaultContentPreloadManager(
-                timelineRepository = get(),
                 timelineEntryRepository = get(),
                 trendingRepository = get(),
                 notificationRepository = get(),
-                userRepository = get(),
             )
         }
     }

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreViewModel.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreViewModel.kt
@@ -69,6 +69,10 @@ class ExploreViewModel(
                             currentUserId = currentUser?.id,
                         )
                     }
+
+                    if (uiState.value.initial) {
+                        refresh(initial = true)
+                    }
                 }.launchIn(this)
             notificationCenter
                 .subscribe(UserUpdatedEvent::class)
@@ -80,10 +84,6 @@ class ExploreViewModel(
                 .onEach { event ->
                     updateEntryInState(event.entry.id) { event.entry }
                 }.launchIn(this)
-
-            if (uiState.value.initial) {
-                refresh(initial = true)
-            }
         }
     }
 


### PR DESCRIPTION
In follow up to #316, this PR takes some corrective actions to limit the number of calls which are sent to the backend whenever the account changes and at app startup.