### PR TITLE
fix: custom emojis in post and thread detail

### DIFF
--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/di/EntryDetailModule.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/di/EntryDetailModule.kt
@@ -18,6 +18,7 @@ val featureEntryDetailModule =
                 notificationCenter = get(),
                 imagePreloadManager = get(),
                 blurHashRepository = get(),
+                emojiHelper = get(),
             )
         }
     }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
@@ -23,7 +23,6 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Sett
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.drop
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -76,9 +75,8 @@ class MyAccountViewModel(
                 }.launchIn(this)
 
             if (uiState.value.initial) {
-                val user = identityRepository.currentUser.first()
                 val currentUser =
-                    user?.let {
+                    identityRepository.currentUser.value?.let {
                         with(emojiHelper) { it.withEmojisIfMissing() }
                     }
                 val initialValues = timelineEntryRepository.getCachedByUser()
@@ -93,7 +91,7 @@ class MyAccountViewModel(
                     }
                     paginationManager.reset(
                         TimelinePaginationSpecification.User(
-                            userId = user?.id.orEmpty(),
+                            userId = currentUser?.id.orEmpty(),
                             excludeReplies = true,
                             includeNsfw =
                                 settingsRepository.current.value?.includeNsfw

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/di/ThreadModule.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/di/ThreadModule.kt
@@ -11,6 +11,7 @@ val featureThreadModule =
         single<PopulateThreadUseCase> {
             DefaultPopulateThreadUseCase(
                 timelineEntryRepository = get(),
+                emojiHelper = get(),
             )
         }
         factory<ThreadMviModel> { params ->


### PR DESCRIPTION
This PR fixes a bug due to which custom emojis were not loaded in user display names in ancestors and descendants in a thread in the post detail screen.