### PR TITLE
fix: ensure custom emojis in initial posts in my account

### DIFF
--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
@@ -79,7 +79,10 @@ class MyAccountViewModel(
                     identityRepository.currentUser.value?.let {
                         with(emojiHelper) { it.withEmojisIfMissing() }
                     }
-                val initialValues = timelineEntryRepository.getCachedByUser()
+                val initialValues =
+                    timelineEntryRepository.getCachedByUser().map {
+                        with(emojiHelper) { it.withEmojisIfMissing() }
+                    }
                 paginationManager.restoreHistory(initialValues)
                 if (initialValues.isNotEmpty()) {
                     updateState {


### PR DESCRIPTION
This PR fixes a bug with post cache in the profile screen, due to which custom emojis in reblogs/replies were not present on Friendica servers.