### PR TITLE
fix: avoid crash when URL can not be opened

### DIFF
--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultCustomUriHandler.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultCustomUriHandler.kt
@@ -111,7 +111,10 @@ internal class DefaultCustomUriHandler(
             customTabsHelper.isSupported && mode == UrlOpeningMode.CustomTabs ->
                 customTabsHelper.handle(url)
 
-            else -> defaultHandler.openUri(url)
+            else ->
+                runCatching {
+                    defaultHandler.openUri(url)
+                }
         }
     }
 


### PR DESCRIPTION
Catch the `ActivityNotFoundException` thrown when an URL can not be opened in `DefaultCustomUriHandler`.