### PR TITLE
fix: initial loading of current user in my account

### DIFF
--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
@@ -74,11 +74,16 @@ class MyAccountViewModel(
                     removeEntryFromState(event.id)
                 }.launchIn(this)
 
+            val currentUser =
+                identityRepository.currentUser.value?.let {
+                    with(emojiHelper) { it.withEmojisIfMissing() }
+                }
+            updateState {
+                it.copy(user = currentUser)
+            }
+
             if (uiState.value.initial) {
-                val currentUser =
-                    identityRepository.currentUser.value?.let {
-                        with(emojiHelper) { it.withEmojisIfMissing() }
-                    }
+
                 val initialValues =
                     timelineEntryRepository.getCachedByUser().map {
                         with(emojiHelper) { it.withEmojisIfMissing() }
@@ -89,7 +94,6 @@ class MyAccountViewModel(
                         it.copy(
                             initial = false,
                             entries = initialValues,
-                            user = currentUser,
                         )
                     }
                     paginationManager.reset(


### PR DESCRIPTION
There was a small bug due to which, sometimes, when navigating back to the profile screen the current user won't load. This makes sure it is always present.