### PR TITLE
chore: add test for active account monitor

### DIFF
--- a/domain/identity/usecase/build.gradle.kts
+++ b/domain/identity/usecase/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.mokkery)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -43,6 +44,13 @@ kotlin {
                 implementation(projects.domain.content.repository)
                 implementation(projects.domain.identity.data)
                 implementation(projects.domain.identity.repository)
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation(libs.kotlinx.coroutines.test)
+                implementation(libs.turbine)
             }
         }
     }

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitor.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitor.kt
@@ -71,29 +71,27 @@ internal class DefaultActiveAccountMonitor(
             supportedFeatureRepository.refresh()
 
             contentPreloadManager.preload()
+        } else {
+            val node = account.handle.nodeName ?: apiConfigurationRepository.defaultNode
+            apiConfigurationRepository.changeNode(node)
 
-            return
+            val credentials = accountCredentialsCache.get(account.id)
+            apiConfigurationRepository.setAuth(credentials)
+
+            val defaultSettings = settingsRepository.get(account.id) ?: SettingsModel()
+
+            contentPreloadManager.preload(
+                userRemoteId = account.remoteId,
+                defaultTimelineType = defaultSettings.defaultTimelineType.toTimelineType(),
+            )
+
+            identityRepository.refreshCurrentUser(account.remoteId)
+
+            supportedFeatureRepository.refresh()
+
+            settingsRepository.changeCurrent(defaultSettings)
+
+            inboxManager.refreshUnreadCount()
         }
-
-        val node = account.handle.nodeName ?: apiConfigurationRepository.defaultNode
-        apiConfigurationRepository.changeNode(node)
-
-        val credentials = accountCredentialsCache.get(account.id)
-        apiConfigurationRepository.setAuth(credentials)
-
-        val defaultSettings = settingsRepository.get(account.id) ?: SettingsModel()
-
-        contentPreloadManager.preload(
-            userRemoteId = account.remoteId,
-            defaultTimelineType = defaultSettings.defaultTimelineType.toTimelineType(),
-        )
-
-        identityRepository.refreshCurrentUser(account.remoteId)
-
-        supportedFeatureRepository.refresh()
-
-        settingsRepository.changeCurrent(defaultSettings)
-
-        inboxManager.refreshUnreadCount()
     }
 }

--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitorTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitorTest.kt
@@ -1,0 +1,104 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toTimelineType
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.InboxManager
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SupportedFeatureRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountCredentialsCache
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiCredentials
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class DefaultActiveAccountMonitorTest {
+    private val accountRepository = mock<AccountRepository>(mode = MockMode.autoUnit)
+    private val apiConfigurationRepository =
+        mock<ApiConfigurationRepository>(mode = MockMode.autoUnit)
+    private val identityRepository = mock<IdentityRepository>(mode = MockMode.autoUnit)
+    private val accountCredentialsCache = mock<AccountCredentialsCache>(mode = MockMode.autoUnit)
+    private val settingsRepository = mock<SettingsRepository>(mode = MockMode.autoUnit)
+    private val supportedFeatureRepository =
+        mock<SupportedFeatureRepository>(mode = MockMode.autoUnit)
+    private val inboxManager = mock<InboxManager>(mode = MockMode.autoUnit)
+    private val contentPreloadManager = mock<ContentPreloadManager>(mode = MockMode.autoUnit)
+    private val sut =
+        DefaultActiveAccountMonitor(
+            accountRepository = accountRepository,
+            apiConfigurationRepository = apiConfigurationRepository,
+            identityRepository = identityRepository,
+            accountCredentialsCache = accountCredentialsCache,
+            settingsRepository = settingsRepository,
+            supportedFeatureRepository = supportedFeatureRepository,
+            inboxManager = inboxManager,
+            contentPreloadManager = contentPreloadManager,
+        )
+
+    @Test
+    fun `given no active account when started then interactions are as expected`() =
+        runTest {
+            val account: AccountModel? = null
+            val accountChannel = Channel<AccountModel?>()
+            every { accountRepository.getActiveAsFlow() } returns accountChannel.receiveAsFlow()
+            everySuspend { accountRepository.getActive() } returns account
+            every { apiConfigurationRepository.node } returns MutableStateFlow("test-instance")
+
+            sut.start()
+            accountChannel.send(account)
+
+            verify {
+                apiConfigurationRepository.setAuth(null)
+            }
+            verifySuspend {
+                identityRepository.refreshCurrentUser(null)
+                supportedFeatureRepository.refresh()
+                contentPreloadManager.preload()
+            }
+        }
+
+    @Test
+    fun `given active account when started then interactions are as expected`() =
+        runTest {
+            val accountId = 1L
+            val userId = "fake-user-id"
+            val account =
+                AccountModel(id = accountId, handle = "user@example.com", remoteId = userId)
+            val accountChannel = Channel<AccountModel?>()
+            every { accountRepository.getActiveAsFlow() } returns accountChannel.receiveAsFlow()
+            everySuspend { accountRepository.getActive() } returns account
+            every { apiConfigurationRepository.node } returns MutableStateFlow("test-instance")
+            val credentials = ApiCredentials.OAuth2("fake-access-token", "")
+            every { accountCredentialsCache.get(any()) } returns credentials
+            val settings = SettingsModel()
+            everySuspend { settingsRepository.get(any()) } returns settings
+
+            sut.start()
+            accountChannel.send(account)
+
+            verify {
+                apiConfigurationRepository.changeNode("example.com")
+                apiConfigurationRepository.setAuth(credentials)
+            }
+            verifySuspend {
+                contentPreloadManager.preload(userId, settings.defaultTimelineType.toTimelineType())
+                identityRepository.refreshCurrentUser(userId)
+                supportedFeatureRepository.refresh()
+                settingsRepository.changeCurrent(settings)
+                inboxManager.refreshUnreadCount()
+            }
+        }
+}


### PR DESCRIPTION
This PR adds the test for `DefaultActiveAccountMonitor`.