### PR TITLE
fix: remove FLAG_GRANT_READ_URI_PERMISSION in gallery helper

### DIFF
--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/gallery/DefaultGalleryHelper.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/gallery/DefaultGalleryHelper.kt
@@ -2,7 +2,6 @@ package com.livefast.eattrash.raccoonforfriendica.core.utils.gallery
 
 import android.content.ContentValues
 import android.content.Context
-import android.content.Intent
 import android.os.Environment
 import android.os.ParcelFileDescriptor
 import android.provider.MediaStore
@@ -68,11 +67,6 @@ internal class DefaultGalleryHelper(
         val pickMedia =
             rememberLauncherForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
                 if (uri != null) {
-                    resolver.takePersistableUriPermission(
-                        uri,
-                        Intent.FLAG_GRANT_READ_URI_PERMISSION,
-                    )
-
                     scope.launch(Dispatchers.IO) {
                         resolver.openInputStream(uri)?.use { stream ->
                             val bytes = stream.readBytes()


### PR DESCRIPTION
Given the limit to persistable permissions for each app on some devices, and considering that Raccoon does not need to perform long tasks on the file but just a one-shot read to upload it to the server, `FLAG_GRANT_READ_URI_PERMISSION` can be removed. This will solve some crashes that have been reported by end users.