### PR TITLE
enhancement: add switch in settings to select default opening mode for groups

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/SharedModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/SharedModule.kt
@@ -20,6 +20,7 @@ internal val sharedModule =
                 navigationCoordinator = get(),
                 identityRepository = get(),
                 userCache = get(),
+                settingsRepository = get(),
                 entryCache = get(),
             )
         }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/Options.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/Options.kt
@@ -24,16 +24,6 @@ sealed interface OptionId {
 
     data object Unpin : OptionId
 
-    data object Move : OptionId
-
-    data object SetSchedule : OptionId
-
-    data object ChangeSchedule : OptionId
-
-    data object PublishDefault : OptionId
-
-    data object SaveDraft : OptionId
-
     data object ReportUser : OptionId
 
     data object ReportEntry : OptionId
@@ -58,11 +48,6 @@ private fun OptionId.toReadableName(): String =
         OptionId.Unblock -> LocalStrings.current.actionUnblock
         OptionId.Pin -> LocalStrings.current.actionPin
         OptionId.Unpin -> LocalStrings.current.actionUnpin
-        OptionId.Move -> LocalStrings.current.actionMove
-        OptionId.SetSchedule -> LocalStrings.current.actionSetScheduleDate
-        OptionId.ChangeSchedule -> LocalStrings.current.actionUpdateScheduleDate
-        OptionId.PublishDefault -> LocalStrings.current.actionPublishDefault
-        OptionId.SaveDraft -> LocalStrings.current.actionSaveDraft
         OptionId.ReportUser -> LocalStrings.current.actionReportUser
         OptionId.ReportEntry -> LocalStrings.current.actionReportEntry
         OptionId.ViewDetails -> LocalStrings.current.actionViewDetails

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserHeader.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserHeader.kt
@@ -11,12 +11,8 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Groups
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.OutlinedIconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -46,7 +42,6 @@ fun UserHeader(
     onOpenUrl: ((String) -> Unit)? = null,
     onRelationshipClicked: ((RelationshipStatusNextAction) -> Unit)? = null,
     onNotificationsClicked: ((NotificationStatusNextAction) -> Unit)? = null,
-    onOpenInForumMode: (() -> Unit)? = null,
     onEditClicked: (() -> Unit)? = null,
 ) {
     val banner = user?.header.orEmpty()
@@ -164,18 +159,6 @@ fun UserHeader(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(Spacing.m),
                     ) {
-                        if (user?.group == true) {
-                            OutlinedIconButton(
-                                onClick = {
-                                    onOpenInForumMode?.invoke()
-                                },
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Default.Groups,
-                                    contentDescription = null,
-                                )
-                            }
-                        }
                         if (notificationStatus != null) {
                             UserNotificationButton(
                                 status = notificationStatus,

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserItem.kt
@@ -97,6 +97,9 @@ fun UserItem(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 emojis = user.emojis,
+                onClick = {
+                    onClick?.invoke()
+                },
             )
             Text(
                 text = user.handle ?: user.username ?: "",

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
@@ -370,4 +370,8 @@ internal val DeStrings =
         override val insertEmojiTitle = "Emoji einfügen"
         override val messageLoadingUsers = "Benutzer laden"
         override val actionOpenPreview = "Vorschau öffnen"
+        override val actionSwitchToClassicMode = "Zum klassischen Modus wechseln"
+        override val actionSwitchToForumMode = "Zum Forum-Modus wechseln"
+        override val settingsItemOpenGroupsInForumModeByDefault =
+            "Gruppen standardmäßig im Forum-Modus öffnen"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -361,4 +361,7 @@ internal open class DefaultStrings : Strings {
     override val insertEmojiTitle = "Insert emoji"
     override val messageLoadingUsers = "Loading users"
     override val actionOpenPreview = "Open preview"
+    override val actionSwitchToClassicMode = "Switch to classic mode"
+    override val actionSwitchToForumMode = "Switch to forum mode"
+    override val settingsItemOpenGroupsInForumModeByDefault = "Open groups in forum mode by default"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -370,4 +370,8 @@ internal val ItStrings =
         override val insertEmojiTitle = "Inserisci emoji"
         override val messageLoadingUsers = "Caricamento utenti"
         override val actionOpenPreview = "Visualizza anteprima"
+        override val actionSwitchToClassicMode = "Passa a modalità classica"
+        override val actionSwitchToForumMode = "Passa a modalità forum"
+        override val settingsItemOpenGroupsInForumModeByDefault =
+            "Apri i gruppi in modalità forum di default"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -325,6 +325,9 @@ interface Strings {
     val insertEmojiTitle: String
     val messageLoadingUsers: String
     val actionOpenPreview: String
+    val actionSwitchToClassicMode: String
+    val actionSwitchToForumMode: String
+    val settingsItemOpenGroupsInForumModeByDefault: String
 }
 
 object Locales {

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationCoordinator.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationCoordinator.kt
@@ -65,6 +65,10 @@ internal class DefaultNavigationCoordinator(
         }
     }
 
+    override fun replace(screen: Screen) {
+        rootNavigator?.replace(screen)
+    }
+
     override fun pop() {
         rootNavigator?.pop()
         canPop.update {

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DetailOpener.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DetailOpener.kt
@@ -9,6 +9,10 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 interface DetailOpener {
     fun openUserDetail(user: UserModel)
 
+    fun switchUserDetailToClassicMode(user: UserModel)
+
+    fun switchUserDetailToForumMode(user: UserModel)
+
     fun openEntryDetail(entry: TimelineEntryModel)
 
     fun openSettings()
@@ -49,8 +53,6 @@ interface DetailOpener {
     )
 
     fun openSearch()
-
-    fun openInForumMode(group: UserModel)
 
     fun openThread(entry: TimelineEntryModel)
 

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/NavigationCoordinator.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/NavigationCoordinator.kt
@@ -28,6 +28,8 @@ interface NavigationCoordinator {
 
     fun setRootNavigator(navigator: Navigator)
 
+    fun replace(screen: Screen)
+
     fun push(screen: Screen)
 
     fun pop()

--- a/core/persistence/schemas/com.livefast.eattrash.raccoonforfriendica.core.persistence.AppDatabase/8.json
+++ b/core/persistence/schemas/com.livefast.eattrash.raccoonforfriendica.core.persistence.AppDatabase/8.json
@@ -1,0 +1,269 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 8,
+    "identityHash": "e7885f87d61184b63cd925c12539181e",
+    "entities": [
+      {
+        "tableName": "AccountEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `handle` TEXT NOT NULL, `active` INTEGER NOT NULL DEFAULT 0, `remoteId` TEXT, `avatar` TEXT, `displayName` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "handle",
+            "columnName": "handle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "active",
+            "columnName": "active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "avatar",
+            "columnName": "avatar",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AccountEntity_handle",
+            "unique": false,
+            "columnNames": [
+              "handle"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AccountEntity_handle` ON `${TABLE_NAME}` (`handle`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SettingsEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `accountId` INTEGER NOT NULL DEFAULT 0, `lang` TEXT NOT NULL DEFAULT 'en', `theme` INTEGER NOT NULL DEFAULT 0, `fontFamily` INTEGER NOT NULL DEFAULT 0, `fontScale` INTEGER NOT NULL DEFAULT 0, `dynamicColors` INTEGER NOT NULL DEFAULT 0, `customSeedColor` INTEGER, `defaultTimelineType` INTEGER NOT NULL DEFAULT 0, `includeNsfw` INTEGER NOT NULL DEFAULT 0, `blurNsfw` INTEGER NOT NULL DEFAULT 0, `urlOpeningMode` INTEGER NOT NULL DEFAULT 0, `defaultPostVisibility` INTEGER NOT NULL DEFAULT 0, `defaultReplyVisibility` INTEGER NOT NULL DEFAULT 0, `excludeRepliesFromTimeline` INTEGER NOT NULL DEFAULT 0, `openGroupsInForumModeByDefault` INTEGER NOT NULL DEFAULT 1)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lang",
+            "columnName": "lang",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'en'"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "fontScale",
+            "columnName": "fontScale",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "dynamicColors",
+            "columnName": "dynamicColors",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "customSeedColor",
+            "columnName": "customSeedColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "defaultTimelineType",
+            "columnName": "defaultTimelineType",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "includeNsfw",
+            "columnName": "includeNsfw",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "blurNsfw",
+            "columnName": "blurNsfw",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "urlOpeningMode",
+            "columnName": "urlOpeningMode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "defaultPostVisibility",
+            "columnName": "defaultPostVisibility",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "defaultReplyVisibility",
+            "columnName": "defaultReplyVisibility",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "excludeRepliesFromTimeline",
+            "columnName": "excludeRepliesFromTimeline",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "openGroupsInForumModeByDefault",
+            "columnName": "openGroupsInForumModeByDefault",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "DraftEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mediaIds` TEXT, `inReplyToId` TEXT, `lang` TEXT, `sensitive` INTEGER, `spoiler` TEXT, `title` TEXT, `text` TEXT, `created` TEXT, `visibility` TEXT, `pollExpiresAt` TEXT, `pollMultiple` INTEGER, `pollOptions` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaIds",
+            "columnName": "mediaIds",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "inReplyToId",
+            "columnName": "inReplyToId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lang",
+            "columnName": "lang",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sensitive",
+            "columnName": "sensitive",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "spoiler",
+            "columnName": "spoiler",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "visibility",
+            "columnName": "visibility",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pollExpiresAt",
+            "columnName": "pollExpiresAt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pollMultiple",
+            "columnName": "pollMultiple",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pollOptions",
+            "columnName": "pollOptions",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e7885f87d61184b63cd925c12539181e')"
+    ]
+  }
+}

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/AppDatabase.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/AppDatabase.kt
@@ -17,7 +17,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.persistence.entities.Setti
         SettingsEntity::class,
         DraftEntity::class,
     ],
-    version = 7,
+    version = 8,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
@@ -25,6 +25,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.persistence.entities.Setti
         AutoMigration(from = 4, to = 5),
         AutoMigration(from = 5, to = 6),
         AutoMigration(from = 6, to = 7),
+        AutoMigration(from = 7, to = 8),
 
     ],
 )

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/entities/SettingsEntity.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/entities/SettingsEntity.kt
@@ -21,4 +21,5 @@ data class SettingsEntity(
     @ColumnInfo(defaultValue = "0") val defaultPostVisibility: Int = 0,
     @ColumnInfo(defaultValue = "0") val defaultReplyVisibility: Int = 0,
     @ColumnInfo(defaultValue = "0") val excludeRepliesFromTimeline: Boolean = false,
+    @ColumnInfo(defaultValue = "1") val openGroupsInForumModeByDefault: Boolean = true,
 )

--- a/domain/identity/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/data/SettingsModel.kt
+++ b/domain/identity/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/data/SettingsModel.kt
@@ -20,4 +20,5 @@ data class SettingsModel(
     val defaultPostVisibility: Int = 0,
     val defaultReplyVisibility: Int = 0,
     val excludeRepliesFromTimeline: Boolean = false,
+    val openGroupsInForumModeByDefault: Boolean = true,
 )

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultSettingsRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultSettingsRepository.kt
@@ -53,6 +53,7 @@ private fun SettingsEntity.toModel() =
         defaultPostVisibility = defaultPostVisibility,
         defaultReplyVisibility = defaultReplyVisibility,
         excludeRepliesFromTimeline = excludeRepliesFromTimeline,
+        openGroupsInForumModeByDefault = openGroupsInForumModeByDefault,
     )
 
 private fun SettingsModel.toEntity() =
@@ -72,4 +73,5 @@ private fun SettingsModel.toEntity() =
         defaultPostVisibility = defaultPostVisibility,
         defaultReplyVisibility = defaultReplyVisibility,
         excludeRepliesFromTimeline = excludeRepliesFromTimeline,
+        openGroupsInForumModeByDefault = openGroupsInForumModeByDefault,
     )

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
@@ -265,21 +265,42 @@ class ComposerScreen(
                             buildList {
                                 when (uiState.publicationType) {
                                     is PublicationType.Scheduled -> {
-                                        this += OptionId.SaveDraft.toOption()
-                                        this += OptionId.ChangeSchedule.toOption()
+                                        this +=
+                                            CustomOptions.SaveDraft.toOption(
+                                                label = LocalStrings.current.actionSaveDraft,
+                                            )
+                                        this +=
+                                            CustomOptions.ChangeSchedule.toOption(
+                                                label = LocalStrings.current.actionUpdateScheduleDate,
+                                            )
                                         if (!isBeingEdited) {
-                                            this += OptionId.PublishDefault.toOption()
+                                            this +=
+                                                CustomOptions.PublishDefault.toOption(
+                                                    label = LocalStrings.current.actionPublishDefault,
+                                                )
                                         }
                                     }
 
                                     PublicationType.Draft -> {
-                                        this += OptionId.SetSchedule.toOption()
-                                        this += OptionId.PublishDefault.toOption()
+                                        this +=
+                                            CustomOptions.SetSchedule.toOption(
+                                                label = LocalStrings.current.actionSetScheduleDate,
+                                            )
+                                        this +=
+                                            CustomOptions.PublishDefault.toOption(
+                                                label = LocalStrings.current.actionPublishDefault,
+                                            )
                                     }
 
                                     PublicationType.Default -> {
-                                        this += OptionId.SaveDraft.toOption()
-                                        this += OptionId.SetSchedule.toOption()
+                                        this +=
+                                            CustomOptions.SaveDraft.toOption(
+                                                label = LocalStrings.current.actionSaveDraft,
+                                            )
+                                        this +=
+                                            CustomOptions.SetSchedule.toOption(
+                                                label = LocalStrings.current.actionSetScheduleDate,
+                                            )
                                     }
                                 }
 
@@ -365,12 +386,12 @@ class ComposerScreen(
                                         onClick = {
                                             optionsMenuOpen = false
                                             when (option.id) {
-                                                OptionId.SetSchedule -> {
+                                                CustomOptions.SetSchedule -> {
                                                     scheduleDateMillis = epochMillis()
                                                     scheduleDatePickerOpen = true
                                                 }
 
-                                                OptionId.ChangeSchedule -> {
+                                                CustomOptions.ChangeSchedule -> {
                                                     scheduleDateMillis =
                                                         (uiState.publicationType as? PublicationType.Scheduled)
                                                             ?.date
@@ -378,14 +399,14 @@ class ComposerScreen(
                                                     scheduleDatePickerOpen = true
                                                 }
 
-                                                OptionId.PublishDefault ->
+                                                CustomOptions.PublishDefault ->
                                                     model.reduce(
                                                         ComposerMviModel.Intent.ChangePublicationType(
                                                             PublicationType.Default,
                                                         ),
                                                     )
 
-                                                OptionId.SaveDraft ->
+                                                CustomOptions.SaveDraft ->
                                                     model.reduce(
                                                         ComposerMviModel.Intent.ChangePublicationType(
                                                             PublicationType.Draft,
@@ -936,8 +957,14 @@ private sealed interface CustomOptions : OptionId.Custom {
     data object TogglePoll : CustomOptions
 
     data object ToggleTitle : CustomOptions
-
     data object InsertCustomEmoji : CustomOptions
 
     data object OpenPreview : CustomOptions
+
+    data object SaveDraft : CustomOptions
+
+    data object ChangeSchedule : CustomOptions
+
+    data object SetSchedule : CustomOptions
+    data object PublishDefault : CustomOptions
 }

--- a/feature/gallery/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/gallery/detail/AlbumDetailScreen.kt
+++ b/feature/gallery/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/gallery/detail/AlbumDetailScreen.kt
@@ -254,7 +254,10 @@ class AlbumDetailScreen(
                                     this += OptionId.Delete.toOption()
                                     this += OptionId.Edit.toOption()
                                     if (uiState.albums.isNotEmpty()) {
-                                        this += OptionId.Move.toOption()
+                                        this +=
+                                            CustomOptions.Move.toOption(
+                                                label = LocalStrings.current.actionMove,
+                                            )
                                     }
                                 },
                             onOptionSelected = { optionId ->
@@ -263,7 +266,7 @@ class AlbumDetailScreen(
                                     OptionId.Edit ->
                                         attachmentWithDescriptionBeingEdited = attachment
 
-                                    OptionId.Move -> attachmentToMove = attachment
+                                    CustomOptions.Move -> attachmentToMove = attachment
 
                                     else -> Unit
                                 }
@@ -358,4 +361,8 @@ class AlbumDetailScreen(
             )
         }
     }
+}
+
+private sealed interface CustomOptions : OptionId.Custom {
+    data object Move : CustomOptions
 }

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsMviModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsMviModel.kt
@@ -68,6 +68,10 @@ interface SettingsMviModel :
         data class ChangeExcludeRepliesFromTimeline(
             val value: Boolean,
         ) : Intent
+
+        data class ChangeOpenGroupsInForumModeByDefault(
+            val value: Boolean,
+        ) : Intent
     }
 
     data class State(
@@ -89,6 +93,7 @@ interface SettingsMviModel :
         val defaultReplyVisibility: Visibility = Visibility.Public,
         val excludeRepliesFromTimeline: Boolean = false,
         val availableVisibilities: List<Visibility> = emptyList(),
+        val openGroupsInForumModeByDefault: Boolean = true,
     )
 
     sealed interface Effect

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
@@ -175,6 +175,15 @@ class SettingsScreen : Screen {
                                 )
                             },
                         )
+                        SettingsSwitchRow(
+                            title = LocalStrings.current.settingsItemOpenGroupsInForumModeByDefault,
+                            value = uiState.openGroupsInForumModeByDefault,
+                            onValueChanged = {
+                                model.reduce(
+                                    SettingsMviModel.Intent.ChangeOpenGroupsInForumModeByDefault(it),
+                                )
+                            },
+                        )
 
                         SettingsHeader(
                             title = LocalStrings.current.settingsHeaderLookAndFeel,

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsViewModel.kt
@@ -99,6 +99,7 @@ class SettingsViewModel(
                                 defaultPostVisibility = settings.defaultPostVisibility.toVisibility(),
                                 defaultReplyVisibility = settings.defaultReplyVisibility.toVisibility(),
                                 excludeRepliesFromTimeline = settings.excludeRepliesFromTimeline,
+                                openGroupsInForumModeByDefault = settings.openGroupsInForumModeByDefault,
                             )
                         }
                     }
@@ -195,6 +196,11 @@ class SettingsViewModel(
                 screenModelScope.launch {
                     changeExcludeRepliesFromTimeline(intent.value)
                 }
+
+            is SettingsMviModel.Intent.ChangeOpenGroupsInForumModeByDefault ->
+                screenModelScope.launch {
+                    changeOpenGroupsInForumModeByDefault(intent.value)
+                }
         }
     }
 
@@ -273,6 +279,12 @@ class SettingsViewModel(
     private suspend fun changeExcludeRepliesFromTimeline(value: Boolean) {
         val currentSettings = settingsRepository.current.value ?: return
         val newSettings = currentSettings.copy(excludeRepliesFromTimeline = value)
+        saveSettings(newSettings)
+    }
+
+    private suspend fun changeOpenGroupsInForumModeByDefault(value: Boolean) {
+        val currentSettings = settingsRepository.current.value ?: return
+        val newSettings = currentSettings.copy(openGroupsInForumModeByDefault = value)
         saveSettings(newSettings)
     }
 

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -244,6 +244,12 @@ class UserDetailScreen(
                                                     LocalStrings.current.actionEditPersonalNote
                                                 },
                                         )
+                                    if (user.group) {
+                                        this +=
+                                            CustomOptions.SwitchToForumMode.toOption(
+                                                label = LocalStrings.current.actionSwitchToForumMode,
+                                            )
+                                    }
                                 }
                             }
                         if (options.isNotEmpty()) {
@@ -318,6 +324,12 @@ class UserDetailScreen(
                                                         uiState.user?.also { userToReport ->
                                                             detailOpener.openCreateReport(user = userToReport)
                                                         }
+
+                                                    CustomOptions.SwitchToForumMode -> {
+                                                        uiState.user?.also { user ->
+                                                            detailOpener.switchUserDetailToForumMode(user)
+                                                        }
+                                                    }
                                                     else -> Unit
                                                 }
                                             },
@@ -438,11 +450,6 @@ class UserDetailScreen(
                                 onOpenFollowing = {
                                     uiState.user?.also { user ->
                                         detailOpener.openFollowing(user)
-                                    }
-                                },
-                                onOpenInForumMode = {
-                                    uiState.user?.also { user ->
-                                        detailOpener.openInForumMode(user)
                                     }
                                 },
                             )
@@ -823,4 +830,8 @@ class UserDetailScreen(
             )
         }
     }
+}
+
+private sealed interface CustomOptions : OptionId.Custom {
+    data object SwitchToForumMode : CustomOptions
 }


### PR DESCRIPTION
This PR adds a new switch in the settings screen to select the default opening mode for groups:
- **classic mode** groups are displayed as regular users with a header and a selector (posts, post & replies, pinned, media) for contents;
- **forum mode** groups are opened as topics (similar to Lemmy communities) with only top-level posts which can be opened as threads in a detail screen.

Even if groups are opened with the default mode, it is always possible to switch among the available modes using the "⋮" button in the top application bar.

Individual users are not affected by this modification.