### PR TITLE
fix: retain state in profile screen

### DIFF
--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitorTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitorTest.kt
@@ -19,9 +19,11 @@ import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify
 import dev.mokkery.verifySuspend
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 
@@ -36,6 +38,8 @@ class DefaultActiveAccountMonitorTest {
         mock<SupportedFeatureRepository>(mode = MockMode.autoUnit)
     private val inboxManager = mock<InboxManager>(mode = MockMode.autoUnit)
     private val contentPreloadManager = mock<ContentPreloadManager>(mode = MockMode.autoUnit)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
     private val sut =
         DefaultActiveAccountMonitor(
             accountRepository = accountRepository,
@@ -46,6 +50,7 @@ class DefaultActiveAccountMonitorTest {
             supportedFeatureRepository = supportedFeatureRepository,
             inboxManager = inboxManager,
             contentPreloadManager = contentPreloadManager,
+            coroutineDispatcher = UnconfinedTestDispatcher(),
         )
 
     @Test

--- a/feature/profile/build.gradle.kts
+++ b/feature/profile/build.gradle.kts
@@ -37,6 +37,7 @@ kotlin {
 
                 implementation(libs.koin.core)
                 implementation(libs.voyager.screenmodel)
+                implementation(libs.voyager.tab)
                 implementation(libs.voyager.koin)
 
                 implementation(projects.core.appearance)

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
-import cafe.adriel.voyager.navigator.Navigator
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomImage
@@ -130,10 +129,10 @@ class ProfileScreen : Screen {
                                 .padding(padding)
                                 .nestedScroll(scrollBehavior.nestedScrollConnection),
                     ) {
-                        if (uiState.currentUserId == null) {
-                            Navigator(AnonymousScreen())
+                        if (uiState.currentUserId != null) {
+                            MyAccountScreen.Content()
                         } else {
-                            Navigator(MyAccountScreen())
+                            AnonymousScreen.Content()
                         }
                     }
                 },

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/anonymous/AnonymousScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/anonymous/AnonymousScreen.kt
@@ -14,12 +14,20 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
-import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
+import cafe.adriel.voyager.navigator.tab.Tab
+import cafe.adriel.voyager.navigator.tab.TabOptions
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
 
-internal class AnonymousScreen : Screen {
+internal object AnonymousScreen : Tab {
+    override val options: TabOptions
+        @Composable get() =
+            TabOptions(
+                index = 0u,
+                title = "",
+            )
+
     @Composable
     override fun Content() {
         val model = getScreenModel<AnonymousMviModel>()

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
@@ -39,8 +39,9 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
+import cafe.adriel.voyager.navigator.tab.Tab
+import cafe.adriel.voyager.navigator.tab.TabOptions
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Dimensions
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
@@ -75,7 +76,14 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
-class MyAccountScreen : Screen {
+object MyAccountScreen : Tab {
+    override val options: TabOptions
+        @Composable get() =
+            TabOptions(
+                index = 1u,
+                title = "",
+            )
+
     @OptIn(
         ExperimentalFoundationApi::class,
         ExperimentalMaterialApi::class,


### PR DESCRIPTION
This PR makes sure the state (e.g. list scroll state) is not lost in the profile screen when navigation back and forth, e. g. when opening a post detail and navigating back.

The solution is (unfortunately) remove the nested navigation and tie everything to the lifecycle of the container screen (`ProfileScreen`).