### PR TITLE
fix: change account and login

### DIFF
--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/ProgressHud.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/ProgressHud.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.graphics.Color
 
 @Composable
 fun ProgressHud(
-    overlayColor: Color = MaterialTheme.colorScheme.scrim,
+    overlayColor: Color = MaterialTheme.colorScheme.scrim.copy(alpha = 0.65f),
     color: Color = MaterialTheme.colorScheme.primary,
 ) {
     Surface(

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/ScreenContent.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/ScreenContent.kt
@@ -1,0 +1,9 @@
+package com.livefast.eattrash.raccoonforfriendica.core.navigation
+
+import androidx.compose.runtime.Composable
+import cafe.adriel.voyager.core.screen.Screen
+
+@Composable
+fun ScreenContent(screen: Screen) {
+    screen.Content()
+}

--- a/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/oauth/LoginViewModel.kt
+++ b/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/oauth/LoginViewModel.kt
@@ -74,14 +74,13 @@ class LoginViewModel(
                 return@launch
             }
 
-            updateState {
-                it.copy(loading = true)
-            }
+            updateState { it.copy(loading = true) }
             try {
                 val url = authManager.startOAuthFlow(node)
                 emitEffect(LoginMviModel.Effect.OpenUrl(url))
             } catch (e: Throwable) {
                 emitEffect(LoginMviModel.Effect.Failure(e.message))
+                updateState { it.copy(loading = false) }
             }
         }
     }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileMviModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileMviModel.kt
@@ -26,6 +26,7 @@ interface ProfileMviModel :
     data class State(
         val currentUserId: String? = null,
         val availableAccounts: List<AccountModel> = emptyList(),
+        val loading: Boolean = false,
     )
 
     sealed interface Effect

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
@@ -42,6 +42,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.Custom
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomModalBottomSheet
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomModalBottomSheetItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.PlaceholderImage
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ProgressHud
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.ScreenContent
@@ -237,6 +238,10 @@ class ProfileScreen : Screen {
                     }
                 },
             )
+        }
+
+        if (uiState.loading) {
+            ProgressHud()
         }
     }
 }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
@@ -44,6 +44,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.Custom
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.PlaceholderImage
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.ScreenContent
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDrawerCoordinator
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
 import com.livefast.eattrash.raccoonforfriendica.feature.profile.anonymous.AnonymousScreen
@@ -130,9 +131,9 @@ class ProfileScreen : Screen {
                                 .nestedScroll(scrollBehavior.nestedScrollConnection),
                     ) {
                         if (uiState.currentUserId != null) {
-                            MyAccountScreen.Content()
+                            ScreenContent(MyAccountScreen)
                         } else {
-                            AnonymousScreen.Content()
+                            ScreenContent(AnonymousScreen)
                         }
                     }
                 },

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
@@ -205,6 +205,7 @@ class ProfileScreen : Screen {
                     }
                 },
                 onLongPress = { index ->
+                    manageAccountsDialogOpened = false
                     val selectedAccount = uiState.availableAccounts[index]
                     if (!selectedAccount.active) {
                         confirmDeleteAccount = selectedAccount

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileViewModel.kt
@@ -29,7 +29,10 @@ class ProfileViewModel(
             identityRepository.currentUser
                 .onEach { currentUser ->
                     updateState {
-                        it.copy(currentUserId = currentUser?.id)
+                        it.copy(
+                            currentUserId = currentUser?.id,
+                            loading = false,
+                        )
                     }
                 }.launchIn(this)
 
@@ -62,6 +65,9 @@ class ProfileViewModel(
             return
         }
         screenModelScope.launch {
+            updateState {
+                it.copy(loading = true)
+            }
             switchAccountUseCase(account)
         }
     }


### PR DESCRIPTION
This PR makes sure loading state is properly shown when switching account or logging in. 

Moreover, there was an issue in the profile screen with the long-press-to-delete in the "Manage accounts" bottom sheet, which caused the screen to be unresponsive if the deletion was canceled.