### PR TITLE
fix: add verticalScroll modifier to Settings column

### DIFF
--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
@@ -7,7 +7,9 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.BugReport
@@ -121,7 +123,9 @@ class SettingsScreen : Screen {
                             .padding(padding)
                             .nestedScroll(scrollBehavior.nestedScrollConnection),
                 ) {
-                    Column {
+                    Column(
+                        modifier = Modifier.verticalScroll(rememberScrollState()),
+                    ) {
                         SettingsHeader(
                             title = LocalStrings.current.settingsHeaderGeneral,
                             icon = Icons.Default.Settings,


### PR DESCRIPTION
This solves an issue due to which the settings screen was not scrollable (#328).