### PR TITLE
fix: avoid spoilers from closing due to recomposition

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
@@ -183,7 +183,10 @@ fun TimelineItem(
                 )
             }
 
-            val contentVisible = entryToDisplay.isSpoilerActive || spoiler.isEmpty()
+            val contentVisible =
+                remember(entryToDisplay.isSpoilerActive) {
+                    entryToDisplay.isSpoilerActive || spoiler.isEmpty()
+                }
             AnimatedVisibility(
                 modifier = modifier.padding(horizontal = contentHorizontalPadding),
                 visible = contentVisible,


### PR DESCRIPTION
This PR fixes a bug due to which spoilers could close immediately after having been opened, due to a recomposition issue.