### PR TITLE
feature: add lists in composer

### DIFF
--- a/core/htmlparse/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/htmlparse/ParseHtml.kt
+++ b/core/htmlparse/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/htmlparse/ParseHtml.kt
@@ -26,9 +26,7 @@ fun String.parseHtml(
                     "p" ->
                         if (builder.length != 0) {
                             // separate paragraphs with a blank line
-                            if (builder.toAnnotatedString().last() != '\n') {
-                                builder.appendLine()
-                            }
+                            builder.appendLineIfNeeded()
                             builder.appendLine()
                         }
 
@@ -48,9 +46,9 @@ fun String.parseHtml(
                     "u" -> builder.pushStyle(SpanStyle(textDecoration = TextDecoration.Underline))
                     "i", "em" -> builder.pushStyle(SpanStyle(fontStyle = FontStyle.Italic))
                     "s" -> builder.pushStyle(SpanStyle(textDecoration = TextDecoration.LineThrough))
-                    "ul" -> builder.appendLine()
+                    "ul" -> builder.appendLineIfNeeded()
                     "ol" -> {
-                        builder.appendLine()
+                        builder.appendLineIfNeeded()
                         inOrderedList = true
                     }
 
@@ -90,6 +88,12 @@ fun String.parseHtml(
     ksoupHtmlParser.end()
 
     return builder.toAnnotatedString()
+}
+
+private fun AnnotatedString.Builder.appendLineIfNeeded() {
+    if (toAnnotatedString().last() != '\n') {
+        appendLine()
+    }
 }
 
 private fun String.sanitize(requiresHtmlDecode: Boolean): String =

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
@@ -373,4 +373,5 @@ internal val DeStrings =
         override val actionSwitchToForumMode = "Zum Forum-Modus wechseln"
         override val settingsItemOpenGroupsInForumModeByDefault =
             "Gruppen standardmäßig im Forum-Modus öffnen"
+        override val actionInsertList = "Liste einfügen"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -365,4 +365,5 @@ internal open class DefaultStrings : Strings {
     override val actionSwitchToClassicMode = "Switch to classic mode"
     override val actionSwitchToForumMode = "Switch to forum mode"
     override val settingsItemOpenGroupsInForumModeByDefault = "Open groups in forum mode by default"
+    override val actionInsertList = "Insert list"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/EsStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/EsStrings.kt
@@ -374,4 +374,5 @@ internal val EsStrings =
         override val actionSwitchToForumMode = "Cambiar al modo foro"
         override val settingsItemOpenGroupsInForumModeByDefault =
             "Abrir grupos en modo foro por defecto"
+        override val actionInsertList = "Insertar lista"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/FrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/FrStrings.kt
@@ -378,4 +378,5 @@ internal val FrStrings =
         override val actionSwitchToForumMode = "Passer en mode forum"
         override val settingsItemOpenGroupsInForumModeByDefault =
             "Ouvrir les groupes en mode forum par défaut"
+        override val actionInsertList = "Insérer une liste"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -347,13 +347,13 @@ internal val ItStrings =
         override val actionReportUser = "Segnala utente"
         override val actionReportEntry = "Segnala post"
         override val actionViewDetails = "Dettagli"
-        override val actionAddImageFromGallery = "Add from gallery"
-        override val actionAddPoll = "Add poll"
-        override val actionRemovePoll = "Remove poll"
-        override val createPostPollSection = "Poll"
-        override val createPostPollOptionLabel = "Option"
-        override val createPostPollItemMultiple = "Allow multiple choice"
-        override val createPostPollItemExpirationDate = "Expiration date"
+        override val actionAddImageFromGallery = "Aggiungi dalla galleria"
+        override val actionAddPoll = "Aggiungi sondaggio"
+        override val actionRemovePoll = "Rimuovi sondaggio"
+        override val createPostPollSection = "Sondaggio"
+        override val createPostPollOptionLabel = "Opzione"
+        override val createPostPollItemMultiple = "Permettere scelta multipla"
+        override val createPostPollItemExpirationDate = "Data di fine"
         override val messageInvalidPollError =
             "Sondaggio non valido, controllare le opzioni e la data di fine"
         override val userFeedbackFieldEmail = "Email o username (opzionale)"
@@ -373,4 +373,5 @@ internal val ItStrings =
         override val actionSwitchToForumMode = "Passa a modalità forum"
         override val settingsItemOpenGroupsInForumModeByDefault =
             "Apri i gruppi in modalità forum di default"
+        override val actionInsertList = "Inserisci lista"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -329,6 +329,7 @@ interface Strings {
     val actionSwitchToClassicMode: String
     val actionSwitchToForumMode: String
     val settingsItemOpenGroupsInForumModeByDefault: String
+    val actionInsertList: String
 }
 
 object Locales {

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
@@ -186,6 +186,8 @@ interface ComposerMviModel :
         ) : Intent
 
         data object CreatePreview : Intent
+
+        data object InsertList : Intent
     }
 
     data class State(

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
@@ -346,6 +346,10 @@ class ComposerScreen(
                                                 },
                                         )
                                 }
+                                this +=
+                                    CustomOptions.InsertList.toOption(
+                                        label = LocalStrings.current.actionInsertList,
+                                    )
                             }
                         Box {
                             var optionsOffset by remember { mutableStateOf(Offset.Zero) }
@@ -439,6 +443,10 @@ class ComposerScreen(
 
                                                 CustomOptions.OpenPreview -> {
                                                     model.reduce(ComposerMviModel.Intent.CreatePreview)
+                                                }
+
+                                                CustomOptions.InsertList -> {
+                                                    model.reduce(ComposerMviModel.Intent.InsertList)
                                                 }
 
                                                 else -> Unit
@@ -957,6 +965,7 @@ private sealed interface CustomOptions : OptionId.Custom {
     data object TogglePoll : CustomOptions
 
     data object ToggleTitle : CustomOptions
+
     data object InsertCustomEmoji : CustomOptions
 
     data object OpenPreview : CustomOptions
@@ -966,5 +975,8 @@ private sealed interface CustomOptions : OptionId.Custom {
     data object ChangeSchedule : CustomOptions
 
     data object SetSchedule : CustomOptions
+
     data object PublishDefault : CustomOptions
+
+    data object InsertList : CustomOptions
 }

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
@@ -465,6 +465,8 @@ class ComposerViewModel(
                     createPreview()
                 }
 
+            is ComposerMviModel.Intent.InsertList -> insertList()
+
             ComposerMviModel.Intent.Submit -> submit()
         }
     }
@@ -1009,6 +1011,34 @@ class ComposerViewModel(
                         )
                 }
             }
+        }
+    }
+
+    private fun insertList() {
+        screenModelScope.launch {
+            val before =
+                if (useBBCode) {
+                    "\n[ul]\n[li]"
+                } else {
+                    "\n<ul>\n<li>"
+                }
+            val after =
+                if (useBBCode) {
+                    "[/li]\n[/ul]"
+                } else {
+                    "</li></ul>"
+                }
+            val newValue =
+                getNewTextFieldValue(
+                    value = uiState.value.bodyValue,
+                    additionalPart =
+                        buildString {
+                            append(before)
+                            append(after)
+                        },
+                    offsetAfter = before.length,
+                )
+            updateState { it.copy(bodyValue = newValue, hasUnsavedChanges = true) }
         }
     }
 

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
@@ -1509,6 +1509,14 @@ class ComposerViewModel(
             .replace("[/b]", "</b>")
             .replace("[code]", "<code>")
             .replace("[/code]", "</code>")
+            .replace("[ul]", "<ul>")
+            .replace("[/ul]", "</ul>")
+            .replace("[ol]", "<ol>")
+            .replace("[/ol]", "</ol>")
+            .replace("[li]", "<li>")
+            .replace("[/li]", "</li>")
+            .replace(Regex("\n\n"), "<br /><br />")
+            .replace("\n", " ")
             .also { original ->
                 val matches = SHARE_REGEX.findAll(original).toList()
                 buildString {


### PR DESCRIPTION
This PR introduces the possibility to insert unordered list in posts using the "Insert list" action in the top app "⋮" menu. 

Moreover it improves post preview by adding support for lists and making sure newlines are displayed in a more faithful way (considering what the back-end does to post source code).