### PR TITLE
fix: resolve deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="https://img.shields.io/badge/Kotlin-2.0.20-7F52FF?logo=kotlin" />
+  <img src="https://img.shields.io/badge/Kotlin-2.0.21-7F52FF?logo=kotlin" />
   <img src="https://img.shields.io/badge/Gradle-8.8-02303A?logo=gradle" />
   <img src="https://img.shields.io/badge/Android-26+-34A853?logo=android" />
   <img src="https://img.shields.io/badge/Compose-1.6.7-4285F4?logo=jetpackcompose" />

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/EditTextualInfoDialog.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/EditTextualInfoDialog.kt
@@ -89,7 +89,6 @@ fun EditTextualInfoDialog(
                 keyboardOptions =
                     KeyboardOptions(
                         keyboardType = KeyboardType.Text,
-                        autoCorrect = true,
                     ),
                 onValueChange = { value ->
                     textFieldValue = value

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SpoilerCard.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SpoilerCard.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.surfaceColorAtElevation
@@ -75,7 +74,7 @@ fun SpoilerCard(
                     ),
             verticalArrangement = Arrangement.spacedBy(Spacing.s),
         ) {
-            ClickableText(
+            TextWithCustomEmojis(
                 style = MaterialTheme.typography.titleMedium.copy(color = fullColor),
                 text = annotatedContent,
                 onClick = { _ ->

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/components/CircleEditorDialog.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/components/CircleEditorDialog.kt
@@ -83,7 +83,6 @@ internal fun CircleEditorDialog(
                 keyboardOptions =
                     KeyboardOptions(
                         keyboardType = KeyboardType.Text,
-                        autoCorrect = true,
                     ),
                 isError = data.titleError != null,
                 supportingText = {

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
@@ -653,7 +653,6 @@ class ComposerScreen(
                                 KeyboardOptions(
                                     imeAction = ImeAction.Next,
                                     keyboardType = KeyboardType.Text,
-                                    autoCorrect = true,
                                     capitalization = KeyboardCapitalization.Sentences,
                                 ),
                             keyboardActions =
@@ -692,7 +691,6 @@ class ComposerScreen(
                                 KeyboardOptions(
                                     imeAction = ImeAction.Next,
                                     keyboardType = KeyboardType.Text,
-                                    autoCorrect = true,
                                     capitalization = KeyboardCapitalization.Sentences,
                                 ),
                             keyboardActions =
@@ -726,7 +724,6 @@ class ComposerScreen(
                         keyboardOptions =
                             KeyboardOptions(
                                 keyboardType = KeyboardType.Text,
-                                autoCorrect = true,
                                 capitalization = KeyboardCapitalization.Sentences,
                             ),
                         onValueChange = { value ->

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/components/InserLinkDialog.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/components/InserLinkDialog.kt
@@ -110,7 +110,6 @@ fun InsertLinkDialog(
                 keyboardOptions =
                     KeyboardOptions(
                         keyboardType = KeyboardType.Text,
-                        autoCorrect = true,
                     ),
                 onValueChange = { value ->
                     anchorTextFieldValue = value
@@ -146,7 +145,6 @@ fun InsertLinkDialog(
                 keyboardOptions =
                     KeyboardOptions(
                         keyboardType = KeyboardType.Uri,
-                        autoCorrect = true,
                     ),
                 onValueChange = { value ->
                     urlTextFieldValue = value

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/components/PollForm.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/components/PollForm.kt
@@ -96,16 +96,15 @@ internal fun PollForm(
             keyboardOptions =
                 KeyboardOptions(
                     keyboardType = KeyboardType.Text,
-                    autoCorrect = true,
                     imeAction = ImeAction.Next,
                 ),
             keyboardActions =
                 KeyboardActions(
                     onNext = {
                         focusManager.moveFocus(FocusDirection.Down)
-                }
-            ),
-                    trailingIcon = {
+                    },
+                ),
+            trailingIcon = {
                 IconButton(
                     onClick = {
                         onRemoveOption?.invoke(idx)

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationScreen.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationScreen.kt
@@ -208,7 +208,6 @@ class ConversationScreen(
                         modifier = Modifier.weight(1f),
                         keyboardOptions =
                             KeyboardOptions(
-                                autoCorrect = true,
                                 keyboardType = KeyboardType.Text,
                             ),
                         value = uiState.newMessageValue,

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerContent.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerContent.kt
@@ -318,7 +318,6 @@ class DrawerContent : Screen {
                         keyboardOptions =
                             KeyboardOptions(
                                 keyboardType = KeyboardType.Text,
-                                autoCorrect = true,
                             ),
                         onValueChange = { value ->
                             model.reduce(DrawerMviModel.Intent.SetAnonymousChangeNode(value))

--- a/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/legacy/LegacyLoginScreen.kt
+++ b/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/legacy/LegacyLoginScreen.kt
@@ -186,7 +186,7 @@ class LegacyLoginScreen : Screen {
                     keyboardOptions =
                         KeyboardOptions(
                             keyboardType = KeyboardType.Email,
-                            autoCorrect = false,
+                            autoCorrectEnabled = false,
                             imeAction = ImeAction.Next,
                         ),
                     onValueChange = { value ->
@@ -233,7 +233,7 @@ class LegacyLoginScreen : Screen {
                     keyboardOptions =
                         KeyboardOptions(
                             keyboardType = KeyboardType.Email,
-                            autoCorrect = false,
+                            autoCorrectEnabled = false,
                             imeAction = ImeAction.Next,
                         ),
                     onValueChange = { value ->

--- a/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/oauth/LoginScreen.kt
+++ b/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/oauth/LoginScreen.kt
@@ -170,7 +170,7 @@ class LoginScreen : Screen {
                     keyboardOptions =
                         KeyboardOptions(
                             keyboardType = KeyboardType.Email,
-                            autoCorrect = false,
+                            autoCorrectEnabled = false,
                             imeAction = ImeAction.Done,
                         ),
                     keyboardActions =

--- a/feature/report/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/report/CreateReportScreen.kt
+++ b/feature/report/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/report/CreateReportScreen.kt
@@ -216,7 +216,6 @@ class CreateReportScreen(
                     keyboardOptions =
                         KeyboardOptions(
                             keyboardType = KeyboardType.Text,
-                            autoCorrect = true,
                             capitalization = KeyboardCapitalization.Sentences,
                         ),
                     onValueChange = { value ->

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/feedback/UserFeedbackScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/feedback/UserFeedbackScreen.kt
@@ -161,7 +161,7 @@ class UserFeedbackScreen : Screen {
                     keyboardOptions =
                         KeyboardOptions(
                             keyboardType = KeyboardType.Email,
-                            autoCorrect = false,
+                            autoCorrectEnabled = false,
                         ),
                     onValueChange = { value ->
                         model.reduce(UserFeedbackMviModel.Intent.SetEmail(value))
@@ -201,7 +201,6 @@ class UserFeedbackScreen : Screen {
                     keyboardOptions =
                         KeyboardOptions(
                             keyboardType = KeyboardType.Text,
-                            autoCorrect = true,
                             capitalization = KeyboardCapitalization.Sentences,
                         ),
                     placeholder = {

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/components/UserNoteField.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/components/UserNoteField.kt
@@ -43,7 +43,6 @@ fun UserNoteField(
             keyboardOptions =
                 KeyboardOptions(
                     keyboardType = KeyboardType.Text,
-                    autoCorrect = true,
                     imeAction = ImeAction.Done,
                 ),
             keyboardActions =


### PR DESCRIPTION
This PR solves some deprecation warnings:
- `KeyboardOptions`'s constructor now takes an `autoCorrectEnabled` parameter (instead of `autoCorrect`);
- `ClickableText` was still used in spoiler cards but it should be replaced with `BasicText` with equivalent annotations;

Moreover, it updates the badges in the project's `README.md` with the current Kotlin version.