### PR TITLE
enhancement: use more visible reblog icon

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentFooter.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentFooter.kt
@@ -14,7 +14,8 @@ import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.BookmarkBorder
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
-import androidx.compose.material.icons.filled.Repeat
+import androidx.compose.material.icons.filled.RocketLaunch
+import androidx.compose.material.icons.outlined.RocketLaunch
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -59,7 +60,8 @@ fun ContentFooter(
         )
         FooterItem(
             modifier = Modifier.width(baseItemWidth),
-            icon = Icons.Default.Repeat,
+            icon = Icons.Outlined.RocketLaunch,
+            toggledIcon = Icons.Filled.RocketLaunch,
             value = reblogCount,
             toggled = reblogged,
             loading = reblogLoading,
@@ -103,10 +105,10 @@ private fun FooterItem(
     ) {
         Row(
             modifier =
-                Modifier
-                    .clickable {
-                        onClick?.invoke()
-                    },
+            Modifier
+                .clickable {
+                    onClick?.invoke()
+                },
             horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -118,9 +120,9 @@ private fun FooterItem(
                     ) {
                         CircularProgressIndicator(
                             color =
-                                MaterialTheme.colorScheme.onBackground.copy(
-                                    ancillaryTextAlpha,
-                                ),
+                            MaterialTheme.colorScheme.onBackground.copy(
+                                ancillaryTextAlpha,
+                            ),
                         )
                     }
                 }
@@ -136,11 +138,11 @@ private fun FooterItem(
             }
             Text(
                 modifier =
-                    Modifier
-                        .padding(start = Spacing.xs)
-                        .alpha(
-                            if (loading || value == 0) 0f else 1f,
-                        ),
+                Modifier
+                    .padding(start = Spacing.xs)
+                    .alpha(
+                        if (loading || value == 0) 0f else 1f,
+                    ),
                 text = value.toString(),
                 style = MaterialTheme.typography.labelMedium,
                 color = toggledColor.takeIf { toggled } ?: fullColor,


### PR DESCRIPTION
Considering a suggestion from my "mentor" for this project, the re-share (boost) icon is not visible enough when active, i.e. after the user has tapped it.

This PR changes the icon to a 🚀 which has more distinguishable filled/outlined variants.