### PR TITLE
enhancement: add top bar button to mark all notifications as read

### DIFF
--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxMviModel.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxMviModel.kt
@@ -30,6 +30,8 @@ interface InboxMviModel :
             val notification: NotificationModel,
         ) : Intent
 
+        data object MarkAllAsRead : Intent
+
         data class ToggleSpoilerActive(
             val entry: TimelineEntryModel,
         ) : Intent
@@ -44,6 +46,7 @@ interface InboxMviModel :
         val notifications: List<NotificationModel> = emptyList(),
         val blurNsfw: Boolean = true,
         val selectedNotificationTypes: List<NotificationType> = NotificationType.ALL,
+        val markAllAsReadLoading: Boolean = false,
     )
 
     sealed interface Effect {

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
@@ -5,16 +5,19 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DoneAll
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -40,6 +43,7 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.style.TextAlign
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
@@ -129,15 +133,34 @@ class InboxScreen : Screen {
                         }
                     },
                     actions = {
-                        IconButton(
-                            onClick = {
-                                configureSelectedTypesDialogOpen = true
-                            },
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.FilterList,
-                                contentDescription = null,
-                            )
+                        if (uiState.currentUserId != null) {
+                            IconButton(
+                                onClick = {
+                                    configureSelectedTypesDialogOpen = true
+                                },
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.FilterList,
+                                    contentDescription = null,
+                                )
+                            }
+                            IconButton(
+                                enabled = uiState.notifications.any { !it.read },
+                                onClick = {
+                                    model.reduce(InboxMviModel.Intent.MarkAllAsRead)
+                                },
+                            ) {
+                                if (uiState.markAllAsReadLoading) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.size(IconSize.s),
+                                    )
+                                } else {
+                                    Icon(
+                                        imageVector = Icons.Default.DoneAll,
+                                        contentDescription = null,
+                                    )
+                                }
+                            }
                         }
                     },
                 )

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
@@ -60,9 +60,13 @@ class InboxViewModel(
                     loadNextPage()
                 }
 
-            InboxMviModel.Intent.Refresh ->
+            InboxMviModel.Intent.MarkAllAsRead ->
                 screenModelScope.launch {
                     markAllAsRead()
+                }
+
+            InboxMviModel.Intent.Refresh ->
+                screenModelScope.launch {
                     refresh()
                 }
 
@@ -253,9 +257,11 @@ class InboxViewModel(
     }
 
     private suspend fun markAllAsRead() {
+        updateState { it.copy(markAllAsReadLoading = true) }
         for (item in uiState.value.notifications.filterNot { it.read }) {
             notificationRepository.markAsRead(item.id)
         }
+        updateState { it.copy(markAllAsReadLoading = false) }
     }
 
     private fun markAsRead(notification: NotificationModel) {


### PR DESCRIPTION
This PR introduces a distinction between refreshing the notification feed and settings all items as read. Even if most Mastodon/Moshidon uses expect this behaviour, the fact that Friendica and Mastodon are not 100% compatible as far as notification management is concerned makes this counterintuitive.

On Mastodon an items disappears from the list once the POST `v1/notifications/:id/dismiss` is called (as the name suggests), whereas in Friendica it is always possible to get even read items with the `include_all` query parameter in the GET `v1/notifications` call.

Maybe switching to the markers API could solve this issue, which will be dealt with in a future PR.