### PR TITLE
enhancement: migrate inbox to markers api

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/MarkerItem.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/MarkerItem.kt
@@ -1,0 +1,11 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MarkerItem(
+    @SerialName("last_read_id") val lastReadId: String,
+    @SerialName("version") val version: Int = 0,
+    @SerialName("updated_at") val updatedAt: String? = null,
+)

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Markers.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Markers.kt
@@ -1,0 +1,10 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Markers(
+    @SerialName("home") val home: MarkerItem? = null,
+    @SerialName("notifications") val notifications: MarkerItem? = null,
+)

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/DefaultServiceProvider.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/DefaultServiceProvider.kt
@@ -5,6 +5,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.service.DirectMessageS
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.FollowRequestService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.InstanceService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.ListService
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.MarkerService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.MediaService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.NotificationService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.PhotoAlbumService
@@ -22,6 +23,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.service.createDirectMe
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.createFollowRequestService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.createInstanceService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.createListService
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.createMarkerService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.createMediaService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.createNotificationService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.createPhotoAlbumService
@@ -69,6 +71,7 @@ internal class DefaultServiceProvider(
     override lateinit var followRequests: FollowRequestService
     override lateinit var instance: InstanceService
     override lateinit var lists: ListService
+    override lateinit var markers: MarkerService
     override lateinit var media: MediaService
     override lateinit var notifications: NotificationService
     override lateinit var photo: PhotoService
@@ -165,6 +168,7 @@ internal class DefaultServiceProvider(
         followRequests = ktorfit.createFollowRequestService()
         instance = ktorfit.createInstanceService()
         lists = ktorfit.createListService()
+        markers = ktorfit.createMarkerService()
         media = ktorfit.createMediaService()
         notifications = ktorfit.createNotificationService()
         photo = ktorfit.createPhotoService()

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/ServiceProvider.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/ServiceProvider.kt
@@ -5,6 +5,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.service.DirectMessageS
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.FollowRequestService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.InstanceService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.ListService
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.MarkerService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.MediaService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.NotificationService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.PhotoAlbumService
@@ -24,6 +25,7 @@ interface ServiceProvider {
     val followRequests: FollowRequestService
     val instance: InstanceService
     val lists: ListService
+    val markers: MarkerService
     val media: MediaService
     val notifications: NotificationService
     val photo: PhotoService

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/MarkerService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/MarkerService.kt
@@ -1,0 +1,17 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.service
+
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Markers
+import de.jensklingenberg.ktorfit.http.Body
+import de.jensklingenberg.ktorfit.http.GET
+import de.jensklingenberg.ktorfit.http.POST
+import io.ktor.client.request.forms.FormDataContent
+
+interface MarkerService {
+    @GET("v1/markers")
+    suspend fun get(): Markers
+
+    @POST("v1/markers")
+    suspend fun update(
+        @Body data: FormDataContent,
+    ): Markers
+}

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/NotificationService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/NotificationService.kt
@@ -24,5 +24,5 @@ interface NotificationService {
     ): Response<Unit>
 
     @POST("v1/notifications/clear")
-    suspend fun dismissAll(): Response<Unit>
+    suspend fun clear(): Response<Unit>
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
@@ -374,4 +374,5 @@ internal val DeStrings =
         override val settingsItemOpenGroupsInForumModeByDefault =
             "Gruppen standardmäßig im Forum-Modus öffnen"
         override val actionInsertList = "Liste einfügen"
+        override val actionDismissAllNotifications = "Alle Benachrichtigungen ablehnen"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -366,4 +366,5 @@ internal open class DefaultStrings : Strings {
     override val actionSwitchToForumMode = "Switch to forum mode"
     override val settingsItemOpenGroupsInForumModeByDefault = "Open groups in forum mode by default"
     override val actionInsertList = "Insert list"
+    override val actionDismissAllNotifications = "Dismiss all notifications"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/EsStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/EsStrings.kt
@@ -375,4 +375,5 @@ internal val EsStrings =
         override val settingsItemOpenGroupsInForumModeByDefault =
             "Abrir grupos en modo foro por defecto"
         override val actionInsertList = "Insertar lista"
+        override val actionDismissAllNotifications = "Desechar todas las notificaciones"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/FrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/FrStrings.kt
@@ -379,4 +379,5 @@ internal val FrStrings =
         override val settingsItemOpenGroupsInForumModeByDefault =
             "Ouvrir les groupes en mode forum par défaut"
         override val actionInsertList = "Insérer une liste"
+        override val actionDismissAllNotifications = "Supprimer toutes les notifications"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -374,4 +374,5 @@ internal val ItStrings =
         override val settingsItemOpenGroupsInForumModeByDefault =
             "Apri i gruppi in modalità forum di default"
         override val actionInsertList = "Inserisci lista"
+        override val actionDismissAllNotifications = "Elimina tutte le notifiche"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -330,6 +330,7 @@ interface Strings {
     val actionSwitchToForumMode: String
     val settingsItemOpenGroupsInForumModeByDefault: String
     val actionInsertList: String
+    val actionDismissAllNotifications: String
 }
 
 object Locales {

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/MarkerModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/MarkerModel.kt
@@ -1,0 +1,12 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.data
+
+sealed interface MarkerType {
+    data object Home : MarkerType
+
+    data object Notifications : MarkerType
+}
+
+data class MarkerModel(
+    val type: MarkerType,
+    val lastReadId: String,
+)

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NotificationModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NotificationModel.kt
@@ -60,3 +60,7 @@ val NotificationModel.blurHashParamsForPreload: List<BlurHashParams>
                     addAll(urls)
                 }
         }
+
+fun NotificationModel.hasLaterIdThan(referenceId: String?): Boolean = (id.toIntOrNull() ?: 0) > (referenceId?.toIntOrNull() ?: 0)
+
+fun NotificationModel.hasPriorIdThen(referenceId: String?): Boolean = !hasLaterIdThan(referenceId)

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultNotificationsPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultNotificationsPaginationManager.kt
@@ -1,7 +1,6 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
 
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationModel
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isNsfw
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toNotificationStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toStatus
@@ -36,7 +35,6 @@ internal class DefaultNotificationsPaginationManager(
                         .getAll(
                             pageCursor = pageCursor,
                             types = specification.types,
-                            includeAll = specification.types.toSet() == NotificationType.ALL.toSet(),
                             refresh = specification.refresh,
                         )?.determineRelationshipStatus()
                         ?.updatePaginationData()

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultInboxManager.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultInboxManager.kt
@@ -1,18 +1,22 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MarkerType
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.hasLaterIdThan
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.getAndUpdate
 import kotlinx.coroutines.flow.update
 
 internal class DefaultInboxManager(
     private val notificationRepository: NotificationRepository,
+    private val markerRepository: MarkerRepository,
 ) : InboxManager {
     override val unreadCount = MutableStateFlow(0)
 
     override suspend fun refreshUnreadCount() {
+        val lastReadId = markerRepository.get(MarkerType.Notifications)?.lastReadId
         val notifications = notificationRepository.getAll()
         unreadCount.update {
-            notifications?.count { !it.read } ?: 0
+            notifications?.count { it.hasLaterIdThan(lastReadId) } ?: 0
         }
     }
 

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMarkerRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMarkerRepository.kt
@@ -1,0 +1,60 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MarkerModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MarkerType
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
+import io.ktor.client.request.forms.FormDataContent
+import io.ktor.http.Parameters
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
+
+internal class DefaultMarkerRepository(
+    private val provider: ServiceProvider,
+) : MarkerRepository {
+    private val cachedValues = mutableMapOf<MarkerType, MarkerModel>()
+
+    override suspend fun get(
+        type: MarkerType,
+        refresh: Boolean,
+    ): MarkerModel? =
+        withContext(Dispatchers.IO) {
+            if (cachedValues.contains(type) && !refresh) {
+                cachedValues[type]
+            } else {
+                runCatching {
+                    provider.markers
+                        .get()
+                        .toModel()
+                        .firstOrNull { it.type == type }
+                        ?.also { cachedValues[type] = it }
+                }.getOrNull()
+            }
+        }
+
+    override suspend fun update(
+        type: MarkerType,
+        id: String,
+    ): MarkerModel? =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val fieldName =
+                    when (type) {
+                        MarkerType.Home -> "home[last_read_id]"
+                        MarkerType.Notifications -> "notifications[last_read_id]"
+                    }
+                val data =
+                    FormDataContent(
+                        Parameters.build {
+                            append(name = fieldName, value = id)
+                        },
+                    )
+                provider.markers
+                    .update(data)
+                    .toModel()
+                    .firstOrNull { it.type == type }
+                    ?.also { cachedValues[type] = it }
+            }.getOrNull()
+        }
+}

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNotificationRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNotificationRepository.kt
@@ -16,7 +16,6 @@ internal class DefaultNotificationRepository(
 
     override suspend fun getAll(
         types: List<NotificationType>,
-        includeAll: Boolean,
         pageCursor: String?,
         refresh: Boolean,
     ): List<NotificationModel>? =
@@ -32,7 +31,6 @@ internal class DefaultNotificationRepository(
                     provider.notifications.get(
                         types = types.mapNotNull { it.toDto() },
                         maxId = pageCursor,
-                        includeAll = includeAll,
                         limit = DEFAULT_PAGE_SIZE,
                     )
                 response
@@ -45,7 +43,7 @@ internal class DefaultNotificationRepository(
             }.getOrNull()
         }
 
-    override suspend fun markAsRead(id: String): Boolean =
+    override suspend fun dismiss(id: String): Boolean =
         withContext(Dispatchers.IO) {
             runCatching {
                 val res = provider.notifications.dismiss(id)
@@ -53,10 +51,10 @@ internal class DefaultNotificationRepository(
             }.getOrElse { false }
         }
 
-    override suspend fun markAllAsRead(): Boolean =
+    override suspend fun dismissAll(): Boolean =
         withContext(Dispatchers.IO) {
             runCatching {
-                val res = provider.notifications.dismissAll()
+                val res = provider.notifications.clear()
                 res.isSuccessful
             }.getOrElse { false }
         }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/MarkerRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/MarkerRepository.kt
@@ -1,0 +1,16 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MarkerModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MarkerType
+
+interface MarkerRepository {
+    suspend fun get(
+        type: MarkerType,
+        refresh: Boolean = false,
+    ): MarkerModel?
+
+    suspend fun update(
+        type: MarkerType,
+        id: String,
+    ): MarkerModel?
+}

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/NotificationRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/NotificationRepository.kt
@@ -6,12 +6,11 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.Notificatio
 interface NotificationRepository {
     suspend fun getAll(
         types: List<NotificationType> = NotificationType.ALL,
-        includeAll: Boolean = false,
         pageCursor: String? = null,
         refresh: Boolean = false,
     ): List<NotificationModel>?
 
-    suspend fun markAsRead(id: String): Boolean
+    suspend fun dismiss(id: String): Boolean
 
-    suspend fun markAllAsRead(): Boolean
+    suspend fun dismissAll(): Boolean
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
@@ -99,6 +99,7 @@ val domainContentRepositoryModule =
         single<InboxManager> {
             DefaultInboxManager(
                 notificationRepository = get(),
+                markerRepository = get(),
             )
         }
         single<NodeInfoRepository> {

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
@@ -10,6 +10,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Defau
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultEmojiRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultInboxManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultLocalItemCache
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultMarkerRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultMediaRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultNodeInfoRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultNotificationRepository
@@ -30,6 +31,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Emoji
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.InboxManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.LocalItemCache
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.MarkerRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.MediaRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.NodeInfoRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.NotificationRepository
@@ -155,6 +157,11 @@ val domainContentRepositoryModule =
         single<EmojiHelper> {
             DefaultEmojiHelper(
                 repository = get(),
+            )
+        }
+        single<MarkerRepository> {
+            DefaultMarkerRepository(
+                provider = get(named("default")),
             )
         }
     }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
@@ -13,6 +13,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaPrivateMe
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.HistoryItem
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Instance
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.InstanceRule
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Markers
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.MediaAttachment
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.MediaType.AUDIO
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.MediaType.GIFV
@@ -43,6 +44,8 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EmojiModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.FieldModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.HashtagHistoryItem
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.LinkModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MarkerModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MarkerType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaAlbumModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NodeInfoModel
@@ -467,3 +470,21 @@ private object FriendicaDateFormats {
     const val PRIVATE_MESSAGES = "EEE MMM dd HH:mm:ss xxxx yyyy"
     const val PHOTO_ALBUMS = "yyyy-MM-dd HH:mm:ss"
 }
+
+internal fun Markers.toModel(): List<MarkerModel> =
+    buildList {
+        this@toModel.home?.lastReadId?.also { lastReadId ->
+            this +=
+                MarkerModel(
+                    type = MarkerType.Home,
+                    lastReadId = lastReadId,
+                )
+        }
+        this@toModel.notifications?.lastReadId?.also { lastReadId ->
+            this +=
+                MarkerModel(
+                    type = MarkerType.Notifications,
+                    lastReadId = lastReadId,
+                )
+        }
+    }

--- a/domain/identity/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultCredentialsRepositoryTest.kt
+++ b/domain/identity/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultCredentialsRepositoryTest.kt
@@ -18,9 +18,9 @@ import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
 import io.ktor.client.engine.HttpClientEngine
-import io.ktor.utils.io.errors.IOException
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
+import kotlinx.io.IOException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse

--- a/domain/identity/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultIdentityRepositoryTest.kt
+++ b/domain/identity/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultIdentityRepositoryTest.kt
@@ -11,8 +11,8 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
-import io.ktor.utils.io.errors.IOException
 import kotlinx.coroutines.test.runTest
+import kotlinx.io.IOException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitor.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitor.kt
@@ -1,7 +1,9 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
 
 import com.livefast.eattrash.raccoonforfriendica.core.utils.nodeName
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MarkerType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.InboxManager
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.MarkerRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SupportedFeatureRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
@@ -29,6 +31,7 @@ internal class DefaultActiveAccountMonitor(
     private val supportedFeatureRepository: SupportedFeatureRepository,
     private val inboxManager: InboxManager,
     private val contentPreloadManager: ContentPreloadManager,
+    private val markerRepository: MarkerRepository,
     coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ActiveAccountMonitor {
     private val scope = CoroutineScope(SupervisorJob() + coroutineDispatcher)
@@ -87,6 +90,7 @@ internal class DefaultActiveAccountMonitor(
 
             settingsRepository.changeCurrent(defaultSettings)
 
+            markerRepository.get(MarkerType.Notifications, refresh = true)
             inboxManager.refreshUnreadCount()
         }
     }

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultContentPreloadManager.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultContentPreloadManager.kt
@@ -37,10 +37,7 @@ internal class DefaultContentPreloadManager(
 
                         this +=
                             async {
-                                notificationRepository.getAll(
-                                    includeAll = true,
-                                    refresh = true,
-                                )
+                                notificationRepository.getAll(refresh = true)
                             }
                     }
                 }

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
@@ -77,6 +77,7 @@ val domainIdentityUseCaseModule =
                 supportedFeatureRepository = get(),
                 inboxManager = get(),
                 contentPreloadManager = get(),
+                markerRepository = get(),
             )
         }
         single<EntryActionRepository> {

--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitorTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitorTest.kt
@@ -1,6 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
 
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.InboxManager
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.MarkerRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SupportedFeatureRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
@@ -37,6 +38,10 @@ class DefaultActiveAccountMonitorTest {
         mock<SupportedFeatureRepository>(mode = MockMode.autoUnit)
     private val inboxManager = mock<InboxManager>(mode = MockMode.autoUnit)
     private val contentPreloadManager = mock<ContentPreloadManager>(mode = MockMode.autoUnit)
+    private val markerRepository =
+        mock<MarkerRepository>(mode = MockMode.autoUnit) {
+            everySuspend { get(any(), any()) } returns null
+        }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private val sut =
@@ -49,6 +54,7 @@ class DefaultActiveAccountMonitorTest {
             supportedFeatureRepository = supportedFeatureRepository,
             inboxManager = inboxManager,
             contentPreloadManager = contentPreloadManager,
+            markerRepository = markerRepository,
             coroutineDispatcher = UnconfinedTestDispatcher(),
         )
 

--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultContentPreloadManagerTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultContentPreloadManagerTest.kt
@@ -24,7 +24,7 @@ class DefaultContentPreloadManagerTest {
         }
     private val notificationRepository =
         mock<NotificationRepository> {
-            everySuspend { getAll(any(), any(), any(), any()) } returns listOf()
+            everySuspend { getAll(any(), any(), any()) } returns listOf()
         }
     private val sut =
         DefaultContentPreloadManager(
@@ -63,10 +63,7 @@ class DefaultContentPreloadManagerTest {
                     enableCache = true,
                     refresh = true,
                 )
-                notificationRepository.getAll(
-                    includeAll = true,
-                    refresh = true,
-                )
+                notificationRepository.getAll(refresh = true)
             }
         }
 }

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxMviModel.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxMviModel.kt
@@ -26,11 +26,15 @@ interface InboxMviModel :
             val types: List<NotificationType>,
         ) : Intent
 
+        data object DismissAll : Intent
+
         data class MarkAsRead(
             val notification: NotificationModel,
         ) : Intent
 
-        data object MarkAllAsRead : Intent
+        data class Dismiss(
+            val notification: NotificationModel,
+        ) : Intent
 
         data class ToggleSpoilerActive(
             val entry: TimelineEntryModel,

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
@@ -80,6 +80,7 @@ class InboxScreen : Screen {
         val lazyListState = rememberLazyListState()
         var confirmUnfollowDialogUserId by remember { mutableStateOf<String?>(null) }
         var confirmDeleteFollowRequestDialogUserId by remember { mutableStateOf<String?>(null) }
+        var confirmDismissAllDialogOpen by remember { mutableStateOf(false) }
         var configureSelectedTypesDialogOpen by remember { mutableStateOf(false) }
 
         suspend fun goBackToTop() {
@@ -145,9 +146,9 @@ class InboxScreen : Screen {
                                 )
                             }
                             IconButton(
-                                enabled = uiState.notifications.any { !it.read },
+                                enabled = uiState.notifications.isNotEmpty(),
                                 onClick = {
-                                    model.reduce(InboxMviModel.Intent.MarkAllAsRead)
+                                    confirmDismissAllDialogOpen = true
                                 },
                             ) {
                                 if (uiState.markAllAsReadLoading) {
@@ -337,6 +338,19 @@ class InboxScreen : Screen {
                     configureSelectedTypesDialogOpen = false
                     if (values != null) {
                         model.reduce(InboxMviModel.Intent.ChangeSelectedNotificationTypes(values))
+                    }
+                },
+            )
+        }
+
+        if (confirmDismissAllDialogOpen) {
+            CustomConfirmDialog(
+                title = LocalStrings.current.actionDismissAllNotifications,
+                body = LocalStrings.current.messageAreYouSure,
+                onClose = { confirm ->
+                    confirmDismissAllDialogOpen = false
+                    if (confirm) {
+                        model.reduce(InboxMviModel.Intent.DismissAll)
                     }
                 },
             )

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/di/InboxModule.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/di/InboxModule.kt
@@ -17,6 +17,7 @@ val featureInboxModule =
                 hapticFeedback = get(),
                 imagePreloadManager = get(),
                 blurHashRepository = get(),
+                markerRepository = get(),
             )
         }
     }


### PR DESCRIPTION
As a follow up to #348, this PR migrates the unread notification management to Mastodon's marker APIs which work on Friendica too.

Notification are cleared (after confirmation) with the top app button introduced in #348, whereas refreshing has the only effect to move upwards the last read position marker on the server.

In this way, notifications are not dismissed unwillingly but the read-unread state remains consistent with the marker. 