### PR TITLE
fix: post inReplyTo on Mastodon

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
@@ -188,7 +188,7 @@ fun TimelineItem(
                     entryToDisplay.isSpoilerActive || spoiler.isEmpty()
                 }
             AnimatedVisibility(
-                modifier = modifier.padding(horizontal = contentHorizontalPadding),
+                modifier = Modifier.padding(horizontal = contentHorizontalPadding),
                 visible = contentVisible,
             ) {
                 Column(
@@ -303,7 +303,7 @@ fun TimelineItem(
                                 top = Spacing.xxs,
                                 start = contentHorizontalPadding,
                                 end = contentHorizontalPadding,
-                        ),
+                            ),
                     favoriteCount = entryToDisplay.favoriteCount,
                     favorite = entryToDisplay.favorite,
                     favoriteLoading = entryToDisplay.favoriteLoading,

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultSearchPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultSearchPaginationManager.kt
@@ -10,6 +10,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isNsfw
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toNotificationStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.ReplyHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SearchRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
 import kotlinx.coroutines.CoroutineDispatcher
@@ -27,6 +28,7 @@ internal class DefaultSearchPaginationManager(
     private val searchRepository: SearchRepository,
     private val userRepository: UserRepository,
     private val emojiHelper: EmojiHelper,
+    private val replyHelper: ReplyHelper,
     notificationCenter: NotificationCenter,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : SearchPaginationManager {
@@ -171,6 +173,16 @@ internal class DefaultSearchPaginationManager(
                 when (it) {
                     is ExploreItemModel.Entry -> it.copy(entry = it.entry.withEmojisIfMissing())
                     is ExploreItemModel.User -> it.copy(user = it.user.withEmojisIfMissing())
+                    else -> it
+                }
+            }
+        }
+
+    private suspend fun List<ExploreItemModel>.fixupInReplyTo(): List<ExploreItemModel> =
+        with(replyHelper) {
+            map {
+                when (it) {
+                    is ExploreItemModel.Entry -> it.copy(entry = it.entry.withInReplyToIfMissing())
                     else -> it
                 }
             }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
@@ -31,6 +31,7 @@ val domainContentPaginationModule =
                 timelineRepository = get(),
                 timelineEntryRepository = get(),
                 emojiHelper = get(),
+                replyHelper = get(),
                 notificationCenter = get(),
             )
         }
@@ -38,6 +39,7 @@ val domainContentPaginationModule =
             DefaultNotificationsPaginationManager(
                 notificationRepository = get(),
                 emojiHelper = get(),
+                replyHelper = get(),
                 userRepository = get(),
             )
         }
@@ -46,6 +48,7 @@ val domainContentPaginationModule =
                 trendingRepository = get(),
                 userRepository = get(),
                 emojiHelper = get(),
+                replyHelper = get(),
                 notificationCenter = get(),
             )
         }
@@ -62,6 +65,7 @@ val domainContentPaginationModule =
             DefaultFavoritesPaginationManager(
                 timelineEntryRepository = get(),
                 emojiHelper = get(),
+                replyHelper = get(),
                 notificationCenter = get(),
             )
         }
@@ -75,6 +79,7 @@ val domainContentPaginationModule =
                 searchRepository = get(),
                 userRepository = get(),
                 emojiHelper = get(),
+                replyHelper = get(),
                 notificationCenter = get(),
             )
         }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultReplyHelper.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultReplyHelper.kt
@@ -1,0 +1,28 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.core.utils.cache.LruCache
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+
+internal class DefaultReplyHelper(
+    private val entryRepository: TimelineEntryRepository,
+    private val entryCache: LruCache<String, TimelineEntryModel> = LruCache(100),
+) : ReplyHelper {
+    override suspend fun TimelineEntryModel.withInReplyToIfMissing(): TimelineEntryModel {
+        val parent = inReplyTo ?: return this
+        if (parent.content.isNotEmpty()) {
+            return this
+        }
+
+        val parentId = parent.id
+        val cachedValue = entryCache.get(parentId)
+        if (cachedValue != null) {
+            return cachedValue
+        }
+
+        val remoteParent =
+            entryRepository
+                .getById(parentId)
+                ?.also { entryCache.put(parentId, it) }
+        return copy(inReplyTo = remoteParent)
+    }
+}

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/ReplyHelper.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/ReplyHelper.kt
@@ -1,0 +1,7 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+
+interface ReplyHelper {
+    suspend fun TimelineEntryModel.withInReplyToIfMissing(): TimelineEntryModel
+}

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
@@ -16,6 +16,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Defau
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultNotificationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultPhotoAlbumRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultPhotoRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultReplyHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultReportRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultScheduledEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultSearchRepository
@@ -37,6 +38,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.NodeI
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.NotificationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.PhotoAlbumRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.PhotoRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.ReplyHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.ReportRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.ScheduledEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SearchRepository
@@ -163,6 +165,11 @@ val domainContentRepositoryModule =
         single<MarkerRepository> {
             DefaultMarkerRepository(
                 provider = get(named("default")),
+            )
+        }
+        single<ReplyHelper> {
+            DefaultReplyHelper(
+                entryRepository = get(),
             )
         }
     }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
@@ -69,8 +69,27 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.dto.NotificationType a
 
 internal fun Status.toModelWithReply() =
     toModel().copy(
-        inReplyTo = inReplyToStatus?.toModel(),
-        reblog = reblog?.toModel(),
+        inReplyTo =
+            inReplyToStatus?.toModel() ?: inReplyToId?.let { parentId ->
+                TimelineEntryModel(
+                    id = parentId,
+                    creator = inReplyToAccountId?.let { userId -> UserModel(id = userId) },
+                    content = "",
+                )
+            },
+        reblog =
+            reblog?.let {
+                it.toModel().copy(
+                    inReplyTo =
+                        it.inReplyToStatus?.toModel() ?: it.inReplyToId?.let { parentId ->
+                            TimelineEntryModel(
+                                id = parentId,
+                                creator = inReplyToAccountId?.let { userId -> UserModel(id = userId) },
+                                content = "",
+                            )
+                        },
+                )
+            },
     )
 
 internal fun Status.toModel() =

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailViewModel.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailViewModel.kt
@@ -15,6 +15,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.LocalItemCache
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.ReplyHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
@@ -36,6 +37,7 @@ class EntryDetailViewModel(
     private val imagePreloadManager: ImagePreloadManager,
     private val blurHashRepository: BlurHashRepository,
     private val emojiHelper: EmojiHelper,
+    private val replyHelper: ReplyHelper,
 ) : DefaultMviModel<EntryDetailMviModel.Intent, EntryDetailMviModel.State, EntryDetailMviModel.Effect>(
         initialState = EntryDetailMviModel.State(),
     ),
@@ -133,6 +135,8 @@ class EntryDetailViewModel(
                         .orEmpty()
                         .map {
                             with(emojiHelper) { it.withEmojisIfMissing() }
+                        }.map {
+                            with(replyHelper) { it.withInReplyToIfMissing() }
                         },
                 )
                 add(entryCache.get(id))
@@ -142,6 +146,8 @@ class EntryDetailViewModel(
                         .orEmpty()
                         .map {
                             with(emojiHelper) { it.withEmojisIfMissing() }
+                        }.map {
+                            with(replyHelper) { it.withInReplyToIfMissing() }
                         },
                 )
             }.filterNotNull()

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/di/EntryDetailModule.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/di/EntryDetailModule.kt
@@ -19,6 +19,7 @@ val featureEntryDetailModule =
                 imagePreloadManager = get(),
                 blurHashRepository = get(),
                 emojiHelper = get(),
+                replyHelper = get(),
             )
         }
     }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/di/ProfileModule.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/di/ProfileModule.kt
@@ -34,6 +34,7 @@ val featureProfileModule =
                 imagePreloadManager = get(),
                 blurHashRepository = get(),
                 emojiHelper = get(),
+                replyHelper = get(),
             )
         }
         factory<AnonymousMviModel> {

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
@@ -16,6 +16,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPrel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationSpecification
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.ReplyHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
@@ -39,6 +40,7 @@ class MyAccountViewModel(
     private val imagePreloadManager: ImagePreloadManager,
     private val blurHashRepository: BlurHashRepository,
     private val emojiHelper: EmojiHelper,
+    private val replyHelper: ReplyHelper,
 ) : DefaultMviModel<MyAccountMviModel.Intent, MyAccountMviModel.State, MyAccountMviModel.Effect>(
         initialState = MyAccountMviModel.State(),
     ),
@@ -85,9 +87,13 @@ class MyAccountViewModel(
             if (uiState.value.initial) {
 
                 val initialValues =
-                    timelineEntryRepository.getCachedByUser().map {
-                        with(emojiHelper) { it.withEmojisIfMissing() }
-                    }
+                    timelineEntryRepository
+                        .getCachedByUser()
+                        .map {
+                            with(emojiHelper) { it.withEmojisIfMissing() }
+                        }.map {
+                            with(replyHelper) { it.withInReplyToIfMissing() }
+                        }
                 paginationManager.restoreHistory(initialValues)
                 if (initialValues.isNotEmpty()) {
                     updateState {

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/usecase/DefaultPopulateThreadUseCase.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/usecase/DefaultPopulateThreadUseCase.kt
@@ -50,9 +50,7 @@ internal class DefaultPopulateThreadUseCase(
                     ?.descendants
                     .orEmpty()
                     .map {
-                        with(emojiHelper) {
-                            it.withEmojisIfMissing()
-                        }
+                        with(emojiHelper) { it.withEmojisIfMissing() }
                     }
             val childNodes =
                 descendants


### PR DESCRIPTION
On the most recent versions of Mastodon, the `in_reply_to_status` property of `Status`es was not populated as expected, but only `in_reply_to_id` and `in_reply_to_account_id` were present.

This completely broke _forum mode_ on Mastodon servers, and made it impossible to determine whether a post was a top-level status or a reply.

This PR introduces a quick fix that leverages the same mechanism used to fix custom emojis on instances were they are not present for users, writing a small wrapper that takes care of retrieving the missing data and caching it to avoid flooding the server with too many requests.