### PR TITLE
fix: notifications retrieve last read id

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/MarkerService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/MarkerService.kt
@@ -4,11 +4,14 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Markers
 import de.jensklingenberg.ktorfit.http.Body
 import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.POST
+import de.jensklingenberg.ktorfit.http.Query
 import io.ktor.client.request.forms.FormDataContent
 
 interface MarkerService {
     @GET("v1/markers")
-    suspend fun get(): Markers
+    suspend fun get(
+        @Query("timeline[]") timelines: List<String>,
+    ): Markers
 
     @POST("v1/markers")
     suspend fun update(

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMarkerRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMarkerRepository.kt
@@ -3,6 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MarkerModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MarkerType
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toDto
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.http.Parameters
@@ -25,7 +26,7 @@ internal class DefaultMarkerRepository(
             } else {
                 runCatching {
                     provider.markers
-                        .get()
+                        .get(timelines = listOf(type.toDto()))
                         .toModel()
                         .firstOrNull { it.type == type }
                         ?.also { cachedValues[type] = it }
@@ -39,11 +40,7 @@ internal class DefaultMarkerRepository(
     ): MarkerModel? =
         withContext(Dispatchers.IO) {
             runCatching {
-                val fieldName =
-                    when (type) {
-                        MarkerType.Home -> "home[last_read_id]"
-                        MarkerType.Notifications -> "notifications[last_read_id]"
-                    }
+                val fieldName = "${type.toDto()}[last_read_id]"
                 val data =
                     FormDataContent(
                         Parameters.build {

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
@@ -490,6 +490,12 @@ private object FriendicaDateFormats {
     const val PHOTO_ALBUMS = "yyyy-MM-dd HH:mm:ss"
 }
 
+internal fun MarkerType.toDto(): String =
+    when (this) {
+        MarkerType.Home -> "home"
+        MarkerType.Notifications -> "notifications"
+    }
+
 internal fun Markers.toModel(): List<MarkerModel> =
     buildList {
         this@toModel.home?.lastReadId?.also { lastReadId ->


### PR DESCRIPTION
This fixes a small bug introduced by #349 due to which the last read id for notifications was not read correctly at app startup.

The reason is that the GET `v1/markers `API requires the types of timeline markers in the query string, otherwise it returns an empty object.