### PR TITLE
fix: avoid crash in HTML rendering

### DIFF
--- a/core/htmlparse/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/htmlparse/ParseHtml.kt
+++ b/core/htmlparse/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/htmlparse/ParseHtml.kt
@@ -91,7 +91,8 @@ fun String.parseHtml(
 }
 
 private fun AnnotatedString.Builder.appendLineIfNeeded() {
-    if (toAnnotatedString().last() != '\n') {
+    val lastChar = toAnnotatedString().lastOrNull()
+    if (lastChar != null && lastChar != '\n') {
         appendLine()
     }
 }


### PR DESCRIPTION
Using `last()` in `appendLineIfNeeded()` throws `NoSuchElementException` if the string is empty. 💥 