### PR TITLE
fix: avoid dismissing bottom sheets on long press

### DIFF
--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/CustomModalBottomSheet.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/CustomModalBottomSheet.kt
@@ -90,14 +90,19 @@ fun CustomModalBottomSheet(
                                                         onSelected?.invoke(idx)
                                                     }
                                             },
-                                            onLongClick = {
-                                                sheetScope
-                                                    .launch {
-                                                        sheetState.hide()
-                                                    }.invokeOnCompletion {
-                                                        onLongPress?.invoke(idx)
+                                            onLongClick =
+                                                if (onLongPress != null) {
+                                                    {
+                                                        sheetScope
+                                                            .launch {
+                                                                sheetState.hide()
+                                                            }.invokeOnCompletion {
+                                                                onLongPress(idx)
+                                                            }
                                                     }
-                                            },
+                                                } else {
+                                                    null
+                                                },
                                         ).padding(10.dp),
                                 verticalAlignment = Alignment.CenterVertically,
                                 horizontalArrangement = Arrangement.spacedBy(Spacing.s),


### PR DESCRIPTION
Avoid dismissing bottom sheets on long press if there is no callback, because this would result in an incorrect state.