### PR TITLE
fix: avoid videos from being stretched out of viewport

### DIFF
--- a/core/commonui/components/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/VideoPlayer.kt
+++ b/core/commonui/components/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/VideoPlayer.kt
@@ -84,10 +84,10 @@ actual fun VideoPlayer(
                 PlayerView(context).apply {
                     controllerAutoShow = true
                     controllerHideOnTouch = true
-                    resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM
+                    resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
                     layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT)
 
-                    addOnLayoutChangeListener { _, left, top, right, bottom, _, _, _, _ ->
+                    videoSurfaceView?.addOnLayoutChangeListener { _, left, top, right, bottom, _, _, _, _ ->
                         val newHeight = abs(bottom - top)
                         val newWidth = abs(right - left)
                         onResize?.invoke(IntSize(width = newWidth, height = newHeight))

--- a/feature/imagedetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/imagedetail/ImageDetailScreen.kt
+++ b/feature/imagedetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/imagedetail/ImageDetailScreen.kt
@@ -3,7 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica.feature.imagedetail
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
@@ -204,16 +204,13 @@ class ImageDetailScreen(
                                 Modifier
                                     .padding(
                                         top = padding.calculateTopPadding(),
-                                    ).fillMaxWidth()
+                                    ).fillMaxSize()
                                     .background(Color.Black),
                             contentAlignment = Alignment.Center,
                         ) {
                             if (!url.isNullOrEmpty()) {
                                 if (isVideo) {
-                                    VideoPlayer(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        url = url,
-                                    )
+                                    VideoPlayer(url = url)
                                 } else {
                                     ZoomableImage(
                                         url = url,


### PR DESCRIPTION
The current VideoPlayer implementation on Android set the `PlayerView`'s `resizeMode` to `RESIZE_MODE_ZOOM` instead of `RESIZE_MODE_FIT`, which made video stretch out of the visible area if they had an aspect ratio > 1.