### PR TITLE
fix: avoid attachment loss when editing an existing post

### DIFF
--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
@@ -1243,6 +1243,7 @@ class ComposerViewModel(
     }
 
     private suspend fun loadEntry(entry: TimelineEntryModel) {
+        // workaround to make sure Friendica-specific circle visibility is preserved
         val visibility =
             entry.visibility.let { visibility ->
                 when (visibility) {
@@ -1258,12 +1259,20 @@ class ComposerViewModel(
                     }
                 }
             } ?: Visibility.Public
-
+        // workaround to make sure IDs are preserved
+        val attachments =
+            entry.attachments.map { attachment ->
+                if (attachment.mediaId.isNotEmpty()) {
+                    attachment
+                } else {
+                    attachment.copy(mediaId = attachment.id)
+                }
+            }
         updateState {
             it.copy(
                 bodyValue = TextFieldValue(text = entry.content),
                 sensitive = entry.sensitive,
-                attachments = entry.attachments,
+                attachments = attachments,
                 visibility = visibility,
                 spoilerValue = TextFieldValue(text = entry.spoiler.orEmpty()),
                 hasSpoiler = !entry.spoiler.isNullOrEmpty(),


### PR DESCRIPTION
When retrieving a post (in order to make sure to edit the latest data) the attachments have their id property set but not the media_id, which in turn is what is used after uploading new ones. As a result, attachments were lost when editing an existing post.

This PR fixes that unwanted behaviour, adding some comments on the workaround to preserve editing data.