### PR TITLE
feat: add support for Markdown and conditional markup

### DIFF
--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
@@ -375,4 +375,6 @@ internal val DeStrings =
             "Gruppen standardmäßig im Forum-Modus öffnen"
         override val actionInsertList = "Liste einfügen"
         override val actionDismissAllNotifications = "Alle Benachrichtigungen ablehnen"
+        override val settingsItemMarkupMode = "Markierung für Compositing"
+        override val markupModePlainText = "Einfacher Text"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -367,4 +367,9 @@ internal open class DefaultStrings : Strings {
     override val settingsItemOpenGroupsInForumModeByDefault = "Open groups in forum mode by default"
     override val actionInsertList = "Insert list"
     override val actionDismissAllNotifications = "Dismiss all notifications"
+    override val settingsItemMarkupMode = "Markup for compositing"
+    override val markupModeBBCode = "BBCode"
+    override val markupModeHTML = "HTML"
+    override val markupModeMarkdown = "Markdown"
+    override val markupModePlainText = "Plain text"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/EsStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/EsStrings.kt
@@ -376,4 +376,6 @@ internal val EsStrings =
             "Abrir grupos en modo foro por defecto"
         override val actionInsertList = "Insertar lista"
         override val actionDismissAllNotifications = "Desechar todas las notificaciones"
+        override val settingsItemMarkupMode = "Marcas de composición"
+        override val markupModePlainText = "Texto sin formato"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/FrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/FrStrings.kt
@@ -380,4 +380,6 @@ internal val FrStrings =
             "Ouvrir les groupes en mode forum par défaut"
         override val actionInsertList = "Insérer une liste"
         override val actionDismissAllNotifications = "Supprimer toutes les notifications"
+        override val settingsItemMarkupMode = "Balisage pour la composition"
+        override val markupModePlainText = "Texte brut"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -375,4 +375,6 @@ internal val ItStrings =
             "Apri i gruppi in modalità forum di default"
         override val actionInsertList = "Inserisci lista"
         override val actionDismissAllNotifications = "Elimina tutte le notifiche"
+        override val settingsItemMarkupMode = "Markup per la composizione"
+        override val markupModePlainText = "Testo semplice"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -331,6 +331,11 @@ interface Strings {
     val settingsItemOpenGroupsInForumModeByDefault: String
     val actionInsertList: String
     val actionDismissAllNotifications: String
+    val settingsItemMarkupMode: String
+    val markupModeBBCode: String
+    val markupModeHTML: String
+    val markupModeMarkdown: String
+    val markupModePlainText: String
 }
 
 object Locales {

--- a/core/persistence/schemas/com.livefast.eattrash.raccoonforfriendica.core.persistence.AppDatabase/9.json
+++ b/core/persistence/schemas/com.livefast.eattrash.raccoonforfriendica.core.persistence.AppDatabase/9.json
@@ -1,0 +1,276 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 9,
+    "identityHash": "235f00bc3deb358583f99d08274a7370",
+    "entities": [
+      {
+        "tableName": "AccountEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `handle` TEXT NOT NULL, `active` INTEGER NOT NULL DEFAULT 0, `remoteId` TEXT, `avatar` TEXT, `displayName` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "handle",
+            "columnName": "handle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "active",
+            "columnName": "active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "avatar",
+            "columnName": "avatar",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AccountEntity_handle",
+            "unique": false,
+            "columnNames": [
+              "handle"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AccountEntity_handle` ON `${TABLE_NAME}` (`handle`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SettingsEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `accountId` INTEGER NOT NULL DEFAULT 0, `lang` TEXT NOT NULL DEFAULT 'en', `theme` INTEGER NOT NULL DEFAULT 0, `fontFamily` INTEGER NOT NULL DEFAULT 0, `fontScale` INTEGER NOT NULL DEFAULT 0, `dynamicColors` INTEGER NOT NULL DEFAULT 0, `customSeedColor` INTEGER, `defaultTimelineType` INTEGER NOT NULL DEFAULT 0, `includeNsfw` INTEGER NOT NULL DEFAULT 0, `blurNsfw` INTEGER NOT NULL DEFAULT 0, `urlOpeningMode` INTEGER NOT NULL DEFAULT 0, `defaultPostVisibility` INTEGER NOT NULL DEFAULT 0, `defaultReplyVisibility` INTEGER NOT NULL DEFAULT 0, `excludeRepliesFromTimeline` INTEGER NOT NULL DEFAULT 0, `openGroupsInForumModeByDefault` INTEGER NOT NULL DEFAULT 1, `markupMode` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lang",
+            "columnName": "lang",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'en'"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "fontScale",
+            "columnName": "fontScale",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "dynamicColors",
+            "columnName": "dynamicColors",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "customSeedColor",
+            "columnName": "customSeedColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "defaultTimelineType",
+            "columnName": "defaultTimelineType",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "includeNsfw",
+            "columnName": "includeNsfw",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "blurNsfw",
+            "columnName": "blurNsfw",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "urlOpeningMode",
+            "columnName": "urlOpeningMode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "defaultPostVisibility",
+            "columnName": "defaultPostVisibility",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "defaultReplyVisibility",
+            "columnName": "defaultReplyVisibility",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "excludeRepliesFromTimeline",
+            "columnName": "excludeRepliesFromTimeline",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "openGroupsInForumModeByDefault",
+            "columnName": "openGroupsInForumModeByDefault",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "markupMode",
+            "columnName": "markupMode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "DraftEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mediaIds` TEXT, `inReplyToId` TEXT, `lang` TEXT, `sensitive` INTEGER, `spoiler` TEXT, `title` TEXT, `text` TEXT, `created` TEXT, `visibility` TEXT, `pollExpiresAt` TEXT, `pollMultiple` INTEGER, `pollOptions` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaIds",
+            "columnName": "mediaIds",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "inReplyToId",
+            "columnName": "inReplyToId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lang",
+            "columnName": "lang",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sensitive",
+            "columnName": "sensitive",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "spoiler",
+            "columnName": "spoiler",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "visibility",
+            "columnName": "visibility",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pollExpiresAt",
+            "columnName": "pollExpiresAt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pollMultiple",
+            "columnName": "pollMultiple",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pollOptions",
+            "columnName": "pollOptions",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '235f00bc3deb358583f99d08274a7370')"
+    ]
+  }
+}

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/AppDatabase.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/AppDatabase.kt
@@ -17,7 +17,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.persistence.entities.Setti
         SettingsEntity::class,
         DraftEntity::class,
     ],
-    version = 8,
+    version = 9,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
@@ -26,7 +26,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.persistence.entities.Setti
         AutoMigration(from = 5, to = 6),
         AutoMigration(from = 6, to = 7),
         AutoMigration(from = 7, to = 8),
-
+        AutoMigration(from = 8, to = 9),
     ],
 )
 @ConstructedBy(AppDatabaseConstructor::class)

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/entities/SettingsEntity.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/entities/SettingsEntity.kt
@@ -22,4 +22,5 @@ data class SettingsEntity(
     @ColumnInfo(defaultValue = "0") val defaultReplyVisibility: Int = 0,
     @ColumnInfo(defaultValue = "0") val excludeRepliesFromTimeline: Boolean = false,
     @ColumnInfo(defaultValue = "1") val openGroupsInForumModeByDefault: Boolean = true,
+    @ColumnInfo(defaultValue = "0") val markupMode: Int = 1,
 )

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NodeFeatures.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NodeFeatures.kt
@@ -8,6 +8,7 @@ data class NodeFeatures(
     val supportsCustomCircles: Boolean = false,
     val supportReportCategoryRuleViolation: Boolean = false,
     val supportsBBCode: Boolean = false,
+    val supportsMarkdown: Boolean = false,
     val supportsEntryShare: Boolean = false,
     val supportsPrivateVisibility: Boolean = false,
 )

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepository.kt
@@ -21,6 +21,7 @@ internal class DefaultSupportedFeatureRepository(
                 supportReportCategoryRuleViolation = info?.isFriendica == false,
                 supportsPolls = info?.isFriendica == false,
                 supportsBBCode = info?.isFriendica == true,
+                supportsMarkdown = info?.isFriendica == false,
                 supportsEntryShare = info?.isFriendica == true,
                 supportsPrivateVisibility = info?.isFriendica == true,
             )

--- a/domain/identity/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/data/MarkupMode.kt
+++ b/domain/identity/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/data/MarkupMode.kt
@@ -1,0 +1,33 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.data
+
+import androidx.compose.runtime.Composable
+import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
+
+sealed interface MarkupMode {
+    val supportsRichEditing: Boolean
+
+    data object PlainText : MarkupMode {
+        override val supportsRichEditing: Boolean get() = false
+    }
+
+    data object HTML : MarkupMode {
+        override val supportsRichEditing: Boolean get() = true
+    }
+
+    data object BBCode : MarkupMode {
+        override val supportsRichEditing: Boolean get() = true
+    }
+
+    data object Markdown : MarkupMode {
+        override val supportsRichEditing: Boolean get() = true
+    }
+}
+
+@Composable
+fun MarkupMode.toReadableName() =
+    when (this) {
+        MarkupMode.BBCode -> LocalStrings.current.markupModeBBCode
+        MarkupMode.HTML -> LocalStrings.current.markupModeHTML
+        MarkupMode.Markdown -> LocalStrings.current.markupModeMarkdown
+        MarkupMode.PlainText -> LocalStrings.current.markupModePlainText
+    }

--- a/domain/identity/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/data/SettingsModel.kt
+++ b/domain/identity/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/data/SettingsModel.kt
@@ -21,4 +21,5 @@ data class SettingsModel(
     val defaultReplyVisibility: Int = 0,
     val excludeRepliesFromTimeline: Boolean = false,
     val openGroupsInForumModeByDefault: Boolean = true,
+    val markupMode: MarkupMode = MarkupMode.HTML,
 )

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultSettingsRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultSettingsRepository.kt
@@ -6,6 +6,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.toUiFontSc
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.toUiTheme
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.dao.SettingsDao
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.entities.SettingsEntity
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.MarkupMode
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.toInt
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.toUrlOpeningMode
@@ -54,6 +55,7 @@ private fun SettingsEntity.toModel() =
         defaultReplyVisibility = defaultReplyVisibility,
         excludeRepliesFromTimeline = excludeRepliesFromTimeline,
         openGroupsInForumModeByDefault = openGroupsInForumModeByDefault,
+        markupMode = markupMode.toMarkupMode(),
     )
 
 private fun SettingsModel.toEntity() =
@@ -74,4 +76,21 @@ private fun SettingsModel.toEntity() =
         defaultReplyVisibility = defaultReplyVisibility,
         excludeRepliesFromTimeline = excludeRepliesFromTimeline,
         openGroupsInForumModeByDefault = openGroupsInForumModeByDefault,
+        markupMode = markupMode.toInt(),
     )
+
+private fun Int.toMarkupMode(): MarkupMode =
+    when (this) {
+        1 -> MarkupMode.HTML
+        2 -> MarkupMode.BBCode
+        3 -> MarkupMode.Markdown
+        else -> MarkupMode.PlainText
+    }
+
+private fun MarkupMode.toInt() =
+    when (this) {
+        MarkupMode.HTML -> 1
+        MarkupMode.BBCode -> 2
+        MarkupMode.Markdown -> 3
+        MarkupMode.PlainText -> 0
+    }

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
@@ -36,6 +36,7 @@ val domainIdentityUseCaseModule =
                 accountRepository = get(),
                 settingsRepository = get(),
                 accountCredentialsCache = get(),
+                supportedFeatureRepository = get(),
             )
         }
 

--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitorTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitorTest.kt
@@ -1,5 +1,6 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
 
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NodeFeatures
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.InboxManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.MarkerRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SupportedFeatureRepository
@@ -35,7 +36,9 @@ class DefaultActiveAccountMonitorTest {
     private val accountCredentialsCache = mock<AccountCredentialsCache>(mode = MockMode.autoUnit)
     private val settingsRepository = mock<SettingsRepository>(mode = MockMode.autoUnit)
     private val supportedFeatureRepository =
-        mock<SupportedFeatureRepository>(mode = MockMode.autoUnit)
+        mock<SupportedFeatureRepository>(mode = MockMode.autoUnit) {
+            every { features } returns MutableStateFlow(NodeFeatures())
+        }
     private val inboxManager = mock<InboxManager>(mode = MockMode.autoUnit)
     private val contentPreloadManager = mock<ContentPreloadManager>(mode = MockMode.autoUnit)
     private val markerRepository =

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
@@ -226,6 +226,7 @@ interface ComposerMviModel :
         val shouldShowMentionSuggestions: Boolean = false,
         val mentionSuggestionsLoading: Boolean = false,
         val mentionSuggestions: List<UserModel> = emptyList(),
+        val supportsRichEditing: Boolean = false,
     )
 
     sealed interface Effect {

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
@@ -311,10 +311,12 @@ class ComposerScreen(
                                         )
                                 }
 
-                                this +=
-                                    CustomOptions.OpenPreview.toOption(
-                                        label = LocalStrings.current.actionOpenPreview,
-                                    )
+                                if (uiState.supportsRichEditing) {
+                                    this +=
+                                        CustomOptions.OpenPreview.toOption(
+                                            label = LocalStrings.current.actionOpenPreview,
+                                        )
+                                }
 
                                 if (uiState.titleFeatureSupported) {
                                     this +=
@@ -346,10 +348,12 @@ class ComposerScreen(
                                                 },
                                         )
                                 }
-                                this +=
-                                    CustomOptions.InsertList.toOption(
-                                        label = LocalStrings.current.actionInsertList,
-                                    )
+                                if (uiState.supportsRichEditing) {
+                                    this +=
+                                        CustomOptions.InsertList.toOption(
+                                            label = LocalStrings.current.actionInsertList,
+                                        )
+                                }
                             }
                         Box {
                             var optionsOffset by remember { mutableStateOf(Offset.Zero) }
@@ -504,83 +508,85 @@ class ComposerScreen(
                             },
                         )
                     }
-                    UtilsBar(
-                        modifier = Modifier.fillMaxWidth(),
-                        onAttachmentClicked = {
-                            val limit = uiState.attachmentLimit ?: Int.MAX_VALUE
-                            if (uiState.attachments.size < limit) {
-                                openImagePicker = true
-                            }
-                        },
-                        hasPoll = uiState.poll != null,
-                        hasSpoiler = uiState.hasSpoiler,
-                        onLinkClicked = {
-                            linkDialogOpen = true
-                        },
-                        onBoldClicked = {
-                            model.reduce(
-                                ComposerMviModel.Intent.AddBoldFormat(
-                                    fieldType =
-                                        when {
-                                            hasTitleFocus -> ComposerFieldType.Title
-                                            hasSpoilerFieldFocus -> ComposerFieldType.Spoiler
-                                            else -> ComposerFieldType.Body
-                                        },
-                                ),
-                            )
-                        },
-                        onItalicClicked = {
-                            model.reduce(
-                                ComposerMviModel.Intent.AddItalicFormat(
-                                    fieldType =
-                                        when {
-                                            hasTitleFocus -> ComposerFieldType.Title
-                                            hasSpoilerFieldFocus -> ComposerFieldType.Spoiler
-                                            else -> ComposerFieldType.Body
-                                        },
-                                ),
-                            )
-                        },
-                        onUnderlineClicked = {
-                            model.reduce(
-                                ComposerMviModel.Intent.AddUnderlineFormat(
-                                    fieldType =
-                                        when {
-                                            hasTitleFocus -> ComposerFieldType.Title
-                                            hasSpoilerFieldFocus -> ComposerFieldType.Spoiler
-                                            else -> ComposerFieldType.Body
-                                        },
-                                ),
-                            )
-                        },
-                        onStrikethroughClicked = {
-                            model.reduce(
-                                ComposerMviModel.Intent.AddStrikethroughFormat(
-                                    fieldType =
-                                        when {
-                                            hasTitleFocus -> ComposerFieldType.Title
-                                            hasSpoilerFieldFocus -> ComposerFieldType.Spoiler
-                                            else -> ComposerFieldType.Body
-                                        },
-                                ),
-                            )
-                        },
-                        onCodeClicked = {
-                            model.reduce(
-                                ComposerMviModel.Intent.AddCodeFormat(
-                                    fieldType =
-                                        when {
-                                            hasTitleFocus -> ComposerFieldType.Title
-                                            hasSpoilerFieldFocus -> ComposerFieldType.Spoiler
-                                            else -> ComposerFieldType.Body
-                                        },
-                                ),
-                            )
-                        },
-                        onSpoilerClicked = {
-                            model.reduce(ComposerMviModel.Intent.ToggleHasSpoiler)
-                        },
-                    )
+                    if (uiState.supportsRichEditing) {
+                        UtilsBar(
+                            modifier = Modifier.fillMaxWidth(),
+                            onAttachmentClicked = {
+                                val limit = uiState.attachmentLimit ?: Int.MAX_VALUE
+                                if (uiState.attachments.size < limit) {
+                                    openImagePicker = true
+                                }
+                            },
+                            hasPoll = uiState.poll != null,
+                            hasSpoiler = uiState.hasSpoiler,
+                            onLinkClicked = {
+                                linkDialogOpen = true
+                            },
+                            onBoldClicked = {
+                                model.reduce(
+                                    ComposerMviModel.Intent.AddBoldFormat(
+                                        fieldType =
+                                            when {
+                                                hasTitleFocus -> ComposerFieldType.Title
+                                                hasSpoilerFieldFocus -> ComposerFieldType.Spoiler
+                                                else -> ComposerFieldType.Body
+                                            },
+                                    ),
+                                )
+                            },
+                            onItalicClicked = {
+                                model.reduce(
+                                    ComposerMviModel.Intent.AddItalicFormat(
+                                        fieldType =
+                                            when {
+                                                hasTitleFocus -> ComposerFieldType.Title
+                                                hasSpoilerFieldFocus -> ComposerFieldType.Spoiler
+                                                else -> ComposerFieldType.Body
+                                            },
+                                    ),
+                                )
+                            },
+                            onUnderlineClicked = {
+                                model.reduce(
+                                    ComposerMviModel.Intent.AddUnderlineFormat(
+                                        fieldType =
+                                            when {
+                                                hasTitleFocus -> ComposerFieldType.Title
+                                                hasSpoilerFieldFocus -> ComposerFieldType.Spoiler
+                                                else -> ComposerFieldType.Body
+                                            },
+                                    ),
+                                )
+                            },
+                            onStrikethroughClicked = {
+                                model.reduce(
+                                    ComposerMviModel.Intent.AddStrikethroughFormat(
+                                        fieldType =
+                                            when {
+                                                hasTitleFocus -> ComposerFieldType.Title
+                                                hasSpoilerFieldFocus -> ComposerFieldType.Spoiler
+                                                else -> ComposerFieldType.Body
+                                            },
+                                    ),
+                                )
+                            },
+                            onCodeClicked = {
+                                model.reduce(
+                                    ComposerMviModel.Intent.AddCodeFormat(
+                                        fieldType =
+                                            when {
+                                                hasTitleFocus -> ComposerFieldType.Title
+                                                hasSpoilerFieldFocus -> ComposerFieldType.Spoiler
+                                                else -> ComposerFieldType.Body
+                                            },
+                                    ),
+                                )
+                            },
+                            onSpoilerClicked = {
+                                model.reduce(ComposerMviModel.Intent.ToggleHasSpoiler)
+                            },
+                        )
+                    }
                 }
             },
             content = { padding ->

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/di/ComposerModule.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/di/ComposerModule.kt
@@ -32,7 +32,7 @@ val featureComposerModule =
                 settingsRepository = get(),
                 emojiRepository = get(),
                 userRepository = get(),
-                apiConfigurationRepository = get(),
+                prepareForPreview = get(),
                 notificationCenter = get(),
             )
         }

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/di/ComposerModule.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/di/ComposerModule.kt
@@ -2,10 +2,17 @@ package com.livefast.eattrash.raccoonforfriendica.feature.composer.di
 
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.ComposerMviModel
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.ComposerViewModel
+import com.livefast.eattrash.raccoonforfriendica.feature.composer.utils.DefaultPrepareForPreviewUseCase
+import com.livefast.eattrash.raccoonforfriendica.feature.composer.utils.PrepareForPreviewUseCase
 import org.koin.dsl.module
 
 val featureComposerModule =
     module {
+        single<PrepareForPreviewUseCase> {
+            DefaultPrepareForPreviewUseCase(
+                apiConfigurationRepository = get(),
+            )
+        }
         factory<ComposerMviModel> { params ->
             ComposerViewModel(
                 inReplyToId = params[0],

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/utils/ComposerRegexes.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/utils/ComposerRegexes.kt
@@ -1,0 +1,10 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.composer.utils
+
+internal object ComposerRegexes {
+    val USER_MENTION =
+        Regex("@(?<handlePrefix>[a-zA-Z0-9-_.]+?(@[a-zA-Z0-9_.]+)?)(?=\\b)")
+    val SHARE =
+        Regex("\\[share](?<url>.*?)\\[share]")
+    val HASHTAG =
+        Regex("#(?<tag>.*?)(?=\\b)")
+}

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/utils/DefaultPrepareForPreviewUseCase.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/utils/DefaultPrepareForPreviewUseCase.kt
@@ -1,0 +1,155 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.composer.utils
+
+import com.livefast.eattrash.raccoonforfriendica.core.utils.nodeName
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.MarkupMode
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
+
+internal class DefaultPrepareForPreviewUseCase(
+    private val apiConfigurationRepository: ApiConfigurationRepository,
+) : PrepareForPreviewUseCase {
+    override fun invoke(
+        text: String,
+        mode: MarkupMode,
+    ): String =
+        run {
+            when (mode) {
+                MarkupMode.BBCode -> text.convertBBCodeToHtml()
+                MarkupMode.Markdown -> text.convertMarkdownToHtml()
+                else -> text
+            }
+        }.withMentions().withHashtags()
+
+    private fun String.convertBBCodeToHtml(): String =
+        replace("[u]", "<u>")
+            .replace("[/u]", "</u>")
+            .replace("[s]", "<s>")
+            .replace("[/s]", "</s>")
+            .replace("[i]", "<i>")
+            .replace("[/i]", "</i>")
+            .replace("[b]", "<b>")
+            .replace("[/b]", "</b>")
+            .replace("[code]", "<code>")
+            .replace("[/code]", "</code>")
+            .replace("[ul]", "<ul>")
+            .replace("[/ul]", "</ul>")
+            .replace("[ol]", "<ol>")
+            .replace("[/ol]", "</ol>")
+            .replace("[li]", "<li>")
+            .replace("[/li]", "</li>")
+            .replace(Regex("\n\n"), "<br /><br />")
+            .replace("\n", " ")
+            .run {
+                ComposerRegexes.SHARE.replaceAllOccurrences(this) { match ->
+                    val url = match.groups["url"]?.value.orEmpty()
+                    append("<a href=\"$url\">#$url</a>")
+                }
+            }
+
+    private fun String.convertMarkdownToHtml(): String =
+        run {
+            Regex("~~(?<content>.*?)~~").replaceAllOccurrences(this) { match ->
+                val content = match.groups["content"]?.value.orEmpty()
+                append("<s>$content</s>")
+            }
+        }.run {
+            Regex("_(?<content>.*?)_").replaceAllOccurrences(this) { match ->
+                val content = match.groups["content"]?.value.orEmpty()
+                append("<i>$content</i>")
+            }
+        }.run {
+            Regex("\\*\\*(?<content>.*?)\\*\\*").replaceAllOccurrences(this) { match ->
+                val content = match.groups["content"]?.value.orEmpty()
+                append("<b>$content</b>")
+            }
+        }.run {
+            Regex("`(?<content>.*?)`").replaceAllOccurrences(this) { match ->
+                val content = match.groups["content"]?.value.orEmpty()
+                append("<code>$content</code>")
+            }
+        }.run {
+            Regex("\\[(?<anchor>.*?)]\\((?<url>.*?)\\)").replaceAllOccurrences(this) { match ->
+                val anchor = match.groups["anchor"]?.value.orEmpty()
+                val url = match.groups["url"]?.value.orEmpty()
+                append("<a href=\"$url\">$anchor</a>")
+            }
+        }.replace("<ul>", "\n")
+            .replace("</ul>", "\n")
+            .replace("<ol>", "\n")
+            .replace("</ol>", "\n")
+            .run {
+                Regex("^- (?<content>.*?)$").replaceAllOccurrences(this) { match ->
+                    val content = match.groups["content"]?.value.orEmpty()
+                    append("<li>$content</li>")
+                }
+            }.run {
+                ComposerRegexes.SHARE.replaceAllOccurrences(this) { match ->
+                    val url = match.groups["url"]?.value.orEmpty()
+                    append(url)
+                }
+            }
+
+    private fun String.withMentions(): String =
+        also { original ->
+            val matches = ComposerRegexes.USER_MENTION.findAll(original).toList()
+            buildString {
+                var index = 0
+                for (match in matches) {
+                    val range = match.range
+                    append(original.substring(index, range.first))
+                    val handle = match.groupValues.firstOrNull().orEmpty()
+                    val currentNode = apiConfigurationRepository.node.value
+                    val node = handle.nodeName ?: currentNode
+                    val name = handle.substringBefore("@")
+                    val url =
+                        if (node == currentNode) {
+                            "https://$node/profile/$name"
+                        } else {
+                            "https://$node/users/$name"
+                        }
+                    append("<a href=\"$url\">#$handle</a>")
+                    index = range.last + 1
+                }
+                if (index < original.length) {
+                    append(original.substring(index, original.length))
+                }
+            }
+        }
+
+    private fun String.withHashtags(): String =
+        also { original ->
+            val matches = ComposerRegexes.HASHTAG.findAll(original).toList()
+            buildString {
+                var index = 0
+                for (match in matches) {
+                    val range = match.range
+                    append(original.substring(index, range.first))
+                    val tag = match.groupValues.firstOrNull().orEmpty()
+                    val node = apiConfigurationRepository.node.value
+                    val url = "https://$node/search?tag=$tag"
+                    append("<a href=\"$url\">#$tag</a>")
+                    index = range.last + 1
+                }
+                if (index < original.length) {
+                    append(original.substring(index, original.length))
+                }
+            }
+        }
+}
+
+private fun Regex.replaceAllOccurrences(
+    original: String,
+    onMatchResult: StringBuilder.(MatchResult) -> Unit,
+): String =
+    buildString {
+        val matches = findAll(original).toList()
+        var index = 0
+        for (match in matches) {
+            val range = match.range
+            append(original.substring(index, range.first))
+            onMatchResult(match)
+            index = range.last + 1
+        }
+        if (index < original.length) {
+            append(original.substring(index, original.length))
+        }
+    }

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/utils/PrepareForPreviewUseCase.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/utils/PrepareForPreviewUseCase.kt
@@ -1,0 +1,10 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.composer.utils
+
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.MarkupMode
+
+interface PrepareForPreviewUseCase {
+    operator fun invoke(
+        text: String,
+        mode: MarkupMode,
+    ): String
+}

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsMviModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsMviModel.kt
@@ -10,6 +10,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.UiTheme
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.Visibility
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.MarkupMode
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.UrlOpeningMode
 
 @Stable
@@ -72,6 +73,10 @@ interface SettingsMviModel :
         data class ChangeOpenGroupsInForumModeByDefault(
             val value: Boolean,
         ) : Intent
+
+        data class ChangeMarkupMode(
+            val mode: MarkupMode,
+        ) : Intent
     }
 
     data class State(
@@ -94,6 +99,8 @@ interface SettingsMviModel :
         val excludeRepliesFromTimeline: Boolean = false,
         val availableVisibilities: List<Visibility> = emptyList(),
         val openGroupsInForumModeByDefault: Boolean = true,
+        val markupMode: MarkupMode = MarkupMode.HTML,
+        val availableMarkupModes: List<MarkupMode> = emptyList(),
     )
 
     sealed interface Effect

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
@@ -88,6 +88,7 @@ class SettingsScreen : Screen {
         var customColorPickerDialogOpened by remember { mutableStateOf(false) }
         var defaultPostVisibilityBottomSheetOpened by remember { mutableStateOf(false) }
         var defaultReplyVisibilityBottomSheetOpened by remember { mutableStateOf(false) }
+        var markupModeBottomSheetOpened by remember { mutableStateOf(false) }
 
         Scaffold(
             topBar = {
@@ -188,6 +189,16 @@ class SettingsScreen : Screen {
                                 )
                             },
                         )
+
+                        if (uiState.isLogged) {
+                            SettingsRow(
+                                title = LocalStrings.current.settingsItemMarkupMode,
+                                value = uiState.markupMode.toReadableName(),
+                                onTap = {
+                                    markupModeBottomSheetOpened = true
+                                },
+                            )
+                        }
 
                         SettingsHeader(
                             title = LocalStrings.current.settingsHeaderLookAndFeel,
@@ -573,6 +584,21 @@ class SettingsScreen : Screen {
                     if (index != null) {
                         val type = types[index]
                         model.reduce(SettingsMviModel.Intent.ChangeDefaultReplyVisibility(type))
+                    }
+                },
+            )
+        }
+
+        if (markupModeBottomSheetOpened) {
+            val modes = uiState.availableMarkupModes
+            CustomModalBottomSheet(
+                title = LocalStrings.current.settingsItemMarkupMode,
+                items = modes.map { CustomModalBottomSheetItem(label = it.toReadableName()) },
+                onSelected = { index ->
+                    markupModeBottomSheetOpened = false
+                    if (index != null) {
+                        val mode = modes[index]
+                        model.reduce(SettingsMviModel.Intent.ChangeMarkupMode(mode))
                     }
                 },
             )

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsViewModel.kt
@@ -17,6 +17,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toInt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toTimelineType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toVisibility
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SupportedFeatureRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.MarkupMode
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.UrlOpeningMode
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
@@ -100,6 +101,7 @@ class SettingsViewModel(
                                 defaultReplyVisibility = settings.defaultReplyVisibility.toVisibility(),
                                 excludeRepliesFromTimeline = settings.excludeRepliesFromTimeline,
                                 openGroupsInForumModeByDefault = settings.openGroupsInForumModeByDefault,
+                                markupMode = settings.markupMode,
                             )
                         }
                     }
@@ -116,6 +118,17 @@ class SettingsViewModel(
                                         this += Visibility.Private
                                     }
                                     this += Visibility.Direct
+                                },
+                            availableMarkupModes =
+                                buildList {
+                                    this += MarkupMode.PlainText
+                                    if (features.supportsBBCode) {
+                                        this += MarkupMode.BBCode
+                                    }
+                                    this += MarkupMode.HTML
+                                    if (features.supportsMarkdown) {
+                                        this += MarkupMode.Markdown
+                                    }
                                 },
                         )
                     }
@@ -201,6 +214,11 @@ class SettingsViewModel(
                 screenModelScope.launch {
                     changeOpenGroupsInForumModeByDefault(intent.value)
                 }
+
+            is SettingsMviModel.Intent.ChangeMarkupMode ->
+                screenModelScope.launch {
+                    changeMarkupMode(intent.mode)
+                }
         }
     }
 
@@ -285,6 +303,12 @@ class SettingsViewModel(
     private suspend fun changeOpenGroupsInForumModeByDefault(value: Boolean) {
         val currentSettings = settingsRepository.current.value ?: return
         val newSettings = currentSettings.copy(openGroupsInForumModeByDefault = value)
+        saveSettings(newSettings)
+    }
+
+    private suspend fun changeMarkupMode(value: MarkupMode) {
+        val currentSettings = settingsRepository.current.value ?: return
+        val newSettings = currentSettings.copy(markupMode = value)
         saveSettings(newSettings)
     }
 


### PR DESCRIPTION
This PR introduces the possibility to have conditional markup for new posts (in the Composer screen and in the preview dialog).

The rationale behind this choice is to:
- let user decide what format will be used (or disable markup altogether);
- leverage the Markdown support added in newer versions of Mastodon.

The markup mode will be defaulted to `BBCode` for Friendica users and `HTML` for Mastodon users, however:
- Friendica users will be able to choose between `PlainText`, `BBCode` and `HTML`
- Mastodon users will be able to choose between `PlainText`, `HTML` and `Markdown`
at any time from the application Settings screen.

In case rich text editing is disabled, post title and spoiler are taken from the response of the GET `v1/statuses/:id/source` endpoint, in order to avoid inserting potentially unwanted markup added on the back-end side.