### PR TITLE
enhancement: add warning if alt text is missing

### DIFF
--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
@@ -347,7 +347,8 @@ internal val DeStrings =
         override val actionReportUser = "Benutzer melden"
         override val actionReportEntry = "Beitrag melden"
         override val actionViewDetails = "Einzelheiten"
-        override val actionAddImageFromGallery = "Aus Galerie hinzufügen"
+        override val actionAddImage = "Bild hinzufügen"
+        override val actionAddImageFromGallery = "Bild hinzufügen (Galerie)"
         override val actionAddPoll = "Umfrage hinzufügen"
         override val actionRemovePoll = "Umfrage entfernen"
         override val createPostPollSection = "Umfrage"
@@ -362,6 +363,8 @@ internal val DeStrings =
             "Beschreiben Sie das aufgetretene Problem oder hinterlassen Sie einfach ein Feedback 🖋️"
         override val changeNodeDialogTitle = "Instanz ändern"
         override val actionQuote = "Zitieren"
+        override val actionAddSpoiler = "Spoiler hinzufügen"
+        override val actionRemoveSpoiler = "Spoiler entfernen"
         override val actionAddTitle = "Titel hinzufügen"
         override val actionRemoveTitle = "Titel entfernen"
         override val actionRevealContent = "Inhalt enthüllen"
@@ -377,4 +380,7 @@ internal val DeStrings =
         override val actionDismissAllNotifications = "Alle Benachrichtigungen ablehnen"
         override val settingsItemMarkupMode = "Markierung für Compositing"
         override val markupModePlainText = "Einfacher Text"
+        override val messageAltTextMissingError =
+            "Einige Anhänge haben keinen alternativen Text, fügen Sie ihn aus Gründen der Zugänglichkeit ein."
+        override val buttonPublishAnyway = "Trotzdem veröffentlichen"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -340,7 +340,8 @@ internal open class DefaultStrings : Strings {
     override val actionReportUser = "Report user"
     override val actionReportEntry = "Report post"
     override val actionViewDetails = "Details"
-    override val actionAddImageFromGallery = "Add from gallery"
+    override val actionAddImage = "Add image"
+    override val actionAddImageFromGallery = "Add image (media gallery)"
     override val actionAddPoll = "Add poll"
     override val actionRemovePoll = "Remove poll"
     override val createPostPollSection = "Poll"
@@ -355,6 +356,8 @@ internal open class DefaultStrings : Strings {
         "Describe the issue you encountered or just leave a feedback 🖋️"
     override val changeNodeDialogTitle = "Change instance"
     override val actionQuote = "Quote"
+    override val actionAddSpoiler = "Add spoiler"
+    override val actionRemoveSpoiler = "Remove spoiler"
     override val actionAddTitle = "Add title"
     override val actionRemoveTitle = "Remove title"
     override val actionRevealContent = "Reveal content"
@@ -372,4 +375,7 @@ internal open class DefaultStrings : Strings {
     override val markupModeHTML = "HTML"
     override val markupModeMarkdown = "Markdown"
     override val markupModePlainText = "Plain text"
+    override val messageAltTextMissingError =
+        "Some attachments do not have an alternate text, consider inserting it for accessibility"
+    override val buttonPublishAnyway = "Publish anyway"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/EsStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/EsStrings.kt
@@ -347,7 +347,8 @@ internal val EsStrings =
         override val actionReportUser = "Denunciar usuario"
         override val actionReportEntry = "Denunciar publicación"
         override val actionViewDetails = "Detalles"
-        override val actionAddImageFromGallery = "Añadir desde la galería"
+        override val actionAddImage = "Añadir imagen"
+        override val actionAddImageFromGallery = "Añadir imagen (galería)"
         override val actionAddPoll = "Añadir encuesta"
         override val actionRemovePoll = "Eliminar encuesta"
         override val createPostPollSection = "Encuesta"
@@ -362,6 +363,8 @@ internal val EsStrings =
             "Describe el problema que has encontrado o simplemente deja un comentario 🖋️"
         override val changeNodeDialogTitle = "Cambiar instancia"
         override val actionQuote = "Citar"
+        override val actionAddSpoiler = "Añadir spoiler"
+        override val actionRemoveSpoiler = "Eliminar spoiler"
         override val actionAddTitle = "Añadir título"
         override val actionRemoveTitle = "Eliminar título"
         override val actionRevealContent = "Mostrar contenido"
@@ -378,4 +381,7 @@ internal val EsStrings =
         override val actionDismissAllNotifications = "Desechar todas las notificaciones"
         override val settingsItemMarkupMode = "Marcas de composición"
         override val markupModePlainText = "Texto sin formato"
+        override val messageAltTextMissingError =
+            "Algunos archivos adjuntos no tienen un texto alternativo, insertarlo puede mejorar la accesibilidad"
+        override val buttonPublishAnyway = "Publicar de todos modos"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/FrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/FrStrings.kt
@@ -351,7 +351,8 @@ internal val FrStrings =
         override val actionReportUser = "Signaler utilisateur"
         override val actionReportEntry = "Signaler poste"
         override val actionViewDetails = "Détails"
-        override val actionAddImageFromGallery = "Ajouter depuis la galerie"
+        override val actionAddImage = "Ajouter image"
+        override val actionAddImageFromGallery = "Ajouter image (galerie)"
         override val actionAddPoll = "Ajouter un sondage"
         override val actionRemovePoll = "Supprimer un sondage"
         override val createPostPollSection = "Sondage"
@@ -366,8 +367,10 @@ internal val FrStrings =
             "Décrivez le problème que vous avez rencontré ou laissez simplement un commentaire 🖋️"
         override val changeNodeDialogTitle = "Modifier l'instance"
         override val actionQuote = "Citation"
-        override val actionAddTitle = "Ajouter un titre"
-        override val actionRemoveTitle = "Supprimer le titre"
+        override val actionAddSpoiler = "Ajouter spoiler"
+        override val actionRemoveSpoiler = "Supprimer spoiler"
+        override val actionAddTitle = "Ajouter titre"
+        override val actionRemoveTitle = "Supprimer titre"
         override val actionRevealContent = "Révéler le contenu"
         override val settingsItemExcludeRepliesFromTimeline =
             "Exclure les réponses de la chronologie"
@@ -382,4 +385,7 @@ internal val FrStrings =
         override val actionDismissAllNotifications = "Supprimer toutes les notifications"
         override val settingsItemMarkupMode = "Balisage pour la composition"
         override val markupModePlainText = "Texte brut"
+        override val messageAltTextMissingError =
+            "Certaines pièces jointes n'ont pas de texte alternatif, pensez à l'insérer pour des raisons d'accessibilité"
+        override val buttonPublishAnyway = "Publier quand même"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -347,7 +347,8 @@ internal val ItStrings =
         override val actionReportUser = "Segnala utente"
         override val actionReportEntry = "Segnala post"
         override val actionViewDetails = "Dettagli"
-        override val actionAddImageFromGallery = "Aggiungi dalla galleria"
+        override val actionAddImage = "Aggiungi immagine"
+        override val actionAddImageFromGallery = "Aggiungi immagine (galleria)"
         override val actionAddPoll = "Aggiungi sondaggio"
         override val actionRemovePoll = "Rimuovi sondaggio"
         override val createPostPollSection = "Sondaggio"
@@ -362,6 +363,8 @@ internal val ItStrings =
             "Descrivi il problema che hai riscontrato o lascia un feedback 🖋️"
         override val changeNodeDialogTitle = "Cambia istanza"
         override val actionQuote = "Cita"
+        override val actionAddSpoiler = "Aggiungi spoiler"
+        override val actionRemoveSpoiler = "Rimuovi spoiler"
         override val actionAddTitle = "Aggiungi titolo"
         override val actionRemoveTitle = "Rimuovi titolo"
         override val actionRevealContent = "Rivela contenuto"
@@ -377,4 +380,7 @@ internal val ItStrings =
         override val actionDismissAllNotifications = "Elimina tutte le notifiche"
         override val settingsItemMarkupMode = "Markup per la composizione"
         override val markupModePlainText = "Testo semplice"
+        override val messageAltTextMissingError =
+            "Alcuni allegati non hanno il testo alternativo, inserirlo può migliorare l'accessibilità"
+        override val buttonPublishAnyway = "Pubblica comunque"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -319,6 +319,8 @@ interface Strings {
     val userFeedbackCommentPlaceholder: String
     val changeNodeDialogTitle: String
     val actionQuote: String
+    val actionAddSpoiler: String
+    val actionRemoveSpoiler: String
     val actionAddTitle: String
     val actionRemoveTitle: String
     val actionRevealContent: String
@@ -336,6 +338,9 @@ interface Strings {
     val markupModeHTML: String
     val markupModeMarkdown: String
     val markupModePlainText: String
+    val messageAltTextMissingError: String
+    val buttonPublishAnyway: String
+    val actionAddImage: String
 }
 
 object Locales {

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
@@ -143,7 +143,9 @@ interface ComposerMviModel :
 
         data object ToggleHasTitle : Intent
 
-        data object Submit : Intent
+        data class Submit(
+            val enableAltTextCheck: Boolean = true,
+        ) : Intent
 
         data object GalleryInitialLoad : Intent
 
@@ -240,6 +242,8 @@ interface ComposerMviModel :
             data object ScheduleDateInThePast : ValidationError
 
             data object InvalidPoll : ValidationError
+
+            data object AltTextMissing : ValidationError
         }
 
         data object Success : Effect


### PR DESCRIPTION
This PR adds a non-blocking warning if no alt text has been inserted for at least one of the attachments.

Moreover it moves the "toggle spoiler" and "add image" actions to the top app bar menu in case the formatting bar were hidden (e.g. in plain text mode).