### PR TITLE
enhancement: improve profile opening

### DIFF
--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
@@ -18,6 +18,24 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.LoginUs
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.LogoutUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.SetupAccountUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.SwitchAccountUseCase
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.DefaultExternalUserProcessor
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.DefaultFetchUserUseCase
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.DefaultFriendicaUserProcessor
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.DefaultGuppeProcessor
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.DefaultHashtagProcessor
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.DefaultLemmyProcessor
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.DefaultMastodonUserProcessor
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.DefaultPeertubeProcessor
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.DefaultPixelfedProcessor
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.ExternalUserProcessor
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.FetchUserUseCase
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.FriendicaUserProcessor
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.GuppeProcessor
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.HashtagProcessor
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.LemmyProcessor
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.MastodonUserProcessor
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.PeertubeProcessor
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.PixelfedProcessor
 import org.koin.dsl.module
 
 val domainIdentityUseCaseModule =
@@ -46,14 +64,72 @@ val domainIdentityUseCaseModule =
                 accountRepository = get(),
             )
         }
+        single<FetchUserUseCase> {
+            DefaultFetchUserUseCase(
+                userRepository = get(),
+            )
+        }
+        single<HashtagProcessor> {
+            DefaultHashtagProcessor(
+                apiConfigurationRepository = get(),
+                detailOpener = get(),
+            )
+        }
+        single<FriendicaUserProcessor> {
+            DefaultFriendicaUserProcessor(
+                detailOpener = get(),
+                fetchUser = get(),
+            )
+        }
+        single<ExternalUserProcessor> {
+            DefaultExternalUserProcessor(
+                detailOpener = get(),
+                fetchUser = get(),
+            )
+        }
+        single<MastodonUserProcessor> {
+            DefaultMastodonUserProcessor(
+                detailOpener = get(),
+                fetchUser = get(),
+            )
+        }
+        single<PixelfedProcessor> {
+            DefaultPixelfedProcessor(
+                detailOpener = get(),
+                fetchUser = get(),
+            )
+        }
+        single<LemmyProcessor> {
+            DefaultLemmyProcessor(
+                detailOpener = get(),
+                fetchUser = get(),
+            )
+        }
+        single<GuppeProcessor> {
+            DefaultGuppeProcessor(
+                detailOpener = get(),
+                fetchUser = get(),
+            )
+        }
+        single<PeertubeProcessor> {
+            DefaultPeertubeProcessor(
+                detailOpener = get(),
+                fetchUser = get(),
+            )
+        }
         single<CustomUriHandler> { params ->
             DefaultCustomUriHandler(
                 defaultHandler = params[0],
-                apiConfigurationRepository = get(),
-                detailOpener = get(),
-                userRepository = get(),
                 customTabsHelper = get(),
                 settingsRepository = get(),
+                hashtagProcessor = get(),
+                friendicaUserProcessor = get(),
+                externalUserProcessor = get(),
+                mastodonUserProcessor = get(),
+                lemmyProcessor = get(),
+                guppeProcessor = get(),
+                peertubeProcessor = get(),
+                pixelfedProcessor = get(),
             )
         }
         single<SwitchAccountUseCase> {

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/DefaultFetchUserUseCase.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/DefaultFetchUserUseCase.kt
@@ -1,0 +1,18 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
+import kotlinx.coroutines.withTimeoutOrNull
+
+internal class DefaultFetchUserUseCase(
+    private val userRepository: UserRepository,
+) : FetchUserUseCase {
+    override suspend fun invoke(handle: String): UserModel? =
+        withTimeoutOrNull(USER_SEARCH_TIMEOUT_MILLIS) {
+            userRepository.getByHandle(handle)
+        }
+
+    companion object {
+        private const val USER_SEARCH_TIMEOUT_MILLIS = 1000L
+    }
+}

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/ExternalUserProcessor.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/ExternalUserProcessor.kt
@@ -1,0 +1,27 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor
+
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.UriHandlerConstants.DETAIL_FRAGMENT
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.UriHandlerConstants.INSTANCE_FRAGMENT
+
+internal interface ExternalUserProcessor : UrlProcessor
+
+internal class DefaultExternalUserProcessor(
+    private val detailOpener: DetailOpener,
+    private val fetchUser: FetchUserUseCase,
+) : ExternalUserProcessor {
+    override suspend fun process(uri: String): Boolean {
+        val group = REGEX.find(uri)?.groups ?: return false
+        val (node, user) =
+            group["instance"]?.value.orEmpty() to group["detail"]?.value.orEmpty().trimStart('@')
+        val remoteUser = fetchUser("$user@$node") ?: return false
+
+        detailOpener.openUserDetail(remoteUser)
+        return true
+    }
+
+    companion object {
+        private val REGEX =
+            Regex("https://(?<instance>$INSTANCE_FRAGMENT)/users/(?<detail>$DETAIL_FRAGMENT)")
+    }
+}

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/FetchUserUseCase.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/FetchUserUseCase.kt
@@ -1,0 +1,7 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+
+internal interface FetchUserUseCase {
+    suspend operator fun invoke(handle: String): UserModel?
+}

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/FriendicaUserProcessor.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/FriendicaUserProcessor.kt
@@ -1,0 +1,26 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor
+
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.UriHandlerConstants.DETAIL_FRAGMENT
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.UriHandlerConstants.INSTANCE_FRAGMENT
+
+internal interface FriendicaUserProcessor : UrlProcessor
+
+internal class DefaultFriendicaUserProcessor(
+    private val detailOpener: DetailOpener,
+    private val fetchUser: FetchUserUseCase,
+) : FriendicaUserProcessor {
+    override suspend fun process(uri: String): Boolean {
+        val group = REGEX.find(uri)?.groups ?: return false
+        val (node, user) = group["instance"]?.value.orEmpty() to group["detail"]?.value.orEmpty()
+        val remoteUser = fetchUser("$user@$node") ?: return false
+
+        detailOpener.openUserDetail(remoteUser)
+        return true
+    }
+
+    companion object {
+        private val REGEX =
+            Regex("https://(?<instance>$INSTANCE_FRAGMENT)/profile/(?<detail>$DETAIL_FRAGMENT)")
+    }
+}

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/GuppeProcessor.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/GuppeProcessor.kt
@@ -1,0 +1,24 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor
+
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.UriHandlerConstants.DETAIL_FRAGMENT
+
+internal interface GuppeProcessor : UrlProcessor
+
+internal class DefaultGuppeProcessor(
+    private val detailOpener: DetailOpener,
+    private val fetchUser: FetchUserUseCase,
+) : GuppeProcessor {
+    override suspend fun process(uri: String): Boolean {
+        val group = REGEX.find(uri)?.groups ?: return false
+        val user = group["detail"]?.value.orEmpty()
+        val remoteUser = fetchUser("$user@a.gup.pe") ?: return false
+
+        detailOpener.openUserDetail(remoteUser)
+        return true
+    }
+
+    companion object {
+        private val REGEX = Regex("https://a\\.gup\\.pe/u/(?<detail>$DETAIL_FRAGMENT)")
+    }
+}

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/HashtagProcessor.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/HashtagProcessor.kt
@@ -1,0 +1,23 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor
+
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
+
+internal interface HashtagProcessor : UrlProcessor
+
+internal class DefaultHashtagProcessor(
+    private val apiConfigurationRepository: ApiConfigurationRepository,
+    private val detailOpener: DetailOpener,
+) : HashtagProcessor {
+    override suspend fun process(uri: String): Boolean {
+        val currentNode = apiConfigurationRepository.node.value
+        val tagPrefix = "https://$currentNode/search?tag="
+        if (!uri.startsWith(tagPrefix)) {
+            return false
+        }
+
+        val tag = uri.replace(tagPrefix, "")
+        detailOpener.openHashtag(tag)
+        return true
+    }
+}

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/LemmyProcessor.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/LemmyProcessor.kt
@@ -1,0 +1,26 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor
+
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.UriHandlerConstants.DETAIL_FRAGMENT
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.UriHandlerConstants.INSTANCE_FRAGMENT
+
+internal interface LemmyProcessor : UrlProcessor
+
+internal class DefaultLemmyProcessor(
+    private val detailOpener: DetailOpener,
+    private val fetchUser: FetchUserUseCase,
+) : LemmyProcessor {
+    override suspend fun process(uri: String): Boolean {
+        val group = REGEX.find(uri)?.groups ?: return false
+        val (node, user) = group["instance"]?.value.orEmpty() to group["detail"]?.value.orEmpty()
+        val remoteUser = fetchUser("$user@$node") ?: return false
+
+        detailOpener.openUserDetail(remoteUser)
+        return true
+    }
+
+    companion object {
+        private val REGEX =
+            Regex("https://(?<instance>$INSTANCE_FRAGMENT)/[uc]/(?<detail>$DETAIL_FRAGMENT)")
+    }
+}

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/MastodonUserProcessor.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/MastodonUserProcessor.kt
@@ -1,0 +1,27 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor
+
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.UriHandlerConstants.DETAIL_FRAGMENT
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.UriHandlerConstants.INSTANCE_FRAGMENT
+
+internal interface MastodonUserProcessor : UrlProcessor
+
+internal class DefaultMastodonUserProcessor(
+    private val detailOpener: DetailOpener,
+    private val fetchUser: FetchUserUseCase,
+) : MastodonUserProcessor {
+    override suspend fun process(uri: String): Boolean {
+        val group = REGEX.find(uri)?.groups ?: return false
+        val (node, user) =
+            group["instance"]?.value.orEmpty() to group["detail"]?.value.orEmpty().trimStart('@')
+        val remoteUser = fetchUser("$user@$node") ?: return false
+
+        detailOpener.openUserDetail(remoteUser)
+        return true
+    }
+
+    companion object {
+        private val REGEX =
+            Regex("https://(?<instance>$INSTANCE_FRAGMENT)/@(?<detail>$DETAIL_FRAGMENT)")
+    }
+}

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/PeertubeProcessor.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/PeertubeProcessor.kt
@@ -1,0 +1,26 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor
+
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.UriHandlerConstants.DETAIL_FRAGMENT
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.UriHandlerConstants.INSTANCE_FRAGMENT
+
+internal interface PeertubeProcessor : UrlProcessor
+
+internal class DefaultPeertubeProcessor(
+    private val detailOpener: DetailOpener,
+    private val fetchUser: FetchUserUseCase,
+) : PeertubeProcessor {
+    override suspend fun process(uri: String): Boolean {
+        val group = REGEX.find(uri)?.groups ?: return false
+        val (node, user) = group["instance"]?.value.orEmpty() to group["detail"]?.value.orEmpty()
+        val remoteUser = fetchUser("$user@$node") ?: return false
+
+        detailOpener.openUserDetail(remoteUser)
+        return true
+    }
+
+    companion object {
+        private val REGEX =
+            Regex("https://(?<instance>$INSTANCE_FRAGMENT)/(video-channels|accounts)/(?<detail>$DETAIL_FRAGMENT)")
+    }
+}

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/PixelfedProcessor.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/PixelfedProcessor.kt
@@ -1,0 +1,26 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor
+
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.UriHandlerConstants.DETAIL_FRAGMENT
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor.UriHandlerConstants.INSTANCE_FRAGMENT
+
+internal interface PixelfedProcessor : UrlProcessor
+
+internal class DefaultPixelfedProcessor(
+    private val detailOpener: DetailOpener,
+    private val fetchUser: FetchUserUseCase,
+) : PixelfedProcessor {
+    override suspend fun process(uri: String): Boolean {
+        val group = REGEX.find(uri)?.groups ?: return false
+        val (node, user) = group["instance"]?.value.orEmpty() to group["detail"]?.value.orEmpty()
+        val remoteUser = fetchUser("$user@$node") ?: return false
+
+        detailOpener.openUserDetail(remoteUser)
+        return true
+    }
+
+    companion object {
+        private val REGEX =
+            Regex("https://(?<instance>$INSTANCE_FRAGMENT)/(?<detail>$DETAIL_FRAGMENT)")
+    }
+}

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/UriHandlerConstants.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/UriHandlerConstants.kt
@@ -1,0 +1,7 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor
+
+internal object UriHandlerConstants {
+    const val DETAIL_FRAGMENT: String = "[a-zA-Z0-9_]{3,}"
+    const val INSTANCE_FRAGMENT: String =
+        "([a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]\\.)+[a-zA-Z]{2,}"
+}

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/UrlProcessor.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/UrlProcessor.kt
@@ -1,0 +1,5 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor
+
+internal interface UrlProcessor {
+    suspend fun process(uri: String): Boolean
+}

--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/DefaultExternalUserProcessorTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/DefaultExternalUserProcessorTest.kt
@@ -1,0 +1,83 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor
+
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DefaultExternalUserProcessorTest {
+    private val detailOpener = mock<DetailOpener>(mode = MockMode.autoUnit)
+    private val fetchUser = mock<FetchUserUseCase>()
+    private val sut =
+        DefaultExternalUserProcessor(
+            detailOpener = detailOpener,
+            fetchUser = fetchUser,
+        )
+
+    @Test
+    fun `given valid user when process URL then interactions are as expected`() =
+        runTest {
+            val user = UserModel(id = "0", username = USERNAME)
+            everySuspend { fetchUser.invoke(any()) } returns user
+            val url = "https://$HOST/users/$USERNAME"
+
+            val res = sut.process(url)
+
+            assertTrue(res)
+            verifySuspend {
+                fetchUser.invoke("$USERNAME@$HOST")
+            }
+            verify {
+                detailOpener.openUserDetail(user)
+            }
+        }
+
+    @Test
+    fun `given user not found when process URL then interactions are as expected`() =
+        runTest {
+            everySuspend { fetchUser.invoke(any()) } returns null
+            val url = "https://$HOST/users/$USERNAME"
+
+            val res = sut.process(url)
+
+            assertFalse(res)
+            verifySuspend {
+                fetchUser.invoke("$USERNAME@$HOST")
+            }
+            verify(mode = VerifyMode.not) {
+                detailOpener.openUserDetail(any())
+            }
+        }
+
+    @Test
+    fun `given invalid URL when process URL then interactions are as expected`() =
+        runTest {
+            everySuspend { fetchUser.invoke(any()) } returns null
+            val url = "https://$HOST/u/$USERNAME"
+
+            val res = sut.process(url)
+
+            assertFalse(res)
+            verifySuspend(mode = VerifyMode.not) {
+                fetchUser.invoke(any())
+            }
+            verify(mode = VerifyMode.not) {
+                detailOpener.openUserDetail(any())
+            }
+        }
+
+    companion object {
+        private const val HOST = "example.com"
+        private const val USERNAME = "username"
+    }
+}

--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/DefaultFetchUserUseCaseTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/DefaultFetchUserUseCaseTest.kt
@@ -1,0 +1,75 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.seconds
+
+class DefaultFetchUserUseCaseTest {
+    private val userRepository = mock<UserRepository>()
+    private val sut =
+        DefaultFetchUserUseCase(
+            userRepository = userRepository,
+        )
+
+    @Test
+    fun `given user found when invoke then result is as expected`() =
+        runTest {
+            val user = UserModel(id = "0", username = USERNAME)
+            everySuspend { userRepository.getByHandle(any()) } returns user
+            val handle = "$USERNAME@$HOST.com"
+
+            val res = sut.invoke(handle)
+
+            assertNotNull(res)
+            verifySuspend {
+                userRepository.getByHandle(handle)
+            }
+        }
+
+    @Test
+    fun `given user not found when invoke then result is as expected`() =
+        runTest {
+            everySuspend { userRepository.getByHandle(any()) } returns null
+            val handle = "$USERNAME@$HOST.com"
+
+            val res = sut.invoke(handle)
+
+            assertNull(res)
+            verifySuspend {
+                userRepository.getByHandle(handle)
+            }
+        }
+
+    @Test
+    fun `given request timeout when invoke then result is as expected`() =
+        runTest {
+            everySuspend { userRepository.getByHandle(any()) } calls {
+                delay(10.seconds)
+                UserModel(id = "0", username = USERNAME)
+            }
+            val handle = "$USERNAME@$HOST.com"
+
+            val res = sut.invoke(handle)
+
+            assertNull(res)
+            verifySuspend {
+                userRepository.getByHandle(handle)
+            }
+        }
+
+    companion object {
+        private const val HOST = "example.com"
+        private const val USERNAME = "username"
+    }
+}

--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/DefaultFriendicaUserProcessorTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/DefaultFriendicaUserProcessorTest.kt
@@ -1,0 +1,83 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor
+
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DefaultFriendicaUserProcessorTest {
+    private val detailOpener = mock<DetailOpener>(mode = MockMode.autoUnit)
+    private val fetchUser = mock<FetchUserUseCase>()
+    private val sut =
+        DefaultFriendicaUserProcessor(
+            detailOpener = detailOpener,
+            fetchUser = fetchUser,
+        )
+
+    @Test
+    fun `given valid user when process URL then interactions are as expected`() =
+        runTest {
+            val user = UserModel(id = "0", username = USERNAME)
+            everySuspend { fetchUser.invoke(any()) } returns user
+            val url = "https://$HOST/profile/$USERNAME"
+
+            val res = sut.process(url)
+
+            assertTrue(res)
+            verifySuspend {
+                fetchUser.invoke("$USERNAME@$HOST")
+            }
+            verify {
+                detailOpener.openUserDetail(user)
+            }
+        }
+
+    @Test
+    fun `given user not found when process URL then interactions are as expected`() =
+        runTest {
+            everySuspend { fetchUser.invoke(any()) } returns null
+            val url = "https://$HOST/profile/$USERNAME"
+
+            val res = sut.process(url)
+
+            assertFalse(res)
+            verifySuspend {
+                fetchUser.invoke("$USERNAME@$HOST")
+            }
+            verify(mode = VerifyMode.not) {
+                detailOpener.openUserDetail(any())
+            }
+        }
+
+    @Test
+    fun `given invalid URL when process URL then interactions are as expected`() =
+        runTest {
+            everySuspend { fetchUser.invoke(any()) } returns null
+            val url = "https://$HOST/u/$USERNAME"
+
+            val res = sut.process(url)
+
+            assertFalse(res)
+            verifySuspend(mode = VerifyMode.not) {
+                fetchUser.invoke(any())
+            }
+            verify(mode = VerifyMode.not) {
+                detailOpener.openUserDetail(any())
+            }
+        }
+
+    companion object {
+        private const val HOST = "example.com"
+        private const val USERNAME = "username"
+    }
+}

--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/DefaultGuppeProcessorTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/DefaultGuppeProcessorTest.kt
@@ -1,0 +1,83 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor
+
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DefaultGuppeProcessorTest {
+    private val detailOpener = mock<DetailOpener>(mode = MockMode.autoUnit)
+    private val fetchUser = mock<FetchUserUseCase>()
+    private val sut =
+        DefaultGuppeProcessor(
+            detailOpener = detailOpener,
+            fetchUser = fetchUser,
+        )
+
+    @Test
+    fun `given valid user when process URL then interactions are as expected`() =
+        runTest {
+            val user = UserModel(id = "0", username = USERNAME)
+            everySuspend { fetchUser.invoke(any()) } returns user
+            val url = "https://$HOST/u/$USERNAME"
+
+            val res = sut.process(url)
+
+            assertTrue(res)
+            verifySuspend {
+                fetchUser.invoke("$USERNAME@$HOST")
+            }
+            verify {
+                detailOpener.openUserDetail(user)
+            }
+        }
+
+    @Test
+    fun `given user not found when process URL then interactions are as expected`() =
+        runTest {
+            everySuspend { fetchUser.invoke(any()) } returns null
+            val url = "https://$HOST/u/$USERNAME"
+
+            val res = sut.process(url)
+
+            assertFalse(res)
+            verifySuspend {
+                fetchUser.invoke("$USERNAME@$HOST")
+            }
+            verify(mode = VerifyMode.not) {
+                detailOpener.openUserDetail(any())
+            }
+        }
+
+    @Test
+    fun `given invalid URL when process URL then interactions are as expected`() =
+        runTest {
+            everySuspend { fetchUser.invoke(any()) } returns null
+            val url = "https://example.com/u/$USERNAME"
+
+            val res = sut.process(url)
+
+            assertFalse(res)
+            verifySuspend(mode = VerifyMode.not) {
+                fetchUser.invoke(any())
+            }
+            verify(mode = VerifyMode.not) {
+                detailOpener.openUserDetail(any())
+            }
+        }
+
+    companion object {
+        private const val HOST = "a.gup.pe"
+        private const val USERNAME = "username"
+    }
+}

--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/DefaultHashtagProcessorTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/DefaultHashtagProcessorTest.kt
@@ -1,0 +1,60 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor
+
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DefaultHashtagProcessorTest {
+    private val detailOpener = mock<DetailOpener>(mode = MockMode.autoUnit)
+    private val apiConfigurationRepository =
+        mock<ApiConfigurationRepository> {
+            every { node } returns MutableStateFlow(HOST)
+        }
+    private val sut =
+        DefaultHashtagProcessor(
+            detailOpener = detailOpener,
+            apiConfigurationRepository = apiConfigurationRepository,
+        )
+
+    @Test
+    fun `given valid user when process URL then interactions are as expected`() =
+        runTest {
+            val url = "https://$HOST/search?tag=$TAG"
+
+            val res = sut.process(url)
+
+            assertTrue(res)
+            verify {
+                detailOpener.openHashtag(TAG)
+            }
+        }
+
+    @Test
+    fun `given invalid URL when process URL then interactions are as expected`() =
+        runTest {
+            val url = "https://$HOST/search?q=$TAG"
+
+            val res = sut.process(url)
+
+            assertFalse(res)
+            verify(mode = VerifyMode.not) {
+                detailOpener.openHashtag(any())
+            }
+        }
+
+    companion object {
+        private const val HOST = "a.gup.pe"
+        private const val TAG = "test"
+    }
+}

--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/DefaultLemmyUserProcessorTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/DefaultLemmyUserProcessorTest.kt
@@ -1,0 +1,118 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor
+
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DefaultLemmyUserProcessorTest {
+    private val detailOpener = mock<DetailOpener>(mode = MockMode.autoUnit)
+    private val fetchUser = mock<FetchUserUseCase>()
+    private val sut =
+        DefaultLemmyProcessor(
+            detailOpener = detailOpener,
+            fetchUser = fetchUser,
+        )
+
+    @Test
+    fun `given valid user when process URL then interactions are as expected`() =
+        runTest {
+            val user = UserModel(id = "0", username = USERNAME)
+            everySuspend { fetchUser.invoke(any()) } returns user
+            val url = "https://$HOST/u/$USERNAME"
+
+            val res = sut.process(url)
+
+            assertTrue(res)
+            verifySuspend {
+                fetchUser.invoke("$USERNAME@$HOST")
+            }
+            verify {
+                detailOpener.openUserDetail(user)
+            }
+        }
+
+    @Test
+    fun `given user not found when process URL then interactions are as expected`() =
+        runTest {
+            everySuspend { fetchUser.invoke(any()) } returns null
+            val url = "https://$HOST/u/$USERNAME"
+
+            val res = sut.process(url)
+
+            assertFalse(res)
+            verifySuspend {
+                fetchUser.invoke("$USERNAME@$HOST")
+            }
+            verify(mode = VerifyMode.not) {
+                detailOpener.openUserDetail(any())
+            }
+        }
+
+    @Test
+    fun `given valid community when process URL then interactions are as expected`() =
+        runTest {
+            val user = UserModel(id = "0", username = USERNAME, group = true)
+            everySuspend { fetchUser.invoke(any()) } returns user
+            val url = "https://$HOST/c/$USERNAME"
+
+            val res = sut.process(url)
+
+            assertTrue(res)
+            verifySuspend {
+                fetchUser.invoke("$USERNAME@$HOST")
+            }
+            verify {
+                detailOpener.openUserDetail(user)
+            }
+        }
+
+    @Test
+    fun `given community not found when process URL then interactions are as expected`() =
+        runTest {
+            everySuspend { fetchUser.invoke(any()) } returns null
+            val url = "https://$HOST/c/$USERNAME"
+
+            val res = sut.process(url)
+
+            assertFalse(res)
+            verifySuspend {
+                fetchUser.invoke("$USERNAME@$HOST")
+            }
+            verify(mode = VerifyMode.not) {
+                detailOpener.openUserDetail(any())
+            }
+        }
+
+    @Test
+    fun `given invalid URL when process URL then interactions are as expected`() =
+        runTest {
+            everySuspend { fetchUser.invoke(any()) } returns null
+            val url = "https://$HOST/profile/$USERNAME"
+
+            val res = sut.process(url)
+
+            assertFalse(res)
+            verifySuspend(mode = VerifyMode.not) {
+                fetchUser.invoke(any())
+            }
+            verify(mode = VerifyMode.not) {
+                detailOpener.openUserDetail(any())
+            }
+        }
+
+    companion object {
+        private const val HOST = "example.com"
+        private const val USERNAME = "username"
+    }
+}

--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/DefaultMastodonUserProcessorTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/DefaultMastodonUserProcessorTest.kt
@@ -1,0 +1,83 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor
+
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DefaultMastodonUserProcessorTest {
+    private val detailOpener = mock<DetailOpener>(mode = MockMode.autoUnit)
+    private val fetchUser = mock<FetchUserUseCase>()
+    private val sut =
+        DefaultMastodonUserProcessor(
+            detailOpener = detailOpener,
+            fetchUser = fetchUser,
+        )
+
+    @Test
+    fun `given valid user when process URL then interactions are as expected`() =
+        runTest {
+            val user = UserModel(id = "0", username = USERNAME)
+            everySuspend { fetchUser.invoke(any()) } returns user
+            val url = "https://$HOST/@$USERNAME"
+
+            val res = sut.process(url)
+
+            assertTrue(res)
+            verifySuspend {
+                fetchUser.invoke("$USERNAME@$HOST")
+            }
+            verify {
+                detailOpener.openUserDetail(user)
+            }
+        }
+
+    @Test
+    fun `given user not found when process URL then interactions are as expected`() =
+        runTest {
+            everySuspend { fetchUser.invoke(any()) } returns null
+            val url = "https://$HOST/@$USERNAME"
+
+            val res = sut.process(url)
+
+            assertFalse(res)
+            verifySuspend {
+                fetchUser.invoke("$USERNAME@$HOST")
+            }
+            verify(mode = VerifyMode.not) {
+                detailOpener.openUserDetail(any())
+            }
+        }
+
+    @Test
+    fun `given invalid URL when process URL then interactions are as expected`() =
+        runTest {
+            everySuspend { fetchUser.invoke(any()) } returns null
+            val url = "https://$HOST/u/$USERNAME"
+
+            val res = sut.process(url)
+
+            assertFalse(res)
+            verifySuspend(mode = VerifyMode.not) {
+                fetchUser.invoke(any())
+            }
+            verify(mode = VerifyMode.not) {
+                detailOpener.openUserDetail(any())
+            }
+        }
+
+    companion object {
+        private const val HOST = "example.com"
+        private const val USERNAME = "username"
+    }
+}

--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/DefaultPeertubeUserProcessorTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/DefaultPeertubeUserProcessorTest.kt
@@ -1,0 +1,118 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor
+
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DefaultPeertubeUserProcessorTest {
+    private val detailOpener = mock<DetailOpener>(mode = MockMode.autoUnit)
+    private val fetchUser = mock<FetchUserUseCase>()
+    private val sut =
+        DefaultPeertubeProcessor(
+            detailOpener = detailOpener,
+            fetchUser = fetchUser,
+        )
+
+    @Test
+    fun `given valid user when process URL then interactions are as expected`() =
+        runTest {
+            val user = UserModel(id = "0", username = USERNAME)
+            everySuspend { fetchUser.invoke(any()) } returns user
+            val url = "https://$HOST/accounts/$USERNAME"
+
+            val res = sut.process(url)
+
+            assertTrue(res)
+            verifySuspend {
+                fetchUser.invoke("$USERNAME@$HOST")
+            }
+            verify {
+                detailOpener.openUserDetail(user)
+            }
+        }
+
+    @Test
+    fun `given user not found when process URL then interactions are as expected`() =
+        runTest {
+            everySuspend { fetchUser.invoke(any()) } returns null
+            val url = "https://$HOST/accounts/$USERNAME"
+
+            val res = sut.process(url)
+
+            assertFalse(res)
+            verifySuspend {
+                fetchUser.invoke("$USERNAME@$HOST")
+            }
+            verify(mode = VerifyMode.not) {
+                detailOpener.openUserDetail(any())
+            }
+        }
+
+    @Test
+    fun `given valid channel when process URL then interactions are as expected`() =
+        runTest {
+            val user = UserModel(id = "0", username = USERNAME, group = true)
+            everySuspend { fetchUser.invoke(any()) } returns user
+            val url = "https://$HOST/video-channels/$USERNAME"
+
+            val res = sut.process(url)
+
+            assertTrue(res)
+            verifySuspend {
+                fetchUser.invoke("$USERNAME@$HOST")
+            }
+            verify {
+                detailOpener.openUserDetail(user)
+            }
+        }
+
+    @Test
+    fun `given channel not found when process URL then interactions are as expected`() =
+        runTest {
+            everySuspend { fetchUser.invoke(any()) } returns null
+            val url = "https://$HOST/video-channels/$USERNAME"
+
+            val res = sut.process(url)
+
+            assertFalse(res)
+            verifySuspend {
+                fetchUser.invoke("$USERNAME@$HOST")
+            }
+            verify(mode = VerifyMode.not) {
+                detailOpener.openUserDetail(any())
+            }
+        }
+
+    @Test
+    fun `given invalid URL when process URL then interactions are as expected`() =
+        runTest {
+            everySuspend { fetchUser.invoke(any()) } returns null
+            val url = "https://$HOST/profile/$USERNAME"
+
+            val res = sut.process(url)
+
+            assertFalse(res)
+            verifySuspend(mode = VerifyMode.not) {
+                fetchUser.invoke(any())
+            }
+            verify(mode = VerifyMode.not) {
+                detailOpener.openUserDetail(any())
+            }
+        }
+
+    companion object {
+        private const val HOST = "example.com"
+        private const val USERNAME = "username"
+    }
+}

--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/DefaultPixelfedProcessorTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/urlprocessor/DefaultPixelfedProcessorTest.kt
@@ -1,0 +1,83 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.urlprocessor
+
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DefaultPixelfedProcessorTest {
+    private val detailOpener = mock<DetailOpener>(mode = MockMode.autoUnit)
+    private val fetchUser = mock<FetchUserUseCase>()
+    private val sut =
+        DefaultPixelfedProcessor(
+            detailOpener = detailOpener,
+            fetchUser = fetchUser,
+        )
+
+    @Test
+    fun `given valid user when process URL then interactions are as expected`() =
+        runTest {
+            val user = UserModel(id = "0", username = USERNAME)
+            everySuspend { fetchUser.invoke(any()) } returns user
+            val url = "https://$HOST/$USERNAME"
+
+            val res = sut.process(url)
+
+            assertTrue(res)
+            verifySuspend {
+                fetchUser.invoke("$USERNAME@$HOST")
+            }
+            verify {
+                detailOpener.openUserDetail(user)
+            }
+        }
+
+    @Test
+    fun `given user not found when process URL then interactions are as expected`() =
+        runTest {
+            everySuspend { fetchUser.invoke(any()) } returns null
+            val url = "https://$HOST/$USERNAME"
+
+            val res = sut.process(url)
+
+            assertFalse(res)
+            verifySuspend {
+                fetchUser.invoke("$USERNAME@$HOST")
+            }
+            verify(mode = VerifyMode.not) {
+                detailOpener.openUserDetail(any())
+            }
+        }
+
+    @Test
+    fun `given invalid URL when process URL then interactions are as expected`() =
+        runTest {
+            everySuspend { fetchUser.invoke(any()) } returns null
+            val url = "https://$HOST/u/$USERNAME"
+
+            val res = sut.process(url)
+
+            assertFalse(res)
+            verifySuspend(mode = VerifyMode.not) {
+                fetchUser.invoke(any())
+            }
+            verify(mode = VerifyMode.not) {
+                detailOpener.openUserDetail(any())
+            }
+        }
+
+    companion object {
+        private const val HOST = "example.com"
+        private const val USERNAME = "username"
+    }
+}


### PR DESCRIPTION
This PR improves the recognition of user profile among various Fediverse platforms, rewriting completely `DefaultCustomUriHandler` in a more modular way.

As a result, now user recognition works on Mastodon instances and recognizes Pixelfed users and Peertube accounts/channels.