### PR TITLE
fix: avoid bug which prevented draft creation

### DIFF
--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultDraftRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultDraftRepository.kt
@@ -69,8 +69,9 @@ internal class DefaultDraftRepository(
             attachments =
                 mediaIds
                     ?.split(",")
+                    ?.filterNot { it.isEmpty() }
                     ?.mapNotNull { id ->
-                        provider.media.getBy(id)?.toModel()
+                        runCatching { provider.media.getBy(id) }.getOrNull()?.toModel()
                     }.orEmpty(),
             parentId = inReplyToId,
             lang = lang,


### PR DESCRIPTION
When creating a draft, there was a validation of the attachments when data was converted back from entity to model.
Unfortunately, this did not work for when the post had _no_ attachments.

This PR solves that bug.