### PR TITLE
feat: add possibility to copy post content to clipboard

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/Options.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/Options.kt
@@ -32,6 +32,8 @@ sealed interface OptionId {
 
     data object Quote : OptionId
 
+    data object CopyToClipboard : OptionId
+
     interface Custom : OptionId
 }
 
@@ -52,6 +54,7 @@ private fun OptionId.toReadableName(): String =
         OptionId.ReportEntry -> LocalStrings.current.actionReportEntry
         OptionId.ViewDetails -> LocalStrings.current.actionViewDetails
         OptionId.Quote -> LocalStrings.current.actionQuote
+        OptionId.CopyToClipboard -> LocalStrings.current.actionCopyToClipboard
         else -> ""
     }
 

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
@@ -383,4 +383,5 @@ internal val DeStrings =
         override val messageAltTextMissingError =
             "Einige Anhänge haben keinen alternativen Text, fügen Sie ihn aus Gründen der Zugänglichkeit ein."
         override val buttonPublishAnyway = "Trotzdem veröffentlichen"
+        override val actionCopyToClipboard = "In die Zwischenablage kopieren"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -378,4 +378,5 @@ internal open class DefaultStrings : Strings {
     override val messageAltTextMissingError =
         "Some attachments do not have an alternate text, consider inserting it for accessibility"
     override val buttonPublishAnyway = "Publish anyway"
+    override val actionCopyToClipboard = "Copy to clipboard"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/EsStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/EsStrings.kt
@@ -384,4 +384,5 @@ internal val EsStrings =
         override val messageAltTextMissingError =
             "Algunos archivos adjuntos no tienen un texto alternativo, insertarlo puede mejorar la accesibilidad"
         override val buttonPublishAnyway = "Publicar de todos modos"
+        override val actionCopyToClipboard = "Copiar al portapapeles"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/FrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/FrStrings.kt
@@ -388,4 +388,5 @@ internal val FrStrings =
         override val messageAltTextMissingError =
             "Certaines pièces jointes n'ont pas de texte alternatif, pensez à l'insérer pour des raisons d'accessibilité"
         override val buttonPublishAnyway = "Publier quand même"
+        override val actionCopyToClipboard = "Copier dans le presse-papiers"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -383,4 +383,5 @@ internal val ItStrings =
         override val messageAltTextMissingError =
             "Alcuni allegati non hanno il testo alternativo, inserirlo può migliorare l'accessibilità"
         override val buttonPublishAnyway = "Pubblica comunque"
+        override val actionCopyToClipboard = "Copia negli appunti"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -341,6 +341,7 @@ interface Strings {
     val messageAltTextMissingError: String
     val buttonPublishAnyway: String
     val actionAddImage: String
+    val actionCopyToClipboard: String
 }
 
 object Locales {

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailMviModel.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailMviModel.kt
@@ -54,6 +54,10 @@ interface EntryDetailMviModel :
         data class ToggleSpoilerActive(
             val entry: TimelineEntryModel,
         ) : Intent
+
+        data class CopyToClipboard(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -71,5 +75,9 @@ interface EntryDetailMviModel :
         ) : Effect
 
         data object PollVoteFailure : Effect
+
+        data class TriggerCopy(
+            val text: String,
+        ) : Effect
     }
 }

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -128,6 +128,10 @@ class EntryDetailScreen(
                             runCatching { lazyListState.scrollToItem(event.index) }
 
                         EntryDetailMviModel.Effect.PollVoteFailure -> pollErrorDialogOpened = true
+                        is EntryDetailMviModel.Effect.TriggerCopy -> {
+                            clipboardManager.setText(AnnotatedString(event.text))
+                            snackbarHostState.showSnackbar(copyToClipboardSuccess)
+                        }
                     }
                 }.launchIn(this)
         }
@@ -353,6 +357,7 @@ class EntryDetailScreen(
                                         this += OptionId.Quote.toOption()
                                     }
                                     this += OptionId.ViewDetails.toOption()
+                                    this += OptionId.CopyToClipboard.toOption()
                                 },
                             onOptionSelected = { optionId ->
                                 when (optionId) {
@@ -406,6 +411,8 @@ class EntryDetailScreen(
                                             )
                                         }
                                     }
+                                    OptionId.CopyToClipboard ->
+                                        model.reduce(EntryDetailMviModel.Intent.CopyToClipboard(entry.original))
                                     else -> Unit
                                 }
                             },

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailViewModel.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailViewModel.kt
@@ -113,6 +113,7 @@ class EntryDetailViewModel(
             is EntryDetailMviModel.Intent.TogglePin -> togglePin(intent.entry)
             is EntryDetailMviModel.Intent.SubmitPollVote -> submitPoll(intent.entry, intent.choices)
             is EntryDetailMviModel.Intent.ToggleSpoilerActive -> toggleSpoiler(intent.entry)
+            is EntryDetailMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
         }
     }
 
@@ -406,6 +407,23 @@ class EntryDetailViewModel(
     private fun toggleSpoiler(entry: TimelineEntryModel) {
         screenModelScope.launch {
             updateEntryInState(entry.id) { entry.copy(isSpoilerActive = !entry.isSpoilerActive) }
+        }
+    }
+
+    private fun copyToClipboard(entry: TimelineEntryModel) {
+        screenModelScope.launch {
+            val source = timelineEntryRepository.getSource(entry.id)
+            if (source != null) {
+                val text =
+                    buildString {
+                        if (!entry.title.isNullOrBlank()) {
+                            append(entry.title)
+                            append("\n")
+                        }
+                        append(source.content)
+                    }
+                emitEffect(EntryDetailMviModel.Effect.TriggerCopy(text))
+            }
         }
     }
 }

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreMviModel.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreMviModel.kt
@@ -69,6 +69,10 @@ interface ExploreMviModel :
         data class ToggleSpoilerActive(
             val entry: TimelineEntryModel,
         ) : Intent
+
+        data class CopyToClipboard(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -87,5 +91,9 @@ interface ExploreMviModel :
         data object BackToTop : Effect
 
         data object PollVoteFailure : Effect
+
+        data class TriggerCopy(
+            val text: String,
+        ) : Effect
     }
 }

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
@@ -136,6 +136,10 @@ class ExploreScreen : Screen {
                     when (event) {
                         ExploreMviModel.Effect.BackToTop -> goBackToTop()
                         ExploreMviModel.Effect.PollVoteFailure -> pollErrorDialogOpened = true
+                        is ExploreMviModel.Effect.TriggerCopy -> {
+                            clipboardManager.setText(AnnotatedString(event.text))
+                            snackbarHostState.showSnackbar(copyToClipboardSuccess)
+                        }
                     }
                 }.launchIn(this)
         }
@@ -400,6 +404,7 @@ class ExploreScreen : Screen {
                                                 this += OptionId.Quote.toOption()
                                             }
                                             this += OptionId.ViewDetails.toOption()
+                                            this += OptionId.CopyToClipboard.toOption()
                                         },
                                     onOptionSelected = { optionId ->
                                         when (optionId) {
@@ -456,6 +461,12 @@ class ExploreScreen : Screen {
                                                     )
                                                 }
                                             }
+                                            OptionId.CopyToClipboard ->
+                                                model.reduce(
+                                                    ExploreMviModel.Intent.CopyToClipboard(
+                                                        item.entry.original,
+                                                    ),
+                                                )
                                             else -> Unit
                                         }
                                     },

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreViewModel.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreViewModel.kt
@@ -130,6 +130,7 @@ class ExploreViewModel(
             is ExploreMviModel.Intent.TogglePin -> togglePin(intent.entry)
             is ExploreMviModel.Intent.SubmitPollVote -> submitPoll(intent.entry, intent.choices)
             is ExploreMviModel.Intent.ToggleSpoilerActive -> toggleSpoiler(intent.entry)
+            is ExploreMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
         }
     }
 
@@ -504,6 +505,23 @@ class ExploreViewModel(
     private fun toggleSpoiler(entry: TimelineEntryModel) {
         screenModelScope.launch {
             updateEntryInState(entry.id) { entry.copy(isSpoilerActive = !entry.isSpoilerActive) }
+        }
+    }
+
+    private fun copyToClipboard(entry: TimelineEntryModel) {
+        screenModelScope.launch {
+            val source = timelineEntryRepository.getSource(entry.id)
+            if (source != null) {
+                val text =
+                    buildString {
+                        if (!entry.title.isNullOrBlank()) {
+                            append(entry.title)
+                            append("\n")
+                        }
+                        append(source.content)
+                    }
+                emitEffect(ExploreMviModel.Effect.TriggerCopy(text))
+            }
         }
     }
 }

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesMviModel.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesMviModel.kt
@@ -55,6 +55,10 @@ interface FavoritesMviModel :
         data class ToggleSpoilerActive(
             val entry: TimelineEntryModel,
         ) : Intent
+
+        data class CopyToClipboard(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -71,5 +75,9 @@ interface FavoritesMviModel :
         data object BackToTop : Effect
 
         data object PollVoteFailure : Effect
+
+        data class TriggerCopy(
+            val text: String,
+        ) : Effect
     }
 }

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
@@ -119,6 +119,10 @@ class FavoritesScreen(
                     when (event) {
                         FavoritesMviModel.Effect.BackToTop -> goBackToTop()
                         FavoritesMviModel.Effect.PollVoteFailure -> pollErrorDialogOpened = true
+                        is FavoritesMviModel.Effect.TriggerCopy -> {
+                            clipboardManager.setText(AnnotatedString(event.text))
+                            snackbarHostState.showSnackbar(copyToClipboardSuccess)
+                        }
                     }
                 }.launchIn(this)
         }
@@ -305,6 +309,7 @@ class FavoritesScreen(
                                         this += OptionId.Quote.toOption()
                                     }
                                     this += OptionId.ViewDetails.toOption()
+                                    this += OptionId.CopyToClipboard.toOption()
                                 },
                             onOptionSelected = { optionId ->
                                 when (optionId) {
@@ -358,6 +363,10 @@ class FavoritesScreen(
                                             )
                                         }
                                     }
+                                    OptionId.CopyToClipboard ->
+                                        model.reduce(
+                                            FavoritesMviModel.Intent.CopyToClipboard(entry.original),
+                                        )
                                     else -> Unit
                                 }
                             },

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesViewModel.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesViewModel.kt
@@ -92,6 +92,7 @@ class FavoritesViewModel(
             is FavoritesMviModel.Intent.TogglePin -> togglePin(intent.entry)
             is FavoritesMviModel.Intent.SubmitPollVote -> submitPoll(intent.entry, intent.choices)
             is FavoritesMviModel.Intent.ToggleSpoilerActive -> toggleSpoiler(intent.entry)
+            is FavoritesMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
         }
     }
 
@@ -383,6 +384,23 @@ class FavoritesViewModel(
     private fun toggleSpoiler(entry: TimelineEntryModel) {
         screenModelScope.launch {
             updateEntryInState(entry.id) { entry.copy(isSpoilerActive = !entry.isSpoilerActive) }
+        }
+    }
+
+    private fun copyToClipboard(entry: TimelineEntryModel) {
+        screenModelScope.launch {
+            val source = timelineEntryRepository.getSource(entry.id)
+            if (source != null) {
+                val text =
+                    buildString {
+                        if (!entry.title.isNullOrBlank()) {
+                            append(entry.title)
+                            append("\n")
+                        }
+                        append(source.content)
+                    }
+                emitEffect(FavoritesMviModel.Effect.TriggerCopy(text))
+            }
         }
     }
 }

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagMviModel.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagMviModel.kt
@@ -59,6 +59,10 @@ interface HashtagMviModel :
         data class ToggleSpoilerActive(
             val entry: TimelineEntryModel,
         ) : Intent
+
+        data class CopyToClipboard(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -75,5 +79,9 @@ interface HashtagMviModel :
 
     sealed interface Effect {
         data object PollVoteFailure : Effect
+
+        data class TriggerCopy(
+            val text: String,
+        ) : Effect
     }
 }

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
@@ -121,6 +121,10 @@ class HashtagScreen(
                 .onEach { event ->
                     when (event) {
                         HashtagMviModel.Effect.PollVoteFailure -> pollErrorDialogOpened = true
+                        is HashtagMviModel.Effect.TriggerCopy -> {
+                            clipboardManager.setText(AnnotatedString(event.text))
+                            snackbarHostState.showSnackbar(copyToClipboardSuccess)
+                        }
                     }
                 }.launchIn(this)
         }
@@ -325,6 +329,7 @@ class HashtagScreen(
                                         this += OptionId.Quote.toOption()
                                     }
                                     this += OptionId.ViewDetails.toOption()
+                                    this += OptionId.CopyToClipboard.toOption()
                                 },
                             onOptionSelected = { optionId ->
                                 when (optionId) {
@@ -378,6 +383,8 @@ class HashtagScreen(
                                             )
                                         }
                                     }
+                                    OptionId.CopyToClipboard ->
+                                        model.reduce(HashtagMviModel.Intent.CopyToClipboard(entry.original))
                                     else -> Unit
                                 }
                             },

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagViewModel.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagViewModel.kt
@@ -101,6 +101,7 @@ class HashtagViewModel(
             is HashtagMviModel.Intent.TogglePin -> togglePin(intent.entry)
             is HashtagMviModel.Intent.SubmitPollVote -> submitPoll(intent.entry, intent.choices)
             is HashtagMviModel.Intent.ToggleSpoilerActive -> toggleSpoiler(intent.entry)
+            is HashtagMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
         }
     }
 
@@ -391,6 +392,23 @@ class HashtagViewModel(
     private fun toggleSpoiler(entry: TimelineEntryModel) {
         screenModelScope.launch {
             updateEntryInState(entry.id) { entry.copy(isSpoilerActive = !entry.isSpoilerActive) }
+        }
+    }
+
+    private fun copyToClipboard(entry: TimelineEntryModel) {
+        screenModelScope.launch {
+            val source = timelineEntryRepository.getSource(entry.id)
+            if (source != null) {
+                val text =
+                    buildString {
+                        if (!entry.title.isNullOrBlank()) {
+                            append(entry.title)
+                            append("\n")
+                        }
+                        append(source.content)
+                    }
+                emitEffect(HashtagMviModel.Effect.TriggerCopy(text))
+            }
         }
     }
 }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountMviModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountMviModel.kt
@@ -43,6 +43,10 @@ interface MyAccountMviModel :
         data class ToggleSpoilerActive(
             val entry: TimelineEntryModel,
         ) : Intent
+
+        data class CopyToClipboard(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -60,5 +64,9 @@ interface MyAccountMviModel :
         data object BackToTop : Effect
 
         data object Failure : Effect
+
+        data class TriggerCopy(
+            val text: String,
+        ) : Effect
     }
 }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
@@ -140,9 +140,12 @@ object MyAccountScreen : Tab {
                     when (event) {
                         MyAccountMviModel.Effect.BackToTop -> goBackToTop()
                         MyAccountMviModel.Effect.Failure ->
-                            snackbarHostState.showSnackbar(
-                                message = genericError,
-                            )
+                            snackbarHostState.showSnackbar(message = genericError)
+
+                        is MyAccountMviModel.Effect.TriggerCopy -> {
+                            clipboardManager.setText(AnnotatedString(event.text))
+                            snackbarHostState.showSnackbar(copyToClipboardSuccess)
+                        }
                     }
                 }.launchIn(this)
         }
@@ -338,6 +341,7 @@ object MyAccountScreen : Tab {
                                     this += OptionId.Quote.toOption()
                                 }
                                 this += OptionId.ViewDetails.toOption()
+                                this += OptionId.CopyToClipboard.toOption()
                             },
                         onOptionSelected = { optionId ->
                             when (optionId) {
@@ -383,6 +387,8 @@ object MyAccountScreen : Tab {
                                         )
                                     }
                                 }
+                                OptionId.CopyToClipboard ->
+                                    model.reduce(MyAccountMviModel.Intent.CopyToClipboard(entry.original))
                                 else -> Unit
                             }
                         },

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
@@ -153,6 +153,7 @@ class MyAccountViewModel(
             is MyAccountMviModel.Intent.DeleteEntry -> deleteEntry(intent.entryId)
             is MyAccountMviModel.Intent.TogglePin -> togglePin(intent.entry)
             is MyAccountMviModel.Intent.ToggleSpoilerActive -> toggleSpoiler(intent.entry)
+            is MyAccountMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
         }
     }
 
@@ -387,6 +388,23 @@ class MyAccountViewModel(
     private fun toggleSpoiler(entry: TimelineEntryModel) {
         screenModelScope.launch {
             updateEntryInState(entry.id) { entry.copy(isSpoilerActive = !entry.isSpoilerActive) }
+        }
+    }
+
+    private fun copyToClipboard(entry: TimelineEntryModel) {
+        screenModelScope.launch {
+            val source = timelineEntryRepository.getSource(entry.id)
+            if (source != null) {
+                val text =
+                    buildString {
+                        if (!entry.title.isNullOrBlank()) {
+                            append(entry.title)
+                            append("\n")
+                        }
+                        append(source.content)
+                    }
+                emitEffect(MyAccountMviModel.Effect.TriggerCopy(text))
+            }
         }
     }
 }

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchMviModel.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchMviModel.kt
@@ -73,6 +73,10 @@ interface SearchMviModel :
         data class ToggleSpoilerActive(
             val entry: TimelineEntryModel,
         ) : Intent
+
+        data class CopyToClipboard(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -92,5 +96,9 @@ interface SearchMviModel :
         data object BackToTop : Effect
 
         data object PollVoteFailure : Effect
+
+        data class TriggerCopy(
+            val text: String,
+        ) : Effect
     }
 }

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
@@ -136,6 +136,10 @@ class SearchScreen : Screen {
                     when (event) {
                         SearchMviModel.Effect.BackToTop -> goBackToTop()
                         SearchMviModel.Effect.PollVoteFailure -> pollErrorDialogOpened = true
+                        is SearchMviModel.Effect.TriggerCopy -> {
+                            clipboardManager.setText(AnnotatedString(event.text))
+                            snackbarHostState.showSnackbar(copyToClipboardSuccess)
+                        }
                     }
                 }.launchIn(this)
         }
@@ -401,6 +405,7 @@ class SearchScreen : Screen {
                                                 this += OptionId.Quote.toOption()
                                             }
                                             this += OptionId.ViewDetails.toOption()
+                                            this += OptionId.CopyToClipboard.toOption()
                                         },
                                     onOptionSelected = { optionId ->
                                         when (optionId) {
@@ -458,6 +463,10 @@ class SearchScreen : Screen {
                                                     )
                                                 }
                                             }
+                                            OptionId.CopyToClipboard ->
+                                                model.reduce(
+                                                    SearchMviModel.Intent.CopyToClipboard(item.entry.original),
+                                                )
                                             else -> Unit
                                         }
                                     },

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchViewModel.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchViewModel.kt
@@ -137,6 +137,7 @@ class SearchViewModel(
             is SearchMviModel.Intent.TogglePin -> togglePin(intent.entry)
             is SearchMviModel.Intent.SubmitPollVote -> submitPoll(intent.entry, intent.choices)
             is SearchMviModel.Intent.ToggleSpoilerActive -> toggleSpoiler(intent.entry)
+            is SearchMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
         }
     }
 
@@ -510,6 +511,23 @@ class SearchViewModel(
     private fun toggleSpoiler(entry: TimelineEntryModel) {
         screenModelScope.launch {
             updateEntryInState(entry.id) { entry.copy(isSpoilerActive = !entry.isSpoilerActive) }
+        }
+    }
+
+    private fun copyToClipboard(entry: TimelineEntryModel) {
+        screenModelScope.launch {
+            val source = timelineEntryRepository.getSource(entry.id)
+            if (source != null) {
+                val text =
+                    buildString {
+                        if (!entry.title.isNullOrBlank()) {
+                            append(entry.title)
+                            append("\n")
+                        }
+                        append(source.content)
+                    }
+                emitEffect(SearchMviModel.Effect.TriggerCopy(text))
+            }
         }
     }
 }

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadMviModel.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadMviModel.kt
@@ -53,6 +53,10 @@ interface ThreadMviModel :
         data class ToggleSpoilerActive(
             val entry: TimelineEntryModel,
         ) : Intent
+
+        data class CopyToClipboard(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -68,5 +72,9 @@ interface ThreadMviModel :
 
     sealed interface Effect {
         data object PollVoteFailure : Effect
+
+        data class TriggerCopy(
+            val text: String,
+        ) : Effect
     }
 }

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
@@ -129,6 +129,10 @@ class ThreadScreen(
                 .onEach { event ->
                     when (event) {
                         ThreadMviModel.Effect.PollVoteFailure -> pollErrorDialogOpened = true
+                        is ThreadMviModel.Effect.TriggerCopy -> {
+                            clipboardManager.setText(AnnotatedString(event.text))
+                            snackbarHostState.showSnackbar(copyToClipboardSuccess)
+                        }
                     }
                 }.launchIn(this)
         }
@@ -330,6 +334,7 @@ class ThreadScreen(
                                             this += OptionId.Quote.toOption()
                                         }
                                         this += OptionId.ViewDetails.toOption()
+                                        this += OptionId.CopyToClipboard.toOption()
                                     },
                                 onOptionSelected = { optionId ->
                                     when (optionId) {
@@ -353,6 +358,10 @@ class ThreadScreen(
                                                 )
                                             }
                                         }
+                                        OptionId.CopyToClipboard ->
+                                            uiState.entry?.original?.also { entry ->
+                                                model.reduce(ThreadMviModel.Intent.CopyToClipboard(entry))
+                                            }
                                         else -> Unit
                                     }
                                 },
@@ -451,6 +460,7 @@ class ThreadScreen(
                                         this += OptionId.Quote.toOption()
                                     }
                                     this += OptionId.ViewDetails.toOption()
+                                    this += OptionId.CopyToClipboard.toOption()
                                 },
                             onOptionSelected = { optionId ->
                                 when (optionId) {
@@ -500,6 +510,8 @@ class ThreadScreen(
                                             )
                                         }
                                     }
+                                    OptionId.CopyToClipboard ->
+                                        model.reduce(ThreadMviModel.Intent.CopyToClipboard(entry.original))
                                     else -> Unit
                                 }
                             },

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadViewModel.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadViewModel.kt
@@ -91,6 +91,7 @@ class ThreadViewModel(
                 )
             is ThreadMviModel.Intent.SubmitPollVote -> submitPoll(intent.entry, intent.choices)
             is ThreadMviModel.Intent.ToggleSpoilerActive -> toggleSpoiler(intent.entry)
+            is ThreadMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
         }
     }
 
@@ -376,6 +377,23 @@ class ThreadViewModel(
     private fun toggleSpoiler(entry: TimelineEntryModel) {
         screenModelScope.launch {
             updateEntryInState(entry.id) { entry.copy(isSpoilerActive = !entry.isSpoilerActive) }
+        }
+    }
+
+    private fun copyToClipboard(entry: TimelineEntryModel) {
+        screenModelScope.launch {
+            val source = timelineEntryRepository.getSource(entry.id)
+            if (source != null) {
+                val text =
+                    buildString {
+                        if (!entry.title.isNullOrBlank()) {
+                            append(entry.title)
+                            append("\n")
+                        }
+                        append(source.content)
+                    }
+                emitEffect(ThreadMviModel.Effect.TriggerCopy(text))
+            }
         }
     }
 }

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineMviModel.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineMviModel.kt
@@ -60,6 +60,10 @@ interface TimelineMviModel :
         data class ToggleSpoilerActive(
             val entry: TimelineEntryModel,
         ) : Intent
+
+        data class CopyToClipboard(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -78,5 +82,9 @@ interface TimelineMviModel :
         data object BackToTop : Effect
 
         data object PollVoteFailure : Effect
+
+        data class TriggerCopy(
+            val text: String,
+        ) : Effect
     }
 }

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
@@ -138,6 +138,10 @@ class TimelineScreen : Screen {
                     when (event) {
                         TimelineMviModel.Effect.BackToTop -> goBackToTop()
                         TimelineMviModel.Effect.PollVoteFailure -> pollErrorDialogOpened = true
+                        is TimelineMviModel.Effect.TriggerCopy -> {
+                            clipboardManager.setText(AnnotatedString(event.text))
+                            snackbarHostState.showSnackbar(copyToClipboardSuccess)
+                        }
                     }
                 }.launchIn(this)
         }
@@ -374,6 +378,7 @@ class TimelineScreen : Screen {
                                         this += OptionId.Quote.toOption()
                                     }
                                     this += OptionId.ViewDetails.toOption()
+                                    this += OptionId.CopyToClipboard.toOption()
                                 },
                             onOptionSelected = { optionId ->
                                 when (optionId) {
@@ -429,6 +434,8 @@ class TimelineScreen : Screen {
                                         }
                                     }
                                     OptionId.ViewDetails -> seeDetailsEntry = entry.original
+                                    OptionId.CopyToClipboard ->
+                                        model.reduce(TimelineMviModel.Intent.CopyToClipboard(entry.original))
                                     else -> Unit
                                 }
                             },

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
@@ -145,6 +145,7 @@ class TimelineViewModel(
                 )
 
             is TimelineMviModel.Intent.ToggleSpoilerActive -> toggleSpoiler(intent.entry)
+            is TimelineMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
         }
     }
 
@@ -478,6 +479,23 @@ class TimelineViewModel(
     private fun toggleSpoiler(entry: TimelineEntryModel) {
         screenModelScope.launch {
             updateEntryInState(entry.id) { entry.copy(isSpoilerActive = !entry.isSpoilerActive) }
+        }
+    }
+
+    private fun copyToClipboard(entry: TimelineEntryModel) {
+        screenModelScope.launch {
+            val source = timelineEntryRepository.getSource(entry.id)
+            if (source != null) {
+                val text =
+                    buildString {
+                        if (!entry.title.isNullOrBlank()) {
+                            append(entry.title)
+                            append("\n")
+                        }
+                        append(source.content)
+                    }
+                emitEffect(TimelineMviModel.Effect.TriggerCopy(text))
+            }
         }
     }
 }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailMviModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailMviModel.kt
@@ -67,6 +67,10 @@ interface UserDetailMviModel :
         ) : Intent
 
         data object SubmitPersonalNote : Intent
+
+        data class CopyToClipboard(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -89,5 +93,9 @@ interface UserDetailMviModel :
         data object PollVoteFailure : Effect
 
         data object Failure : Effect
+
+        data class TriggerCopy(
+            val text: String,
+        ) : Effect
     }
 }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -183,6 +183,10 @@ class UserDetailScreen(
                         UserDetailMviModel.Effect.PollVoteFailure -> pollErrorDialogOpened = true
                         UserDetailMviModel.Effect.Failure ->
                             snackbarHostState.showSnackbar(genericError)
+                        is UserDetailMviModel.Effect.TriggerCopy -> {
+                            clipboardManager.setText(AnnotatedString(event.text))
+                            snackbarHostState.showSnackbar(copyToClipboardSuccess)
+                        }
                     }
                 }.launchIn(this)
         }
@@ -636,6 +640,7 @@ class UserDetailScreen(
                                         this += OptionId.Quote.toOption()
                                     }
                                     this += OptionId.ViewDetails.toOption()
+                                    this += OptionId.CopyToClipboard.toOption()
                                 },
                             onOptionSelected = { optionId ->
                                 when (optionId) {
@@ -670,6 +675,8 @@ class UserDetailScreen(
                                             )
                                         }
                                     }
+                                    OptionId.CopyToClipboard ->
+                                        model.reduce(UserDetailMviModel.Intent.CopyToClipboard(entry.original))
                                     else -> Unit
                                 }
                             },

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailViewModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailViewModel.kt
@@ -116,6 +116,7 @@ class UserDetailViewModel(
                 }
 
             UserDetailMviModel.Intent.SubmitPersonalNote -> updatePersonalNote()
+            is UserDetailMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
         }
     }
 
@@ -510,6 +511,23 @@ class UserDetailViewModel(
                 }
             } else {
                 emitEffect(UserDetailMviModel.Effect.Failure)
+            }
+        }
+    }
+
+    private fun copyToClipboard(entry: TimelineEntryModel) {
+        screenModelScope.launch {
+            val source = timelineEntryRepository.getSource(entry.id)
+            if (source != null) {
+                val text =
+                    buildString {
+                        if (!entry.title.isNullOrBlank()) {
+                            append(entry.title)
+                            append("\n")
+                        }
+                        append(source.content)
+                    }
+                emitEffect(UserDetailMviModel.Effect.TriggerCopy(text))
             }
         }
     }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListMviModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListMviModel.kt
@@ -53,6 +53,10 @@ interface ForumListMviModel :
         data class ToggleSpoilerActive(
             val entry: TimelineEntryModel,
         ) : Intent
+
+        data class CopyToClipboard(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -68,5 +72,9 @@ interface ForumListMviModel :
 
     sealed interface Effect {
         data object PollVoteFailure : Effect
+
+        data class TriggerCopy(
+            val text: String,
+        ) : Effect
     }
 }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
@@ -140,6 +140,10 @@ class ForumListScreen(
                 .onEach { event ->
                     when (event) {
                         ForumListMviModel.Effect.PollVoteFailure -> pollErrorDialogOpened = true
+                        is ForumListMviModel.Effect.TriggerCopy -> {
+                            clipboardManager.setText(AnnotatedString(event.text))
+                            snackbarHostState.showSnackbar(copyToClipboardSuccess)
+                        }
                     }
                 }.launchIn(this)
         }
@@ -412,6 +416,7 @@ class ForumListScreen(
                                         this += OptionId.Quote.toOption()
                                     }
                                     this += OptionId.ViewDetails.toOption()
+                                    this += OptionId.CopyToClipboard.toOption()
                                 },
                             onOptionSelected = { optionId ->
                                 when (optionId) {
@@ -461,6 +466,8 @@ class ForumListScreen(
                                         }
                                     }
                                     OptionId.ViewDetails -> seeDetailsEntry = entry.original
+                                    OptionId.CopyToClipboard ->
+                                        model.reduce(ForumListMviModel.Intent.CopyToClipboard(entry.original))
                                     else -> Unit
                                 }
                             },

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListViewModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListViewModel.kt
@@ -95,6 +95,7 @@ class ForumListViewModel(
 
             is ForumListMviModel.Intent.SubmitPollVote -> submitPoll(intent.entry, intent.choices)
             is ForumListMviModel.Intent.ToggleSpoilerActive -> toggleSpoiler(intent.entry)
+            is ForumListMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
         }
     }
 
@@ -365,6 +366,23 @@ class ForumListViewModel(
     private fun toggleSpoiler(entry: TimelineEntryModel) {
         screenModelScope.launch {
             updateEntryInState(entry.id) { entry.copy(isSpoilerActive = !entry.isSpoilerActive) }
+        }
+    }
+
+    private fun copyToClipboard(entry: TimelineEntryModel) {
+        screenModelScope.launch {
+            val source = timelineEntryRepository.getSource(entry.id)
+            if (source != null) {
+                val text =
+                    buildString {
+                        if (!entry.title.isNullOrBlank()) {
+                            append(entry.title)
+                            append("\n")
+                        }
+                        append(source.content)
+                    }
+                emitEffect(ForumListMviModel.Effect.TriggerCopy(text))
+            }
         }
     }
 }


### PR DESCRIPTION
This PR adds a "Copy to clipboard" action to copy post title and body (without markup) to the device clipboard.