### PR TITLE
feat: event calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ features such as media gallery, circle management, direct messages and support f
 groups.
 
 With this respect, it takes a different approach compared to other existing solutions
-like the very feature-complete [Relatica](https://gitlab.com/mysocialportal/relatica) app, in trying
+like the feature-complete [Relatica](https://gitlab.com/mysocialportal/relatica) app, in trying
 to look familiar to users with a UI they are already accustomed to, adding a thin layer on
 top of it to support the additional features.
 
@@ -129,8 +129,7 @@ The app is under ongoing development, here is a list of the features that are be
 - [x] scheduled posts and drafts
 - [x] report posts and users
 - [x] custom emojis
-- [ ] event calendar
-- [ ] content moderation
+- [x] event calendar
 
 ## Technologies used
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -76,6 +76,7 @@ kotlin {
             implementation(projects.domain.identity.repository)
             implementation(projects.domain.identity.usecase)
 
+            implementation(projects.feature.calendar)
             implementation(projects.feature.circles)
             implementation(projects.feature.composer)
             implementation(projects.feature.directmessages)

--- a/composeApp/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/DiHelper.kt
+++ b/composeApp/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/DiHelper.kt
@@ -11,6 +11,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.persistence.di.corePersist
 import com.livefast.eattrash.raccoonforfriendica.core.preferences.di.corePreferencesModule
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreCrashReportModule
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreHapticFeedbackModule
+import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreUtilsCalendarModule
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreUtilsDebugModule
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreUtilsFileSystemModule
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreUtilsGalleryModule
@@ -21,6 +22,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.di.do
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.di.domainContentRepositoryModule
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di.domainIdentityRepositoryModule
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.domainIdentityUseCaseModule
+import com.livefast.eattrash.raccoonforfriendica.feature.calendar.di.featureCalendarModule
 import com.livefast.eattrash.raccoonforfriendica.feature.circles.di.featureCirclesModule
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.di.featureComposerModule
 import com.livefast.eattrash.raccoonforfriendica.feature.directmessages.di.featureDirectMessagesModule
@@ -61,6 +63,7 @@ val sharedHelperModule =
             coreNavigationModule,
             coreNotificationsModule,
             coreResourceModule,
+            coreUtilsCalendarModule,
             coreUtilsDebugModule,
             coreUtilsFileSystemModule,
             coreUtilsGalleryModule,
@@ -71,6 +74,7 @@ val sharedHelperModule =
             domainContentRepositoryModule,
             domainIdentityRepositoryModule,
             domainIdentityUseCaseModule,
+            featureCalendarModule,
             featureCirclesModule,
             featureComposerModule,
             featureTimelineModule,

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/SharedModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/SharedModule.kt
@@ -22,6 +22,7 @@ internal val sharedModule =
                 userCache = get(),
                 settingsRepository = get(),
                 entryCache = get(),
+                eventCache = get(),
             )
         }
         single<AuthManager> {

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
@@ -4,6 +4,7 @@ import com.livefast.eattrash.feature.userdetail.classic.UserDetailScreen
 import com.livefast.eattrash.feature.userdetail.forum.ForumListScreen
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.NavigationCoordinator
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EventModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.FavoritesType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UnpublishedType
@@ -13,6 +14,8 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toInt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.LocalItemCache
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
+import com.livefast.eattrash.raccoonforfriendica.feature.calendar.detail.EventDetailScreen
+import com.livefast.eattrash.raccoonforfriendica.feature.calendar.list.CalendarScreen
 import com.livefast.eattrash.raccoonforfriendica.feature.circles.detail.CircleDetailScreen
 import com.livefast.eattrash.raccoonforfriendica.feature.circles.list.CirclesScreen
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.ComposerScreen
@@ -43,6 +46,7 @@ class DefaultDetailOpener(
     private val settingsRepository: SettingsRepository,
     private val userCache: LocalItemCache<UserModel>,
     private val entryCache: LocalItemCache<TimelineEntryModel>,
+    private val eventCache: LocalItemCache<EventModel>,
 ) : DetailOpener {
     private val currentUserId: String? get() = identityRepository.currentUser.value?.id
     private val isLogged: Boolean get() = currentUserId != null
@@ -329,6 +333,17 @@ class DefaultDetailOpener(
 
     override fun openUserFeedback() {
         val screen = UserFeedbackScreen()
+        navigationCoordinator.push(screen)
+    }
+
+    override fun openCalendar() {
+        val screen = CalendarScreen()
+        navigationCoordinator.push(screen)
+    }
+
+    override fun openEvent(event: EventModel) {
+        eventCache.put(event.id, event)
+        val screen = EventDetailScreen(event.id)
         navigationCoordinator.push(screen)
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpenerTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpenerTest.kt
@@ -3,6 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica.navigation
 import com.livefast.eattrash.feature.userdetail.classic.UserDetailScreen
 import com.livefast.eattrash.feature.userdetail.forum.ForumListScreen
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.NavigationCoordinator
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EventModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UnpublishedType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
@@ -10,6 +11,8 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Local
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
+import com.livefast.eattrash.raccoonforfriendica.feature.calendar.detail.EventDetailScreen
+import com.livefast.eattrash.raccoonforfriendica.feature.calendar.list.CalendarScreen
 import com.livefast.eattrash.raccoonforfriendica.feature.circles.detail.CircleDetailScreen
 import com.livefast.eattrash.raccoonforfriendica.feature.circles.list.CirclesScreen
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.ComposerScreen
@@ -55,6 +58,7 @@ class DefaultDetailOpenerTest {
         }
     private val userCache = mock<LocalItemCache<UserModel>>(mode = MockMode.autoUnit)
     private val entryCache = mock<LocalItemCache<TimelineEntryModel>>(mode = MockMode.autoUnit)
+    private val eventCache = mock<LocalItemCache<EventModel>>(mode = MockMode.autoUnit)
     private val sut =
         DefaultDetailOpener(
             navigationCoordinator = navigationCoordinator,
@@ -62,6 +66,7 @@ class DefaultDetailOpenerTest {
             settingsRepository = settingsRepository,
             userCache = userCache,
             entryCache = entryCache,
+            eventCache = eventCache,
         )
 
     @Test
@@ -286,7 +291,7 @@ class DefaultDetailOpenerTest {
     }
 
     @Test
-    fun `given reply when openBlockedAndMuted then interactions are as expected`() {
+    fun `when openBlockedAndMuted then interactions are as expected`() {
         sut.openBlockedAndMuted()
 
         verify {
@@ -295,7 +300,7 @@ class DefaultDetailOpenerTest {
     }
 
     @Test
-    fun `given reply when openCircles then interactions are as expected`() {
+    fun `when openCircles then interactions are as expected`() {
         sut.openCircles()
 
         verify {
@@ -304,7 +309,7 @@ class DefaultDetailOpenerTest {
     }
 
     @Test
-    fun `given reply when openCircle then interactions are as expected`() {
+    fun `when openCircle then interactions are as expected`() {
         sut.openCircle(groupId = "1")
 
         verify {
@@ -313,7 +318,7 @@ class DefaultDetailOpenerTest {
     }
 
     @Test
-    fun `given reply when openFollowRequests then interactions are as expected`() {
+    fun `when openFollowRequests then interactions are as expected`() {
         sut.openFollowRequests()
 
         verify {
@@ -322,7 +327,7 @@ class DefaultDetailOpenerTest {
     }
 
     @Test
-    fun `given reply openEditProfile then interactions are as expected`() {
+    fun `when openEditProfile then interactions are as expected`() {
         sut.openEditProfile()
 
         verify {
@@ -331,7 +336,7 @@ class DefaultDetailOpenerTest {
     }
 
     @Test
-    fun `given reply openNodeInfo then interactions are as expected`() {
+    fun `when openNodeInfo then interactions are as expected`() {
         sut.openNodeInfo()
 
         verify {
@@ -340,7 +345,7 @@ class DefaultDetailOpenerTest {
     }
 
     @Test
-    fun `given reply openDirectMessages then interactions are as expected`() {
+    fun `when openDirectMessages then interactions are as expected`() {
         sut.openDirectMessages()
 
         verify {
@@ -349,7 +354,7 @@ class DefaultDetailOpenerTest {
     }
 
     @Test
-    fun `given reply openConversation then interactions are as expected`() {
+    fun `when openConversation then interactions are as expected`() {
         sut.openConversation(
             otherUser = UserModel(id = "1"),
             parentUri = "",
@@ -361,7 +366,7 @@ class DefaultDetailOpenerTest {
     }
 
     @Test
-    fun `given reply openGallery then interactions are as expected`() {
+    fun `when openGallery then interactions are as expected`() {
         sut.openGallery()
 
         verify {
@@ -370,7 +375,7 @@ class DefaultDetailOpenerTest {
     }
 
     @Test
-    fun `given reply openAlbum then interactions are as expected`() {
+    fun `when openAlbum then interactions are as expected`() {
         sut.openAlbum(name = "album")
 
         verify {
@@ -379,7 +384,7 @@ class DefaultDetailOpenerTest {
     }
 
     @Test
-    fun `given reply openUnpublished then interactions are as expected`() {
+    fun `when openUnpublished then interactions are as expected`() {
         sut.openUnpublished()
 
         verify {
@@ -388,7 +393,7 @@ class DefaultDetailOpenerTest {
     }
 
     @Test
-    fun `given reply openCreateReport for user then interactions are as expected`() {
+    fun `when openCreateReport for user then interactions are as expected`() {
         sut.openCreateReport(user = UserModel(id = "1"))
 
         verify {
@@ -397,7 +402,7 @@ class DefaultDetailOpenerTest {
     }
 
     @Test
-    fun `given reply openCreateReport for entry then interactions are as expected`() {
+    fun `when openCreateReport for entry then interactions are as expected`() {
         sut.openCreateReport(
             user = UserModel(id = "1"),
             entry = TimelineEntryModel(id = "2", content = ""),
@@ -409,11 +414,38 @@ class DefaultDetailOpenerTest {
     }
 
     @Test
-    fun `given reply openUserFeedback for user then interactions are as expected`() {
+    fun `when openUserFeedback then interactions are as expected`() {
         sut.openUserFeedback()
 
         verify {
             navigationCoordinator.push(any<UserFeedbackScreen>())
+        }
+    }
+
+    @Test
+    fun `when openCalendar then interactions are as expected`() {
+        sut.openCalendar()
+
+        verify {
+            navigationCoordinator.push(any<CalendarScreen>())
+        }
+    }
+
+    @Test
+    fun `when openEvent then interactions are as expected`() {
+        val event =
+            EventModel(
+                id = "0",
+                uri = "www.example.com",
+                title = "test event",
+                description = "",
+                startTime = "",
+            )
+        sut.openEvent(event)
+
+        verify {
+            eventCache.put("0", event)
+            navigationCoordinator.push(any<EventDetailScreen>())
         }
     }
 }

--- a/composeApp/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/DiHelper.kt
+++ b/composeApp/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/DiHelper.kt
@@ -11,6 +11,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.persistence.di.corePersist
 import com.livefast.eattrash.raccoonforfriendica.core.preferences.di.corePreferencesModule
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreCrashReportModule
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreHapticFeedbackModule
+import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreUtilsCalendarModule
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreUtilsDebugModule
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreUtilsFileSystemModule
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreUtilsGalleryModule
@@ -21,6 +22,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.di.do
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.di.domainContentRepositoryModule
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di.domainIdentityRepositoryModule
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.domainIdentityUseCaseModule
+import com.livefast.eattrash.raccoonforfriendica.feature.calendar.di.featureCalendarModule
 import com.livefast.eattrash.raccoonforfriendica.feature.circles.di.featureCirclesModule
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.di.featureComposerModule
 import com.livefast.eattrash.raccoonforfriendica.feature.directmessages.di.featureDirectMessagesModule
@@ -63,6 +65,7 @@ fun initKoin(): Koin {
                 coreNavigationModule,
                 coreNotificationsModule,
                 coreResourceModule,
+                coreUtilsCalendarModule,
                 coreUtilsDebugModule,
                 coreUtilsFileSystemModule,
                 coreUtilsGalleryModule,
@@ -73,6 +76,7 @@ fun initKoin(): Koin {
                 domainContentRepositoryModule,
                 domainIdentityRepositoryModule,
                 domainIdentityUseCaseModule,
+                featureCalendarModule,
                 featureCirclesModule,
                 featureComposerModule,
                 featureTimelineModule,

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Event.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Event.kt
@@ -1,0 +1,19 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Event(
+    @SerialName("id") val id: Long,
+    @SerialName("uid") val uid: Long,
+    @SerialName("cid") val cid: Long,
+    @SerialName("uri") val uri: String,
+    @SerialName("name") val name: String,
+    @SerialName("desc") val description: String,
+    @SerialName("start_time") val startTime: String,
+    @SerialName("end_time") val endTime: String? = null,
+    @SerialName("type") val type: String,
+    @SerialName("nofinish") val noFinish: Int = 0,
+    @SerialName("place") val place: String? = null,
+)

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/DefaultServiceProvider.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/DefaultServiceProvider.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.core.api.provider
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.AppService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.DirectMessageService
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.EventService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.FollowRequestService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.InstanceService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.ListService
@@ -20,6 +21,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.service.TrendsService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.UserService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.createAppService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.createDirectMessageService
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.createEventService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.createFollowRequestService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.createInstanceService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.createListService
@@ -68,6 +70,7 @@ internal class DefaultServiceProvider(
 
     override lateinit var apps: AppService
     override lateinit var directMessage: DirectMessageService
+    override lateinit var events: EventService
     override lateinit var followRequests: FollowRequestService
     override lateinit var instance: InstanceService
     override lateinit var lists: ListService
@@ -165,6 +168,7 @@ internal class DefaultServiceProvider(
                 .build()
         apps = ktorfit.createAppService()
         directMessage = ktorfit.createDirectMessageService()
+        events = ktorfit.createEventService()
         followRequests = ktorfit.createFollowRequestService()
         instance = ktorfit.createInstanceService()
         lists = ktorfit.createListService()

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/ServiceProvider.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/ServiceProvider.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.core.api.provider
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.AppService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.DirectMessageService
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.EventService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.FollowRequestService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.InstanceService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.ListService
@@ -22,6 +23,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.service.UserService
 interface ServiceProvider {
     val apps: AppService
     val directMessage: DirectMessageService
+    val events: EventService
     val followRequests: FollowRequestService
     val instance: InstanceService
     val lists: ListService

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/EventService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/EventService.kt
@@ -1,0 +1,13 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.service
+
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Event
+import de.jensklingenberg.ktorfit.http.GET
+import de.jensklingenberg.ktorfit.http.Query
+
+interface EventService {
+    @GET("friendica/events")
+    suspend fun getAll(
+        @Query("since_id") maxId: Long? = null,
+        @Query("count") count: Int,
+    ): List<Event>
+}

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentBody.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentBody.kt
@@ -13,6 +13,7 @@ fun ContentBody(
     content: String = "",
     color: Color = MaterialTheme.colorScheme.onBackground,
     modifier: Modifier = Modifier,
+    maxLines: Int = Int.MAX_VALUE,
     emojis: List<EmojiModel> = emptyList(),
     onClick: (() -> Unit)? = null,
     onOpenUrl: ((String) -> Unit)? = null,
@@ -25,6 +26,7 @@ fun ContentBody(
         TextWithCustomEmojis(
             style = MaterialTheme.typography.bodyMedium.copy(color = color),
             text = annotatedContent,
+            maxLines = maxLines,
             emojis = emojis,
             onClick = { offset ->
                 val url =

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentTitle.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentTitle.kt
@@ -12,6 +12,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EmojiModel
 fun ContentTitle(
     content: String = "",
     modifier: Modifier = Modifier,
+    maxLines: Int = Int.MAX_VALUE,
     emojis: List<EmojiModel> = emptyList(),
     color: Color = MaterialTheme.colorScheme.onBackground,
     onClick: (() -> Unit)? = null,
@@ -25,6 +26,7 @@ fun ContentTitle(
         TextWithCustomEmojis(
             style = MaterialTheme.typography.titleMedium.copy(color = color),
             text = annotatedContent,
+            maxLines = maxLines,
             emojis = emojis,
             onClick = { offset ->
                 val url =

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
@@ -384,4 +384,5 @@ internal val DeStrings =
             "Einige Anhänge haben keinen alternativen Text, fügen Sie ihn aus Gründen der Zugänglichkeit ein."
         override val buttonPublishAnyway = "Trotzdem veröffentlichen"
         override val actionCopyToClipboard = "In die Zwischenablage kopieren"
+        override val actionSaveToCalendar = "Im Kalender speichern"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -379,4 +379,6 @@ internal open class DefaultStrings : Strings {
         "Some attachments do not have an alternate text, consider inserting it for accessibility"
     override val buttonPublishAnyway = "Publish anyway"
     override val actionCopyToClipboard = "Copy to clipboard"
+    override val calendarTitle = "Calendar"
+    override val actionSaveToCalendar = "Save to calendar"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/EsStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/EsStrings.kt
@@ -385,4 +385,5 @@ internal val EsStrings =
             "Algunos archivos adjuntos no tienen un texto alternativo, insertarlo puede mejorar la accesibilidad"
         override val buttonPublishAnyway = "Publicar de todos modos"
         override val actionCopyToClipboard = "Copiar al portapapeles"
+        override val actionSaveToCalendar = "Guardar en el calendario"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/FrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/FrStrings.kt
@@ -389,4 +389,5 @@ internal val FrStrings =
             "Certaines pièces jointes n'ont pas de texte alternatif, pensez à l'insérer pour des raisons d'accessibilité"
         override val buttonPublishAnyway = "Publier quand même"
         override val actionCopyToClipboard = "Copier dans le presse-papiers"
+        override val actionSaveToCalendar = "Enregistrer dans le calendrier"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -384,4 +384,6 @@ internal val ItStrings =
             "Alcuni allegati non hanno il testo alternativo, inserirlo può migliorare l'accessibilità"
         override val buttonPublishAnyway = "Pubblica comunque"
         override val actionCopyToClipboard = "Copia negli appunti"
+        override val calendarTitle = "Calendario"
+        override val actionSaveToCalendar = "Salva su calendario"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -342,6 +342,8 @@ interface Strings {
     val buttonPublishAnyway: String
     val actionAddImage: String
     val actionCopyToClipboard: String
+    val calendarTitle: String
+    val actionSaveToCalendar: String
 }
 
 object Locales {

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DetailOpener.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DetailOpener.kt
@@ -1,6 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.core.navigation
 
 import androidx.compose.runtime.Stable
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EventModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UnpublishedType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
@@ -101,4 +102,8 @@ interface DetailOpener {
     )
 
     fun openUserFeedback()
+
+    fun openCalendar()
+
+    fun openEvent(event: EventModel)
 }

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/calendar/DefaultCalendarHelper.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/calendar/DefaultCalendarHelper.kt
@@ -1,0 +1,41 @@
+package com.livefast.eattrash.raccoonforfriendica.core.utils.calendar
+
+import android.content.Intent
+import android.provider.CalendarContract
+import io.sentry.kotlin.multiplatform.Context
+
+class DefaultCalendarHelper(
+    private val context: Context,
+) : CalendarHelper {
+    override val supportsExport: Boolean = true
+
+    override fun export(
+        title: String,
+        startDate: Long,
+        endDate: Long?,
+        location: String?,
+    ) {
+        val intent =
+            Intent(Intent.ACTION_INSERT).apply {
+                data = CalendarContract.Events.CONTENT_URI
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                putExtra(CalendarContract.Events.TITLE, title)
+                if (location != null) {
+                    putExtra(CalendarContract.Events.EVENT_LOCATION, location)
+                }
+                putExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, startDate)
+                if (endDate != null) {
+                    putExtra(CalendarContract.EXTRA_EVENT_END_TIME, endDate)
+                } else {
+                    putExtra(CalendarContract.EXTRA_EVENT_ALL_DAY, true)
+                }
+            }
+        runCatching {
+            context.startActivity(intent)
+        }.also {
+            it.exceptionOrNull()?.also { e ->
+                e.printStackTrace()
+            }
+        }
+    }
+}

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
@@ -79,6 +79,14 @@ actual fun Long.extractTimePart(): Pair<Int, Int> {
     return hours to minutes
 }
 
+actual fun Long.extractDatePart(): Pair<Int, Int> {
+    val calendar = GregorianCalendar.getInstance()
+    calendar.timeInMillis = this
+    val year = calendar.get(Calendar.YEAR)
+    val month = calendar.get(Calendar.MONTH)
+    return year to month
+}
+
 actual fun getFormattedDate(
     iso8601Timestamp: String,
     format: String,

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/Utils.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/Utils.kt
@@ -1,5 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.core.utils.di
 
+import com.livefast.eattrash.raccoonforfriendica.core.utils.calendar.CalendarHelper
+import com.livefast.eattrash.raccoonforfriendica.core.utils.calendar.DefaultCalendarHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.debug.AppInfoRepository
 import com.livefast.eattrash.raccoonforfriendica.core.utils.debug.CrashReportManager
 import com.livefast.eattrash.raccoonforfriendica.core.utils.debug.DefaultAppInfoRepository
@@ -47,6 +49,11 @@ actual fun getBlurHashRepository(): BlurHashRepository {
 
 actual fun getCrashReportManager(): CrashReportManager {
     val res by KoinJavaComponent.inject<CrashReportManager>(CrashReportManager::class.java)
+    return res
+}
+
+actual fun getCalendarHelper(): CalendarHelper {
+    val res by KoinJavaComponent.inject<CalendarHelper>(CalendarHelper::class.java)
     return res
 }
 
@@ -108,6 +115,15 @@ actual val coreCrashReportModule =
     module {
         single<CrashReportManager> {
             DefaultCrashReportManager(
+                context = get(),
+            )
+        }
+    }
+
+actual val coreUtilsCalendarModule =
+    module {
+        single<CalendarHelper> {
+            DefaultCalendarHelper(
                 context = get(),
             )
         }

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/calendar/CalendarHelper.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/calendar/CalendarHelper.kt
@@ -1,0 +1,12 @@
+package com.livefast.eattrash.raccoonforfriendica.core.utils.calendar
+
+interface CalendarHelper {
+    val supportsExport: Boolean
+
+    fun export(
+        title: String,
+        startDate: Long,
+        endDate: Long? = null,
+        location: String? = null,
+    )
+}

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
@@ -32,6 +32,11 @@ expect fun Long.concatDateWithTime(
 expect fun Long.extractTimePart(): Pair<Int, Int>
 
 /**
+ * Extract the date (year, month) from a timestamp (in milliseconds).
+ */
+expect fun Long.extractDatePart(): Pair<Int, Int>
+
+/**
  * Converts a date (in the ISO 8601 format) to another given format.
  */
 expect fun getFormattedDate(

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/Utils.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/Utils.kt
@@ -1,5 +1,6 @@
 package com.livefast.eattrash.raccoonforfriendica.core.utils.di
 
+import com.livefast.eattrash.raccoonforfriendica.core.utils.calendar.CalendarHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.debug.AppInfoRepository
 import com.livefast.eattrash.raccoonforfriendica.core.utils.debug.CrashReportManager
 import com.livefast.eattrash.raccoonforfriendica.core.utils.gallery.GalleryHelper
@@ -20,6 +21,8 @@ expect fun getBlurHashRepository(): BlurHashRepository
 
 expect fun getCrashReportManager(): CrashReportManager
 
+expect fun getCalendarHelper(): CalendarHelper
+
 expect val coreUtilsFileSystemModule: Module
 
 expect val coreUtilsGalleryModule: Module
@@ -33,3 +36,5 @@ expect val coreUtilsDebugModule: Module
 expect val coreHapticFeedbackModule: Module
 
 expect val coreCrashReportModule: Module
+
+expect val coreUtilsCalendarModule: Module

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/calendar/DefaultCalendarHelper.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/calendar/DefaultCalendarHelper.kt
@@ -1,0 +1,14 @@
+package com.livefast.eattrash.raccoonforfriendica.core.utils.calendar
+
+class DefaultCalendarHelper : CalendarHelper {
+    override val supportsExport: Boolean = false
+
+    override fun export(
+        title: String,
+        startDate: Long,
+        endDate: Long?,
+        location: String?,
+    ) {
+        // no-op
+    }
+}

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
@@ -100,6 +100,22 @@ actual fun Long.extractTimePart(): Pair<Int, Int> {
     return hours to minutes
 }
 
+actual fun Long.extractDatePart(): Pair<Int, Int> {
+    val date = NSDate(timeIntervalSinceReferenceDate = (this.toDouble() / 1000))
+    val calendar = NSCalendar(calendarIdentifier = NSCalendarIdentifierGregorian)
+    val dateComponents =
+        calendar.components(
+            unitFlags =
+                NSCalendarUnitSecond
+                    .or(NSCalendarUnitMonth)
+                    .or(NSCalendarUnitYear),
+            fromDate = date,
+        )
+    val year = dateComponents.year.toInt()
+    val month = dateComponents.month.toInt()
+    return year to month
+}
+
 actual fun getFormattedDate(
     iso8601Timestamp: String,
     format: String,

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/Utils.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/Utils.kt
@@ -1,5 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.core.utils.di
 
+import com.livefast.eattrash.raccoonforfriendica.core.utils.calendar.CalendarHelper
+import com.livefast.eattrash.raccoonforfriendica.core.utils.calendar.DefaultCalendarHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.debug.AppInfoRepository
 import com.livefast.eattrash.raccoonforfriendica.core.utils.debug.CrashReportManager
 import com.livefast.eattrash.raccoonforfriendica.core.utils.debug.DefaultAppInfoRepository
@@ -31,6 +33,8 @@ actual fun getAppInfoRepository(): AppInfoRepository = CoreUtilsDiHelper.appInfo
 actual fun getBlurHashRepository(): BlurHashRepository = CoreUtilsDiHelper.blurHashRepository
 
 actual fun getCrashReportManager(): CrashReportManager = CoreUtilsDiHelper.crashReportManager
+
+actual fun getCalendarHelper(): CalendarHelper = CoreUtilsDiHelper.calendarHelper
 
 actual val coreUtilsFileSystemModule =
     module {
@@ -81,6 +85,13 @@ actual val coreCrashReportModule =
         }
     }
 
+actual val coreUtilsCalendarModule =
+    module {
+        single<CalendarHelper> {
+            DefaultCalendarHelper()
+        }
+    }
+
 internal object CoreUtilsDiHelper : KoinComponent {
     val imageLoaderProvider: ImageLoaderProvider by inject()
     val galleryHelper: GalleryHelper by inject()
@@ -88,4 +99,5 @@ internal object CoreUtilsDiHelper : KoinComponent {
     val appInfoRepository: AppInfoRepository by inject()
     val blurHashRepository: BlurHashRepository by inject()
     val crashReportManager by inject<CrashReportManager>()
+    val calendarHelper by inject<CalendarHelper>()
 }

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/EventModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/EventModel.kt
@@ -1,0 +1,19 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.data
+
+sealed interface EventType {
+    data object Event : EventType
+
+    data object Birthday : EventType
+}
+
+data class EventModel(
+    val id: String,
+    val uri: String,
+    val title: String,
+    val description: String? = null,
+    val startTime: String,
+    val endTime: String? = null,
+    val type: EventType = EventType.Event,
+    val ongoing: Boolean = false,
+    val place: String? = null,
+)

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NodeFeatures.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NodeFeatures.kt
@@ -11,4 +11,5 @@ data class NodeFeatures(
     val supportsMarkdown: Boolean = false,
     val supportsEntryShare: Boolean = false,
     val supportsPrivateVisibility: Boolean = false,
+    val supportsCalendar: Boolean = false,
 )

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultEventPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultEventPaginationManager.kt
@@ -1,0 +1,58 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EventModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EventRepository
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+internal class DefaultEventPaginationManager(
+    private val eventRepository: EventRepository,
+) : EventPaginationManager {
+    private var specification: EventsPaginationSpecification? = null
+    private var pageCursor: String? = null
+    override var canFetchMore: Boolean = true
+    private val history = mutableListOf<EventModel>()
+    private val mutex = Mutex()
+
+    override suspend fun reset(specification: EventsPaginationSpecification) {
+        this.specification = specification
+        pageCursor = null
+        mutex.withLock {
+            history.clear()
+        }
+        canFetchMore = true
+    }
+
+    override suspend fun loadNextPage(): List<EventModel> {
+        val specification = this.specification ?: return emptyList()
+        val results =
+            when (specification) {
+                EventsPaginationSpecification.All ->
+                    eventRepository.getAll(
+                        pageCursor = pageCursor,
+                    )
+            }?.updatePaginationData()
+                ?.deduplicate()
+                .orEmpty()
+
+        mutex.withLock {
+            history.addAll(results)
+        }
+
+        // return a copy
+        return history.map { it }
+    }
+
+    private fun List<EventModel>.updatePaginationData(): List<EventModel> =
+        apply {
+            lastOrNull()?.also {
+                pageCursor = it.id
+            }
+            canFetchMore = isNotEmpty()
+        }
+
+    private fun List<EventModel>.deduplicate(): List<EventModel> =
+        filter { e1 ->
+            history.none { e2 -> e1.id == e2.id }
+        }.distinctBy { it.id }
+}

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/EventPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/EventPaginationManager.kt
@@ -1,0 +1,11 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EventModel
+
+interface EventPaginationManager {
+    val canFetchMore: Boolean
+
+    suspend fun reset(specification: EventsPaginationSpecification)
+
+    suspend fun loadNextPage(): List<EventModel>
+}

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/EventsPaginationSpecification.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/EventsPaginationSpecification.kt
@@ -1,0 +1,5 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
+
+sealed interface EventsPaginationSpecification {
+    data object All : EventsPaginationSpecification
+}

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
@@ -3,6 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.di
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.AlbumPhotoPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultAlbumPhotoPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultDirectMessagesPaginationManager
+import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultEventPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultExplorePaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultFavoritesPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultFollowRequestPaginationManager
@@ -13,6 +14,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.Defau
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultUnpublishedPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultUserPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DirectMessagesPaginationManager
+import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.EventPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.ExplorePaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.FavoritesPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.FollowRequestPaginationManager
@@ -105,6 +107,11 @@ val domainContentPaginationModule =
                 scheduledEntryRepository = get(),
                 draftRepository = get(),
                 notificationCenter = get(),
+            )
+        }
+        factory<EventPaginationManager> {
+            DefaultEventPaginationManager(
+                eventRepository = get(),
             )
         }
     }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEventRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEventRepository.kt
@@ -1,0 +1,27 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EventModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
+
+internal class DefaultEventRepository(
+    private val provider: ServiceProvider,
+) : EventRepository {
+    override suspend fun getAll(pageCursor: String?): List<EventModel>? =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                provider.events
+                    .getAll(
+                        maxId = pageCursor?.toLong(),
+                        count = DEFAULT_PAGE_SIZE,
+                    ).map { it.toModel() }
+            }.getOrNull()
+        }
+
+    companion object {
+        const val DEFAULT_PAGE_SIZE = 20
+    }
+}

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultLocalItemCache.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultLocalItemCache.kt
@@ -23,6 +23,6 @@ internal class DefaultLocalItemCache<T> : LocalItemCache<T> {
     }
 
     companion object {
-        private const val MAX_SIZE = 10
+        private const val MAX_SIZE = 20
     }
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepository.kt
@@ -24,6 +24,7 @@ internal class DefaultSupportedFeatureRepository(
                 supportsMarkdown = info?.isFriendica == false,
                 supportsEntryShare = info?.isFriendica == true,
                 supportsPrivateVisibility = info?.isFriendica == true,
+                supportsCalendar = info?.isFriendica == true,
             )
         }
     }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/EventRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/EventRepository.kt
@@ -1,0 +1,7 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EventModel
+
+interface EventRepository {
+    suspend fun getAll(pageCursor: String?): List<EventModel>?
+}

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
@@ -1,5 +1,6 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.repository.di
 
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EventModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.CirclesRepository
@@ -8,6 +9,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Defau
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultDraftRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultEmojiHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultEmojiRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultEventRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultInboxManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultLocalItemCache
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultMarkerRepository
@@ -30,6 +32,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Direc
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DraftRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EventRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.InboxManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.LocalItemCache
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.MarkerRepository
@@ -125,6 +128,9 @@ val domainContentRepositoryModule =
         single<LocalItemCache<TimelineEntryModel>> {
             DefaultLocalItemCache()
         }
+        single<LocalItemCache<EventModel>> {
+            DefaultLocalItemCache()
+        }
         single<ScheduledEntryRepository> {
             DefaultScheduledEntryRepository(
                 provider = get(named("default")),
@@ -170,6 +176,11 @@ val domainContentRepositoryModule =
         single<ReplyHelper> {
             DefaultReplyHelper(
                 entryRepository = get(),
+            )
+        }
+        single<EventRepository> {
+            DefaultEventRepository(
+                provider = get(named("default")),
             )
         }
     }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
@@ -4,6 +4,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Account
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.ContentVisibility
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.CredentialAccount
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.CustomEmoji
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Event
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Field
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaCircle
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaContact
@@ -35,12 +36,16 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Tag
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.TrendsLink
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.UserList
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.UserListReplyPolicy
+import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.extractDatePart
 import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.parseDate
+import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.toEpochMillis
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.AttachmentModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.CircleModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.CircleReplyPolicy
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.DirectMessageModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EmojiModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EventModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EventType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.FieldModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.HashtagHistoryItem
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.LinkModel
@@ -513,3 +518,36 @@ internal fun Markers.toModel(): List<MarkerModel> =
                 )
         }
     }
+
+private fun String.toEventType(): EventType =
+    when (this) {
+        "birthday" -> EventType.Birthday
+        else -> EventType.Event
+    }
+
+internal fun Event.toModel() =
+    EventModel(
+        id = id.toString(),
+        uri = uri,
+        title = name,
+        description = description,
+        startTime =
+            parseDate(
+                value = startTime,
+                format = FriendicaDateFormats.PHOTO_ALBUMS,
+            ),
+        endTime =
+            endTime?.let { date ->
+                parseDate(
+                    value = date,
+                    format = FriendicaDateFormats.PHOTO_ALBUMS,
+                ).takeIf {
+                    val t = it.toEpochMillis()
+                    val (y, _) = t.extractDatePart()
+                    y > 1970
+                }
+            },
+        type = type.toEventType(),
+        ongoing = noFinish != 0,
+        place = place,
+    )

--- a/feature/calendar/build.gradle.kts
+++ b/feature/calendar/build.gradle.kts
@@ -1,0 +1,72 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.jetbrains.compose)
+    alias(libs.plugins.compose.compiler)
+}
+
+@OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
+kotlin {
+    applyDefaultHierarchyTemplate()
+    androidTarget {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_1_8)
+        }
+    }
+    listOf(
+        iosX64(),
+        iosArm64(),
+        iosSimulatorArm64(),
+    ).forEach {
+        it.binaries.framework {
+            baseName = "feature.calendar"
+            isStatic = true
+        }
+    }
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(compose.runtime)
+                implementation(compose.foundation)
+                implementation(compose.material)
+                implementation(compose.material3)
+                implementation(compose.materialIconsExtended)
+
+                implementation(libs.koin.core)
+                implementation(libs.voyager.navigator)
+                implementation(libs.voyager.screenmodel)
+                implementation(libs.voyager.koin)
+
+                implementation(projects.core.appearance)
+                implementation(projects.core.architecture)
+                implementation(projects.core.commonui.components)
+                implementation(projects.core.commonui.content)
+                implementation(projects.core.l10n)
+                implementation(projects.core.navigation)
+                implementation(projects.core.utils)
+
+                implementation(projects.domain.content.data)
+                implementation(projects.domain.content.pagination)
+                implementation(projects.domain.content.repository)
+                implementation(projects.domain.identity.repository)
+            }
+        }
+    }
+}
+
+android {
+    namespace = "com.livefast.eattrash.raccoonforfriendica.feature.calendar"
+    compileSdk =
+        libs.versions.android.targetSdk
+            .get()
+            .toInt()
+    defaultConfig {
+        minSdk =
+            libs.versions.android.minSdk
+                .get()
+                .toInt()
+    }
+}

--- a/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/composables/CalendarEventFooter.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/composables/CalendarEventFooter.kt
@@ -1,0 +1,61 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.calendar.composables
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
+import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.getFormattedDate
+
+@Composable
+fun CalendarEventFooter(
+    modifier: Modifier = Modifier,
+    startDate: String? = null,
+    endDate: String? = null,
+    place: String? = null,
+) {
+    val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha)
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
+    ) {
+        val startDateString =
+            startDate?.let {
+                getFormattedDate(
+                    iso8601Timestamp = it,
+                    format = "dd/MM/yy HH:mm",
+                )
+            }
+        val endDateString =
+            endDate?.let {
+                getFormattedDate(
+                    iso8601Timestamp = it,
+                    format = "dd/MM/yy HH:mm",
+                )
+            }
+        Text(
+            text =
+                buildString {
+                    append(startDateString)
+                    if (!endDateString.isNullOrEmpty()) {
+                        append(" – ")
+                        append(endDateString)
+                    }
+                },
+            style = MaterialTheme.typography.bodyMedium,
+            color = ancillaryColor,
+        )
+
+        if (!place.isNullOrEmpty()) {
+            Text(
+                text = place,
+                style = MaterialTheme.typography.bodyMedium,
+                color = ancillaryColor,
+            )
+        }
+    }
+}

--- a/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/composables/CalendarHeader.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/composables/CalendarHeader.kt
@@ -1,0 +1,47 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.calendar.composables
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.getFormattedDate
+import com.livefast.eattrash.raccoonforfriendica.feature.calendar.list.CalendarItem
+
+@Composable
+fun CalendarHeader(
+    header: CalendarItem.Header,
+    modifier: Modifier = Modifier,
+) {
+    val referenceDate =
+        "${header.year}-${header.month.toString().padStart(2, '0')}-01T12:00:00.000Z"
+    Box(
+        modifier =
+            modifier
+                .border(
+                    width = Dp.Hairline,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    shape = RoundedCornerShape(CornerSize.xl),
+                ).background(
+                    color = MaterialTheme.colorScheme.surfaceVariant,
+                    shape = RoundedCornerShape(CornerSize.xl),
+                ).padding(vertical = Spacing.xs),
+    ) {
+        Text(
+            modifier = Modifier.fillMaxWidth(),
+            text = getFormattedDate(referenceDate, "MMMM YYYY").uppercase(),
+            style = MaterialTheme.typography.titleMedium,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/composables/CalendarRow.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/composables/CalendarRow.kt
@@ -1,0 +1,131 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.calendar.composables
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.DpOffset
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomDropDown
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ContentTitle
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.Option
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EventModel
+
+@Composable
+fun CalendarRow(
+    event: EventModel,
+    modifier: Modifier = Modifier,
+    options: List<Option> = emptyList(),
+    onOpenUrl: ((String) -> Unit)? = null,
+    onClick: (() -> Unit)? = null,
+    onOptionSelected: ((OptionId) -> Unit)? = null,
+) {
+    var optionsOffset by remember { mutableStateOf(Offset.Zero) }
+    var optionsMenuOpen by remember { mutableStateOf(false) }
+
+    Column(
+        modifier =
+            modifier
+                .padding(bottom = Spacing.xxs)
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                ) {
+                    onClick?.invoke()
+                },
+        verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            ContentTitle(
+                modifier = Modifier.weight(1f).padding(horizontal = Spacing.s),
+                content = event.title,
+                onOpenUrl = onOpenUrl,
+                maxLines = 5,
+                onClick = {
+                    onClick?.invoke()
+                },
+            )
+
+            if (options.isNotEmpty()) {
+                Box {
+                    IconButton(
+                        modifier =
+                            Modifier.onGloballyPositioned {
+                                optionsOffset = it.positionInParent()
+                            },
+                        onClick = {
+                            optionsMenuOpen = true
+                        },
+                    ) {
+                        Icon(
+                            modifier = Modifier.size(IconSize.s),
+                            imageVector = Icons.Default.MoreVert,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onBackground,
+                        )
+                    }
+
+                    CustomDropDown(
+                        expanded = optionsMenuOpen,
+                        onDismiss = {
+                            optionsMenuOpen = false
+                        },
+                        offset =
+                            with(LocalDensity.current) {
+                                DpOffset(
+                                    x = optionsOffset.x.toDp(),
+                                    y = optionsOffset.y.toDp(),
+                                )
+                            },
+                    ) {
+                        options.forEach { option ->
+                            DropdownMenuItem(
+                                text = {
+                                    Text(option.label)
+                                },
+                                onClick = {
+                                    optionsMenuOpen = false
+                                    onOptionSelected?.invoke(option.id)
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        CalendarEventFooter(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.s),
+            startDate = event.startTime,
+            endDate = event.endTime,
+            place = event.place,
+        )
+    }
+}

--- a/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/composables/CalendarRowPlaceholder.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/composables/CalendarRowPlaceholder.kt
@@ -1,0 +1,60 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.calendar.composables
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.utils.compose.shimmerEffect
+
+@Composable
+fun CalendarRowPlaceholder(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.padding(horizontal = Spacing.s),
+        verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier =
+                    Modifier
+                        .size(IconSize.l)
+                        .clip(CircleShape)
+                        .shimmerEffect(),
+            )
+
+            Box(
+                modifier =
+                    Modifier
+                        .height(30.dp)
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(CornerSize.s))
+                        .shimmerEffect(),
+            )
+        }
+
+        Box(
+            modifier =
+                Modifier
+                    .height(60.dp)
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(CornerSize.s))
+                    .shimmerEffect(),
+        )
+    }
+}

--- a/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/detail/EventDetailMviModel.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/detail/EventDetailMviModel.kt
@@ -1,0 +1,17 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.calendar.detail
+
+import cafe.adriel.voyager.core.model.ScreenModel
+import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EventModel
+
+interface EventDetailMviModel :
+    ScreenModel,
+    MviModel<EventDetailMviModel.Intent, EventDetailMviModel.State, EventDetailMviModel.Effect> {
+    sealed interface Intent
+
+    data class State(
+        val event: EventModel? = null,
+    )
+
+    sealed interface Effect
+}

--- a/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/detail/EventDetailScreen.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/detail/EventDetailScreen.kt
@@ -1,0 +1,169 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.calendar.detail
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.style.TextOverflow
+import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.koin.getScreenModel
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ContentBody
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ContentTitle
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
+import com.livefast.eattrash.raccoonforfriendica.feature.calendar.composables.CalendarEventFooter
+import kotlinx.coroutines.launch
+import org.koin.core.parameter.parametersOf
+
+class EventDetailScreen(
+    private val eventId: String,
+) : Screen {
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    override fun Content() {
+        val model = getScreenModel<EventDetailMviModel>(parameters = { parametersOf(eventId) })
+        val uiState by model.uiState.collectAsState()
+        val topAppBarState = rememberTopAppBarState()
+        val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
+        val uriHandler = LocalUriHandler.current
+        val navigationCoordinator = remember { getNavigationCoordinator() }
+        val lazyListState = rememberLazyListState()
+        val scope = rememberCoroutineScope()
+        val snackbarHostState = remember { SnackbarHostState() }
+
+        fun goBackToTop() {
+            runCatching {
+                scope.launch {
+                    lazyListState.scrollToItem(0)
+                    topAppBarState.heightOffset = 0f
+                    topAppBarState.contentOffset = 0f
+                }
+            }
+        }
+
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    modifier = Modifier.clickable { scope.launch { goBackToTop() } },
+                    windowInsets = topAppBarState.toWindowInsets(),
+                    scrollBehavior = scrollBehavior,
+                    title = {
+                        Text(
+                            text = uiState.event?.title.orEmpty(),
+                            style = MaterialTheme.typography.titleMedium,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    },
+                    navigationIcon = {
+                        if (navigationCoordinator.canPop.value) {
+                            IconButton(
+                                onClick = {
+                                    navigationCoordinator.pop()
+                                },
+                            ) {
+                                Icon(
+                                    imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                                    contentDescription = null,
+                                )
+                            }
+                        }
+                    },
+                )
+            },
+            snackbarHost = {
+                SnackbarHost(
+                    hostState = snackbarHostState,
+                ) { data ->
+                    Snackbar(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        snackbarData = data,
+                    )
+                }
+            },
+        ) { padding ->
+            Box(
+                modifier =
+                    Modifier
+                        .padding(padding)
+                        .fillMaxWidth()
+                        .nestedScroll(scrollBehavior.nestedScrollConnection),
+            ) {
+                LazyColumn(
+                    state = lazyListState,
+                    verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+                ) {
+                    uiState.event?.title?.also { title ->
+                        item {
+                            ContentTitle(
+                                modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.s),
+                                content = title,
+                                onOpenUrl = {
+                                    uriHandler.openUri(it)
+                                },
+                            )
+                        }
+                    }
+
+                    item {
+                        CalendarEventFooter(
+                            modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.s),
+                            startDate = uiState.event?.startTime,
+                            endDate = uiState.event?.endTime,
+                            place = uiState.event?.place,
+                        )
+                    }
+
+                    uiState.event?.description?.also { title ->
+                        item {
+                            HorizontalDivider(
+                                modifier = Modifier.padding(vertical = Spacing.s),
+                            )
+
+                            ContentBody(
+                                modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.s),
+                                content = title,
+                                onOpenUrl = {
+                                    uriHandler.openUri(it)
+                                },
+                            )
+                        }
+                    }
+                    item {
+                        Spacer(modifier = Modifier.height(Spacing.xxl))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/detail/EventDetailViewModel.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/detail/EventDetailViewModel.kt
@@ -1,0 +1,24 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.calendar.detail
+
+import cafe.adriel.voyager.core.model.screenModelScope
+import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EventModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.LocalItemCache
+import kotlinx.coroutines.launch
+
+class EventDetailViewModel(
+    eventId: String,
+    eventCache: LocalItemCache<EventModel>,
+) : DefaultMviModel<EventDetailMviModel.Intent, EventDetailMviModel.State, EventDetailMviModel.Effect>(
+        initialState = EventDetailMviModel.State(),
+    ),
+    EventDetailMviModel {
+    init {
+        screenModelScope.launch {
+            val event = eventCache.get(eventId)
+            updateState {
+                it.copy(event = event)
+            }
+        }
+    }
+}

--- a/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/di/CalendarModule.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/di/CalendarModule.kt
@@ -1,0 +1,23 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.calendar.di
+
+import com.livefast.eattrash.raccoonforfriendica.feature.calendar.detail.EventDetailMviModel
+import com.livefast.eattrash.raccoonforfriendica.feature.calendar.detail.EventDetailViewModel
+import com.livefast.eattrash.raccoonforfriendica.feature.calendar.list.CalendarMviModel
+import com.livefast.eattrash.raccoonforfriendica.feature.calendar.list.CalendarViewModel
+import org.koin.dsl.module
+
+val featureCalendarModule =
+    module {
+        factory<CalendarMviModel> {
+            CalendarViewModel(
+                identityRepository = get(),
+                paginationManager = get(),
+            )
+        }
+        factory<EventDetailMviModel> {
+            EventDetailViewModel(
+                eventId = it[0],
+                eventCache = get(),
+            )
+        }
+    }

--- a/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/list/CalendarMviModel.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/list/CalendarMviModel.kt
@@ -1,0 +1,38 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.calendar.list
+
+import cafe.adriel.voyager.core.model.ScreenModel
+import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EventModel
+
+sealed interface CalendarItem {
+    data class Header(
+        val month: Int,
+        val year: Int,
+    ) : CalendarItem
+
+    data class EventItem(
+        val event: EventModel,
+    ) : CalendarItem
+}
+
+interface CalendarMviModel :
+    ScreenModel,
+    MviModel<CalendarMviModel.Intent, CalendarMviModel.State, CalendarMviModel.Effect> {
+    sealed interface Intent {
+        data object Refresh : Intent
+
+        data object LoadNextPage : Intent
+    }
+
+    data class State(
+        val initial: Boolean = true,
+        val refreshing: Boolean = false,
+        val loading: Boolean = false,
+        val canFetchMore: Boolean = true,
+        val items: List<CalendarItem> = emptyList(),
+    )
+
+    sealed interface Effect {
+        data object BackToTop : Effect
+    }
+}

--- a/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/list/CalendarScreen.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/list/CalendarScreen.kt
@@ -1,0 +1,262 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.calendar.list
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.koin.getScreenModel
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toOption
+import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDetailOpener
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
+import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.toEpochMillis
+import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getCalendarHelper
+import com.livefast.eattrash.raccoonforfriendica.core.utils.isNearTheEnd
+import com.livefast.eattrash.raccoonforfriendica.feature.calendar.composables.CalendarHeader
+import com.livefast.eattrash.raccoonforfriendica.feature.calendar.composables.CalendarRow
+import com.livefast.eattrash.raccoonforfriendica.feature.calendar.composables.CalendarRowPlaceholder
+import kotlinx.coroutines.launch
+
+class CalendarScreen : Screen {
+    @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
+    @Composable
+    override fun Content() {
+        val model = getScreenModel<CalendarMviModel>()
+        val uiState by model.uiState.collectAsState()
+        val topAppBarState = rememberTopAppBarState()
+        val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
+        val uriHandler = LocalUriHandler.current
+        val detailOpener = getDetailOpener()
+        val navigationCoordinator = remember { getNavigationCoordinator() }
+        val lazyListState = rememberLazyListState()
+        val scope = rememberCoroutineScope()
+        val snackbarHostState = remember { SnackbarHostState() }
+        val calendarHelper = getCalendarHelper()
+
+        fun goBackToTop() {
+            runCatching {
+                scope.launch {
+                    lazyListState.scrollToItem(0)
+                    topAppBarState.heightOffset = 0f
+                    topAppBarState.contentOffset = 0f
+                }
+            }
+        }
+
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    modifier = Modifier.clickable { scope.launch { goBackToTop() } },
+                    windowInsets = topAppBarState.toWindowInsets(),
+                    scrollBehavior = scrollBehavior,
+                    title = {
+                        Text(
+                            text = LocalStrings.current.calendarTitle,
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                    },
+                    navigationIcon = {
+                        if (navigationCoordinator.canPop.value) {
+                            IconButton(
+                                onClick = {
+                                    navigationCoordinator.pop()
+                                },
+                            ) {
+                                Icon(
+                                    imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                                    contentDescription = null,
+                                )
+                            }
+                        }
+                    },
+                )
+            },
+            snackbarHost = {
+                SnackbarHost(
+                    hostState = snackbarHostState,
+                ) { data ->
+                    Snackbar(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        snackbarData = data,
+                    )
+                }
+            },
+        ) { padding ->
+            val pullRefreshState =
+                rememberPullRefreshState(
+                    refreshing = uiState.refreshing,
+                    onRefresh = {
+                        model.reduce(CalendarMviModel.Intent.Refresh)
+                    },
+                )
+            Box(
+                modifier =
+                    Modifier
+                        .padding(padding)
+                        .fillMaxWidth()
+                        .nestedScroll(scrollBehavior.nestedScrollConnection)
+                        .pullRefresh(pullRefreshState),
+            ) {
+                LazyColumn(
+                    state = lazyListState,
+                ) {
+                    if (uiState.initial) {
+                        val placeholderCount = 20
+                        items(placeholderCount) { idx ->
+                            CalendarRowPlaceholder(modifier = Modifier.fillMaxWidth())
+                            if (idx < placeholderCount - 1) {
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(vertical = Spacing.s),
+                                )
+                            }
+                        }
+                    }
+                    itemsIndexed(
+                        items = uiState.items,
+                        key = { _, item ->
+                            when (item) {
+                                is CalendarItem.EventItem -> item.event.id
+                                is CalendarItem.Header -> "${item.year}-${item.month}"
+                            }
+                        },
+                    ) { idx, item ->
+                        when (item) {
+                            is CalendarItem.Header ->
+                                CalendarHeader(
+                                    modifier =
+                                        Modifier.fillMaxWidth().padding(
+                                            top = if (idx == 0) 0.dp else Spacing.m,
+                                            bottom = Spacing.s,
+                                        ),
+                                    header = item,
+                                )
+
+                            is CalendarItem.EventItem -> {
+                                CalendarRow(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    event = item.event,
+                                    onOpenUrl = { url ->
+                                        uriHandler.openUri(url)
+                                    },
+                                    onClick = {
+                                        detailOpener.openEvent(event = item.event)
+                                    },
+                                    options =
+                                        buildList {
+                                            if (calendarHelper.supportsExport) {
+                                                this += SaveToCalendar.toOption(LocalStrings.current.actionSaveToCalendar)
+                                            }
+                                        },
+                                    onOptionSelected = { optionId ->
+                                        when (optionId) {
+                                            SaveToCalendar ->
+                                                with(item.event) {
+                                                    calendarHelper.export(
+                                                        title = title,
+                                                        startDate = startTime.toEpochMillis(),
+                                                        endDate = endTime?.toEpochMillis(),
+                                                        location = place,
+                                                    )
+                                                }
+
+                                            else -> Unit
+                                        }
+                                    },
+                                )
+                                if (idx < uiState.items.lastIndex && uiState.items[idx + 1] !is CalendarItem.Header) {
+                                    HorizontalDivider(
+                                        modifier = Modifier.padding(vertical = Spacing.s),
+                                    )
+                                }
+                            }
+                        }
+
+                        val canFetchMore =
+                            !uiState.initial && !uiState.loading && uiState.canFetchMore
+                        val isNearTheEnd = idx.isNearTheEnd(uiState.items)
+                        if (isNearTheEnd && canFetchMore) {
+                            model.reduce(CalendarMviModel.Intent.LoadNextPage)
+                        }
+                    }
+
+                    item {
+                        if (uiState.loading && !uiState.refreshing) {
+                            Box(
+                                modifier = Modifier.fillMaxWidth(),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                ListLoadingIndicator()
+                            }
+                        }
+                    }
+
+                    if (!uiState.initial && !uiState.refreshing && !uiState.loading && uiState.items.isEmpty()) {
+                        item {
+                            Text(
+                                modifier = Modifier.fillMaxWidth().padding(top = Spacing.m),
+                                text = LocalStrings.current.messageEmptyList,
+                                textAlign = TextAlign.Center,
+                                style = MaterialTheme.typography.bodyLarge,
+                            )
+                        }
+                    }
+
+                    item {
+                        Spacer(modifier = Modifier.height(Spacing.xxxl))
+                    }
+                }
+
+                PullRefreshIndicator(
+                    refreshing = uiState.refreshing,
+                    state = pullRefreshState,
+                    modifier = Modifier.align(Alignment.TopCenter),
+                    backgroundColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                    contentColor = MaterialTheme.colorScheme.primary,
+                )
+            }
+        }
+    }
+}
+
+private object SaveToCalendar : OptionId.Custom

--- a/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/list/CalendarViewModel.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/list/CalendarViewModel.kt
@@ -1,0 +1,94 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.calendar.list
+
+import cafe.adriel.voyager.core.model.screenModelScope
+import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
+import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.extractDatePart
+import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.toEpochMillis
+import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.EventPaginationManager
+import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.EventsPaginationSpecification
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+
+class CalendarViewModel(
+    private val identityRepository: IdentityRepository,
+    private val paginationManager: EventPaginationManager,
+) : DefaultMviModel<CalendarMviModel.Intent, CalendarMviModel.State, CalendarMviModel.Effect>(
+        initialState = CalendarMviModel.State(),
+    ),
+    CalendarMviModel {
+    init {
+        screenModelScope.launch {
+            identityRepository.currentUser
+                .onEach {
+                    refresh(initial = true)
+                }.launchIn(this)
+        }
+    }
+
+    override fun reduce(intent: CalendarMviModel.Intent) {
+        when (intent) {
+            CalendarMviModel.Intent.LoadNextPage ->
+                screenModelScope.launch {
+                    loadNextPage()
+                }
+
+            CalendarMviModel.Intent.Refresh ->
+                screenModelScope.launch {
+                    refresh()
+                }
+        }
+    }
+
+    private suspend fun refresh(initial: Boolean = false) {
+        updateState {
+            it.copy(initial = initial, refreshing = !initial)
+        }
+        paginationManager.reset(EventsPaginationSpecification.All)
+        loadNextPage()
+    }
+
+    private suspend fun loadNextPage() {
+        if (uiState.value.loading) {
+            return
+        }
+        val wasRefreshing = uiState.value.refreshing
+        updateState { it.copy(loading = true) }
+        val events = paginationManager.loadNextPage()
+        val eventsGrouped =
+            events.groupBy {
+                val timestamp = it.startTime.toEpochMillis()
+                val (year, month) = timestamp.extractDatePart()
+                CalendarItem.Header(year = year, month = month)
+            }
+        val keys =
+            eventsGrouped.keys.sortedByDescending {
+                val monthPart = "${it.month}".padStart(2, '0')
+                "${it.year}-$monthPart"
+            }
+        val items =
+            buildList {
+                for (key in keys) {
+                    this += key
+                    val monthEvents =
+                        eventsGrouped[key]?.sortedByDescending { it.startTime }.orEmpty()
+                    for (event in monthEvents) {
+                        this += CalendarItem.EventItem(event)
+                    }
+                }
+            }
+        updateState {
+            it.copy(
+                items = items,
+                canFetchMore = paginationManager.canFetchMore,
+                loading = false,
+                initial = false,
+                refreshing = false,
+            )
+        }
+        if (wasRefreshing) {
+            emitEffect(CalendarMviModel.Effect.BackToTop)
+        }
+    }
+}

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerContent.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerContent.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.filled.Bookmarks
+import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Dashboard
 import androidx.compose.material.icons.filled.Drafts
 import androidx.compose.material.icons.filled.Favorite
@@ -188,6 +189,15 @@ class DrawerContent : Screen {
                         handleOpen { detailOpener.openUnpublished() }
                     },
                 )
+                if (uiState.hasCalendar) {
+                    DrawerShortcut(
+                        title = LocalStrings.current.calendarTitle,
+                        icon = Icons.Default.CalendarMonth,
+                        onSelected = {
+                            handleOpen { detailOpener.openCalendar() }
+                        },
+                    )
+                }
             }
 
             DrawerShortcut(

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerMviModel.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerMviModel.kt
@@ -28,6 +28,7 @@ interface DrawerMviModel :
         val node: String? = null,
         val hasDirectMessages: Boolean = false,
         val hasGallery: Boolean = false,
+        val hasCalendar: Boolean = false,
         val anonymousChangeNodeName: String = "",
         val anonymousChangeNodeValidationInProgress: Boolean = false,
         val anonymousChangeNodeNameError: ValidationError? = null,

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerViewModel.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerViewModel.kt
@@ -51,6 +51,7 @@ class DrawerViewModel(
                         it.copy(
                             hasDirectMessages = features.supportsDirectMessages,
                             hasGallery = features.supportsPhotoGallery,
+                            hasCalendar = features.supportsCalendar,
                         )
                     }
                 }.launchIn(this)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -50,6 +50,7 @@ include(":domain:identity:data")
 include(":domain:identity:repository")
 include(":domain:identity:usecase")
 
+include(":feature:calendar")
 include(":feature:circles")
 include(":feature:composer")
 include(":feature:directmessages")


### PR DESCRIPTION
This PR adds the event calendar which can be accessed from the side menu if you are logged into a Friendica server.

Since the APIs only allow to read the list of events, the calendar is read-only.