### PR TITLE
fix: apply fixes for user-reported issues

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/bottomnavigation/TabNavigationItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/bottomnavigation/TabNavigationItem.kt
@@ -2,7 +2,6 @@ package com.livefast.eattrash.raccoonforfriendica.bottomnavigation
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.offset
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Article
 import androidx.compose.material.icons.filled.AccountCircle
@@ -20,7 +19,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.BottomNavigationSection
@@ -45,7 +43,7 @@ internal fun RowScope.BottomNavigationItem(
                     val unreadCount = (section as? BottomNavigationSection.Inbox)?.unreadItems ?: 0
                     if (unreadCount > 0) {
                         Badge(
-                            modifier = Modifier.align(Alignment.TopEnd).offset(x = (-5).dp),
+                            modifier = Modifier.align(Alignment.TopEnd),
                         ) {
                             Text(
                                 text = if (unreadCount <= 10) "$unreadCount" else "10+",

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/CustomModalBottomSheet.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/CustomModalBottomSheet.kt
@@ -16,13 +16,13 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -72,17 +72,16 @@ fun CustomModalBottomSheet(
                 Spacer(modifier = Modifier.height(Spacing.s))
                 LazyColumn {
                     itemsIndexed(items = items) { idx, item ->
-                        Surface(
-                            shape = RoundedCornerShape(CornerSize.xl),
-                        ) {
                             Row(
                                 modifier =
                                     Modifier
                                         .fillMaxWidth()
-                                        .combinedClickable(
-                                            onClick = {
-                                                sheetScope
-                                                    .launch {
+                                    .clip(
+                                        shape = RoundedCornerShape(CornerSize.xl),
+                                    ).combinedClickable(
+                                        onClick = {
+                                            sheetScope
+                                                .launch {
                                                         sheetState.hide()
                                                     }.invokeOnCompletion {
                                                         onSelected?.invoke(idx)
@@ -128,7 +127,6 @@ fun CustomModalBottomSheet(
                                 item.trailingContent?.invoke()
                             }
                         }
-                    }
                 }
             }
         },

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SettingsColorRow.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SettingsColorRow.kt
@@ -2,21 +2,22 @@ package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
 
@@ -34,10 +35,9 @@ fun SettingsColorRow(
     Row(
         modifier =
             modifier
-                .clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null,
-                ) {
+                .clip(
+                    shape = RoundedCornerShape(CornerSize.l),
+                ).clickable {
                     onTap?.invoke()
                 }.padding(vertical = Spacing.s, horizontal = Spacing.m),
         verticalAlignment = Alignment.CenterVertically,

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SettingsImageInfo.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SettingsImageInfo.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FileOpen
 import androidx.compose.material3.Icon
@@ -15,8 +16,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomImage
@@ -37,7 +40,9 @@ fun SettingsImageInfo(
         modifier =
             modifier
                 .fillMaxWidth()
-                .clickable {
+                .clip(
+                    shape = RoundedCornerShape(CornerSize.l),
+                ).clickable {
                     onEdit?.invoke()
                 }.padding(
                     vertical = Spacing.xs,

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SettingsRow.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SettingsRow.kt
@@ -2,25 +2,27 @@ package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
@@ -42,13 +44,12 @@ fun SettingsRow(
     Row(
         modifier =
             modifier
-                .clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null,
-                ) {
+                .clip(
+                    shape = RoundedCornerShape(CornerSize.l),
+                ).clickable {
                     onTap?.invoke()
                 }.padding(
-                    vertical = Spacing.s,
+                    vertical = 10.dp,
                     horizontal = Spacing.m,
                 ),
         verticalAlignment = Alignment.CenterVertically,

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SettingsSwitchRow.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SettingsSwitchRow.kt
@@ -1,15 +1,19 @@
 package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
 
@@ -21,7 +25,13 @@ fun SettingsSwitchRow(
     onValueChanged: (Boolean) -> Unit,
 ) {
     Row(
-        modifier = Modifier.padding(horizontal = Spacing.m),
+        modifier =
+            Modifier
+                .clip(
+                    shape = RoundedCornerShape(CornerSize.l),
+                ).clickable {
+                    onValueChanged(!value)
+                }.padding(horizontal = Spacing.m),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
@@ -852,7 +852,9 @@ class ComposerScreen(
             InsertLinkDialog(
                 initialAnchor =
                     uiState.bodyValue.selection.takeIf { it.length > 0 }?.let { range ->
-                        uiState.bodyValue.text.substring(range.start, range.end)
+                        runCatching {
+                            uiState.bodyValue.text.substring(range.start, range.end)
+                        }.getOrNull()
                     },
                 onClose = { link ->
                     linkDialogOpen = false

--- a/feature/nodeinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/NodeInfoScreen.kt
+++ b/feature/nodeinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/NodeInfoScreen.kt
@@ -334,10 +334,12 @@ private fun ContactUserItem(
                     .clickable {
                         onClick?.invoke()
                     }.padding(
-                        horizontal = Spacing.s,
-                        vertical = Spacing.s,
+                        start = Spacing.m,
+                        end = Spacing.s,
+                        top = Spacing.s,
+                        bottom = Spacing.s,
                     ),
-            horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+            horizontalArrangement = Arrangement.spacedBy(Spacing.m),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             if (avatar.isNotEmpty()) {


### PR DESCRIPTION
This PR applies a series of fixes for some issues reported on version 0.1.0-beta11:
- bottom sheet items have an unwanted background;
- badges for unread notifications have an end offset which makes them look weird (due to Compose update);
- settings items could have a ripple effect, moreover textual items are too close to each other;
- the contact information in the node info screen has too little horizontal spacing;
- there was a crash report in the Composer while inserting a hyperlink.