### PR TITLE
chore: add more domain identity use case tests

### DIFF
--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultLoginUseCaseTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultLoginUseCaseTest.kt
@@ -1,0 +1,150 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NodeFeatures
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SupportedFeatureRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountCredentialsCache
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiCredentials
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.CredentialsRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.sequentiallyReturns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class DefaultLoginUseCaseTest {
+    private val apiConfigurationRepository =
+        mock<ApiConfigurationRepository>(mode = MockMode.autoUnit)
+    private val credentialsRepository = mock<CredentialsRepository>(mode = MockMode.autoUnit)
+    private val accountRepository = mock<AccountRepository>(mode = MockMode.autoUnit)
+    private val settingsRepository = mock<SettingsRepository>(mode = MockMode.autoUnit)
+    private val accountCredentialsCache = mock<AccountCredentialsCache>(mode = MockMode.autoUnit)
+    private val supportedFeatureRepository =
+        mock<SupportedFeatureRepository>(mode = MockMode.autoUnit) {
+            every { features } returns MutableStateFlow(NodeFeatures())
+        }
+    private val sut =
+        DefaultLoginUseCase(
+            apiConfigurationRepository = apiConfigurationRepository,
+            credentialsRepository = credentialsRepository,
+            accountRepository = accountRepository,
+            settingsRepository = settingsRepository,
+            accountCredentialsCache = accountCredentialsCache,
+            supportedFeatureRepository = supportedFeatureRepository,
+        )
+
+    @Test
+    fun `given invalid credentials when execute then interactions are as expected`() =
+        runTest {
+            everySuspend { credentialsRepository.validate(any(), any()) } returns null
+            val node = "example.com"
+            val credentials = ApiCredentials.OAuth2("fake-access-token", "")
+
+            assertFailsWith<IllegalStateException> {
+                sut.invoke(node = node, credentials = credentials)
+            }
+
+            verifySuspend {
+                apiConfigurationRepository.changeNode(node)
+                apiConfigurationRepository.setAuth(credentials)
+                credentialsRepository.validate(node, credentials)
+            }
+            verifySuspend(mode = VerifyMode.not) {
+                accountRepository.getBy(any())
+                accountRepository.create(any())
+                accountCredentialsCache.get(any())
+                settingsRepository.get(any())
+                settingsRepository.create(any())
+            }
+        }
+
+    @Test
+    fun `given valid credentials and not existing account when execute then interactions are as expected`() =
+        runTest {
+            val node = "example.com"
+            val username = "fake-username"
+            val userId = "0"
+            everySuspend {
+                credentialsRepository.validate(node = any(), credentials = any())
+            } returns UserModel(id = userId, username = username)
+            val accountData =
+                AccountModel(
+                    id = 1,
+                    handle = "$username@$node",
+                    remoteId = userId,
+                )
+            val credentials = ApiCredentials.OAuth2("fake-access-token", "")
+            everySuspend { accountRepository.getBy(any()) } sequentiallyReturns
+                listOf(
+                    null,
+                    accountData,
+                    AccountModel(),
+                )
+            everySuspend { settingsRepository.get(any()) } returns null
+
+            sut.invoke(node = node, credentials = credentials)
+
+            verifySuspend {
+                apiConfigurationRepository.changeNode(node)
+                apiConfigurationRepository.setAuth(credentials)
+                credentialsRepository.validate(node, credentials)
+                accountRepository.getBy("$username@$node")
+                accountRepository.create(accountData.copy(id = 0))
+                accountRepository.getBy("$username@$node")
+                accountCredentialsCache.save(accountId = accountData.id, credentials)
+                settingsRepository.get(accountData.id)
+                settingsRepository.create(SettingsModel(accountId = accountData.id))
+                accountRepository.setActive(accountData, true)
+            }
+        }
+
+    @Test
+    fun `given valid credentials and existing account when execute then interactions are as expected`() =
+        runTest {
+            val node = "example.com"
+            val username = "fake-username"
+            val userId = "0"
+            everySuspend {
+                credentialsRepository.validate(node = any(), credentials = any())
+            } returns UserModel(id = userId, username = username)
+            val accountData =
+                AccountModel(
+                    id = 1,
+                    handle = "$username@$node",
+                    remoteId = userId,
+                )
+            val credentials = ApiCredentials.OAuth2("fake-access-token", "")
+            everySuspend { accountRepository.getBy(any()) } returns accountData
+            everySuspend { settingsRepository.get(any()) } returns null
+
+            sut.invoke(node = node, credentials = credentials)
+
+            verifySuspend {
+                apiConfigurationRepository.changeNode(node)
+                apiConfigurationRepository.setAuth(credentials)
+                credentialsRepository.validate(node, credentials)
+                accountRepository.getBy("$username@$node")
+                accountRepository.getBy("$username@$node")
+                accountCredentialsCache.save(accountId = accountData.id, credentials)
+                settingsRepository.get(accountData.id)
+                settingsRepository.create(SettingsModel(accountId = accountData.id))
+                accountRepository.setActive(accountData, true)
+            }
+            verifySuspend(mode = VerifyMode.not) {
+                accountRepository.create(accountData)
+            }
+        }
+}

--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultLogoutUseCaseTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultLogoutUseCaseTest.kt
@@ -1,0 +1,78 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
+
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class DefaultLogoutUseCaseTest {
+    private val apiConfigurationRepository =
+        mock<ApiConfigurationRepository>(mode = MockMode.autoUnit)
+    private val accountRepository = mock<AccountRepository>(mode = MockMode.autoUnit)
+    private val sut =
+        DefaultLogoutUseCase(
+            apiConfigurationRepository,
+            accountRepository,
+        )
+
+    @Test
+    fun `when invoke then interactions are as expected`() =
+        runTest {
+            val accountData = AccountModel(id = 2)
+            everySuspend { accountRepository.getActive() } returns accountData
+            val anonymousAccount = AccountModel(id = 1)
+            everySuspend { accountRepository.getBy(any()) } returns anonymousAccount
+
+            sut.invoke()
+
+            verifySuspend {
+                apiConfigurationRepository.setAuth(null)
+                accountRepository.getActive()
+                accountRepository.getBy("")
+                accountRepository.setActive(account = anonymousAccount, active = true)
+            }
+        }
+
+    @Test
+    fun `given no anonymous account when invoke then interactions are as expected`() =
+        runTest {
+            val accountData = AccountModel(id = 2)
+            everySuspend { accountRepository.getActive() } returns accountData
+            everySuspend { accountRepository.getBy(any()) } returns null
+
+            sut.invoke()
+
+            verifySuspend {
+                apiConfigurationRepository.setAuth(null)
+                accountRepository.getActive()
+                accountRepository.getBy("")
+                accountRepository.setActive(account = accountData, active = false)
+            }
+        }
+
+    @Test
+    fun `given no active account when invoke then interactions are as expected`() =
+        runTest {
+            everySuspend { accountRepository.getActive() } returns null
+            val anonymousAccount = AccountModel(id = 1)
+            everySuspend { accountRepository.getBy(any()) } returns anonymousAccount
+
+            sut.invoke()
+
+            verifySuspend {
+                apiConfigurationRepository.setAuth(null)
+                accountRepository.getActive()
+            }
+            verifySuspend(mode = VerifyMode.not) {
+                accountRepository.setActive(account = any(), active = any())
+            }
+        }
+}

--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultSetupAccountUseCaseTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultSetupAccountUseCaseTest.kt
@@ -1,0 +1,65 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
+
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class DefaultSetupAccountUseCaseTest {
+    private val accountRepository = mock<AccountRepository>(mode = MockMode.autoUnit)
+    private val settingsRepository = mock<SettingsRepository>(mode = MockMode.autoUnit)
+    private val sut =
+        DefaultSetupAccountUseCase(
+            accountRepository = accountRepository,
+            settingsRepository = settingsRepository,
+        )
+
+    @Test
+    fun `given no accounts when invoke then interactions are as expected`() =
+        runTest {
+            everySuspend { accountRepository.getAll() } returns emptyList()
+            val anonymousAccount = AccountModel(handle = "", id = 1)
+            everySuspend { accountRepository.getBy(any()) } returns anonymousAccount
+            everySuspend { settingsRepository.get(any()) } returns null
+
+            sut.invoke()
+
+            verifySuspend {
+                accountRepository.getAll()
+                accountRepository.create(anonymousAccount.copy(id = 0))
+                accountRepository.getBy("")
+                settingsRepository.get(anonymousAccount.id)
+                settingsRepository.create(SettingsModel(accountId = anonymousAccount.id))
+                accountRepository.setActive(anonymousAccount, true)
+            }
+        }
+
+    @Test
+    fun `given existing anonymous account when invoke then interactions are as expected`() =
+        runTest {
+            val anonymousAccount = AccountModel(handle = "", id = 1)
+            everySuspend { accountRepository.getAll() } returns listOf(anonymousAccount)
+
+            sut.invoke()
+
+            verifySuspend {
+                accountRepository.getAll()
+            }
+            verifySuspend(mode = VerifyMode.not) {
+                accountRepository.create(anonymousAccount.copy(id = 0))
+                accountRepository.getBy("")
+                settingsRepository.get(anonymousAccount.id)
+                settingsRepository.create(SettingsModel())
+                accountRepository.setActive(anonymousAccount, true)
+            }
+        }
+}

--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultSwitchAccountUseCaseTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultSwitchAccountUseCaseTest.kt
@@ -1,0 +1,26 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
+
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
+import dev.mokkery.MockMode
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class DefaultSwitchAccountUseCaseTest {
+    private val accountRepository = mock<AccountRepository>(mode = MockMode.autoUnit)
+    private val sut = DefaultSwitchAccountUseCase(accountRepository = accountRepository)
+
+    @Test
+    fun `when invoke then interactions are as expected`() =
+        runTest {
+            val account = AccountModel(id = 1)
+
+            sut.invoke(account)
+
+            verifySuspend {
+                accountRepository.setActive(account, true)
+            }
+        }
+}


### PR DESCRIPTION
This PR completes the test for the `:domain:identity:usecase `module.