### PR TITLE
feat: allow using circle as default timeline

### DIFF
--- a/core/persistence/schemas/com.livefast.eattrash.raccoonforfriendica.core.persistence.AppDatabase/11.json
+++ b/core/persistence/schemas/com.livefast.eattrash.raccoonforfriendica.core.persistence.AppDatabase/11.json
@@ -1,0 +1,288 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 11,
+    "identityHash": "8a856205c1e99a6746fdcf8c2cd345e3",
+    "entities": [
+      {
+        "tableName": "AccountEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `handle` TEXT NOT NULL, `active` INTEGER NOT NULL DEFAULT 0, `remoteId` TEXT, `avatar` TEXT, `displayName` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "handle",
+            "columnName": "handle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "active",
+            "columnName": "active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "avatar",
+            "columnName": "avatar",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AccountEntity_handle",
+            "unique": false,
+            "columnNames": [
+              "handle"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AccountEntity_handle` ON `${TABLE_NAME}` (`handle`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SettingsEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `accountId` INTEGER NOT NULL DEFAULT 0, `lang` TEXT NOT NULL DEFAULT 'en', `theme` INTEGER NOT NULL DEFAULT 0, `fontFamily` INTEGER NOT NULL DEFAULT 0, `fontScale` INTEGER NOT NULL DEFAULT 0, `dynamicColors` INTEGER NOT NULL DEFAULT 0, `customSeedColor` INTEGER, `defaultTimelineType` INTEGER NOT NULL DEFAULT 0, `includeNsfw` INTEGER NOT NULL DEFAULT 0, `blurNsfw` INTEGER NOT NULL DEFAULT 0, `urlOpeningMode` INTEGER NOT NULL DEFAULT 0, `defaultPostVisibility` INTEGER NOT NULL DEFAULT 0, `defaultReplyVisibility` INTEGER NOT NULL DEFAULT 0, `excludeRepliesFromTimeline` INTEGER NOT NULL DEFAULT 0, `openGroupsInForumModeByDefault` INTEGER NOT NULL DEFAULT 1, `markupMode` INTEGER NOT NULL DEFAULT 1, `maxPostBodyLines` INTEGER NOT NULL DEFAULT 0, `defaultTimelineId` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lang",
+            "columnName": "lang",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'en'"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "fontScale",
+            "columnName": "fontScale",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "dynamicColors",
+            "columnName": "dynamicColors",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "customSeedColor",
+            "columnName": "customSeedColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "defaultTimelineType",
+            "columnName": "defaultTimelineType",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "includeNsfw",
+            "columnName": "includeNsfw",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "blurNsfw",
+            "columnName": "blurNsfw",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "urlOpeningMode",
+            "columnName": "urlOpeningMode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "defaultPostVisibility",
+            "columnName": "defaultPostVisibility",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "defaultReplyVisibility",
+            "columnName": "defaultReplyVisibility",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "excludeRepliesFromTimeline",
+            "columnName": "excludeRepliesFromTimeline",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "openGroupsInForumModeByDefault",
+            "columnName": "openGroupsInForumModeByDefault",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "markupMode",
+            "columnName": "markupMode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "maxPostBodyLines",
+            "columnName": "maxPostBodyLines",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "defaultTimelineId",
+            "columnName": "defaultTimelineId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "DraftEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mediaIds` TEXT, `inReplyToId` TEXT, `lang` TEXT, `sensitive` INTEGER, `spoiler` TEXT, `title` TEXT, `text` TEXT, `created` TEXT, `visibility` TEXT, `pollExpiresAt` TEXT, `pollMultiple` INTEGER, `pollOptions` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaIds",
+            "columnName": "mediaIds",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "inReplyToId",
+            "columnName": "inReplyToId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lang",
+            "columnName": "lang",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sensitive",
+            "columnName": "sensitive",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "spoiler",
+            "columnName": "spoiler",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "visibility",
+            "columnName": "visibility",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pollExpiresAt",
+            "columnName": "pollExpiresAt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pollMultiple",
+            "columnName": "pollMultiple",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pollOptions",
+            "columnName": "pollOptions",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '8a856205c1e99a6746fdcf8c2cd345e3')"
+    ]
+  }
+}

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/AppDatabase.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/AppDatabase.kt
@@ -17,7 +17,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.persistence.entities.Setti
         SettingsEntity::class,
         DraftEntity::class,
     ],
-    version = 10,
+    version = 11,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
@@ -28,6 +28,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.persistence.entities.Setti
         AutoMigration(from = 7, to = 8),
         AutoMigration(from = 8, to = 9),
         AutoMigration(from = 9, to = 10),
+        AutoMigration(from = 10, to = 11),
     ],
 )
 @ConstructedBy(AppDatabaseConstructor::class)

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/entities/SettingsEntity.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/entities/SettingsEntity.kt
@@ -24,4 +24,5 @@ data class SettingsEntity(
     @ColumnInfo(defaultValue = "1") val openGroupsInForumModeByDefault: Boolean = true,
     @ColumnInfo(defaultValue = "1") val markupMode: Int = 1,
     @ColumnInfo(defaultValue = "0") val maxPostBodyLines: Int = 0,
+    val defaultTimelineId: String? = null,
 )

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/TimelineType.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/TimelineType.kt
@@ -35,6 +35,7 @@ fun TimelineType.toInt(): Int =
     when (this) {
         TimelineType.All -> 1
         TimelineType.Subscriptions -> 2
+        is TimelineType.Circle -> 3
         else -> 0
     }
 
@@ -42,6 +43,7 @@ fun Int.toTimelineType(): TimelineType =
     when (this) {
         1 -> TimelineType.All
         2 -> TimelineType.Subscriptions
+        3 -> TimelineType.Circle("", "")
         else -> TimelineType.Local
     }
 

--- a/domain/identity/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/data/SettingsModel.kt
+++ b/domain/identity/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/data/SettingsModel.kt
@@ -14,6 +14,7 @@ data class SettingsModel(
     val dynamicColors: Boolean = false,
     val customSeedColor: Int? = null,
     val defaultTimelineType: Int = 0,
+    val defaultTimelineId: String? = null,
     val includeNsfw: Boolean = false,
     val blurNsfw: Boolean = true,
     val urlOpeningMode: UrlOpeningMode = UrlOpeningMode.External,

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultSettingsRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultSettingsRepository.kt
@@ -57,6 +57,7 @@ private fun SettingsEntity.toModel() =
         openGroupsInForumModeByDefault = openGroupsInForumModeByDefault,
         markupMode = markupMode.toMarkupMode(),
         maxPostBodyLines = maxPostBodyLines.toDomainMaxLines(),
+        defaultTimelineId = defaultTimelineId,
     )
 
 private fun SettingsModel.toEntity() =
@@ -79,6 +80,7 @@ private fun SettingsModel.toEntity() =
         openGroupsInForumModeByDefault = openGroupsInForumModeByDefault,
         markupMode = markupMode.toInt(),
         maxPostBodyLines = maxPostBodyLines.toEntityMaxLines(),
+        defaultTimelineId = defaultTimelineId,
     )
 
 private fun Int.toMarkupMode(): MarkupMode =

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/di/SettingsModule.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/di/SettingsModule.kt
@@ -17,6 +17,7 @@ val featureSettingsModule =
                 themeColorRepository = get(),
                 identityRepository = get(),
                 supportedFeatureRepository = get(),
+                circlesRepository = get(),
             )
         }
         factory<UserFeedbackMviModel> {


### PR DESCRIPTION
This PR allows to select a circle (or channel) as default timeline in the settings screen and to use it in the home screen as the preferred choice.