### PR TITLE
refactor: move app info to navigation drawer

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SettingsColorRow.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SettingsColorRow.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -44,6 +45,7 @@ fun SettingsColorRow(
     ) {
         Column(
             modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
         ) {
             Text(
                 text = title,

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SettingsRow.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SettingsRow.kt
@@ -72,6 +72,7 @@ fun SettingsRow(
         }
         Column(
             modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
         ) {
             Text(
                 text = title,

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SettingsSwitchRow.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SettingsSwitchRow.kt
@@ -36,7 +36,7 @@ fun SettingsSwitchRow(
     ) {
         Column(
             modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(Spacing.xxxs),
+            verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
         ) {
             val fullColor = MaterialTheme.colorScheme.onBackground
             val ancillaryColor =

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerContent.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerContent.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Chat
+import androidx.compose.material.icons.automirrored.filled.ContactSupport
 import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Dashboard
@@ -65,6 +66,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDrawerCoo
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.utils.validation.toReadableMessage
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.DefaultFriendicaInstances
+import com.livefast.eattrash.raccoonforfriendica.feature.drawer.about.AboutDialog
 import com.livefast.eattrash.raccoonforfriendica.feature.drawer.components.DrawerHeader
 import com.livefast.eattrash.raccoonforfriendica.feature.drawer.components.DrawerShortcut
 import kotlinx.coroutines.delay
@@ -83,9 +85,10 @@ class DrawerContent : Screen {
         val detailOpener = remember { getDetailOpener() }
         val scope = rememberCoroutineScope()
         var manageAccountsDialogOpened by remember { mutableStateOf(false) }
-        var changeInstanceDialogOpen by remember { mutableStateOf(false) }
+        var changeInstanceDialogOpened by remember { mutableStateOf(false) }
+        var aboutDialogOpened by remember { mutableStateOf(false) }
 
-        fun handleOpen(action: suspend () -> Unit) {
+        fun handleAction(action: suspend () -> Unit) {
             scope.launch {
                 navigationCoordinator.popUntilRoot()
                 drawerCoordinator.toggleDrawer()
@@ -99,7 +102,7 @@ class DrawerContent : Screen {
                 .onEach { event ->
                     when (event) {
                         DrawerMviModel.Effect.AnonymousChangeNodeSuccess -> {
-                            changeInstanceDialogOpen = false
+                            changeInstanceDialogOpened = false
                             drawerCoordinator.closeDrawer()
                         }
                     }
@@ -112,7 +115,7 @@ class DrawerContent : Screen {
                 node = uiState.node,
                 canSwitchAccount = uiState.availableAccounts.size > 1,
                 onOpenChangeInstance = {
-                    changeInstanceDialogOpen = true
+                    changeInstanceDialogOpened = true
                 },
                 onOpenSwitchAccount = {
                     manageAccountsDialogOpened = true
@@ -132,35 +135,35 @@ class DrawerContent : Screen {
                     title = LocalStrings.current.favoritesTitle,
                     icon = Icons.Default.Favorite,
                     onSelected = {
-                        handleOpen { detailOpener.openFavorites() }
+                        handleAction { detailOpener.openFavorites() }
                     },
                 )
                 DrawerShortcut(
                     title = LocalStrings.current.bookmarksTitle,
                     icon = Icons.Default.Bookmarks,
                     onSelected = {
-                        handleOpen { detailOpener.openBookmarks() }
+                        handleAction { detailOpener.openBookmarks() }
                     },
                 )
                 DrawerShortcut(
                     title = LocalStrings.current.followedHashtagsTitle,
                     icon = Icons.Default.Tag,
                     onSelected = {
-                        handleOpen { detailOpener.openFollowedHashtags() }
+                        handleAction { detailOpener.openFollowedHashtags() }
                     },
                 )
                 DrawerShortcut(
                     title = LocalStrings.current.followRequestsTitle,
                     icon = Icons.Default.Flaky,
                     onSelected = {
-                        handleOpen { detailOpener.openFollowRequests() }
+                        handleAction { detailOpener.openFollowRequests() }
                     },
                 )
                 DrawerShortcut(
                     title = LocalStrings.current.manageCirclesTitle,
                     icon = Icons.Default.Workspaces,
                     onSelected = {
-                        handleOpen { detailOpener.openCircles() }
+                        handleAction { detailOpener.openCircles() }
                     },
                 )
 
@@ -169,7 +172,7 @@ class DrawerContent : Screen {
                         title = LocalStrings.current.directMessagesTitle,
                         icon = Icons.AutoMirrored.Default.Chat,
                         onSelected = {
-                            handleOpen { detailOpener.openDirectMessages() }
+                            handleAction { detailOpener.openDirectMessages() }
                         },
                     )
                 }
@@ -178,7 +181,7 @@ class DrawerContent : Screen {
                         title = LocalStrings.current.galleryTitle,
                         icon = Icons.Default.Dashboard,
                         onSelected = {
-                            handleOpen { detailOpener.openGallery() }
+                            handleAction { detailOpener.openGallery() }
                         },
                     )
                 }
@@ -186,7 +189,7 @@ class DrawerContent : Screen {
                     title = LocalStrings.current.unpublishedTitle,
                     icon = Icons.Default.Drafts,
                     onSelected = {
-                        handleOpen { detailOpener.openUnpublished() }
+                        handleAction { detailOpener.openUnpublished() }
                     },
                 )
                 if (uiState.hasCalendar) {
@@ -194,7 +197,7 @@ class DrawerContent : Screen {
                         title = LocalStrings.current.calendarTitle,
                         icon = Icons.Default.CalendarMonth,
                         onSelected = {
-                            handleOpen { detailOpener.openCalendar() }
+                            handleAction { detailOpener.openCalendar() }
                         },
                     )
                 }
@@ -204,7 +207,7 @@ class DrawerContent : Screen {
                 title = LocalStrings.current.nodeInfoTitle,
                 icon = Icons.Default.Info,
                 onSelected = {
-                    handleOpen { detailOpener.openNodeInfo() }
+                    handleAction { detailOpener.openNodeInfo() }
                 },
             )
 
@@ -213,10 +216,21 @@ class DrawerContent : Screen {
             )
 
             DrawerShortcut(
+                title = LocalStrings.current.settingsAbout,
+                icon = Icons.AutoMirrored.Default.ContactSupport,
+                onSelected = {
+                    scope.launch {
+                        drawerCoordinator.closeDrawer()
+                    }
+                    aboutDialogOpened = true
+                },
+            )
+
+            DrawerShortcut(
                 title = LocalStrings.current.settingsTitle,
                 icon = Icons.Default.Settings,
                 onSelected = {
-                    handleOpen { detailOpener.openSettings() }
+                    handleAction { detailOpener.openSettings() }
                 },
             )
         }
@@ -273,11 +287,11 @@ class DrawerContent : Screen {
             )
         }
 
-        if (changeInstanceDialogOpen) {
+        if (changeInstanceDialogOpened) {
             BasicAlertDialog(
                 modifier = Modifier.clip(RoundedCornerShape(CornerSize.xxl)),
                 onDismissRequest = {
-                    changeInstanceDialogOpen = false
+                    changeInstanceDialogOpened = false
                 },
             ) {
                 Column(
@@ -355,6 +369,14 @@ class DrawerContent : Screen {
                     }
                 }
             }
+        }
+
+        if (aboutDialogOpened) {
+            AboutDialog(
+                onClose = {
+                    aboutDialogOpened = false
+                },
+            )
         }
     }
 }

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/about/AboutConstants.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/about/AboutConstants.kt
@@ -1,4 +1,4 @@
-package com.livefast.eattrash.raccoonforfriendica.feature.settings.about
+package com.livefast.eattrash.raccoonforfriendica.feature.drawer.about
 
 internal object AboutConstants {
     const val CHANGELOG_URL =

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/about/AboutDialog.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/about/AboutDialog.kt
@@ -1,4 +1,4 @@
-package com.livefast.eattrash.raccoonforfriendica.feature.settings.about
+package com.livefast.eattrash.raccoonforfriendica.feature.drawer.about
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -45,6 +45,11 @@ fun AboutDialog(onClose: (() -> Unit)? = null) {
     val appInfo by appInfoRepository.appInfo.collectAsState()
     val detailOpener = remember { getDetailOpener() }
 
+    fun handleAction(block: () -> Unit) {
+        onClose?.invoke()
+        block()
+    }
+
     BasicAlertDialog(
         modifier = Modifier.clip(RoundedCornerShape(CornerSize.xxl)),
         onDismissRequest = {
@@ -83,14 +88,18 @@ fun AboutDialog(onClose: (() -> Unit)? = null) {
                         icon = Icons.AutoMirrored.Default.Article,
                         textDecoration = TextDecoration.Underline,
                         onClick = {
-                            uriHandler.openUri(AboutConstants.CHANGELOG_URL)
+                            handleAction {
+                                uriHandler.openUri(AboutConstants.CHANGELOG_URL)
+                            }
                         },
                     )
                 }
                 item {
                     Button(
                         onClick = {
-                            detailOpener.openUserFeedback()
+                            handleAction {
+                                detailOpener.openUserFeedback()
+                            }
                         },
                     ) {
                         Text(
@@ -106,7 +115,9 @@ fun AboutDialog(onClose: (() -> Unit)? = null) {
                         text = LocalStrings.current.settingsAboutViewGithub,
                         textDecoration = TextDecoration.Underline,
                         onClick = {
-                            uriHandler.openUri(AboutConstants.WEBSITE_URL)
+                            handleAction {
+                                uriHandler.openUri(AboutConstants.WEBSITE_URL)
+                            }
                         },
                     )
                 }
@@ -116,7 +127,9 @@ fun AboutDialog(onClose: (() -> Unit)? = null) {
                         text = LocalStrings.current.settingsAboutViewFriendica,
                         textDecoration = TextDecoration.Underline,
                         onClick = {
-                            uriHandler.openUri(AboutConstants.GROUP_URL)
+                            handleAction {
+                                uriHandler.openUri(AboutConstants.GROUP_URL)
+                            }
                         },
                     )
                 }
@@ -126,7 +139,9 @@ fun AboutDialog(onClose: (() -> Unit)? = null) {
                         icon = Icons.Default.Gavel,
                         textDecoration = TextDecoration.Underline,
                         onClick = {
-                            detailOpener.openLicences()
+                            handleAction {
+                                detailOpener.openLicences()
+                            }
                         },
                     )
                 }

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/about/AboutItem.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/about/AboutItem.kt
@@ -1,4 +1,4 @@
-package com.livefast.eattrash.raccoonforfriendica.feature.settings.about
+package com.livefast.eattrash.raccoonforfriendica.feature.drawer.about
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Explicit
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Style
@@ -66,7 +65,6 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toIcon
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toReadableName
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.UrlOpeningMode
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.toReadableName
-import com.livefast.eattrash.raccoonforfriendica.feature.settings.about.AboutDialog
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 
@@ -87,7 +85,6 @@ class SettingsScreen : Screen {
         var themeColorBottomSheetOpened by remember { mutableStateOf(false) }
         var defaultTimelineTypeBottomSheetOpened by remember { mutableStateOf(false) }
         var urlOpeningModeBottomSheetOpened by remember { mutableStateOf(false) }
-        var aboutDialogOpened by remember { mutableStateOf(false) }
         var customColorPickerDialogOpened by remember { mutableStateOf(false) }
         var defaultPostVisibilityBottomSheetOpened by remember { mutableStateOf(false) }
         var defaultReplyVisibilityBottomSheetOpened by remember { mutableStateOf(false) }
@@ -305,18 +302,6 @@ class SettingsScreen : Screen {
                             value = uiState.blurNsfw,
                             onValueChanged = {
                                 model.reduce(SettingsMviModel.Intent.ChangeBlurNsfw(it))
-                            },
-                        )
-
-                        SettingsHeader(
-                            icon = Icons.Default.BugReport,
-                            title = LocalStrings.current.settingsSectionDebug,
-                        )
-                        SettingsRow(
-                            title = LocalStrings.current.settingsAbout,
-                            disclosureIndicator = true,
-                            onTap = {
-                                aboutDialogOpened = true
                             },
                         )
 
@@ -680,14 +665,6 @@ class SettingsScreen : Screen {
                             ),
                         )
                     }
-                },
-            )
-        }
-
-        if (aboutDialogOpened) {
-            AboutDialog(
-                onClose = {
-                    aboutDialogOpened = false
                 },
             )
         }


### PR DESCRIPTION
In order to simplify the settings screen, it's better to move the "App information" item, which opens the `AboutDialog`, to the navigation drawer.

Additionally, this fixes a layout issue in setting rows adding some space between the title and the subtitle of each item.