### PR TITLE
fix: prevent spoilers from autoclosing

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SpoilerCard.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SpoilerCard.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
 import com.livefast.eattrash.raccoonforfriendica.core.htmlparse.parseHtml
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
 
@@ -37,6 +38,7 @@ fun SpoilerCard(
     onClick: (() -> Unit)? = null,
 ) {
     val fullColor = MaterialTheme.colorScheme.onBackground
+    val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha)
     var contentHeightPx by remember { mutableStateOf(0f) }
     val contentHeightDp = with(LocalDensity.current) { contentHeightPx.toDp() }
     val annotatedContent =
@@ -88,7 +90,7 @@ fun SpoilerCard(
                     } else {
                         LocalStrings.current.actionRevealContent
                     },
-                style = MaterialTheme.typography.labelMedium.copy(color = fullColor),
+                style = MaterialTheme.typography.labelMedium.copy(color = ancillaryColor),
             )
         }
         SpoilerBar(

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
@@ -60,7 +60,6 @@ fun TimelineItem(
     onOpenImage: ((List<String>, Int, List<Int>) -> Unit)? = null,
     onOptionSelected: ((OptionId) -> Unit)? = null,
     onPollVote: ((TimelineEntryModel, List<Int>) -> Unit)? = null,
-    onToggleSpoilerActive: ((TimelineEntryModel) -> Unit)? = null,
 ) {
     val isReblog = entry.reblog != null
     val isReply = entry.inReplyTo != null
@@ -170,6 +169,7 @@ fun TimelineItem(
             }
 
             // post spoiler
+            var spoilerActive by remember { mutableStateOf(false) }
             if (spoiler.isNotEmpty()) {
                 SpoilerCard(
                     modifier =
@@ -178,20 +178,16 @@ fun TimelineItem(
                             horizontal = contentHorizontalPadding,
                         ),
                     content = spoiler,
-                    active = entryToDisplay.isSpoilerActive,
+                    active = spoilerActive,
                     onClick = {
-                        onToggleSpoilerActive?.invoke(entryToDisplay)
+                        spoilerActive = !spoilerActive
                     },
                 )
             }
 
-            val contentVisible =
-                remember(entryToDisplay.isSpoilerActive) {
-                    entryToDisplay.isSpoilerActive || spoiler.isEmpty()
-                }
             AnimatedVisibility(
                 modifier = Modifier.padding(horizontal = contentHorizontalPadding),
-                visible = contentVisible,
+                visible = spoilerActive || spoiler.isEmpty(),
             ) {
                 Column(
                     verticalArrangement = Arrangement.spacedBy(Spacing.xs),
@@ -269,7 +265,7 @@ fun TimelineItem(
                                             .takeIf { !entryToDisplay.content.startsWith(it) }
                                             .orEmpty(),
                                     image = preview.image.takeIf { attachments.isEmpty() },
-                                ),
+                            ),
                             onOpen = onOpenUrl,
                             onOpenImage = { url ->
                                 onOpenImage?.invoke(listOf(url), 0, emptyList())

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/TimelineEntryModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/TimelineEntryModel.kt
@@ -21,7 +21,6 @@ data class TimelineEntryModel(
     @Transient val favoriteLoading: Boolean = false,
     val id: String,
     val inReplyTo: TimelineEntryModel? = null,
-    @Transient val isSpoilerActive: Boolean = false,
     val lang: String? = null,
     @Transient val loadMoreButtonVisible: Boolean = false,
     val mentions: List<UserModel> = emptyList(),

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailMviModel.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailMviModel.kt
@@ -51,10 +51,6 @@ interface EntryDetailMviModel :
             val choices: List<Int>,
         ) : Intent
 
-        data class ToggleSpoilerActive(
-            val entry: TimelineEntryModel,
-        ) : Intent
-
         data class CopyToClipboard(
             val entry: TimelineEntryModel,
         ) : Intent

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -312,9 +312,6 @@ class EntryDetailScreen(
                                         )
                                     }
                                 },
-                            onToggleSpoilerActive = { e ->
-                                model.reduce(EntryDetailMviModel.Intent.ToggleSpoilerActive(e))
-                            },
                             options =
                                 buildList {
                                     if (actionRepository.canShare(entry.original)) {

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailViewModel.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailViewModel.kt
@@ -112,7 +112,6 @@ class EntryDetailViewModel(
                 )
             is EntryDetailMviModel.Intent.TogglePin -> togglePin(intent.entry)
             is EntryDetailMviModel.Intent.SubmitPollVote -> submitPoll(intent.entry, intent.choices)
-            is EntryDetailMviModel.Intent.ToggleSpoilerActive -> toggleSpoiler(intent.entry)
             is EntryDetailMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
         }
     }
@@ -401,12 +400,6 @@ class EntryDetailViewModel(
                 updateEntryInState(entry.id) { it.copy(poll = poll.copy(loading = false)) }
                 emitEffect(EntryDetailMviModel.Effect.PollVoteFailure)
             }
-        }
-    }
-
-    private fun toggleSpoiler(entry: TimelineEntryModel) {
-        screenModelScope.launch {
-            updateEntryInState(entry.id) { entry.copy(isSpoilerActive = !entry.isSpoilerActive) }
         }
     }
 

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreMviModel.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreMviModel.kt
@@ -66,10 +66,6 @@ interface ExploreMviModel :
             val choices: List<Int>,
         ) : Intent
 
-        data class ToggleSpoilerActive(
-            val entry: TimelineEntryModel,
-        ) : Intent
-
         data class CopyToClipboard(
             val entry: TimelineEntryModel,
         ) : Intent

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
@@ -357,9 +357,6 @@ class ExploreScreen : Screen {
                                                 )
                                             }
                                         },
-                                    onToggleSpoilerActive = { e ->
-                                        model.reduce(ExploreMviModel.Intent.ToggleSpoilerActive(e))
-                                    },
                                     options =
                                         buildList {
                                             val entry = item.entry

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreViewModel.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreViewModel.kt
@@ -130,7 +130,6 @@ class ExploreViewModel(
                 )
             is ExploreMviModel.Intent.TogglePin -> togglePin(intent.entry)
             is ExploreMviModel.Intent.SubmitPollVote -> submitPoll(intent.entry, intent.choices)
-            is ExploreMviModel.Intent.ToggleSpoilerActive -> toggleSpoiler(intent.entry)
             is ExploreMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
         }
     }
@@ -500,12 +499,6 @@ class ExploreViewModel(
                 updateEntryInState(entry.id) { it.copy(poll = poll.copy(loading = false)) }
                 emitEffect(ExploreMviModel.Effect.PollVoteFailure)
             }
-        }
-    }
-
-    private fun toggleSpoiler(entry: TimelineEntryModel) {
-        screenModelScope.launch {
-            updateEntryInState(entry.id) { entry.copy(isSpoilerActive = !entry.isSpoilerActive) }
         }
     }
 

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesMviModel.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesMviModel.kt
@@ -52,10 +52,6 @@ interface FavoritesMviModel :
             val choices: List<Int>,
         ) : Intent
 
-        data class ToggleSpoilerActive(
-            val entry: TimelineEntryModel,
-        ) : Intent
-
         data class CopyToClipboard(
             val entry: TimelineEntryModel,
         ) : Intent

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
@@ -256,9 +256,6 @@ class FavoritesScreen(
                                         inReplyToUser = e.creator,
                                     )
                                 }.takeIf { actionRepository.canReply(entry.original) },
-                            onToggleSpoilerActive = { e ->
-                                model.reduce(FavoritesMviModel.Intent.ToggleSpoilerActive(e))
-                            },
                             onPollVote =
                                 uiState.currentUserId?.let {
                                     { e, choices ->

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesViewModel.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesViewModel.kt
@@ -96,7 +96,6 @@ class FavoritesViewModel(
                 )
             is FavoritesMviModel.Intent.TogglePin -> togglePin(intent.entry)
             is FavoritesMviModel.Intent.SubmitPollVote -> submitPoll(intent.entry, intent.choices)
-            is FavoritesMviModel.Intent.ToggleSpoilerActive -> toggleSpoiler(intent.entry)
             is FavoritesMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
         }
     }
@@ -383,12 +382,6 @@ class FavoritesViewModel(
                 updateEntryInState(entry.id) { it.copy(poll = poll.copy(loading = false)) }
                 emitEffect(FavoritesMviModel.Effect.PollVoteFailure)
             }
-        }
-    }
-
-    private fun toggleSpoiler(entry: TimelineEntryModel) {
-        screenModelScope.launch {
-            updateEntryInState(entry.id) { entry.copy(isSpoilerActive = !entry.isSpoilerActive) }
         }
     }
 

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagMviModel.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagMviModel.kt
@@ -56,10 +56,6 @@ interface HashtagMviModel :
             val choices: List<Int>,
         ) : Intent
 
-        data class ToggleSpoilerActive(
-            val entry: TimelineEntryModel,
-        ) : Intent
-
         data class CopyToClipboard(
             val entry: TimelineEntryModel,
         ) : Intent

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
@@ -287,9 +287,6 @@ class HashtagScreen(
                                         )
                                     }
                                 },
-                            onToggleSpoilerActive = { e ->
-                                model.reduce(HashtagMviModel.Intent.ToggleSpoilerActive(e))
-                            },
                             options =
                                 buildList {
                                     if (actionRepository.canShare(entry.original)) {

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagViewModel.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagViewModel.kt
@@ -105,7 +105,6 @@ class HashtagViewModel(
                 )
             is HashtagMviModel.Intent.TogglePin -> togglePin(intent.entry)
             is HashtagMviModel.Intent.SubmitPollVote -> submitPoll(intent.entry, intent.choices)
-            is HashtagMviModel.Intent.ToggleSpoilerActive -> toggleSpoiler(intent.entry)
             is HashtagMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
         }
     }
@@ -391,12 +390,6 @@ class HashtagViewModel(
                 updateEntryInState(entry.id) { it.copy(poll = poll.copy(loading = false)) }
                 emitEffect(HashtagMviModel.Effect.PollVoteFailure)
             }
-        }
-    }
-
-    private fun toggleSpoiler(entry: TimelineEntryModel) {
-        screenModelScope.launch {
-            updateEntryInState(entry.id) { entry.copy(isSpoilerActive = !entry.isSpoilerActive) }
         }
     }
 

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxMviModel.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxMviModel.kt
@@ -4,7 +4,6 @@ import cafe.adriel.voyager.core.model.ScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationType
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 
 interface InboxMviModel :
     ScreenModel,
@@ -34,10 +33,6 @@ interface InboxMviModel :
 
         data class Dismiss(
             val notification: NotificationModel,
-        ) : Intent
-
-        data class ToggleSpoilerActive(
-            val entry: TimelineEntryModel,
         ) : Intent
     }
 

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
@@ -239,9 +239,6 @@ class InboxScreen : Screen {
                                     }
                                 }
                             },
-                            onToggleSpoilerActive = { e ->
-                                model.reduce(InboxMviModel.Intent.ToggleSpoilerActive(e))
-                            },
                         )
                         if (idx < uiState.notifications.lastIndex) {
                             HorizontalDivider(

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
@@ -90,7 +90,6 @@ class InboxViewModel(
             is InboxMviModel.Intent.MarkAsRead -> markAsRead(intent.notification)
             InboxMviModel.Intent.DismissAll -> dismissAll()
             is InboxMviModel.Intent.Dismiss -> dismiss(intent.notification)
-            is InboxMviModel.Intent.ToggleSpoilerActive -> toggleSpoiler(intent.entry)
         }
     }
 
@@ -314,12 +313,6 @@ class InboxViewModel(
             notificationRepository.dismissAll()
             updateState { it.copy(markAllAsReadLoading = false) }
             refresh()
-        }
-    }
-
-    private fun toggleSpoiler(entry: TimelineEntryModel) {
-        screenModelScope.launch {
-            updateEntryInState(entry.id) { entry.copy(isSpoilerActive = !entry.isSpoilerActive) }
         }
     }
 }

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationItem.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationItem.kt
@@ -51,7 +51,6 @@ internal fun NotificationItem(
     onOpenUser: ((UserModel) -> Unit)? = null,
     onOpenEntry: ((TimelineEntryModel) -> Unit)? = null,
     onUserRelationshipClicked: ((String, RelationshipStatusNextAction) -> Unit)? = null,
-    onToggleSpoilerActive: ((TimelineEntryModel) -> Unit)? = null,
 ) {
     val boxColor = MaterialTheme.colorScheme.surfaceColorAtElevation(5.dp)
     val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha)
@@ -136,7 +135,6 @@ internal fun NotificationItem(
                     },
                     onOpenUser = onOpenUser,
                     onOpenUrl = onOpenUrl,
-                    onToggleSpoilerActive = onToggleSpoilerActive,
                 )
             } else if (user != null) {
                 NotificationUserInfo(

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountMviModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountMviModel.kt
@@ -40,10 +40,6 @@ interface MyAccountMviModel :
             val entry: TimelineEntryModel,
         ) : Intent
 
-        data class ToggleSpoilerActive(
-            val entry: TimelineEntryModel,
-        ) : Intent
-
         data class CopyToClipboard(
             val entry: TimelineEntryModel,
         ) : Intent

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
@@ -305,9 +305,6 @@ object MyAccountScreen : Tab {
                                     inReplyToUser = e.creator,
                                 )
                             }.takeIf { actionRepository.canReply(entry.original) },
-                        onToggleSpoilerActive = { e ->
-                            model.reduce(MyAccountMviModel.Intent.ToggleSpoilerActive(e))
-                        },
                         options =
                             buildList {
                                 if (actionRepository.canShare(entry.original)) {

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
@@ -157,7 +157,6 @@ class MyAccountViewModel(
             is MyAccountMviModel.Intent.ToggleBookmark -> toggleBookmark(intent.entry)
             is MyAccountMviModel.Intent.DeleteEntry -> deleteEntry(intent.entryId)
             is MyAccountMviModel.Intent.TogglePin -> togglePin(intent.entry)
-            is MyAccountMviModel.Intent.ToggleSpoilerActive -> toggleSpoiler(intent.entry)
             is MyAccountMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
         }
     }
@@ -387,12 +386,6 @@ class MyAccountViewModel(
                     }
                 }
             }
-        }
-    }
-
-    private fun toggleSpoiler(entry: TimelineEntryModel) {
-        screenModelScope.launch {
-            updateEntryInState(entry.id) { entry.copy(isSpoilerActive = !entry.isSpoilerActive) }
         }
     }
 

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchMviModel.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchMviModel.kt
@@ -70,10 +70,6 @@ interface SearchMviModel :
             val choices: List<Int>,
         ) : Intent
 
-        data class ToggleSpoilerActive(
-            val entry: TimelineEntryModel,
-        ) : Intent
-
         data class CopyToClipboard(
             val entry: TimelineEntryModel,
         ) : Intent

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
@@ -358,9 +358,6 @@ class SearchScreen : Screen {
                                                 )
                                             }
                                         },
-                                    onToggleSpoilerActive = { e ->
-                                        model.reduce(SearchMviModel.Intent.ToggleSpoilerActive(e))
-                                    },
                                     options =
                                         buildList {
                                             val entry = item.entry

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchViewModel.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchViewModel.kt
@@ -141,7 +141,6 @@ class SearchViewModel(
                 )
             is SearchMviModel.Intent.TogglePin -> togglePin(intent.entry)
             is SearchMviModel.Intent.SubmitPollVote -> submitPoll(intent.entry, intent.choices)
-            is SearchMviModel.Intent.ToggleSpoilerActive -> toggleSpoiler(intent.entry)
             is SearchMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
         }
     }
@@ -510,12 +509,6 @@ class SearchViewModel(
                 updateEntryInState(entry.id) { it.copy(poll = poll.copy(loading = false)) }
                 emitEffect(SearchMviModel.Effect.PollVoteFailure)
             }
-        }
-    }
-
-    private fun toggleSpoiler(entry: TimelineEntryModel) {
-        screenModelScope.launch {
-            updateEntryInState(entry.id) { entry.copy(isSpoilerActive = !entry.isSpoilerActive) }
         }
     }
 

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadMviModel.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadMviModel.kt
@@ -50,10 +50,6 @@ interface ThreadMviModel :
             val choices: List<Int>,
         ) : Intent
 
-        data class ToggleSpoilerActive(
-            val entry: TimelineEntryModel,
-        ) : Intent
-
         data class CopyToClipboard(
             val entry: TimelineEntryModel,
         ) : Intent

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
@@ -311,9 +311,6 @@ class ThreadScreen(
                                             )
                                         }
                                     },
-                                onToggleSpoilerActive = { e ->
-                                    model.reduce(ThreadMviModel.Intent.ToggleSpoilerActive(e))
-                                },
                                 options =
                                     buildList {
                                         val entry = uiState.entry ?: return@buildList

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadViewModel.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadViewModel.kt
@@ -90,7 +90,6 @@ class ThreadViewModel(
                     entryId = intent.entryId,
                 )
             is ThreadMviModel.Intent.SubmitPollVote -> submitPoll(intent.entry, intent.choices)
-            is ThreadMviModel.Intent.ToggleSpoilerActive -> toggleSpoiler(intent.entry)
             is ThreadMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
         }
     }
@@ -371,12 +370,6 @@ class ThreadViewModel(
                 }
                 emitEffect(ThreadMviModel.Effect.PollVoteFailure)
             }
-        }
-    }
-
-    private fun toggleSpoiler(entry: TimelineEntryModel) {
-        screenModelScope.launch {
-            updateEntryInState(entry.id) { entry.copy(isSpoilerActive = !entry.isSpoilerActive) }
         }
     }
 

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineMviModel.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineMviModel.kt
@@ -57,10 +57,6 @@ interface TimelineMviModel :
             val choices: List<Int>,
         ) : Intent
 
-        data class ToggleSpoilerActive(
-            val entry: TimelineEntryModel,
-        ) : Intent
-
         data class CopyToClipboard(
             val entry: TimelineEntryModel,
         ) : Intent

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
@@ -325,9 +325,6 @@ class TimelineScreen : Screen {
                                         inReplyToUser = e.creator,
                                     )
                                 }.takeIf { actionRepository.canReply(entry.original) },
-                            onToggleSpoilerActive = { e ->
-                                model.reduce(TimelineMviModel.Intent.ToggleSpoilerActive(e))
-                            },
                             onPollVote =
                                 uiState.currentUserId?.let {
                                     { e, choices ->

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
@@ -159,7 +159,6 @@ class TimelineViewModel(
                     intent.choices,
                 )
 
-            is TimelineMviModel.Intent.ToggleSpoilerActive -> toggleSpoiler(intent.entry)
             is TimelineMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
         }
     }
@@ -493,12 +492,6 @@ class TimelineViewModel(
                 updateEntryInState(entry.id) { it.copy(poll = poll.copy(loading = false)) }
                 emitEffect(TimelineMviModel.Effect.PollVoteFailure)
             }
-        }
-    }
-
-    private fun toggleSpoiler(entry: TimelineEntryModel) {
-        screenModelScope.launch {
-            updateEntryInState(entry.id) { entry.copy(isSpoilerActive = !entry.isSpoilerActive) }
         }
     }
 

--- a/feature/unpublished/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/unpublished/UnpublishedMviModel.kt
+++ b/feature/unpublished/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/unpublished/UnpublishedMviModel.kt
@@ -18,10 +18,6 @@ interface UnpublishedMviModel :
             val section: UnpublishedType,
         ) : Intent
 
-        data class ToggleSpoilerActive(
-            val entry: TimelineEntryModel,
-        ) : Intent
-
         data class DeleteEntry(
             val entryId: String,
         ) : Intent

--- a/feature/unpublished/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/unpublished/UnpublishedScreen.kt
+++ b/feature/unpublished/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/unpublished/UnpublishedScreen.kt
@@ -201,9 +201,6 @@ class UnpublishedScreen : Screen {
                             blurNsfw = uiState.blurNsfw,
                             maxBodyLines = uiState.maxBodyLines,
                             actionsEnabled = false,
-                            onToggleSpoilerActive = { e ->
-                                model.reduce(UnpublishedMviModel.Intent.ToggleSpoilerActive(e))
-                            },
                             options =
                                 buildList {
                                     this += OptionId.Edit.toOption()

--- a/feature/unpublished/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/unpublished/UnpublishedViewModel.kt
+++ b/feature/unpublished/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/unpublished/UnpublishedViewModel.kt
@@ -96,8 +96,6 @@ class UnpublishedViewModel(
                 screenModelScope.launch {
                     refresh()
                 }
-
-            is UnpublishedMviModel.Intent.ToggleSpoilerActive -> toggleSpoiler(intent.entry)
         }
     }
 
@@ -184,12 +182,6 @@ class UnpublishedViewModel(
                 notificationCenter.send(TimelineEntryDeletedEvent(entryId))
                 removeEntryFromState(entryId)
             }
-        }
-    }
-
-    private fun toggleSpoiler(entry: TimelineEntryModel) {
-        screenModelScope.launch {
-            updateEntryInState(entry.id) { entry.copy(isSpoilerActive = !entry.isSpoilerActive) }
         }
     }
 }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailMviModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailMviModel.kt
@@ -56,10 +56,6 @@ interface UserDetailMviModel :
             val blocked: Boolean,
         ) : Intent
 
-        data class ToggleSpoilerActive(
-            val entry: TimelineEntryModel,
-        ) : Intent
-
         data object TogglePersonalNoteEditMode : Intent
 
         data class SetPersonalNote(

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -614,9 +614,6 @@ class UserDetailScreen(
                                         )
                                     }
                                 },
-                            onToggleSpoilerActive = { e ->
-                                model.reduce(UserDetailMviModel.Intent.ToggleSpoilerActive(e))
-                            },
                             options =
                                 buildList {
                                     if (actionRepository.canShare(entry.original)) {

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailViewModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailViewModel.kt
@@ -111,7 +111,6 @@ class UserDetailViewModel(
                     duration = intent.duration,
                     disableNotifications = intent.disableNotifications,
                 )
-            is UserDetailMviModel.Intent.ToggleSpoilerActive -> toggleSpoiler(intent.entry)
             UserDetailMviModel.Intent.TogglePersonalNoteEditMode ->
                 toggleEditPersonalNote()
 
@@ -478,12 +477,6 @@ class UserDetailViewModel(
                     )
                 }
             }
-        }
-    }
-
-    private fun toggleSpoiler(entry: TimelineEntryModel) {
-        screenModelScope.launch {
-            updateEntryInState(entry.id) { entry.copy(isSpoilerActive = !entry.isSpoilerActive) }
         }
     }
 

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListMviModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListMviModel.kt
@@ -50,10 +50,6 @@ interface ForumListMviModel :
             val choices: List<Int>,
         ) : Intent
 
-        data class ToggleSpoilerActive(
-            val entry: TimelineEntryModel,
-        ) : Intent
-
         data class CopyToClipboard(
             val entry: TimelineEntryModel,
         ) : Intent

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
@@ -378,9 +378,6 @@ class ForumListScreen(
                                         )
                                     }
                                 },
-                            onToggleSpoilerActive = { e ->
-                                model.reduce(ForumListMviModel.Intent.ToggleSpoilerActive(e))
-                            },
                             options =
                                 buildList {
                                     if (actionRepository.canShare(entry.original)) {

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListViewModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListViewModel.kt
@@ -99,7 +99,6 @@ class ForumListViewModel(
                 )
 
             is ForumListMviModel.Intent.SubmitPollVote -> submitPoll(intent.entry, intent.choices)
-            is ForumListMviModel.Intent.ToggleSpoilerActive -> toggleSpoiler(intent.entry)
             is ForumListMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
         }
     }
@@ -365,12 +364,6 @@ class ForumListViewModel(
                 updateEntryInState(entry.id) { it.copy(poll = poll.copy(loading = false)) }
                 emitEffect(ForumListMviModel.Effect.PollVoteFailure)
             }
-        }
-    }
-
-    private fun toggleSpoiler(entry: TimelineEntryModel) {
-        screenModelScope.launch {
-            updateEntryInState(entry.id) { entry.copy(isSpoilerActive = !entry.isSpoilerActive) }
         }
     }
 


### PR DESCRIPTION
This PR fixes a subtle bug due to which spoilers closed immediately after having been opened. Moreover it makes use of a different text color for the hide/reveal subtitle to make it more distinguishable from the spoiler title.