### PR TITLE
refactor: update section selectors

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserSection.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserSection.kt
@@ -13,22 +13,6 @@ sealed interface UserSection {
     data object Media : UserSection
 }
 
-fun UserSection.toInt(): Int =
-    when (this) {
-        UserSection.Posts -> 0
-        UserSection.All -> 1
-        UserSection.Pinned -> 2
-        UserSection.Media -> 3
-    }
-
-fun Int.toAccountSection(): UserSection =
-    when (this) {
-        1 -> UserSection.All
-        2 -> UserSection.Pinned
-        3 -> UserSection.Media
-        else -> UserSection.Posts
-    }
-
 @Composable
 fun UserSection.toReadableName(): String =
     when (this) {

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/UnpublishedType.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/UnpublishedType.kt
@@ -15,15 +15,3 @@ fun UnpublishedType.toReadableName(): String =
         UnpublishedType.Drafts -> LocalStrings.current.unpublishedSectionDrafts
         UnpublishedType.Scheduled -> LocalStrings.current.unpublishedSectionScheduled
     }
-
-fun UnpublishedType.toInt(): Int =
-    when (this) {
-        UnpublishedType.Drafts -> 1
-        UnpublishedType.Scheduled -> 0
-    }
-
-fun Int.toUnpublishedType(): UnpublishedType =
-    when (this) {
-        1 -> UnpublishedType.Drafts
-        else -> UnpublishedType.Scheduled
-    }

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
@@ -78,8 +78,6 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getEntryActionRepository
 import com.livefast.eattrash.raccoonforfriendica.feature.explore.data.ExploreSection
-import com.livefast.eattrash.raccoonforfriendica.feature.explore.data.toExploreSection
-import com.livefast.eattrash.raccoonforfriendica.feature.explore.data.toInt
 import com.livefast.eattrash.raccoonforfriendica.feature.explore.data.toReadableName
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -231,11 +229,10 @@ class ExploreScreen : Screen {
                                 uiState.availableSections.map {
                                     it.toReadableName()
                                 },
-                            currentSection = uiState.section.toInt(),
+                            currentSection = uiState.availableSections.indexOf(uiState.section),
                             onSectionSelected = {
-                                val section = it.toExploreSection()
                                 model.reduce(
-                                    ExploreMviModel.Intent.ChangeSection(section),
+                                    ExploreMviModel.Intent.ChangeSection(uiState.availableSections[it]),
                                 )
                             },
                         )

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/data/ExploreSection.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/data/ExploreSection.kt
@@ -13,22 +13,6 @@ sealed interface ExploreSection {
     data object Suggestions : ExploreSection
 }
 
-fun ExploreSection.toInt(): Int =
-    when (this) {
-        ExploreSection.Hashtags -> 0
-        ExploreSection.Posts -> 1
-        ExploreSection.Links -> 2
-        ExploreSection.Suggestions -> 3
-    }
-
-fun Int.toExploreSection(): ExploreSection =
-    when (this) {
-        0 -> ExploreSection.Hashtags
-        2 -> ExploreSection.Links
-        3 -> ExploreSection.Suggestions
-        else -> ExploreSection.Posts
-    }
-
 @Composable
 fun ExploreSection.toReadableName(): String =
     when (this) {

--- a/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/ManageBlocksScreen.kt
+++ b/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/ManageBlocksScreen.kt
@@ -55,8 +55,6 @@ import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDetailOpe
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.utils.isNearTheEnd
 import com.livefast.eattrash.raccoonforfriendica.feature.manageblocks.data.ManageBlocksSection
-import com.livefast.eattrash.raccoonforfriendica.feature.manageblocks.data.toInt
-import com.livefast.eattrash.raccoonforfriendica.feature.manageblocks.data.toManageBlocksSection
 import com.livefast.eattrash.raccoonforfriendica.feature.manageblocks.data.toReadableName
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -152,6 +150,11 @@ class ManageBlocksScreen : Screen {
                     state = lazyListState,
                 ) {
                     stickyHeader {
+                        val titles =
+                            listOf(
+                                ManageBlocksSection.Muted,
+                                ManageBlocksSection.Blocked,
+                            )
                         SectionSelector(
                             modifier =
                                 Modifier
@@ -160,16 +163,11 @@ class ManageBlocksScreen : Screen {
                                         top = Dimensions.maxTopBarInset * topAppBarState.collapsedFraction,
                                         bottom = Spacing.s,
                                     ),
-                            titles =
-                                listOf(
-                                    ManageBlocksSection.Muted.toReadableName(),
-                                    ManageBlocksSection.Blocked.toReadableName(),
-                                ),
-                            currentSection = uiState.section.toInt(),
+                            titles = titles.map { it.toReadableName() },
+                            currentSection = titles.indexOf(uiState.section),
                             onSectionSelected = {
-                                val section = it.toManageBlocksSection()
                                 model.reduce(
-                                    ManageBlocksMviModel.Intent.ChangeSection(section),
+                                    ManageBlocksMviModel.Intent.ChangeSection(titles[it]),
                                 )
                             },
                         )

--- a/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/data/ManageBlocksSection.kt
+++ b/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/data/ManageBlocksSection.kt
@@ -15,15 +15,3 @@ fun ManageBlocksSection.toReadableName(): String =
         ManageBlocksSection.Blocked -> LocalStrings.current.manageBlocksSectionBlocked
         ManageBlocksSection.Muted -> LocalStrings.current.manageBlocksSectionMuted
     }
-
-fun ManageBlocksSection.toInt(): Int =
-    when (this) {
-        ManageBlocksSection.Muted -> 0
-        ManageBlocksSection.Blocked -> 1
-    }
-
-fun Int.toManageBlocksSection(): ManageBlocksSection =
-    when (this) {
-        1 -> ManageBlocksSection.Blocked
-        else -> ManageBlocksSection.Muted
-    }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
@@ -52,8 +52,6 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.UserField
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.UserHeader
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.UserHeaderPlaceholder
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.UserSection
-import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toAccountSection
-import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toInt
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toOption
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toReadableName
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
@@ -227,6 +225,13 @@ object MyAccountScreen : Tab {
                 }
 
                 stickyHeader {
+                    val titles =
+                        listOf(
+                            UserSection.Posts,
+                            UserSection.All,
+                            UserSection.Pinned,
+                            UserSection.Media,
+                        )
                     SectionSelector(
                         modifier =
                             Modifier
@@ -235,19 +240,12 @@ object MyAccountScreen : Tab {
                                     top = stickyHeaderTopOffset,
                                     bottom = Spacing.s,
                                 ),
-                        titles =
-                            listOf(
-                                UserSection.Posts.toReadableName(),
-                                UserSection.All.toReadableName(),
-                                UserSection.Pinned.toReadableName(),
-                                UserSection.Media.toReadableName(),
-                            ),
+                        titles = titles.map { it.toReadableName() },
                         scrollable = true,
-                        currentSection = uiState.section.toInt(),
+                        currentSection = titles.indexOf(uiState.section),
                         onSectionSelected = {
-                            val section = it.toAccountSection()
                             model.reduce(
-                                MyAccountMviModel.Intent.ChangeSection(section),
+                                MyAccountMviModel.Intent.ChangeSection(titles[it]),
                             )
                         },
                     )

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchMviModel.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchMviModel.kt
@@ -83,7 +83,7 @@ interface SearchMviModel :
         val loading: Boolean = false,
         val initial: Boolean = true,
         val canFetchMore: Boolean = true,
-        val section: SearchSection = SearchSection.Hashtags,
+        val section: SearchSection = SearchSection.Posts,
         val items: List<ExploreItemModel> = emptyList(),
         val blurNsfw: Boolean = true,
         val maxBodyLines: Int = Int.MAX_VALUE,

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
@@ -79,9 +79,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getEntryActionRepository
 import com.livefast.eattrash.raccoonforfriendica.feaure.search.data.SearchSection
-import com.livefast.eattrash.raccoonforfriendica.feaure.search.data.toInt
 import com.livefast.eattrash.raccoonforfriendica.feaure.search.data.toReadableName
-import com.livefast.eattrash.raccoonforfriendica.feaure.search.data.toSearchSection
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -202,6 +200,12 @@ class SearchScreen : Screen {
                     state = lazyListState,
                 ) {
                     stickyHeader {
+                        val titles =
+                            listOf(
+                                SearchSection.Posts,
+                                SearchSection.Users,
+                                SearchSection.Hashtags,
+                            )
                         SectionSelector(
                             modifier =
                                 Modifier
@@ -210,17 +214,11 @@ class SearchScreen : Screen {
                                         top = Dimensions.maxTopBarInset * topAppBarState.collapsedFraction,
                                         bottom = Spacing.s,
                                     ),
-                            titles =
-                                listOf(
-                                    SearchSection.Hashtags.toReadableName(),
-                                    SearchSection.Posts.toReadableName(),
-                                    SearchSection.Users.toReadableName(),
-                                ),
-                            currentSection = uiState.section.toInt(),
+                            titles = titles.map { it.toReadableName() },
+                            currentSection = titles.indexOf(uiState.section),
                             onSectionSelected = {
-                                val section = it.toSearchSection()
                                 model.reduce(
-                                    SearchMviModel.Intent.ChangeSection(section),
+                                    SearchMviModel.Intent.ChangeSection(titles[it]),
                                 )
                             },
                         )

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/data/SearchSection.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/data/SearchSection.kt
@@ -6,29 +6,15 @@ import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
 sealed interface SearchSection {
     data object Posts : SearchSection
 
-    data object Hashtags : SearchSection
-
     data object Users : SearchSection
+
+    data object Hashtags : SearchSection
 }
-
-fun SearchSection.toInt(): Int =
-    when (this) {
-        SearchSection.Hashtags -> 0
-        SearchSection.Posts -> 1
-        SearchSection.Users -> 2
-    }
-
-fun Int.toSearchSection(): SearchSection =
-    when (this) {
-        0 -> SearchSection.Hashtags
-        2 -> SearchSection.Users
-        else -> SearchSection.Posts
-    }
 
 @Composable
 fun SearchSection.toReadableName(): String =
     when (this) {
         SearchSection.Posts -> LocalStrings.current.accountSectionPosts
-        SearchSection.Hashtags -> LocalStrings.current.exploreSectionHashtags
         SearchSection.Users -> LocalStrings.current.searchSectionUsers
+        SearchSection.Hashtags -> LocalStrings.current.exploreSectionHashtags
     }

--- a/feature/unpublished/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/unpublished/UnpublishedScreen.kt
+++ b/feature/unpublished/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/unpublished/UnpublishedScreen.kt
@@ -51,9 +51,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDetailOpe
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UnpublishedType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toInt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toReadableName
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toUnpublishedType
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -145,6 +143,11 @@ class UnpublishedScreen : Screen {
                     state = lazyListState,
                 ) {
                     stickyHeader {
+                        val titles =
+                            listOf(
+                                UnpublishedType.Scheduled,
+                                UnpublishedType.Drafts,
+                            )
                         SectionSelector(
                             modifier =
                                 Modifier
@@ -153,16 +156,11 @@ class UnpublishedScreen : Screen {
                                         top = Dimensions.maxTopBarInset * topAppBarState.collapsedFraction,
                                         bottom = Spacing.s,
                                     ),
-                            titles =
-                                listOf(
-                                    UnpublishedType.Scheduled.toReadableName(),
-                                    UnpublishedType.Drafts.toReadableName(),
-                                ),
-                            currentSection = uiState.section.toInt(),
+                            titles = titles.map { it.toReadableName() },
+                            currentSection = titles.indexOf(uiState.section),
                             onSectionSelected = {
-                                val section = it.toUnpublishedType()
                                 model.reduce(
-                                    UnpublishedMviModel.Intent.ChangeSection(section),
+                                    UnpublishedMviModel.Intent.ChangeSection(titles[it]),
                                 )
                             },
                         )

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -83,8 +83,6 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.UserField
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.UserHeader
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.UserHeaderPlaceholder
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.UserSection
-import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toAccountSection
-import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toInt
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toOption
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toReadableName
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
@@ -506,6 +504,13 @@ class UserDetailScreen(
                     }
 
                     stickyHeader {
+                        val titles =
+                            listOf(
+                                UserSection.Posts,
+                                UserSection.All,
+                                UserSection.Pinned,
+                                UserSection.Media,
+                            )
                         SectionSelector(
                             modifier =
                                 Modifier
@@ -514,21 +519,12 @@ class UserDetailScreen(
                                         top = stickyHeaderTopOffset,
                                         bottom = Spacing.s,
                                     ),
-                            titles =
-                                listOf(
-                                    UserSection.Posts.toReadableName(),
-                                    UserSection.All.toReadableName(),
-                                    UserSection.Pinned.toReadableName(),
-                                    UserSection.Media.toReadableName(),
-                                ),
+                            titles = titles.map { it.toReadableName() },
                             scrollable = true,
-                            currentSection = uiState.section.toInt(),
+                            currentSection = titles.indexOf(uiState.section),
                             onSectionSelected = {
-                                val section = it.toAccountSection()
                                 model.reduce(
-                                    UserDetailMviModel.Intent.ChangeSection(
-                                        section,
-                                    ),
+                                    UserDetailMviModel.Intent.ChangeSection(titles[it]),
                                 )
                             },
                         )


### PR DESCRIPTION
This PR makes more robust section selectors by not relying any more on positional indices, making it easier to reorder them  or change the initial selection.

Moreover, it makes the Search screen open in the Posts section by default.