### PR TITLE
chore: add test for LruCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ The app is under ongoing development, here is a list of the features that are be
 - [x] support for post addons (spoilers and titles)
 - [x] multi-account
 - [x] edit one's own profile (custom fields and images not supported yet by the back-end)
-- [x] direct messages
-- [x] photo gallery
+- [x] direct messages (Friendica-specific)
+- [x] photo gallery (Friendica-specific)
 - [x] advanced media visualization (videos, GIFs, multiple images)
-- [x] scheduled posts and drafts
-- [x] report posts and users
+- [x] scheduled posts and local drafts
+- [x] create reports for posts and users 
 - [x] custom emojis
-- [x] event calendar
+- [x] calendar (Friendica-specific + read-only, creating events is not supported yet by the back-end)
 
 ## Technologies used
 

--- a/core/utils/build.gradle.kts
+++ b/core/utils/build.gradle.kts
@@ -57,6 +57,13 @@ kotlin {
                 implementation(libs.ktor.darwin)
             }
         }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation(libs.kotlinx.coroutines.test)
+                implementation(libs.turbine)
+            }
+        }
     }
 }
 

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/cache/LruCache.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/cache/LruCache.kt
@@ -14,7 +14,7 @@ class LruCache<K, V>(
     ) {
         if (keysSortedByLastAccess.contains(key)) {
             keysSortedByLastAccess.remove(key)
-        } else if (keysSortedByLastAccess.size > capacity) {
+        } else if (keysSortedByLastAccess.size >= capacity) {
             keysSortedByLastAccess.lastOrNull()?.also { lastKey ->
                 keysSortedByLastAccess.remove(lastKey)
                 map.remove(lastKey)

--- a/core/utils/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/cache/LruCacheTest.kt
+++ b/core/utils/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/cache/LruCacheTest.kt
@@ -1,0 +1,118 @@
+package com.livefast.eattrash.raccoonforfriendica.core.utils.cache
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class LruCacheTest {
+    private val sut = LruCache<String, Any>(CAPACITY)
+
+    @Test
+    fun `given ley not in cache when get then result is as expected`() {
+        val key = "key"
+
+        val res = sut.containsKey(key)
+
+        assertFalse(res)
+    }
+
+    @Test
+    fun `given key in cache when get then result is as expected`() {
+        val key = "key"
+        sut.put(key, "value")
+
+        val res = sut.containsKey(key)
+
+        assertTrue(res)
+    }
+
+    @Test
+    fun `given value not in cache when get then result is as expected`() {
+        val key = "key"
+
+        val res = sut.get(key)
+
+        assertNull(res)
+    }
+
+    @Test
+    fun `given value in cache when get then result is as expected`() {
+        val key = "key"
+        val value = "value"
+        sut.put(key, value)
+
+        val res = sut.get(key)
+
+        assertNotNull(res)
+        assertEquals(value, res)
+    }
+
+    @Test
+    fun `when clear then result is as expected`() {
+        val key = "key"
+        sut.put(key, "value")
+
+        sut.clear()
+        val res = sut.get(key)
+
+        assertNull(res)
+    }
+
+    @Test
+    fun `when remove then result is as expected`() {
+        val key = "key"
+        sut.put(key, "value")
+
+        sut.remove(key)
+        val res = sut.get(key)
+
+        assertNull(res)
+    }
+
+    @Test
+    fun `given empty when remove then result is as expected`() {
+        val key = "key"
+
+        sut.remove(key)
+        val res = sut.get(key)
+
+        assertNull(res)
+    }
+
+    @Test
+    fun `given capacity exceeded when put then oldest items are discarded`() {
+        repeat(CAPACITY + 1) { idx ->
+            val key = "key$idx"
+            sut.put(key, "value$idx")
+        }
+
+        val res0 = sut.get("key0")
+        assertNull(res0)
+        val res1 = sut.get("key1")
+        assertNotNull(res1)
+    }
+
+    @Test
+    fun `given capacity exceeded when put then last referenced items are discarded`() {
+        repeat(CAPACITY) { idx ->
+            val key = "key$idx"
+            sut.put(key, "value$idx")
+        }
+        // reference first item
+        sut.get("key0")
+        // put additional item afterwards
+        sut.put("key11", "value11")
+
+        val res0 = sut.get("key0")
+        assertNotNull(res0)
+        val res1 = sut.get("key1")
+        assertNull(res1)
+    }
+
+    companion object {
+        private const val CAPACITY = 10
+    }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,7 +86,9 @@ Here is a list of the most important features of the app:
 - multi-account with easy ability to switch between accounts (and, in anonymous mode, to switch
   instance);
 - send direct messages (only on Friendica) to other users and see conversations;
-- manage one's own photo gallery (only on Friendica).
+- manage one's own photo gallery (only on Friendica);
+- view one's own calendar (only on Friendica) in read-only mode (creating events is not supported by
+  the back-end yet).
 
 # Acknowledgements
 


### PR DESCRIPTION
As per title. Additionally, an off-by-one (causing caches to have 1 element over their declared limit) has been fixed.