### PR TITLE
refactor: create utility to substitute regexes iteratively; add experimental support to images in post bodies

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TextWithCustomEmojis.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TextWithCustomEmojis.kt
@@ -18,10 +18,10 @@ import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.em
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomImage
+import com.livefast.eattrash.raccoonforfriendica.core.utils.substituteAllOccurrences
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EmojiModel
 
 private val EMOJI_REGEX = Regex(":(\\w+):")
@@ -40,36 +40,24 @@ fun TextWithCustomEmojis(
     onTextLayout: (TextLayoutResult) -> Unit = {},
     onClick: ((Int) -> Unit) = {},
 ) {
-    var index = 0
-    val occurrences = EMOJI_REGEX.findAll(text)
     val foundEmojis = mutableListOf<EmojiModel>()
     val processedText =
-        buildAnnotatedString {
-            for (occurrence in occurrences) {
-                val (start, end) = occurrence.range.first to occurrence.range.last
-                if (start > index) {
-                    append(text.subSequence(startIndex = index, endIndex = start))
-                }
-                val emojiCode =
-                    occurrence.groups
-                        .first()
-                        ?.value
-                        .orEmpty()
-                        .trim(':')
-                val foundEmoji = emojis.firstOrNull { it.code == emojiCode }
-                if (foundEmoji != null) {
-                    appendInlineContent(
-                        id = emojiCode,
-                        alternateText = occurrence.value,
-                    )
-                    foundEmojis += foundEmoji
-                } else {
-                    append(occurrence.value)
-                }
-                index = end + 1
-            }
-            if (index < text.length) {
-                append(text.subSequence(startIndex = index, endIndex = text.length))
+        EMOJI_REGEX.substituteAllOccurrences(text) { occurrence ->
+            val emojiCode =
+                occurrence.groups
+                    .first()
+                    ?.value
+                    .orEmpty()
+                    .trim(':')
+            val foundEmoji = emojis.firstOrNull { it.code == emojiCode }
+            if (foundEmoji != null) {
+                appendInlineContent(
+                    id = emojiCode,
+                    alternateText = occurrence.value,
+                )
+                foundEmojis += foundEmoji
+            } else {
+                append(occurrence.value)
             }
         }
     val inlineContent =

--- a/core/htmlparse/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/htmlparse/ParseHtml.kt
+++ b/core/htmlparse/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/htmlparse/ParseHtml.kt
@@ -60,11 +60,17 @@ fun String.parseHtml(
                             builder.append(" • ")
                         }
                     "code" -> builder.pushStyle(SpanStyle(fontFamily = FontFamily.Monospace))
+                    "img" -> {
+                        val url = attributes["src"]
+                        builder.appendLine()
+                        builder.append("<img src=\"$url\" />")
+                        builder.appendLine()
+                    }
                     else -> println("onOpenTag: Unhandled span $name")
                 }
             }.onCloseTag { name, _ ->
                 when (name) {
-                    "p", "span", "br" -> Unit
+                    "p", "span", "br", "img" -> Unit
                     "b", "strong", "u", "i", "em", "s", "code" -> builder.pop()
                     "a" -> {
                         builder.pop() // corresponds to pushStyle

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/Extensions.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/Extensions.kt
@@ -1,5 +1,8 @@
 package com.livefast.eattrash.raccoonforfriendica.core.utils
 
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.buildAnnotatedString
+
 fun String?.ellipsize(
     length: Int = 100,
     ellipsis: String = "…",
@@ -25,3 +28,39 @@ val String?.nodeName: String?
             }.takeIf { it.isNotEmpty() }
 
 fun Int.isNearTheEnd(list: List<*>): Boolean = this >= list.lastIndex - 5 || list.size <= 5
+
+fun Regex.substituteAllOccurrences(
+    original: String,
+    onMatchResult: StringBuilder.(MatchResult) -> Unit,
+): String =
+    buildString {
+        val matches = findAll(original).toList()
+        var index = 0
+        for (match in matches) {
+            val range = match.range
+            append(original.subSequence(index, range.first))
+            onMatchResult(match)
+            index = range.last + 1
+        }
+        if (index < original.length) {
+            append(original.subSequence(index, original.length))
+        }
+    }
+
+fun Regex.substituteAllOccurrences(
+    original: AnnotatedString,
+    onMatchResult: AnnotatedString.Builder.(MatchResult) -> Unit,
+): AnnotatedString =
+    buildAnnotatedString {
+        val matches = findAll(original).toList()
+        var index = 0
+        for (match in matches) {
+            val range = match.range
+            append(original.subSequence(index, range.first))
+            onMatchResult(match)
+            index = range.last + 1
+        }
+        if (index < original.length) {
+            append(original.subSequence(index, original.length))
+        }
+    }

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/utils/ComposerRegexes.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/utils/ComposerRegexes.kt
@@ -3,8 +3,10 @@ package com.livefast.eattrash.raccoonforfriendica.feature.composer.utils
 internal object ComposerRegexes {
     val USER_MENTION =
         Regex("@(?<handlePrefix>[a-zA-Z0-9-_.]+?(@[a-zA-Z0-9_.]+)?)(?=\\b)")
-    val SHARE =
-        Regex("\\[share](?<url>.*?)\\[share]")
+    val BBCODE_SHARE =
+        Regex("\\[share](?<url>.*?)\\[/share]")
     val HASHTAG =
-        Regex("#(?<tag>.*?)(?=\\b)")
+        Regex("#(?<hashtag>.+?)(?=\\b)")
+    val BBCODE_URL =
+        Regex("\\[url=(?<url>.*?)](?<anchor>.*?)\\[/url]")
 }

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/utils/DefaultPrepareForPreviewUseCase.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/utils/DefaultPrepareForPreviewUseCase.kt
@@ -1,6 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.composer.utils
 
 import com.livefast.eattrash.raccoonforfriendica.core.utils.nodeName
+import com.livefast.eattrash.raccoonforfriendica.core.utils.substituteAllOccurrences
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.MarkupMode
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
 
@@ -11,12 +12,10 @@ internal class DefaultPrepareForPreviewUseCase(
         text: String,
         mode: MarkupMode,
     ): String =
-        run {
-            when (mode) {
-                MarkupMode.BBCode -> text.convertBBCodeToHtml()
-                MarkupMode.Markdown -> text.convertMarkdownToHtml()
-                else -> text
-            }
+        when (mode) {
+            MarkupMode.BBCode -> text.convertBBCodeToHtml()
+            MarkupMode.Markdown -> text.convertMarkdownToHtml()
+            else -> text
         }.withMentions().withHashtags()
 
     private fun String.convertBBCodeToHtml(): String =
@@ -39,35 +38,41 @@ internal class DefaultPrepareForPreviewUseCase(
             .replace(Regex("\n\n"), "<br /><br />")
             .replace("\n", " ")
             .run {
-                ComposerRegexes.SHARE.replaceAllOccurrences(this) { match ->
+                ComposerRegexes.BBCODE_SHARE.substituteAllOccurrences(this) { match ->
                     val url = match.groups["url"]?.value.orEmpty()
-                    append("<a href=\"$url\">#$url</a>")
+                    append("<a href=\"$url\">$url</a>")
+                }
+            }.run {
+                ComposerRegexes.BBCODE_URL.substituteAllOccurrences(this) { match ->
+                    val url = match.groups["url"]?.value.orEmpty()
+                    val anchor = match.groups["anchor"]?.value.orEmpty()
+                    append("<a href=\"$url\">$anchor</a>")
                 }
             }
 
     private fun String.convertMarkdownToHtml(): String =
         run {
-            Regex("~~(?<content>.*?)~~").replaceAllOccurrences(this) { match ->
+            Regex("~~(?<content>.*?)~~").substituteAllOccurrences(this) { match ->
                 val content = match.groups["content"]?.value.orEmpty()
                 append("<s>$content</s>")
             }
         }.run {
-            Regex("_(?<content>.*?)_").replaceAllOccurrences(this) { match ->
+            Regex("_(?<content>.*?)_").substituteAllOccurrences(this) { match ->
                 val content = match.groups["content"]?.value.orEmpty()
                 append("<i>$content</i>")
             }
         }.run {
-            Regex("\\*\\*(?<content>.*?)\\*\\*").replaceAllOccurrences(this) { match ->
+            Regex("\\*\\*(?<content>.*?)\\*\\*").substituteAllOccurrences(this) { match ->
                 val content = match.groups["content"]?.value.orEmpty()
                 append("<b>$content</b>")
             }
         }.run {
-            Regex("`(?<content>.*?)`").replaceAllOccurrences(this) { match ->
+            Regex("`(?<content>.*?)`").substituteAllOccurrences(this) { match ->
                 val content = match.groups["content"]?.value.orEmpty()
                 append("<code>$content</code>")
             }
         }.run {
-            Regex("\\[(?<anchor>.*?)]\\((?<url>.*?)\\)").replaceAllOccurrences(this) { match ->
+            Regex("\\[(?<anchor>.*?)]\\((?<url>.*?)\\)").substituteAllOccurrences(this) { match ->
                 val anchor = match.groups["anchor"]?.value.orEmpty()
                 val url = match.groups["url"]?.value.orEmpty()
                 append("<a href=\"$url\">$anchor</a>")
@@ -77,79 +82,37 @@ internal class DefaultPrepareForPreviewUseCase(
             .replace("<ol>", "\n")
             .replace("</ol>", "\n")
             .run {
-                Regex("^- (?<content>.*?)$").replaceAllOccurrences(this) { match ->
+                Regex("^- (?<content>.*?)$").substituteAllOccurrences(this) { match ->
                     val content = match.groups["content"]?.value.orEmpty()
                     append("<li>$content</li>")
                 }
             }.run {
-                ComposerRegexes.SHARE.replaceAllOccurrences(this) { match ->
+                ComposerRegexes.BBCODE_SHARE.substituteAllOccurrences(this) { match ->
                     val url = match.groups["url"]?.value.orEmpty()
                     append(url)
                 }
             }
 
     private fun String.withMentions(): String =
-        also { original ->
-            val matches = ComposerRegexes.USER_MENTION.findAll(original).toList()
-            buildString {
-                var index = 0
-                for (match in matches) {
-                    val range = match.range
-                    append(original.substring(index, range.first))
-                    val handle = match.groupValues.firstOrNull().orEmpty()
-                    val currentNode = apiConfigurationRepository.node.value
-                    val node = handle.nodeName ?: currentNode
-                    val name = handle.substringBefore("@")
-                    val url =
-                        if (node == currentNode) {
-                            "https://$node/profile/$name"
-                        } else {
-                            "https://$node/users/$name"
-                        }
-                    append("<a href=\"$url\">#$handle</a>")
-                    index = range.last + 1
+        ComposerRegexes.USER_MENTION.substituteAllOccurrences(this) { match ->
+            val handle = match.groups["handlePrefix"]?.value.orEmpty()
+            val currentNode = apiConfigurationRepository.node.value
+            val node = handle.nodeName ?: currentNode
+            val name = handle.substringBefore("@")
+            val url =
+                if (node == currentNode) {
+                    "https://$node/profile/$name"
+                } else {
+                    "https://$node/users/$name"
                 }
-                if (index < original.length) {
-                    append(original.substring(index, original.length))
-                }
-            }
+            append("<a href=\"$url\">@$handle</a>")
         }
 
     private fun String.withHashtags(): String =
-        also { original ->
-            val matches = ComposerRegexes.HASHTAG.findAll(original).toList()
-            buildString {
-                var index = 0
-                for (match in matches) {
-                    val range = match.range
-                    append(original.substring(index, range.first))
-                    val tag = match.groupValues.firstOrNull().orEmpty()
-                    val node = apiConfigurationRepository.node.value
-                    val url = "https://$node/search?tag=$tag"
-                    append("<a href=\"$url\">#$tag</a>")
-                    index = range.last + 1
-                }
-                if (index < original.length) {
-                    append(original.substring(index, original.length))
-                }
-            }
+        ComposerRegexes.HASHTAG.substituteAllOccurrences(this) { match ->
+            val tag = match.groups["hashtag"]?.value.orEmpty()
+            val node = apiConfigurationRepository.node.value
+            val url = "https://$node/search?tag=$tag"
+            append("<a href=\"$url\">#$tag</a>")
         }
 }
-
-private fun Regex.replaceAllOccurrences(
-    original: String,
-    onMatchResult: StringBuilder.(MatchResult) -> Unit,
-): String =
-    buildString {
-        val matches = findAll(original).toList()
-        var index = 0
-        for (match in matches) {
-            val range = match.range
-            append(original.substring(index, range.first))
-            onMatchResult(match)
-            index = range.last + 1
-        }
-        if (index < original.length) {
-            append(original.substring(index, original.length))
-        }
-    }


### PR DESCRIPTION
This PR introduce consistent uages in all the app of two extension functions (`substituteAllOccurrences`) to rewrite all occurrences of a given `Regex` within a `String` or `AnnotatedString`.

Moreover, it fixes a couple of bugs in post in-app preview:
- hashtags were not recognized properly under certain circumstances;
- BBCode URLs where not substituted with links.

Finally, it adds experimental support to images inside post bodies.