### PR TITLE
feat: add support for post extended content

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/StatusAddons.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/StatusAddons.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class StatusAddons(
     @SerialName("title") val title: String? = null,
+    @SerialName("content") val content: String? = null,
     @SerialName("disliked") val disliked: Boolean? = null,
     @SerialName("dislikes_count") val dislikesCount: Int? = null,
     @SerialName("platform") val platform: String? = null,

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/AlbumImageItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/AlbumImageItem.kt
@@ -90,6 +90,7 @@ fun AlbumImageItem(
                         onClick?.invoke()
                     },
             url = attachment.thumbnail ?: attachment.url,
+            contentDescription = attachment.description,
             quality = FilterQuality.Low,
             contentScale = ContentScale.FillWidth,
         )

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentImage.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentImage.kt
@@ -92,6 +92,7 @@ fun ContentImage(
                         onClick?.invoke()
                     },
             url = url,
+            contentDescription = altText,
             quality = FilterQuality.Low,
             blurred = !revealing,
             contentScale = contentScale,

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
@@ -100,7 +100,8 @@ internal fun Status.toModelWithReply() =
 internal fun Status.toModel() =
     TimelineEntryModel(
         attachments = attachments.map { it.toModel() },
-        content = content,
+        // taking HTML content from Friendica-specific add-ons if available (with embedded images)
+        content = addons?.content.takeIf { !it.isNullOrBlank() } ?: content,
         bookmarked = bookmarked,
         card = card?.toModel(),
         created = createdAt,
@@ -124,7 +125,8 @@ internal fun Status.toModel() =
         // needed because, for compatibility, Friendica titles are replicated as spoilers on Mastodon
         spoiler = spoiler.takeIf { it != addons?.title },
         tags = tags.map { it.toModel() },
-        title = addons?.title?.takeIf { it.isNotBlank() },
+        // taking content from Friendica-specific add-ons if available
+        title = addons?.title.takeIf { !it.isNullOrBlank() },
         updated = editedAt,
         url = url,
         visibility = visibility.toVisibility(),


### PR DESCRIPTION
This PR adds support for the `content` property in Friendica add-ons to posts, which will allow embedded images in posts.

<details><summary><h4>Related PRs</h4></summary>

- #399 
</details>

Back-end counterpart: https://github.com/friendica/friendica/pull/14501 