### PR TITLE
feat: add hide_collections in profile settings; add matrix room in about; add manual sections

### DIFF
--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
@@ -404,4 +404,6 @@ internal val DeStrings =
             }
 
         override val settingsAboutUserManual = "Benutzerhandbuch"
+        override val editProfileItemHideCollections = "Follower und Followerlisten privat machen"
+        override val settingsAboutMatrix = "Matrix-Raum beitreten"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -402,4 +402,6 @@ internal open class DefaultStrings : Strings {
         }
 
     override val settingsAboutUserManual = "User manual"
+    override val editProfileItemHideCollections = "Make following and follower lists private"
+    override val settingsAboutMatrix = "Join Matrix room"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/EsStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/EsStrings.kt
@@ -404,4 +404,7 @@ internal val EsStrings =
             }
 
         override val settingsAboutUserManual = "Manual del usuario"
+        override val editProfileItemHideCollections =
+            "Hacer privadas las listas de seguidores y seguidos"
+        override val settingsAboutMatrix = "Unirse a la sala Matrix"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/FrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/FrStrings.kt
@@ -408,4 +408,7 @@ internal val FrStrings =
             }
 
         override val settingsAboutUserManual = "Manuel de l'utilisateur"
+        override val editProfileItemHideCollections =
+            "Rendre les listes de suiveurs et de suivis privées"
+        override val settingsAboutMatrix = "Rejoindre la salle Matrix"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -404,4 +404,7 @@ internal val ItStrings =
             }
 
         override val settingsAboutUserManual = "Manuale utente"
+        override val editProfileItemHideCollections =
+            "Rendi privati gli elenchi di seguiti e seguaci"
+        override val settingsAboutMatrix = "Entra nella room Matrix"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/PlStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/PlStrings.kt
@@ -402,4 +402,7 @@ internal val PlStrings =
             }
 
         override val settingsAboutUserManual = "Podręcznik użytkownika"
+        override val editProfileItemHideCollections =
+            "Prywatność list obserwujących i obserwowanych"
+        override val settingsAboutMatrix = "Dołącz do pokoju Matrix"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/PtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/PtStrings.kt
@@ -409,4 +409,7 @@ internal val PtStrings =
             }
 
         override val settingsAboutUserManual = "Manual do utilizador"
+        override val editProfileItemHideCollections =
+            "Tornar privadas as listas de seguidores e de seguidos"
+        override val settingsAboutMatrix = "Join Matrix room"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -358,6 +358,8 @@ interface Strings {
     fun unreadNotificationBody(count: Int): String
 
     val settingsAboutUserManual: String
+    val editProfileItemHideCollections: String
+    val settingsAboutMatrix: String
 }
 
 object Locales {

--- a/docs/manual/main.md
+++ b/docs/manual/main.md
@@ -125,7 +125,8 @@ users) and _forum mode_ (for group accounts).
 
 The screen is made up by two parts:
 
-- a header containing display name, username, banner and avatar, bio and custom fields;
+- a header containing display name, username, banner and avatar, number of following/followers (from
+  which you can open the user list), bio and custom fields;
 - the list of posts created by the user, which has the following sections:
   - **Posts** list of top-level posts by the user;
   - **Posts & replies** all posts including replies by the user;
@@ -189,10 +190,105 @@ unfollow each one of them.
 
 Each item of this list allows to open the corresponding [feed](#hashtag-feed).
 
+## Explore
+
+This section allows you to see the most trending content in the instance you are connected to. The
+screen is divided into the following sections:
+
+- **Hashtags** contains the list of trending hashtags, with the number of people talking about it
+  and a
+  chart about its usage in the last 7 days;<sup><a href="#hashtag-usage-disclaimer">(*)</a></sup>
+- **Posts** list of treding posts
+- **Links** aggregated view of the URLS used most frequently in posts;
+- (only for logged users) **For you** contains the list of follow suggestions for your user.
+
+Opening a hashtag will lead you to the [dedicated feed](#hashtag-feed), opening a post to
+its [detail](#post-detail) and opening a user to the corresponding [profile](#user-profile). Opening
+a link will either open the external browser or custom tabs depending on the "URL opening mode"
+option selected in the [app settings](#application-settings).
+
+<p id="hashtag-usage-disclaimer">
+  * note that on different backends the number or days may vary from 1 (single point) to more
+</p>
+
+## Search
+
+This screen makes it possible to search in the Fediverse: it contains a search field to enter the
+query string and a tab selector to choose the desired result type (either Posts, Users or Hashtags).
+
+Please notice that it is not possible to search unless a non-empty query has been inserted.
+
+Opening a hashtag will lead you to the [dedicated feed](#hashtag-feed), opening a post to
+its [detail](#post-detail) and opening a user to the corresponding [profile](#user-profile).
+
+## Inbox
+
+This screen contains the list of notifications for the events you have subscribed to, so it is only
+available for logged users.
+
+The main content presents the list of notifications, which can be of the following types:
+
+- **Post** a user you enabled notifications for has published a new post;
+- **Edit** a post you have re-shared has been modified by its author;
+- **Mention** you have been mentioned in a post;
+- **Re-share** one of your posts has been re-shared;
+- **Favorite** one of your posts has been added to favorites;
+- **Follow** someone has started following you;
+- **Follow request** someone has sent you a follow request;
+- **Poll** a poll you have participated in has expired.
+
+From the top bar menu it is possible to select/unselect specific categories of notifications to
+filter the results displayed in the list.
+
+Tapping on each item of the list, it is possible to open the [user profile](#user-profile)
+or [post detail](#post-detail).
+
+## Profile
+
+If you are running the app in anonymous mode, the Profile screen contains the Login button to start
+the authentication flow. If, on the other hand, you are already logged in, it looks similar to a
+regular [user profile](#user-profile) but has some additional actions specific for your user.
+
+If you have multiple accounts, in the top app bar you will find a "Manage account" button to switch
+between one another.
+
+### Login
+
+There are two possible ways to login, depending on your preferences (or what your backend allows):
+
+- **OAuth2** (recommended) web-based flow, a browser tab will be opened to log-in and a
+  client-specific token allowing the app to operate on the user's behalf will be generated;
+- **HTTP Basic** (legacy, available on Friendica) this in-app flows involves selecting the instance
+  and inserting your credentials, all API calls will be using HTTP Basic auth header.
+
+Needless to say – but we'll repeat it for the sake of clarity – the recommended way to login is
+OAuth2 because:
+
+- your username/password never go outside browser and remain unknown to all third-party subjects
+  (including the Raccoon app);
+- it has finer-grained access levels, meaning you can control the various _scopes_ each individual
+  token can be used for;
+- tokens can be revoked at any time, making it easier to mitigate potentially unwanted accesses.
+
+### One's own user detail
+
+In the header, instead of the relationship/notification buttons you will find an "Edit profile"
+button to open your [profile preferences](#profile-settings).
+
+## User list
+
+This screen contains a generic list of users; it can be opened either from
+the [post detail](#post-detail) (to see who added a post to favorites or re-shared it) or from
+the [user profile](#user-profile) (to see who is following or followed by a given user). It displays
+the avatar, display name and username of users plus the corresponding relationship status.
+
+You can use the follow/send request/mutuals button to modify your relationship with the given
+account.
+
 ## Follow requests
 
-If in your profile settings you have enabled manual approval for follow requests, this screen
-contains the list of pending follow request you have received.
+If in your [profile settings](#profile-settings) you have enabled manual approval for follow
+requests, this screen contains the list of pending follow request you have received.
 
 For each one of the items you can either accept or reject the request.
 
@@ -206,3 +302,126 @@ This screen contains some information about the current instance you are connect
 - contact account;
 - list of rules members of this server have to comply with;
 - backend type and version.
+
+## App information
+
+This dialog contains more information about the app:
+
+- version name and code;
+- a link to the changelog;
+- a button to open a feedback form;
+- a link to the GitHub main page of the app;
+- a shortcut to the Friendica discussion group for the app;
+- a link to the project's Matrix room;
+- the entry point for the list of licences for the libraries and resources used in the app.
+
+## Profile settings
+
+This screen allows you to edit your profile data and configure (to some extent) the discoverability
+and visibility of your profile.
+
+The profile data which can be edited are:
+
+- display name;
+- bio;
+- avatar;<sup><a href="#user-profile-experimental-disclaimer">(*)</a></sup>
+- banner;<sup><a href="#user-profile-experimental-disclaimer">(*)</a></sup>
+- custom fields;<sup><a href="#user-profile-experimental-disclaimer">(*)</a></sup>
+- bot (mark account as bot);
+- manual approval of follow requests (`locked`);
+- make account visible in searches (`discoverable`);
+- make following and follower lists private (`hide_collections`);
+- include posts by this account in public timeline (`indexable`).
+
+<p id="user-profile-experimental-disclaimer">
+  * depending on the back-end type these fields may not work, e.g. there are some known compatibility
+issues on some versions of Friendica
+</p>
+
+## Application settings
+
+This screen allows to customize the application appearance and behaviour, it has the following
+sections:
+
+- **General**
+  - **Language**  configures the language for the user interface;
+  - **Default timeline type** configures the timeline type used by default in the Timeline screen
+  - **Default visibility for posts** configures the visibility (`public`, `unlisted`, `private` -
+    i.e. only followers - or `direct` - i.e. ony mentions) used for posts by default;
+  - **Default visibility for replies** configures the visibility used for replies by default;
+  - **URL opening mode** configures how URLs will be opened (external browser or custom tabs);
+  - **Exclude replies from timeline** configures whether replies are included by default in the
+    Timeline screen;
+  - **Open groups in forum mode** by default configures whether group accounts are going to be
+    opened in forum mode (as opposed to classic mode) by default;
+  - **Markup for compositing** determines the type of markup syntax used in new posts (plain text -
+    i.e. no markup – BBCode – Friendica-specific – HTML or Markdown – Mastodon specific);(*)
+  - **Max post body lines** configures the maximum number of lines for posts which will be shown in
+    feeds;
+  - **Check for notifications in background** configures the time interval between background checks
+    for incoming notifications;
+- **Look & Feel**
+  - **UI theme** configures the color theme (light, dark or dark optimized for AMOLED screens);
+  - **Font family** configures the font used in the UI;
+  - **Font size** configures the scale factor applied to fonts in the UI
+  - **Theme color** allows to choose a color to generate a Material 3 palette from;
+  - **Material You** generate a color palette based on the launcher image;
+- **NSFW**
+  - **Manage filters** opens the ban and [filter management](#manage-filters) screen;
+  - **Include NSFW contents** configures a client-side filter to exclude sensitive posts;
+  - **Blur NSFW media** allows, if sensitive contents are included, to blur images and hide videos
+    when they occur in timelines.
+
+## Manage filters
+
+This screen allows to revoke current restrictions on other accounts. It is divided into two
+sections:
+
+- **Muted** for muted accounts;
+- **Bans** for banned ones.
+
+## Post composer
+
+This screen allows to create new posts or replies. The top bar contains the Submit button which can
+have different icons depending on the publishing type:
+
+- a Send icon for regular publication;
+- a Save icon for drafts;
+- a Schedule icon for scheduled posts;
+
+whereas the action menu contains the following items:
+
+- **Save draft** changes the publishing type from regular to draft;
+- **Set schedule** changes the publishing type from regular to scheduled posts;
+- **Insert emoji** allows to insert a custom emoji;
+- **Open preview** opens a preview of the post (only if "Markup for compositing" option in Settings
+  is
+  _not_ plain text);
+- **Add title**/**Remove title** to add or remove a title for the post;
+- **Add image (media gallery)** adds an image from an album in the Friendica media gallery;
+- **Insert list** adds an itemized list;
+- **Add spoiler**/**Remove spoiler** (only if "Markup for compositing" option in Settings is plain
+  text) to add or remove a spoiler for the post;
+- **Add image** (only if "Markup for compositing" option in Settings is plain text) adds an image
+  from
+  the device gallery;
+
+Below the top bar there is a header containing:
+
+- an indication of the current user (who will be the author of the post);
+- the visibility (`public`, `unlisted`, `private`, `direct` or a Friendica circle);
+- the schedule date and time (for scheduled posts);
+- the current character count / character limit according to instance configuration.
+
+Afterwards you can find the main text field for the post body. In the bottom part of the screen,
+only if "Markup for compositing" option in Settings is _not_ plain text, you will find a formatting
+toolbar with the following buttons:
+
+- **Add image** to add an image from the device gallery;
+- **Add link** to add a hyperlink
+- **Bold** to insert some text in bold;
+- **Italic** to insert some text in italic;
+- **Underline** to insert some underlined text;
+- **Strikethrough** to insert some text with a strikethrough effect;
+- Code to insert monospaced font;
+- Toggle spoiler to add or remove a spoiler for the post.

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepository.kt
@@ -339,6 +339,9 @@ internal class DefaultUserRepository(
                         if (hideCollections != null) {
                             append("hide_collections", if (hideCollections) "1" else "0")
                         }
+                        if (indexable != null) {
+                            append("indexable", if (indexable) "1" else "0")
+                        }
                         if (fields != null) {
                             val serializedFields =
                                 buildList {

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/about/AboutConstants.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/about/AboutConstants.kt
@@ -7,4 +7,5 @@ internal object AboutConstants {
     const val GROUP_URL = "https://poliverso.org/users/raccoonforfriendicaapp"
     const val MANUAL_URL =
         "https://livefasteattrashraccoon.github.io/RaccoonForFriendica/manual/main"
+    const val MATRIX_URL = "https://matrix.to/#/#raccoonforfriendicaapp:matrix.org"
 }

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/about/AboutDialog.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/about/AboutDialog.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Article
+import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.filled.Book
 import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Code
@@ -143,6 +144,18 @@ fun AboutDialog(onClose: (() -> Unit)? = null) {
                         onClick = {
                             handleAction {
                                 uriHandler.openUri(AboutConstants.GROUP_URL)
+                            }
+                        },
+                    )
+                }
+                item {
+                    AboutItem(
+                        icon = Icons.AutoMirrored.Default.Chat,
+                        text = LocalStrings.current.settingsAboutMatrix,
+                        textDecoration = TextDecoration.Underline,
+                        onClick = {
+                            handleAction {
+                                uriHandler.openUri(AboutConstants.MATRIX_URL)
                             }
                         },
                     )

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileMviModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileMviModel.kt
@@ -32,6 +32,10 @@ interface EditProfileMviModel :
             val value: Boolean,
         ) : Intent
 
+        data class ChangeHideCollections(
+            val value: Boolean,
+        ) : Intent
+
         data class ChangeNoIndex(
             val value: Boolean,
         ) : Intent
@@ -98,6 +102,7 @@ interface EditProfileMviModel :
         val bot: Boolean = false,
         val locked: Boolean = false,
         val discoverable: Boolean = false,
+        val hideCollections: Boolean = false,
         val noIndex: Boolean = false,
         val fields: List<FieldModel> = emptyList(),
         val canAddFields: Boolean = false,
@@ -130,6 +135,7 @@ interface EditProfileMviModel :
             if (bot != other.bot) return false
             if (locked != other.locked) return false
             if (discoverable != other.discoverable) return false
+            if (hideCollections != other.hideCollections) return false
             if (noIndex != other.noIndex) return false
             if (fields != other.fields) return false
             if (canAddFields != other.canAddFields) return false
@@ -150,6 +156,7 @@ interface EditProfileMviModel :
             result = 31 * result + bot.hashCode()
             result = 31 * result + locked.hashCode()
             result = 31 * result + discoverable.hashCode()
+            result = 31 * result + hideCollections.hashCode()
             result = 31 * result + noIndex.hashCode()
             result = 31 * result + fields.hashCode()
             result = 31 * result + canAddFields.hashCode()

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileScreen.kt
@@ -448,6 +448,15 @@ class EditProfileScreen : Screen {
                 }
                 item {
                     SettingsSwitchRow(
+                        title = LocalStrings.current.editProfileItemHideCollections,
+                        value = uiState.hideCollections,
+                        onValueChanged = {
+                            model.reduce(EditProfileMviModel.Intent.ChangeHideCollections(it))
+                        },
+                    )
+                }
+                item {
+                    SettingsSwitchRow(
                         title = LocalStrings.current.editProfileItemNoIndex,
                         value = uiState.noIndex,
                         onValueChanged = {

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileViewModel.kt
@@ -101,6 +101,16 @@ class EditProfileViewModel(
                     }
                 }
 
+            is EditProfileMviModel.Intent.ChangeHideCollections ->
+                screenModelScope.launch {
+                    updateState {
+                        it.copy(
+                            hideCollections = intent.value,
+                            hasUnsavedChanges = true,
+                        )
+                    }
+                }
+
             is EditProfileMviModel.Intent.ChangeNoIndex ->
                 screenModelScope.launch {
                     updateState {
@@ -293,6 +303,7 @@ class EditProfileViewModel(
                     bot = currentState.bot,
                     locked = currentState.locked,
                     indexable = !currentState.noIndex,
+                    hideCollections = currentState.hideCollections,
                     discoverable = currentState.discoverable,
                     fields = fieldMap,
                     avatar = currentState.avatarBytes,


### PR DESCRIPTION
This PR adds some more sections in the user manual.

Moreover, it fixes a bug due to which the `indexable` field was not affected by the profile settings and adds the `hide_collections` parameter to the call.

The Matrix room can now be opened from the "App information" dialog as well.