### PR TITLE
fix: timeline reload after feed change

### DIFF
--- a/core/htmlparse/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/htmlparse/ParseHtml.kt
+++ b/core/htmlparse/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/htmlparse/ParseHtml.kt
@@ -71,7 +71,7 @@ fun String.parseHtml(
                         builder.append(" />")
                         builder.appendLine()
                     }
-                    else -> println("onOpenTag: Unhandled span $name")
+                    else -> println("onOpenTag: Unhandled tag $name")
                 }
             }.onCloseTag { name, _ ->
                 when (name) {
@@ -87,7 +87,7 @@ fun String.parseHtml(
                         inOrderedList = false
                     }
                     "li" -> builder.appendLine()
-                    else -> println("onCloseTag: Unhandled span $name")
+                    else -> println("onCloseTag: Unhandled tag $name")
                 }
             }.onText { text ->
                 builder.append(text)

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
@@ -105,7 +105,10 @@ class TimelineViewModel(
                     val hasUser =
                         user != null || !apiConfigurationRepository.hasCachedAuthCredentials()
                     if (hasSettings && hasUser) {
-                        refresh(initial = true, forceRefresh = true)
+                        refresh(
+                            initial = true,
+                            forceRefresh = true,
+                        )
                     }
                 }.launchIn(this)
         }
@@ -130,10 +133,16 @@ class TimelineViewModel(
                     }
 
                     updateState {
-                        it.copy(timelineType = intent.type, initial = true)
+                        it.copy(
+                            initial = true,
+                            timelineType = intent.type,
+                        )
                     }
                     emitEffect(TimelineMviModel.Effect.BackToTop)
-                    refresh(initial = true)
+                    refresh(
+                        initial = true,
+                        forceRefresh = true,
+                    )
                 }
 
             is TimelineMviModel.Intent.ToggleReblog -> toggleReblog(intent.entry)


### PR DESCRIPTION
This solves a bug due to which the timeline screen was not reloaded after a feed type change.