### PR TITLE
enhancement: improve startup flow

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/App.kt
@@ -69,8 +69,8 @@ fun App(onLoadingFinished: (() -> Unit)? = null) {
                     )
 
                     if (!isInitialized) {
-                        apiConfigurationRepository.initialize()
                         isInitialized = true
+                        apiConfigurationRepository.initialize()
                         onLoadingFinished?.invoke()
                     }
                 }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
@@ -140,7 +140,7 @@ internal class DefaultTimelinePaginationManager(
                             enableCache = specification.enableCache,
                             refresh = specification.refresh,
                         )
-                        // intended: there is a bug in user pagination
+                        // intended: there is a bug in user post pagination
                         ?.deduplicate()
                         ?.updatePaginationData()
                         ?.filterNsfw(specification.includeNsfw)

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
@@ -23,6 +23,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Iden
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -50,6 +51,7 @@ class MyAccountViewModel(
             identityRepository
                 .currentUser
                 .drop(1)
+                .distinctUntilChanged()
                 .debounce(750)
                 .onEach { user ->
                     val currentUser =
@@ -59,7 +61,7 @@ class MyAccountViewModel(
                     updateState {
                         it.copy(user = currentUser)
                     }
-                    refresh(initial = true, forceRefresh = true)
+                    refresh(initial = true)
                 }.launchIn(this)
             settingsRepository.current
                 .onEach { settings ->


### PR DESCRIPTION
This PR is intended to optimize a couple of issues that may have occurred at application startup or upon account switch:
- potentially multiple GET `v1/apps/verify_credentials` were done during the initialization phase;
- the post list was loaded multiple times when, from the "Manage account" bottom sheet the account changes.