### PR TITLE
fix: image size calculation for autoload

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentImage.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentImage.kt
@@ -90,8 +90,13 @@ fun ContentImage(
             modifier =
                 Modifier
                     .clip(RoundedCornerShape(CornerSize.xl))
-                    .aspectRatio(originalWidth / originalHeight.toFloat())
-                    .clickable {
+                    .then(
+                        if (originalWidth > 0 && originalHeight > 0) {
+                            Modifier.aspectRatio(originalWidth / originalHeight.toFloat())
+                        } else {
+                            Modifier.heightIn(150.dp)
+                        },
+                    ).clickable {
                         onClick?.invoke()
                     },
             url = url,


### PR DESCRIPTION
This PR prevents an IllegalArgumentException due to null aspect ratio for images (which can happen if the original height is not provided by the backend).