### PR TITLE
enhancement: filter out embedded images from attachments

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
@@ -34,6 +34,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomDropDown
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.embeddedImageUrls
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 
 @Composable
@@ -239,7 +240,10 @@ fun TimelineItem(
                                 top = Spacing.s,
                                 bottom = Spacing.xxxs,
                             ),
-                        attachments = entryToDisplay.attachments,
+                        attachments =
+                            entryToDisplay.attachments.filter {
+                                it.url !in entryToDisplay.embeddedImageUrls
+                            },
                         blurNsfw = blurNsfw,
                         autoloadImages = autoloadImages,
                         sensitive = entryToDisplay.sensitive,

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/TimelineEntryModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/TimelineEntryModel.kt
@@ -1,6 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.data
 
 import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.BlurHashParams
+import com.livefast.eattrash.raccoonforfriendica.core.utils.substituteAllOccurrences
 import kotlin.jvm.Transient
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
@@ -102,3 +103,15 @@ val TimelineEntryModel.isNsfw: Boolean get() = reblog?.sensitive ?: sensitive
 
 val Duration.isOldEntry: Boolean
     get() = this > 30.days
+
+private val IMAGE_REGEX = Regex("<img src=\"(?<url>.+?)\"(alt=\"(?<alt>.+?)\")? />")
+
+val TimelineEntryModel.embeddedImageUrls: List<String>
+    get() =
+        buildList {
+            IMAGE_REGEX.substituteAllOccurrences(content) { match ->
+                match.groups["url"]?.value.takeIf { !isNullOrBlank() }?.also { url ->
+                    this@buildList += url
+                }
+            }
+        }

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/composable/TimelineReplyItem.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/composable/TimelineReplyItem.kt
@@ -44,6 +44,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.Option
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.embeddedImageUrls
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 
 @Composable
@@ -199,7 +200,10 @@ fun TimelineReplyItem(
                             start = Spacing.s,
                             end = Spacing.s,
                         ),
-                    attachments = entryToDisplay.attachments,
+                    attachments =
+                        entryToDisplay.attachments.filter {
+                            it.url !in entryToDisplay.embeddedImageUrls
+                        },
                     blurNsfw = blurNsfw,
                     autoloadImages = autoloadImages,
                     sensitive = entryToDisplay.sensitive,


### PR DESCRIPTION
This PR continues the work needed to support embedded images in posts, avoiding the same attachments to be displayed both embedded and at the end of posts.