### PR TITLE
fix: circle list item type (only circles can be edited/deleted/opened)

### DIFF
--- a/domain/identity/usecase/build.gradle.kts
+++ b/domain/identity/usecase/build.gradle.kts
@@ -38,6 +38,7 @@ kotlin {
                 implementation(compose.runtime)
 
                 implementation(libs.koin.core)
+                implementation(libs.kotlinx.coroutines)
 
                 implementation(projects.core.appearance)
                 implementation(projects.core.l10n)

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitor.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitor.kt
@@ -66,19 +66,11 @@ internal class DefaultActiveAccountMonitor(
     }
 
     private suspend fun process(account: AccountModel?) {
-        supportedFeatureRepository.refresh()
-        val supportsBBCode = supportedFeatureRepository.features.value.supportsBBCode
-        val defaultMarkupMode =
-            if (supportsBBCode) {
-                MarkupMode.BBCode
-            } else {
-                MarkupMode.HTML
-            }
-        val defaultSettings = SettingsModel(markupMode = defaultMarkupMode)
         val defaultNode = apiConfigurationRepository.defaultNode
         if (account == null) {
             apiConfigurationRepository.changeNode(defaultNode)
             apiConfigurationRepository.setAuth(null)
+            supportedFeatureRepository.refresh()
 
             contentPreloadManager.preload()
 
@@ -92,6 +84,7 @@ internal class DefaultActiveAccountMonitor(
             val credentials = accountCredentialsCache.get(account.id)
             apiConfigurationRepository.changeNode(node)
             apiConfigurationRepository.setAuth(credentials)
+            supportedFeatureRepository.refresh()
 
             contentPreloadManager.preload(userRemoteId = account.remoteId)
 
@@ -104,4 +97,15 @@ internal class DefaultActiveAccountMonitor(
             inboxManager.refreshUnreadCount()
         }
     }
+
+    private val defaultSettings: SettingsModel
+        get() =
+            SettingsModel(
+                markupMode =
+                    if (supportedFeatureRepository.features.value.supportsBBCode) {
+                        MarkupMode.BBCode
+                    } else {
+                        MarkupMode.HTML
+                    },
+            )
 }


### PR DESCRIPTION
This PR fixes the circle loading making it sure only Friendica circles can be opened and edited (not channels and groups).

This accidentally broke in #416.

Moreover, since determining which items are circles and which are not requires two API calls, these are parallelized to improve performance.