### PR TITLE
fix: notification interval bottom sheet title

### DIFF
--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
@@ -649,7 +649,7 @@ class SettingsScreen : Screen {
 
         if (backgroundNotificationCheckIntervalDialogOpened) {
             CustomModalBottomSheet(
-                title = LocalStrings.current.settingsItemMaxPostBodyLines,
+                title = LocalStrings.current.settingsOptionBackgroundNotificationCheck,
                 items =
                     BACKGROUND_NOTIFICATION_CHECK_INTERVALS.map {
                         CustomModalBottomSheetItem(


### PR DESCRIPTION
The modal bottom sheet to configure the notification check interval had the wrong title (copy-paste error).