### PR TITLE
fix: avoid crash on user or hashtag search

### DIFF
--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultSearchPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultSearchPaginationManager.kt
@@ -123,6 +123,7 @@ internal class DefaultSearchPaginationManager(
             }?.deduplicate()
                 ?.updatePaginationData()
                 ?.fixupCreatorEmojis()
+                ?.fixupInReplyTo()
                 .orEmpty()
         mutex.withLock {
             history.addAll(results)

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
@@ -6,6 +6,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.Timel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isNsfw
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.ReplyHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
@@ -190,7 +191,7 @@ internal class DefaultTimelinePaginationManager(
     private fun List<TimelineEntryModel>.deduplicate(): List<TimelineEntryModel> =
         filter { e1 ->
             history.none { e2 -> e1.id == e2.id }
-        }.distinctBy { it.id }
+        }.distinctBy { it.safeKey }
 
     private fun List<TimelineEntryModel>.filterReplies(included: Boolean): List<TimelineEntryModel> =
         filter {

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
@@ -288,7 +288,7 @@ class SearchScreen : Screen {
                         key = { _, e ->
                             when (e) {
                                 is ExploreItemModel.Entry -> "search-${e.entry.safeKey}"
-                                else -> "search-{e.id}"
+                                else -> "search-${e.id}"
                             }
                         },
                     ) { idx, item ->

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -545,7 +545,7 @@ class UserDetailScreen(
 
                     itemsIndexed(
                         items = uiState.entries,
-                        key = { _, e -> "user-detail-${e.safeKey }" },
+                        key = { _, e -> "user-detail-${e.safeKey}" },
                     ) { idx, entry ->
                         TimelineItem(
                             entry = entry,


### PR DESCRIPTION
This PR fixes some issues in the search screen for result types other than Posts. Moreover, it solves a couple of additional issues:
- post parent-child relationship on Mastodon were not retrieved in search results;
- occasional crashes due to duplicates in post lists (occurred in user detail but may happen elsewhere).