### PR TITLE
fix: opening hashtags on Mastodon

### DIFF
--- a/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/di/UrlHandlerModule.kt
+++ b/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/di/UrlHandlerModule.kt
@@ -31,7 +31,6 @@ val domainUrlHandlerModule =
         }
         single<HashtagProcessor> {
             DefaultHashtagProcessor(
-                apiConfigurationRepository = get(),
                 detailOpener = get(),
             )
         }

--- a/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/HashtagProcessor.kt
+++ b/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/HashtagProcessor.kt
@@ -1,23 +1,29 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor
 
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor.UriHandlerConstants.DETAIL_FRAGMENT
+import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor.UriHandlerConstants.INSTANCE_FRAGMENT
 
 internal interface HashtagProcessor : UrlProcessor
 
 internal class DefaultHashtagProcessor(
-    private val apiConfigurationRepository: ApiConfigurationRepository,
     private val detailOpener: DetailOpener,
 ) : HashtagProcessor {
     override suspend fun process(uri: String): Boolean {
-        val currentNode = apiConfigurationRepository.node.value
-        val tagPrefix = "https://$currentNode/search?tag="
-        if (!uri.startsWith(tagPrefix)) {
-            return false
-        }
+        val tag =
+            listOfNotNull(
+                REGEX_1.find(uri)?.groups?.let { it["tag"]?.value },
+                REGEX_2.find(uri)?.groups?.let { it["tag"]?.value },
+            ).firstOrNull() ?: return false
 
-        val tag = uri.replace(tagPrefix, "")
         detailOpener.openHashtag(tag)
         return true
+    }
+
+    companion object {
+        private val REGEX_1 =
+            Regex("https://(?<instance>$INSTANCE_FRAGMENT)/search\\?tag=(?<tag>$DETAIL_FRAGMENT)")
+        private val REGEX_2 =
+            Regex("https://(?<instance>$INSTANCE_FRAGMENT)/tags/(?<tag>$DETAIL_FRAGMENT)")
     }
 }

--- a/domain/urlhandler/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/DefaultHashtagProcessorTest.kt
+++ b/domain/urlhandler/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/DefaultHashtagProcessorTest.kt
@@ -1,15 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor
 
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
 import dev.mokkery.MockMode
-import dev.mokkery.answering.returns
-import dev.mokkery.every
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertFalse
@@ -17,21 +13,26 @@ import kotlin.test.assertTrue
 
 class DefaultHashtagProcessorTest {
     private val detailOpener = mock<DetailOpener>(mode = MockMode.autoUnit)
-    private val apiConfigurationRepository =
-        mock<ApiConfigurationRepository> {
-            every { node } returns
-                MutableStateFlow(HOST)
-        }
-    private val sut =
-        DefaultHashtagProcessor(
-            detailOpener = detailOpener,
-            apiConfigurationRepository = apiConfigurationRepository,
-        )
+
+    private val sut = DefaultHashtagProcessor(detailOpener = detailOpener)
 
     @Test
-    fun `given valid user when process URL then interactions are as expected`() =
+    fun `given valid URL in format 1 when process URL then interactions are as expected`() =
         runTest {
             val url = "https://$HOST/search?tag=$TAG"
+
+            val res = sut.process(url)
+
+            assertTrue(res)
+            verify {
+                detailOpener.openHashtag(TAG)
+            }
+        }
+
+    @Test
+    fun `given valid URL in format 2 when process URL then interactions are as expected`() =
+        runTest {
+            val url = "https://$HOST/tags/$TAG"
 
             val res = sut.process(url)
 
@@ -55,7 +56,7 @@ class DefaultHashtagProcessorTest {
         }
 
     companion object {
-        private const val HOST = "a.gup.pe"
+        private const val HOST = "example.com"
         private const val TAG = "test"
     }
 }


### PR DESCRIPTION
Opening hashtags on Mastodon did not work for several reasons:
- only URLs referencing the local instance were accepted in the `host/search?tag=<...>` format, which should not not the case;
- URLs in different formats e.g. `host/tags/<...>` were not accepted.

This PR solves both issues.

![PERL regex problems xkcd](https://imgs.xkcd.com/comics/perl_problems.png)