### PR TITLE
fix: calendar header for events in first month

### DIFF
--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
@@ -83,7 +83,8 @@ actual fun Long.extractDatePart(): Pair<Int, Int> {
     val calendar = GregorianCalendar.getInstance()
     calendar.timeInMillis = this
     val year = calendar.get(Calendar.YEAR)
-    val month = calendar.get(Calendar.MONTH)
+    // months are starting from 0
+    val month = calendar.get(Calendar.MONTH) + 1
     return year to month
 }
 


### PR DESCRIPTION
I forgot months are starting from 0 in Java `GregorianCalendar`, this fixes a bug due to which the app crashes when opening the Calendar screen.