### PR TITLE
chore: add test for :feat:nodeinfo module

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -37,7 +37,7 @@ jobs:
           echo $ENCODED_STRING > keystore-b64.txt
           base64 -d keystore-b64.txt > composeApp/keystore.jks
 
-      - name: Build
+      - name: Run unit test
         env:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEYSTORE_ALIAS: ${{ secrets.KEYSTORE_ALIAS }}

--- a/core/testutils/build.gradle.kts
+++ b/core/testutils/build.gradle.kts
@@ -1,0 +1,50 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.android.library)
+}
+
+@OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
+kotlin {
+    applyDefaultHierarchyTemplate()
+    androidTarget {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_1_8)
+        }
+    }
+    listOf(
+        iosX64(),
+        iosArm64(),
+        iosSimulatorArm64(),
+    ).forEach {
+        it.binaries.framework {
+            baseName = "core.testutils"
+            isStatic = true
+        }
+    }
+
+    sourceSets {
+        val commonMain by getting
+        val androidMain by getting {
+            dependencies {
+                implementation(kotlin("test-junit"))
+                implementation(libs.koin.core)
+            }
+        }
+    }
+}
+
+android {
+    namespace = "com.livefast.eattrash.raccoonforfriendica.core.testutils"
+    compileSdk =
+        libs.versions.android.targetSdk
+            .get()
+            .toInt()
+    defaultConfig {
+        minSdk =
+            libs.versions.android.minSdk
+                .get()
+                .toInt()
+    }
+}

--- a/core/testutils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/testutils/KoinTestRule.kt
+++ b/core/testutils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/testutils/KoinTestRule.kt
@@ -1,0 +1,27 @@
+package com.livefast.eattrash.raccoonforfriendica.core.testutils
+
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import org.koin.core.context.GlobalContext.getKoinApplicationOrNull
+import org.koin.core.context.GlobalContext.startKoin
+import org.koin.core.context.GlobalContext.unloadKoinModules
+import org.koin.core.context.loadKoinModules
+import org.koin.core.module.Module
+
+class KoinTestRule(
+    private val modules: List<Module>,
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        if (getKoinApplicationOrNull() == null) {
+            startKoin {
+                modules(modules)
+            }
+        } else {
+            loadKoinModules(modules)
+        }
+    }
+
+    override fun finished(description: Description) {
+        unloadKoinModules(modules)
+    }
+}

--- a/feature/nodeinfo/build.gradle.kts
+++ b/feature/nodeinfo/build.gradle.kts
@@ -1,10 +1,13 @@
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.mokkery)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -54,7 +57,35 @@ kotlin {
                 implementation(projects.domain.identity.repository)
             }
         }
+        val commonTest by getting {
+            dependencies {
+                dependencies {
+                    implementation(kotlin("test"))
+                    implementation(libs.kotlinx.coroutines.test)
+                    implementation(libs.turbine)
+                    implementation(projects.core.testutils)
+                }
+            }
+        }
+        val androidUnitTest by getting {
+            dependencies {
+                @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+                implementation(compose.uiTest)
+                implementation(libs.compose.ui.test)
+                implementation(libs.robolectric)
+                implementation(projects.core.testutils)
+            }
+        }
     }
+
+    androidTarget {
+        @OptIn(ExperimentalKotlinGradlePluginApi::class)
+        instrumentedTestVariant.sourceSetTree.set(KotlinSourceSetTree.test)
+    }
+}
+
+dependencies {
+    debugImplementation(libs.compose.ui.test.manifest)
 }
 
 android {
@@ -68,5 +99,7 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+        testOptions.unitTests.isIncludeAndroidResources = true
+        testInstrumentationRunner = "org.robolectric.RobolectricTestRunner"
     }
 }

--- a/feature/nodeinfo/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/NodeInfoScreenTest.kt
+++ b/feature/nodeinfo/src/androidUnitTest/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/NodeInfoScreenTest.kt
@@ -1,0 +1,195 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.nodeinfo
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performScrollToNode
+import cafe.adriel.voyager.navigator.Navigator
+import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
+import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.Strings
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.NavigationCoordinator
+import com.livefast.eattrash.raccoonforfriendica.core.testutils.KoinTestRule
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NodeInfoModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.RuleModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.dsl.module
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NodeInfoScreenTest {
+    private val strings =
+        mock<Strings> {
+            every { nodeInfoTitle } returns "Node Info"
+            every { settingsHeaderGeneral } returns "General"
+            every { nodeInfoSectionContact } returns "Contact"
+            every { nodeInfoSectionRules } returns "Rules"
+            every { itemOther } returns "Other"
+            every { settingsAboutAppVersion } returns "Version"
+        }
+    private val uriHandler = mock<UriHandler>()
+
+    private val viewModel =
+        mock<NodeInfoMviModel>(MockMode.autoUnit) {
+            every { uiState }
+        }
+    private val navigationCoordinator =
+        mock<NavigationCoordinator> {
+            every { canPop } returns MutableStateFlow(true)
+        }
+    private val detailOpener = mock<DetailOpener>(MockMode.autoUnit)
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @get:Rule
+    val koinRule =
+        KoinTestRule(
+            listOf(
+                module {
+                    factory<NodeInfoMviModel> { viewModel }
+                    single<NavigationCoordinator> { navigationCoordinator }
+                    single<DetailOpener> { detailOpener }
+                },
+            ),
+        )
+
+    @Test
+    fun `given all data present when displayed then content is as expected`() {
+        with(composeTestRule) {
+            every {
+                viewModel.uiState
+            } returns
+                MutableStateFlow(
+                    NodeInfoMviModel.State(
+                        info =
+                            NodeInfoModel(
+                                title = "Instance title",
+                                description = "Instance description",
+                                contact = UserModel(id = "1", displayName = "Admin"),
+                                rules =
+                                    listOf(
+                                        RuleModel(id = "1", text = "First rule"),
+                                        RuleModel(id = "2", text = "Second rule"),
+                                    ),
+                                version = "1.0.0",
+                            ),
+                    ),
+                )
+
+            setup()
+
+            onNodeWithText("Node Info").assertIsDisplayed()
+            onNodeWithText("General").assertIsDisplayed()
+            onNodeWithText("Instance title").assertIsDisplayed()
+            onNodeWithText("Instance description").assertIsDisplayed()
+            onNodeWithText("Contact").assertIsDisplayed()
+            onNodeWithText("Admin").assertIsDisplayed()
+            onNodeWithText("Rules").assertIsDisplayed()
+            onNodeWithTag(NodeInfoTestTags.COLUMN).performScrollToNode(hasText("1.0.0"))
+            onNodeWithText("First rule").assertIsDisplayed()
+            onNodeWithText("Second rule").assertIsDisplayed()
+            onNodeWithText("Other").assertIsDisplayed()
+            onNodeWithText("Version").assertIsDisplayed()
+            onNodeWithText("1.0.0").assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun `given no contact when displayed then content is as expected`() {
+        with(composeTestRule) {
+            every {
+                viewModel.uiState
+            } returns
+                MutableStateFlow(
+                    NodeInfoMviModel.State(
+                        info =
+                            NodeInfoModel(
+                                title = "Instance title",
+                                description = "Instance description",
+                                rules =
+                                    listOf(
+                                        RuleModel(id = "1", text = "First rule"),
+                                        RuleModel(id = "2", text = "Second rule"),
+                                    ),
+                                version = "1.0.0",
+                            ),
+                    ),
+                )
+
+            setup()
+
+            onNodeWithText("Node Info").assertIsDisplayed()
+            onNodeWithText("General").assertIsDisplayed()
+            onNodeWithText("Instance title").assertIsDisplayed()
+            onNodeWithText("Instance description").assertIsDisplayed()
+            onNodeWithText("Contact").assertDoesNotExist()
+            onNodeWithText("Rules").assertIsDisplayed()
+            onNodeWithTag(NodeInfoTestTags.COLUMN).performScrollToNode(hasText("1.0.0"))
+            onNodeWithText("First rule").assertIsDisplayed()
+            onNodeWithText("Second rule").assertIsDisplayed()
+            onNodeWithText("Other").assertIsDisplayed()
+            onNodeWithText("Version").assertIsDisplayed()
+            onNodeWithText("1.0.0").assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun `given no rules when displayed then content is as expected`() {
+        with(composeTestRule) {
+            every {
+                viewModel.uiState
+            } returns
+                MutableStateFlow(
+                    NodeInfoMviModel.State(
+                        info =
+                            NodeInfoModel(
+                                title = "Instance title",
+                                description = "Instance description",
+                                contact = UserModel(id = "1", displayName = "Admin"),
+                                version = "1.0.0",
+                            ),
+                    ),
+                )
+
+            setup()
+
+            onNodeWithText("Node Info").assertIsDisplayed()
+            onNodeWithText("General").assertIsDisplayed()
+            onNodeWithText("Instance title").assertIsDisplayed()
+            onNodeWithText("Instance description").assertIsDisplayed()
+            onNodeWithText("Contact").assertIsDisplayed()
+            onNodeWithText("Admin").assertIsDisplayed()
+            onNodeWithText("Rules").assertDoesNotExist()
+            onNodeWithTag(NodeInfoTestTags.COLUMN).performScrollToNode(hasText("1.0.0"))
+            onNodeWithText("Other").assertIsDisplayed()
+            onNodeWithText("Version").assertIsDisplayed()
+            onNodeWithText("1.0.0").assertIsDisplayed()
+        }
+    }
+
+    private fun ComposeContentTestRule.setup() {
+        setContent {
+            CompositionLocalProvider(
+                LocalStrings provides strings,
+                LocalUriHandler provides uriHandler,
+            ) {
+                Navigator(NodeInfoScreen())
+            }
+        }
+    }
+}

--- a/feature/nodeinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/NodeInfoScreen.kt
+++ b/feature/nodeinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/NodeInfoScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
@@ -124,6 +125,7 @@ class NodeInfoScreen : Screen {
                 LazyColumn(
                     modifier =
                         Modifier
+                            .testTag(NodeInfoTestTags.COLUMN)
                             .padding(padding)
                             .fillMaxWidth()
                             .nestedScroll(scrollBehavior.nestedScrollConnection),
@@ -413,4 +415,8 @@ private fun RuleItem(
         content = rule.text,
         onOpenUrl = onOpenUrl,
     )
+}
+
+internal object NodeInfoTestTags {
+    const val COLUMN = "column"
 }

--- a/feature/nodeinfo/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/NodeInfoViewModelTest.kt
+++ b/feature/nodeinfo/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/NodeInfoViewModelTest.kt
@@ -1,0 +1,104 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.nodeinfo
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NodeInfoModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.RuleModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.NodeInfoRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.returnsArgAt
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class NodeInfoViewModelTest {
+    private val nodeInfo =
+        NodeInfoModel(
+            title = "Instance title",
+            description = "Instance description",
+            contact = UserModel(id = "1", displayName = "Admin"),
+            rules =
+                listOf(
+                    RuleModel(id = "1", text = "First rule"),
+                    RuleModel(id = "2", text = "Second rule"),
+                ),
+            version = "1.0.0",
+        )
+    private val nodeInfoRepository =
+        mock<NodeInfoRepository> {
+            everySuspend { getInfo() } returns nodeInfo
+        }
+    private val settingsRepository =
+        mock<SettingsRepository> {
+            every { current } returns MutableStateFlow(SettingsModel())
+        }
+    private val emojiHelper =
+        mock<EmojiHelper> {
+            everySuspend { any<UserModel>().withEmojisIfMissing() } returnsArgAt (0)
+        }
+
+    private lateinit var sut: NodeInfoMviModel
+
+    @BeforeTest
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun setup() {
+        Dispatchers.run { setMain(UnconfinedTestDispatcher()) }
+
+        sut = viewModelFactory()
+    }
+
+    @AfterTest
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun teardown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `when initialized then state is as expected`() {
+        val state = sut.uiState.value
+        assertEquals(nodeInfo, state.info)
+        assertTrue(state.autoloadImages)
+
+        verifySuspend {
+            nodeInfoRepository.getInfo()
+        }
+    }
+
+    @Test
+    fun `given autoload images disabled when initialized then state is as expected`() {
+        every { settingsRepository.current } returns
+            MutableStateFlow(SettingsModel(autoloadImages = false))
+        sut = viewModelFactory()
+
+        val state = sut.uiState.value
+        assertEquals(nodeInfo, state.info)
+        assertFalse(state.autoloadImages)
+
+        verifySuspend {
+            nodeInfoRepository.getInfo()
+        }
+    }
+
+    private fun viewModelFactory() =
+        NodeInfoViewModel(
+            nodeInfoRepository = nodeInfoRepository,
+            settingsRepository = settingsRepository,
+            emojiHelper = emojiHelper,
+        )
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ bouncycastle = "1.79"
 coil = "3.0.0"
 compose-colorpicker = "1.1.2"
 compose-plugin = "1.7.0"
+compose-ui-test = "1.7.5"
 koin = "4.0.0"
 kotlin = "2.0.21"
 kotlinx-coroutines = "1.9.0"
@@ -28,6 +29,7 @@ lyricist = "1.7.0"
 materialKolor = "2.0.0"
 mokkery = "2.5.0"
 multiplatform-settings = "1.2.0"
+robolectric = "4.13"
 room = "2.7.0-alpha11"
 sentry = "0.10.0"
 stately = "2.1.0"
@@ -49,6 +51,9 @@ coil = { module = "io.coil-kt.coil3:coil", version.ref = "coil" }
 coil-network-ktor = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose-core", version.ref = "coil" }
 coil-gif = { module = "io.coil-kt.coil3:coil-gif", version.ref = "coil" }
+
+compose-ui-test = { module = "androidx.compose.ui:ui-test-junit4-android", version.ref = "compose-ui-test" }
+compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose-ui-test" }
 
 multiplatform-settings = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatform-settings" }
 
@@ -86,6 +91,7 @@ exoplayer-ui = { module = "androidx.media3:media3-ui", version.ref = "androidx-m
 
 sentry = { module = "io.sentry:sentry-kotlin-multiplatform", version.ref = "sentry" }
 stately-common = { module = "co.touchlab:stately-common", version.ref = "stately" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
 room-sqlite = { module = "androidx.sqlite:sqlite-bundled", version.ref = "androidx-sqlite" }
 room-ksp = { module = "androidx.room:room-compiler", version.ref = "room" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,6 +41,7 @@ include(":core:notifications")
 include(":core:persistence")
 include(":core:preferences")
 include(":core:resources")
+include(":core:testutils")
 include(":core:utils")
 
 include(":domain:content:data")


### PR DESCRIPTION
This PR adds some example tests:
- for a screen model in the `commonTest` source set;
- for a screen in `androidUnitTest` run with Robolectric.

This is an experiment, because on the one side I never tested view models in common code, and on the other side I discovered how to test Compose Multiplatform screens in a Robolectric test, dealing with dependency injection.