### PR TITLE
fix: post image scaling in timeline

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentImage.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentImage.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -91,10 +92,18 @@ fun ContentImage(
                 Modifier
                     .clip(RoundedCornerShape(CornerSize.xl))
                     .then(
-                        if (originalWidth > 0 && originalHeight > 0) {
-                            Modifier.aspectRatio(originalWidth / originalHeight.toFloat())
-                        } else {
-                            Modifier.heightIn(min = minHeight, max = maxHeight)
+                        when {
+                            minHeight == Dp.Unspecified && maxHeight == Dp.Unspecified -> {
+                                Modifier.fillMaxHeight()
+                            }
+
+                            originalWidth > 0 && originalHeight > 0 -> {
+                                Modifier.aspectRatio(originalWidth / originalHeight.toFloat())
+                            }
+
+                            else -> {
+                                Modifier.heightIn(min = minHeight, max = maxHeight)
+                            }
                         },
                     ).clickable {
                         onClick?.invoke()

--- a/feature/nodeinfo/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/NodeInfoViewModelTest.kt
+++ b/feature/nodeinfo/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/NodeInfoViewModelTest.kt
@@ -59,7 +59,6 @@ class NodeInfoViewModelTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     fun setup() {
         Dispatchers.run { setMain(UnconfinedTestDispatcher()) }
-
         sut = viewModelFactory()
     }
 


### PR DESCRIPTION
This PR allows images inside carousels (the new way they are displayed in timelines) to fill the whole height, avoiding awkward layouts where in a carousel images had different aspect ratio.