### PR TITLE
chore: add test for temporary key store

### DIFF
--- a/core/preferences/build.gradle.kts
+++ b/core/preferences/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlinx.serialization)
+    alias(libs.plugins.mokkery)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -41,6 +42,13 @@ kotlin {
                 implementation(libs.multiplatform.settings)
 
                 implementation(projects.core.utils)
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation(libs.kotlinx.coroutines.test)
+                implementation(libs.turbine)
             }
         }
     }

--- a/core/preferences/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/di/Utils.kt
+++ b/core/preferences/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/di/Utils.kt
@@ -4,14 +4,14 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
-import com.livefast.eattrash.raccoonforfriendica.core.preferences.DefaultTemporaryKeyStore
-import com.livefast.eattrash.raccoonforfriendica.core.preferences.TemporaryKeyStore
+import com.livefast.eattrash.raccoonforfriendica.core.preferences.DefaultSettingsWrapper
+import com.livefast.eattrash.raccoonforfriendica.core.preferences.SettingsWrapper
 import com.russhwolf.settings.Settings
 import com.russhwolf.settings.SharedPreferencesSettings
 import org.koin.core.parameter.parametersOf
 import org.koin.dsl.module
 
-actual val corePreferencesModule =
+internal actual val nativePreferencesModule =
     module {
         single { params ->
             SharedPreferencesProvider(
@@ -29,8 +29,8 @@ actual val corePreferencesModule =
                 commit = false,
             )
         }
-        single<TemporaryKeyStore> {
-            DefaultTemporaryKeyStore(settings = get(parameters = { parametersOf(PREFERENCES_NAME) }))
+        single<SettingsWrapper> {
+            DefaultSettingsWrapper(settings = get(parameters = { parametersOf(PREFERENCES_NAME) }))
         }
     }
 

--- a/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/DefaultSettingsWrapper.kt
+++ b/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/DefaultSettingsWrapper.kt
@@ -1,0 +1,93 @@
+package com.livefast.eattrash.raccoonforfriendica.core.preferences
+
+import com.russhwolf.settings.Settings
+import com.russhwolf.settings.get
+import com.russhwolf.settings.set
+
+internal class DefaultSettingsWrapper(
+    private val settings: Settings,
+) : SettingsWrapper {
+    override val keys: Set<String> = settings.keys
+
+    override fun hasKey(key: String): Boolean = settings.hasKey(key)
+
+    override fun remove(key: String) {
+        settings.remove(key)
+    }
+
+    override fun clear() {
+        settings.clear()
+    }
+
+    override fun get(
+        key: String,
+        default: Int,
+    ): Int = settings[key, default]
+
+    override fun get(
+        key: String,
+        default: Long,
+    ): Long = settings[key, default]
+
+    override fun get(
+        key: String,
+        default: String,
+    ): String = settings[key, default]
+
+    override fun get(
+        key: String,
+        default: Boolean,
+    ): Boolean = settings[key, default]
+
+    override fun get(
+        key: String,
+        default: Float,
+    ): Float = settings[key, default]
+
+    override fun get(
+        key: String,
+        default: Double,
+    ): Double = settings[key, default]
+
+    override fun set(
+        key: String,
+        value: Int,
+    ) {
+        settings[key] = value
+    }
+
+    override fun set(
+        key: String,
+        value: Long,
+    ) {
+        settings[key] = value
+    }
+
+    override fun set(
+        key: String,
+        value: String,
+    ) {
+        settings[key] = value
+    }
+
+    override fun set(
+        key: String,
+        value: Float,
+    ) {
+        settings[key] = value
+    }
+
+    override fun set(
+        key: String,
+        value: Double,
+    ) {
+        settings[key] = value
+    }
+
+    override fun set(
+        key: String,
+        value: Boolean,
+    ) {
+        settings[key] = value
+    }
+}

--- a/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/DefaultTemporaryKeyStore.kt
+++ b/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/DefaultTemporaryKeyStore.kt
@@ -1,11 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.core.preferences
 
-import com.russhwolf.settings.Settings
-import com.russhwolf.settings.get
-import com.russhwolf.settings.set
-
 internal class DefaultTemporaryKeyStore(
-    private val settings: Settings,
+    private val settings: SettingsWrapper,
 ) : TemporaryKeyStore {
     override fun containsKey(key: String): Boolean = settings.keys.contains(key)
 

--- a/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/SettingsWrapper.kt
+++ b/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/SettingsWrapper.kt
@@ -1,0 +1,71 @@
+package com.livefast.eattrash.raccoonforfriendica.core.preferences
+
+internal interface SettingsWrapper {
+    val keys: Set<String>
+
+    fun hasKey(key: String): Boolean
+
+    fun remove(key: String)
+
+    fun clear()
+
+    operator fun get(
+        key: String,
+        default: Int,
+    ): Int
+
+    operator fun get(
+        key: String,
+        default: Long,
+    ): Long
+
+    operator fun get(
+        key: String,
+        default: String,
+    ): String
+
+    operator fun get(
+        key: String,
+        default: Boolean,
+    ): Boolean
+
+    operator fun get(
+        key: String,
+        default: Float,
+    ): Float
+
+    operator fun get(
+        key: String,
+        default: Double,
+    ): Double
+
+    operator fun set(
+        key: String,
+        value: Int,
+    )
+
+    operator fun set(
+        key: String,
+        value: Long,
+    )
+
+    operator fun set(
+        key: String,
+        value: String,
+    )
+
+    operator fun set(
+        key: String,
+        value: Float,
+    )
+
+    operator fun set(
+        key: String,
+        value: Double,
+    )
+
+    operator fun set(
+        key: String,
+        value: Boolean,
+    )
+}

--- a/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/di/PreferencesModule.kt
+++ b/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/di/PreferencesModule.kt
@@ -1,5 +1,16 @@
 package com.livefast.eattrash.raccoonforfriendica.core.preferences.di
 
-import org.koin.core.module.Module
+import com.livefast.eattrash.raccoonforfriendica.core.preferences.DefaultTemporaryKeyStore
+import com.livefast.eattrash.raccoonforfriendica.core.preferences.TemporaryKeyStore
+import org.koin.dsl.module
 
-expect val corePreferencesModule: Module
+val corePreferencesModule =
+    module {
+        includes(nativePreferencesModule)
+
+        single<TemporaryKeyStore> {
+            DefaultTemporaryKeyStore(
+                settings = get(),
+            )
+        }
+    }

--- a/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/di/Utils.kt
+++ b/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/di/Utils.kt
@@ -1,0 +1,5 @@
+package com.livefast.eattrash.raccoonforfriendica.core.preferences.di
+
+import org.koin.core.module.Module
+
+internal expect val nativePreferencesModule: Module

--- a/core/preferences/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/DefaultTemporaryKeyStoreTest.kt
+++ b/core/preferences/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/DefaultTemporaryKeyStoreTest.kt
@@ -1,0 +1,214 @@
+package com.livefast.eattrash.raccoonforfriendica.core.preferences
+
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DefaultTemporaryKeyStoreTest {
+    private val settings = mock<SettingsWrapper>(MockMode.autoUnit)
+
+    private val sut = DefaultTemporaryKeyStore(settings)
+
+    @Test
+    fun `given non existing key when contains key then interactions are as expected`() {
+        every { settings.hasKey(any()) } returns false
+        every { settings.keys } returns setOf()
+
+        val res = sut.containsKey("key")
+
+        assertFalse(res)
+    }
+
+    @Test
+    fun `given existing key when contains key then interactions are as expected`() {
+        every { settings.keys } returns setOf("key")
+
+        val res = sut.containsKey("key")
+
+        assertTrue(res)
+        verify {
+            settings.keys
+        }
+    }
+
+    @Test
+    fun `when get Int then result is as expected`() {
+        every { settings.hasKey(any()) } returns true
+        every { settings[any(), any<Int>()] } returns 2
+
+        val res = sut["key", 1]
+        assertEquals(2, res)
+        verify {
+            settings["key", 1]
+        }
+    }
+
+    @Test
+    fun `when save Int then interactions are as expected`() {
+        sut.save("key", 0)
+
+        verify {
+            settings["key"] = 0
+        }
+    }
+
+    @Test
+    fun `when get Long then result is as expected`() {
+        every { settings.hasKey(any()) } returns true
+        every { settings[any(), any<Long>()] } returns 2
+
+        val res = sut["key", 1L]
+        assertEquals(2L, res)
+        verify {
+            settings["key", 1L]
+        }
+    }
+
+    @Test
+    fun `when save Long then interactions are as expected`() {
+        sut.save("key", 1L)
+        verify {
+            settings["key"] = 1L
+        }
+    }
+
+    @Test
+    fun `when get Boolean then result is as expected`() {
+        every { settings.hasKey(any()) } returns true
+        every { settings[any(), any<Boolean>()] } returns true
+
+        val res = sut["key", false]
+        assertTrue(res)
+        verify {
+            settings["key", false]
+        }
+    }
+
+    @Test
+    fun `when save Boolean then interactions are as expected`() {
+        sut.save("key", true)
+
+        verify {
+            settings["key"] = true
+        }
+    }
+
+    @Test
+    fun `when get String then result is as expected`() {
+        every { settings.hasKey(any()) } returns true
+        every { settings[any(), any<String>()] } returns "b"
+
+        val res = sut["key", "a"]
+        assertEquals("b", res)
+        verify {
+            settings["key", "a"]
+        }
+    }
+
+    @Test
+    fun `when save String then interactions are as expected`() {
+        sut.save("key", "value")
+
+        verify {
+            settings["key"] = "value"
+        }
+    }
+
+    @Test
+    fun `when get Float then result is as expected`() {
+        every { settings.hasKey(any()) } returns true
+        every { settings[any(), any<Float>()] } returns 2.0f
+
+        val res = sut["key", 1.0f]
+        assertEquals(2.0f, res)
+        verify {
+            settings["key", 1.0f]
+        }
+    }
+
+    @Test
+    fun `when save Float then interactions are as expected`() {
+        sut.save("key", 1.0f)
+        verify {
+            settings["key"] = 1.0f
+        }
+    }
+
+    @Test
+    fun `when get Double then result is as expected`() {
+        every { settings.hasKey(any()) } returns true
+        every { settings[any(), any<Double>()] } returns 2.0
+
+        val res = sut["key", 1.0]
+        assertEquals(2.0, res)
+        verify {
+            settings["key", 1.0]
+        }
+    }
+
+    @Test
+    fun `when save Double then interactions are as expected`() {
+        sut.save("key", 1.0)
+
+        verify {
+            settings["key"] = 1.0
+        }
+    }
+
+    @Test
+    fun `given non existing key when get string list then result is as expected`() {
+        every { settings.hasKey(any()) } returns false
+
+        val res = sut.get("key", listOf(""))
+        assertEquals(listOf(""), res)
+    }
+
+    @Test
+    fun `given existing key when get string list then result is as expected`() {
+        every { settings.hasKey(any()) } returns true
+        every { settings[any(), any<String>()] } returns "a, b"
+
+        val res = sut.get("key", listOf("c", "d"))
+        assertEquals(2, res.size)
+        assertEquals("a", res.first())
+        assertEquals("b", res[1])
+        verify {
+            settings["key", ""]
+        }
+    }
+
+    @Test
+    fun `when save String list then interactions are as expected`() {
+        val values = listOf("a", "b", "c")
+        sut.save("key", values)
+
+        verify {
+            sut.save(key = "key", value = values, delimiter = ", ")
+        }
+    }
+
+    @Test
+    fun `when remove then interactions are as expected`() {
+        sut.remove("key")
+
+        verify {
+            settings.remove("key")
+        }
+    }
+
+    @Test
+    fun `when remove all then interactions are as expected`() {
+        sut.removeAll()
+
+        verify {
+            settings.clear()
+        }
+    }
+}

--- a/core/preferences/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/di/Utils.kt
+++ b/core/preferences/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/di/Utils.kt
@@ -1,7 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.core.preferences.di
 
-import com.livefast.eattrash.raccoonforfriendica.core.preferences.DefaultTemporaryKeyStore
-import com.livefast.eattrash.raccoonforfriendica.core.preferences.TemporaryKeyStore
+import com.livefast.eattrash.raccoonforfriendica.core.preferences.DefaultSettingsWrapper
+import com.livefast.eattrash.raccoonforfriendica.core.preferences.SettingsWrapper
 import com.russhwolf.settings.ExperimentalSettingsImplementation
 import com.russhwolf.settings.KeychainSettings
 import com.russhwolf.settings.Settings
@@ -10,14 +10,14 @@ import org.koin.dsl.module
 
 private const val DEFAULT_NAME = "secret_shared_prefs"
 
-actual val corePreferencesModule =
+internal actual val nativePreferencesModule =
     module {
         single<Settings> { params ->
             val name: String? = params[0]
             @OptIn(ExperimentalSettingsImplementation::class)
             KeychainSettings(service = name ?: DEFAULT_NAME)
         }
-        single<TemporaryKeyStore> {
-            DefaultTemporaryKeyStore(settings = get(parameters = { parametersOf(DEFAULT_NAME) }))
+        single<SettingsWrapper> {
+            DefaultSettingsWrapper(settings = get(parameters = { parametersOf(DEFAULT_NAME) }))
         }
     }


### PR DESCRIPTION
This PR adds a unit test for `DefaultTemporaryKeyStore`. Unfortunately, since with mokkery it is easy to mock interfaces but not so easy to mock extension functions on an interface type, an adapter has been introduced to wrap the usages of settings.

A positive outcome of this is that the dependency injection of `TemporaryKeyStore` can now become common (and only the wrapper will have native binding).