### PR TITLE
fix: add client side deduplication for posts in conversation

### DIFF
--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -415,9 +415,6 @@ class EntryDetailScreen(
 
                     // here to show the initial entry from cache at startup
                     if (uiState.initial) {
-                        item {
-                            Spacer(modifier = Modifier.height(Spacing.xxs))
-                        }
                         val placeholderCount = 5
                         items(placeholderCount) { idx ->
                             TimelineItemPlaceholder(modifier = Modifier.fillMaxWidth())

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailViewModel.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailViewModel.kt
@@ -12,6 +12,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate.HapticFeedba
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.blurHashParamsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.LocalItemCache
@@ -127,7 +128,11 @@ class EntryDetailViewModel(
             it.copy(
                 initial = initial,
                 refreshing = !initial,
-                entries = currentEntry?.let { e -> listOf(e) } ?: emptyList(),
+                entries =
+                    currentEntry
+                        ?.let { e -> listOf(e) }
+                        ?.distinctBy { e -> e.safeKey }
+                        ?: emptyList(),
             )
         }
 
@@ -155,7 +160,7 @@ class EntryDetailViewModel(
                             with(replyHelper) { it.withInReplyToIfMissing() }
                         },
                 )
-            }.filterNotNull()
+            }.filterNotNull().distinctBy { e -> e.safeKey }
 
         entries.preloadImages()
         updateState {


### PR DESCRIPTION
This solves a bug due to which, on Mastodon, opening a post detail caused a crash due to post ID being duplicated.