### PR TITLE
fix: user URL resolution on local instance

### DIFF
--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/Extensions.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/Extensions.kt
@@ -27,6 +27,17 @@ val String?.nodeName: String?
                 }
             }.takeIf { it.isNotEmpty() }
 
+val String?.detailName: String?
+    get() =
+        orEmpty()
+            .let {
+                if (it.contains('@')) {
+                    it.substringBefore('@')
+                } else {
+                    ""
+                }
+            }.takeIf { it.isNotEmpty() }
+
 fun Int.isNearTheEnd(list: List<*>): Boolean = this >= list.lastIndex - 5 || list.size <= 5
 
 fun Regex.substituteAllOccurrences(

--- a/docs/manual/it/main.md
+++ b/docs/manual/it/main.md
@@ -653,7 +653,7 @@ costituita dalle seguenti sezioni:
     e nascondere i video all'interno delle timeline.
 
 <p id="markdown-formatting">
-* scgliere con cautela: <em>Markdown</em> è supportato solo da alcune versioni di Mastodon (es.
+* scegliere con cautela: <em>Markdown</em> è supportato solo da alcune versioni di Mastodon (es.
 glitch-soc), se non sei sicuro/a di quel che stai facendo usa HTML o testo semplice, altrimenti i 
 tuoi post potrebbero non essere formattati correttamente
 </p>
@@ -759,7 +759,7 @@ In alto è presente un selettore per selezionare la categoria di violazione tra:
 - **Altro** qualsiasi altro tipo di problema.
 
 A seguire, è possibile scrivere il testo del report in un campo di immissione e, infine, è presente
-l'intrruttore "Inoltra segnalazione" al fine di selezionare se questo rapporto deve essere
+l'interruttore "Inoltra segnalazione" al fine di selezionare se questo rapporto deve essere
 consegnato solo agli amministratori dell'istanza locale o, se stai segnalando un contenuto
 proveniente da un'istanza federata, la sgnalazione dovrebbe essere inoltrata anche agli
 amministratori dell'istanza di origine.<a href="#report-forward-disclaimer">**</a>

--- a/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/di/UrlHandlerModule.kt
+++ b/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/di/UrlHandlerModule.kt
@@ -27,6 +27,7 @@ val domainUrlHandlerModule =
         single<FetchUserUseCase> {
             DefaultFetchUserUseCase(
                 userRepository = get(),
+                apiConfigurationRepository = get(),
             )
         }
         single<HashtagProcessor> {

--- a/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/DefaultFetchUserUseCase.kt
+++ b/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/DefaultFetchUserUseCase.kt
@@ -1,18 +1,30 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor
 
+import com.livefast.eattrash.raccoonforfriendica.core.utils.detailName
+import com.livefast.eattrash.raccoonforfriendica.core.utils.nodeName
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
 import kotlinx.coroutines.withTimeoutOrNull
 
 internal class DefaultFetchUserUseCase(
     private val userRepository: UserRepository,
+    private val apiConfigurationRepository: ApiConfigurationRepository,
 ) : FetchUserUseCase {
     override suspend fun invoke(handle: String): UserModel? =
         // wait at most USER_SEARCH_TIMEOUT_MILLIS failing if the request takes longer
         withTimeoutOrNull(USER_SEARCH_TIMEOUT_MILLIS) {
             userRepository.getByHandle(handle).takeIf {
                 // eventual consistency check: the match should be exact
-                it?.handle == handle
+                val currentNode = apiConfigurationRepository.node.value
+                val userNode = handle.nodeName
+                if (currentNode == userNode) {
+                    // local user
+                    it?.handle == handle.detailName
+                } else {
+                    // federated user
+                    it?.handle == handle
+                }
             }
         }
 

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/utils/DefaultPrepareForPreviewUseCase.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/utils/DefaultPrepareForPreviewUseCase.kt
@@ -1,5 +1,6 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.composer.utils
 
+import com.livefast.eattrash.raccoonforfriendica.core.utils.detailName
 import com.livefast.eattrash.raccoonforfriendica.core.utils.nodeName
 import com.livefast.eattrash.raccoonforfriendica.core.utils.substituteAllOccurrences
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.MarkupMode
@@ -125,7 +126,7 @@ internal class DefaultPrepareForPreviewUseCase(
             val handle = match.groups["handlePrefix"]?.value.orEmpty()
             val currentNode = apiConfigurationRepository.node.value
             val node = handle.nodeName ?: currentNode
-            val name = handle.substringBefore("@")
+            val name = handle.detailName.orEmpty()
             val url =
                 if (node == currentNode) {
                     "https://$node/profile/$name"


### PR DESCRIPTION
This PR prevents URL pointing to local users from not being opened on Friendica because they have the short form for handles (without the domain part).