### PR TITLE
fix: chat title and bottom sheet dismissal on long press

### DIFF
--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/CustomModalBottomSheet.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/CustomModalBottomSheet.kt
@@ -90,14 +90,19 @@ fun CustomModalBottomSheet(
                                                         onSelected?.invoke(idx)
                                                     }
                                             },
-                                            onLongClick = {
-                                                sheetScope
-                                                    .launch {
-                                                        sheetState.hide()
-                                                    }.invokeOnCompletion {
-                                                        onLongPress?.invoke(idx)
+                                            onLongClick =
+                                                if (onLongPress != null) {
+                                                    {
+                                                        sheetScope
+                                                            .launch {
+                                                                sheetState.hide()
+                                                            }.invokeOnCompletion {
+                                                                onLongPress(idx)
+                                                            }
                                                     }
-                                            },
+                                                } else {
+                                                    null
+                                                },
                                         ).padding(10.dp),
                                 verticalAlignment = Alignment.CenterVertically,
                                 horizontalArrangement = Arrangement.spacedBy(Spacing.s),

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationScreen.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationScreen.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
@@ -84,9 +85,11 @@ class ConversationScreen(
     @Composable
     override fun Content() {
         val model =
-            getScreenModel<ConversationMviModel>(parameters = {
-                parametersOf(otherUserId, parentUri)
-            })
+            getScreenModel<ConversationMviModel>(
+                parameters = {
+                    parametersOf(otherUserId, parentUri)
+                },
+            )
         val uiState by model.uiState.collectAsState()
         val navigationCoordinator = remember { getNavigationCoordinator() }
         val topAppBarState = rememberTopAppBarState()
@@ -160,6 +163,9 @@ class ConversationScreen(
                                 text = otherUserName,
                                 emojis = uiState.otherUser?.emojis.orEmpty(),
                                 style = MaterialTheme.typography.titleMedium,
+                                color = MaterialTheme.colorScheme.onBackground,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
                             )
                         }
                     },


### PR DESCRIPTION
This PR is 3 weeks old and I think I lost it halfway through my regular working schedule.

It contains a fix for conversation title (avoid spanning multiple lines) and a fix for bottom sheets if no onLongPress callback is passed.