### PR TITLE
chore: add tests for network state images

### DIFF
--- a/core/utils/build.gradle.kts
+++ b/core/utils/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.mokkery)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)

--- a/core/utils/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/network/DefaultNetworkStateObserverTest.kt
+++ b/core/utils/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/network/DefaultNetworkStateObserverTest.kt
@@ -1,0 +1,86 @@
+package com.livefast.eattrash.raccoonforfriendica.core.utils.network
+
+import app.cash.turbine.test
+import dev.jordond.connectivity.Connectivity
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DefaultNetworkStateObserverTest {
+    private val connectivityStatusUpdates = MutableSharedFlow<Connectivity.Status>()
+    private val connectivity =
+        mock<Connectivity>(MockMode.autoUnit) {
+            every { statusUpdates } returns connectivityStatusUpdates
+        }
+
+    private val sut =
+        DefaultNetworkStateObserver(
+            connectivity = connectivity,
+            dispatcher = UnconfinedTestDispatcher(),
+        )
+
+    @Test
+    fun `given not started when connectivity changes then result is as expected`() =
+        runTest {
+            sut.state.test {
+                val state1 = awaitItem()
+                assertEquals(NetworkState.Disconnected, state1)
+                connectivityStatusUpdates.emit(Connectivity.Status.Connected(false))
+                val state2 = awaitItem()
+                assertEquals(NetworkState.Connected(false), state2)
+            }
+
+            verify(VerifyMode.not) {
+                connectivity.start()
+                connectivity.stop()
+            }
+        }
+
+    @Test
+    fun `given started when connectivity changes then result is as expected`() =
+        runTest {
+            sut.state.test {
+                val state1 = awaitItem()
+                assertEquals(NetworkState.Disconnected, state1)
+
+                sut.start()
+                connectivityStatusUpdates.emit(Connectivity.Status.Connected(false))
+
+                val state2 = awaitItem()
+                assertEquals(NetworkState.Connected(false), state2)
+            }
+
+            verify {
+                connectivity.start()
+            }
+        }
+
+    @Test
+    fun `given started and metered network when connectivity changes then result is as expected`() =
+        runTest {
+            sut.state.test {
+                val state1 = awaitItem()
+                assertEquals(NetworkState.Disconnected, state1)
+
+                sut.start()
+                connectivityStatusUpdates.emit(Connectivity.Status.Connected(true))
+
+                val state2 = awaitItem()
+                assertEquals(NetworkState.Connected(true), state2)
+            }
+
+            verify {
+                connectivity.start()
+            }
+        }
+}

--- a/domain/identity/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultImageAutoloadObserverTest.kt
+++ b/domain/identity/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultImageAutoloadObserverTest.kt
@@ -1,0 +1,90 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository
+
+import app.cash.turbine.test
+import com.livefast.eattrash.raccoonforfriendica.core.utils.network.NetworkState
+import com.livefast.eattrash.raccoonforfriendica.core.utils.network.NetworkStateObserver
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.ImageLoadingMode
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DefaultImageAutoloadObserverTest {
+    private val networkState = MutableStateFlow<NetworkState>(NetworkState.Disconnected)
+    private val settings = MutableStateFlow(SettingsModel(autoloadImages = ImageLoadingMode.Always))
+    private val networkStateObserver =
+        mock<NetworkStateObserver> {
+            every { state } returns networkState
+        }
+    private val settingsRepository =
+        mock<SettingsRepository> {
+            every { current } returns settings
+        }
+    private val sut =
+        DefaultImageAutoloadObserver(
+            networkStateObserver = networkStateObserver,
+            settingsRepository = settingsRepository,
+            dispatcher = UnconfinedTestDispatcher(),
+        )
+
+    @Test
+    fun `given always mode when initialized then result is as expected`() =
+        runTest {
+            sut.enabled.test {
+                val value = awaitItem()
+                assertTrue(value)
+            }
+        }
+
+    @Test
+    fun `given on demand mode when initialized then result is as expected`() =
+        runTest {
+            sut.enabled.drop(1).test {
+                settings.emit(SettingsModel(autoloadImages = ImageLoadingMode.OnDemand))
+                val value = awaitItem()
+                assertFalse(value)
+            }
+        }
+
+    @Test
+    fun `given on WiFi mode and disconnected when initialized then result is as expected`() =
+        runTest {
+            sut.enabled.drop(1).test {
+                settings.emit(SettingsModel(autoloadImages = ImageLoadingMode.OnWifi))
+                val value = awaitItem()
+                assertFalse(value)
+            }
+        }
+
+    @Test
+    fun `given on WiFi mode and connected on metered network when initialized then result is as expected`() =
+        runTest {
+            sut.enabled.drop(1).test {
+                settings.emit(SettingsModel(autoloadImages = ImageLoadingMode.OnWifi))
+                networkState.emit(NetworkState.Connected(true))
+                val value = awaitItem()
+                assertFalse(value)
+            }
+        }
+
+    @Test
+    fun `given on WiFi mode and connected when initialized then result is as expected`() =
+        runTest {
+            sut.enabled.drop(1).test {
+                settings.emit(SettingsModel(autoloadImages = ImageLoadingMode.OnWifi))
+                awaitItem()
+                networkState.emit(NetworkState.Connected(false))
+                val value = awaitItem()
+                assertTrue(value)
+            }
+        }
+}


### PR DESCRIPTION
This PR adds the tests for the classes introduced in #474.