### PR TITLE
feat: add option to open links in internal web view

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.navigation
 
 import com.livefast.eattrash.feature.userdetail.classic.UserDetailScreen
 import com.livefast.eattrash.feature.userdetail.forum.ForumListScreen
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.WebViewScreen
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.NavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EventModel
@@ -378,6 +379,11 @@ class DefaultDetailOpener(
 
     override fun openLicences() {
         val screen = LicencesScreen()
+        navigationCoordinator.push(screen)
+    }
+
+    override fun openInternalWebView(url: String) {
+        val screen = WebViewScreen(url)
         navigationCoordinator.push(screen)
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpenerTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpenerTest.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.navigation
 
 import com.livefast.eattrash.feature.userdetail.classic.UserDetailScreen
 import com.livefast.eattrash.feature.userdetail.forum.ForumListScreen
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.WebViewScreen
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.NavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EventModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
@@ -461,6 +462,15 @@ class DefaultDetailOpenerTest {
 
         verify {
             navigationCoordinator.push(any<LicencesScreen>())
+        }
+    }
+
+    @Test
+    fun `when openInternalWebView then interactions are as expected`() {
+        sut.openInternalWebView("https://www.google.com")
+
+        verify {
+            navigationCoordinator.push(any<WebViewScreen>())
         }
     }
 }

--- a/core/commonui/content/build.gradle.kts
+++ b/core/commonui/content/build.gradle.kts
@@ -35,12 +35,15 @@ kotlin {
                 implementation(compose.material3)
                 implementation(compose.materialIconsExtended)
 
+                implementation(libs.calf)
                 implementation(libs.koin.core)
+                implementation(libs.voyager.navigator)
 
                 implementation(projects.core.appearance)
                 implementation(projects.core.commonui.components)
                 implementation(projects.core.htmlparse)
                 implementation(projects.core.l10n)
+                implementation(projects.core.navigation)
                 implementation(projects.core.utils)
 
                 implementation(projects.domain.content.data)

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/WebViewScreen.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/WebViewScreen.kt
@@ -1,0 +1,86 @@
+package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import cafe.adriel.voyager.core.screen.Screen
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDrawerCoordinator
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
+import com.mohamedrejeb.calf.ui.web.WebView
+import com.mohamedrejeb.calf.ui.web.rememberWebViewState
+
+class WebViewScreen(
+    private val url: String,
+) : Screen {
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    override fun Content() {
+        val navigationCoordinator = remember { getNavigationCoordinator() }
+        val drawerCoordinator = remember { getDrawerCoordinator() }
+        val state =
+            rememberWebViewState(
+                url = url,
+            )
+
+        LaunchedEffect(Unit) {
+            state.settings.javaScriptEnabled = true
+            state.settings.androidSettings.supportZoom = true
+        }
+        LaunchedEffect(drawerCoordinator) {
+            drawerCoordinator.setGesturesEnabled(false)
+        }
+        DisposableEffect(drawerCoordinator) {
+            onDispose {
+                drawerCoordinator.setGesturesEnabled(true)
+            }
+        }
+
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = {
+                        Text(
+                            text = url,
+                            style = MaterialTheme.typography.titleMedium,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    },
+                    navigationIcon = {
+                        if (navigationCoordinator.canPop.value) {
+                            IconButton(
+                                onClick = {
+                                    navigationCoordinator.pop()
+                                },
+                            ) {
+                                Icon(
+                                    imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                                    contentDescription = null,
+                                )
+                            }
+                        }
+                    },
+                )
+            },
+        ) { padding ->
+            WebView(
+                modifier = Modifier.padding(top = padding.calculateTopPadding()).fillMaxSize(),
+                state = state,
+            )
+        }
+    }
+}

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
@@ -206,8 +206,9 @@ internal val DeStrings =
         override val fontScaleLarger = "Größer"
         override val fontScaleLargest = "Größte"
         override val settingsItemUrlOpeningMode = "URL-Öffnungsmodus"
-        override val urlOpeningModeExternal = "Extern"
+        override val urlOpeningModeExternal = "Externer Browser"
         override val urlOpeningModeCustomTabs = "Benutzerdefinierte Registerkarten"
+        override val urlOpeningModeInternal = "Interne Webansicht"
         override val dialogErrorTitle = "Ups…"
         override val messagePollVoteErrorBody =
             "Leider bin ich nur ein mobiler Entwickler und kann keine fehlenden Backend-Methoden hinzufügen!\nSchauen Sie sich dieses Problem an und setzen Sie ein 👍, damit die Entwickler wissen, dass es sich lohnen könnte, es zu implementieren."

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -203,8 +203,9 @@ internal open class DefaultStrings : Strings {
     override val fontScaleLarger = "Larger"
     override val fontScaleLargest = "Largest"
     override val settingsItemUrlOpeningMode = "URL opening mode"
-    override val urlOpeningModeExternal = "External"
+    override val urlOpeningModeExternal = "External browser"
     override val urlOpeningModeCustomTabs = "Custom tabs"
+    override val urlOpeningModeInternal = "Internal web view"
     override val dialogErrorTitle = "Oops…"
     override val messagePollVoteErrorBody =
         "Unfortunately, I'm just a mobile dev and I can't add missing back-end methods!\nCheck out this issue and put a 👍 so that the devs know it may be worth implementing it."

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/EsStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/EsStrings.kt
@@ -202,8 +202,9 @@ internal val EsStrings =
         override val fontScaleLarger = "Más grande"
         override val fontScaleLargest = "Grandísimo"
         override val settingsItemUrlOpeningMode = "Modo de apertura de URL"
-        override val urlOpeningModeExternal = "Externo"
+        override val urlOpeningModeExternal = "Navegador externo"
         override val urlOpeningModeCustomTabs = "Pestañas personalizadas"
+        override val urlOpeningModeInternal = "Vista web interna"
         override val dialogErrorTitle = "Ups…"
         override val messagePollVoteErrorBody =
             "Por desgracia, sólo soy un desarrollador móvil y no puedo añadir los métodos back-end que faltan."

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/FrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/FrStrings.kt
@@ -203,8 +203,9 @@ internal val FrStrings =
         override val fontScaleLarger = "Plus grand"
         override val fontScaleLargest = "Le plus grand"
         override val settingsItemUrlOpeningMode = "Mode d'ouverture de l'URL"
-        override val urlOpeningModeExternal = "Externe"
+        override val urlOpeningModeExternal = "Navigateur externe"
         override val urlOpeningModeCustomTabs = "Onglets personnalisés"
+        override val urlOpeningModeInternal = "Vue interne du web"
         override val dialogErrorTitle = "Oups..."
         override val messagePollVoteErrorBody =
             "Malheureusement, je ne suis qu'un développeur mobile et je ne peux pas ajouter les méthodes back-end manquantes !\nJetez un œil à ce problème et mettez un 👍 pour que les développeurs sachent que cela peut valoir la peine de l'implémenter."

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -202,6 +202,7 @@ internal val ItStrings =
         override val fontScaleLargest = "Grandissimo"
         override val settingsItemUrlOpeningMode = "Modalità apertura URL"
         override val urlOpeningModeExternal = "Browser esterno"
+        override val urlOpeningModeInternal = "Web view interna"
         override val urlOpeningModeCustomTabs = "Schede personalizzate"
         override val dialogErrorTitle = "Ops…"
         override val messagePollVoteErrorBody =

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/PlStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/PlStrings.kt
@@ -197,8 +197,9 @@ internal val PlStrings =
         override val fontScaleLarger = "Większa"
         override val fontScaleLargest = "Największa"
         override val settingsItemUrlOpeningMode = "Tryb otwierania adresu URL"
-        override val urlOpeningModeExternal = "Zewnętrzny"
+        override val urlOpeningModeExternal = "Zewnętrzna przeglądarka"
         override val urlOpeningModeCustomTabs = "Zakładki niestandardowe"
+        override val urlOpeningModeInternal = "Wewnętrzny widok sieciowy"
         override val dialogErrorTitle = "Ups…"
         override val messagePollVoteErrorBody =
             "Niestety, jestem tylko deweloperem mobilnym i nie mogę dodać brakujących metod back-endowych!\nSprawdź tę kwestię i umieść 👍, aby deweloperzy wiedzieli, że warto ją wdrożyć."

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/PtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/PtStrings.kt
@@ -201,8 +201,9 @@ internal val PtStrings =
         override val fontScaleLarger = "Maior"
         override val fontScaleLargest = "Maior"
         override val settingsItemUrlOpeningMode = "Modo de abertura do URL"
-        override val urlOpeningModeExternal = "Externo"
-        override val urlOpeningModeCustomTabs = "Separadores personalizados"
+        override val urlOpeningModeExternal = "Navegador externo"
+        override val urlOpeningModeCustomTabs = "Guias personalizadas"
+        override val urlOpeningModeInternal = "Vista interna da Web"
         override val dialogErrorTitle = "Oops…"
         override val messagePollVoteErrorBody =
             "Infelizmente, sou apenas um programador móvel e não posso adicionar métodos back-end em falta!"

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -193,6 +193,7 @@ interface Strings {
     val settingsItemUrlOpeningMode: String
     val urlOpeningModeExternal: String
     val urlOpeningModeCustomTabs: String
+    val urlOpeningModeInternal: String
     val dialogErrorTitle: String
     val messagePollVoteErrorBody: String
     val buttonPollErrorOpenIssue: String

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DetailOpener.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DetailOpener.kt
@@ -108,4 +108,6 @@ interface DetailOpener {
     fun openEvent(event: EventModel)
 
     fun openLicences()
+
+    fun openInternalWebView(url: String)
 }

--- a/domain/identity/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/data/UrlOpeningMode.kt
+++ b/domain/identity/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/data/UrlOpeningMode.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.Composable
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
 
 sealed interface UrlOpeningMode {
+    data object Internal : UrlOpeningMode
+
     data object External : UrlOpeningMode
 
     data object CustomTabs : UrlOpeningMode
@@ -11,12 +13,14 @@ sealed interface UrlOpeningMode {
 
 fun Int.toUrlOpeningMode(): UrlOpeningMode =
     when (this) {
+        2 -> UrlOpeningMode.Internal
         1 -> UrlOpeningMode.CustomTabs
         else -> UrlOpeningMode.External
     }
 
 fun UrlOpeningMode.toInt(): Int =
     when (this) {
+        UrlOpeningMode.Internal -> 2
         UrlOpeningMode.CustomTabs -> 1
         UrlOpeningMode.External -> 0
     }
@@ -24,6 +28,8 @@ fun UrlOpeningMode.toInt(): Int =
 @Composable
 fun UrlOpeningMode.toReadableName(): String =
     when (this) {
+        // TODO: l10n
+        UrlOpeningMode.Internal -> LocalStrings.current.urlOpeningModeInternal
         UrlOpeningMode.CustomTabs -> LocalStrings.current.urlOpeningModeCustomTabs
         UrlOpeningMode.External -> LocalStrings.current.urlOpeningModeExternal
     }

--- a/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/DefaultCustomUriHandler.kt
+++ b/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/DefaultCustomUriHandler.kt
@@ -1,6 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.urlhandler
 
 import androidx.compose.ui.platform.UriHandler
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
 import com.livefast.eattrash.raccoonforfriendica.core.utils.url.CustomTabsHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.UrlOpeningMode
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
@@ -31,6 +32,7 @@ internal class DefaultCustomUriHandler(
     private val guppeProcessor: GuppeProcessor,
     private val peertubeProcessor: PeertubeProcessor,
     private val pixelfedProcessor: PixelfedProcessor,
+    private val detailOpener: DetailOpener,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : CustomUriHandler {
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
@@ -63,6 +65,9 @@ internal class DefaultCustomUriHandler(
         mode: UrlOpeningMode,
     ) {
         when {
+            mode == UrlOpeningMode.Internal ->
+                detailOpener.openInternalWebView(url)
+
             customTabsHelper.isSupported && mode == UrlOpeningMode.CustomTabs ->
                 customTabsHelper.handle(url)
 

--- a/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/di/UrlHandlerModule.kt
+++ b/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/di/UrlHandlerModule.kt
@@ -90,6 +90,7 @@ val domainUrlHandlerModule =
                 guppeProcessor = get(),
                 peertubeProcessor = get(),
                 pixelfedProcessor = get(),
+                detailOpener = get(),
             )
         }
     }

--- a/domain/urlhandler/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/DefaultCustomUriHandlerTest.kt
+++ b/domain/urlhandler/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/DefaultCustomUriHandlerTest.kt
@@ -86,6 +86,7 @@ class DefaultCustomUriHandlerTest {
             guppeProcessor = guppeProcessor,
             peertubeProcessor = peertubeProcessor,
             pixelfedProcessor = pixelfedProcessor,
+            detailOpener = detailOpener,
             dispatcher = UnconfinedTestDispatcher(),
         )
 
@@ -126,6 +127,20 @@ class DefaultCustomUriHandlerTest {
 
         verify {
             customTabsHelper.handle(url)
+        }
+    }
+
+    @Test
+    fun `given URL and internal mode when openUri then interactions are as expected`() {
+        every {
+            settingsRepository.current
+        } returns MutableStateFlow(SettingsModel(urlOpeningMode = UrlOpeningMode.Internal))
+        val url = "https://www.example.com"
+
+        sut.openUri(url)
+
+        verify {
+            detailOpener.openInternalWebView(url)
         }
     }
 

--- a/feature/imagedetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/imagedetail/ImageDetailScreen.kt
+++ b/feature/imagedetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/imagedetail/ImageDetailScreen.kt
@@ -1,6 +1,5 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.imagedetail
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -58,7 +57,7 @@ class ImageDetailScreen(
     override val key: ScreenKey
         get() = super.key + urls.joinToString("-")
 
-    @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+    @OptIn(ExperimentalMaterial3Api::class)
     @Composable
     override fun Content() {
         val model =
@@ -193,96 +192,90 @@ class ImageDetailScreen(
                     )
                 }
             },
-            content =
-                { padding ->
-                    HorizontalPager(
-                        state = pagerState,
-                        beyondViewportPageCount = 1,
-                    ) {
-                        Box(
-                            modifier =
-                                Modifier
-                                    .padding(
-                                        top = padding.calculateTopPadding(),
-                                    ).fillMaxSize()
-                                    .background(Color.Black),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            if (!url.isNullOrEmpty()) {
-                                if (isVideo) {
-                                    VideoPlayer(url = url)
-                                } else {
-                                    ZoomableImage(
-                                        url = url,
-                                        contentScale = uiState.contentScale,
-                                    )
-                                }
-                            }
+        ) { padding ->
+            HorizontalPager(
+                modifier = Modifier.padding(top = padding.calculateTopPadding()),
+                state = pagerState,
+                beyondViewportPageCount = 1,
+            ) {
+                Box(
+                    modifier = Modifier.fillMaxSize().background(Color.Black),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    if (!url.isNullOrEmpty()) {
+                        if (isVideo) {
+                            VideoPlayer(url = url)
+                        } else {
+                            ZoomableImage(
+                                url = url,
+                                contentScale = uiState.contentScale,
+                            )
                         }
                     }
-                },
-        )
+                }
+            }
 
-        if (uiState.loading) {
-            ProgressHud()
-        }
+            if (uiState.loading) {
+                ProgressHud()
+            }
 
-        if (scaleModeBottomSheetOpened) {
-            CustomModalBottomSheet(
-                title = LocalStrings.current.contentScaleTitle,
-                items =
-                    listOf(
-                        CustomModalBottomSheetItem(
-                            label = LocalStrings.current.contentScaleFit,
-                        ),
-                        CustomModalBottomSheetItem(
-                            label = LocalStrings.current.contentScaleFillWidth,
-                        ),
-                        CustomModalBottomSheetItem(
-                            label = LocalStrings.current.contentScaleFillHeight,
-                        ),
-                    ),
-                onSelected = { index ->
-                    scaleModeBottomSheetOpened = false
-                    if (index != null) {
-                        model.reduce(
-                            ImageDetailMviModel.Intent.ChangeContentScale(
-                                when (index) {
-                                    1 -> ContentScale.FillWidth
-                                    2 -> ContentScale.FillHeight
-                                    else -> ContentScale.Fit
-                                },
+            if (scaleModeBottomSheetOpened) {
+                CustomModalBottomSheet(
+                    title = LocalStrings.current.contentScaleTitle,
+                    items =
+                        listOf(
+                            CustomModalBottomSheetItem(
+                                label = LocalStrings.current.contentScaleFit,
                             ),
-                        )
-                    }
-                },
-            )
-        }
+                            CustomModalBottomSheetItem(
+                                label = LocalStrings.current.contentScaleFillWidth,
+                            ),
+                            CustomModalBottomSheetItem(
+                                label = LocalStrings.current.contentScaleFillHeight,
+                            ),
+                        ),
+                    onSelected = { index ->
+                        scaleModeBottomSheetOpened = false
+                        if (index != null) {
+                            model.reduce(
+                                ImageDetailMviModel.Intent.ChangeContentScale(
+                                    when (index) {
+                                        1 -> ContentScale.FillWidth
+                                        2 -> ContentScale.FillHeight
+                                        else -> ContentScale.Fit
+                                    },
+                                ),
+                            )
+                        }
+                    },
+                )
+            }
 
-        if (shareModeBottomSheetOpened) {
-            CustomModalBottomSheet(
-                title = LocalStrings.current.actionShare,
-                items =
-                    listOf(
-                        CustomModalBottomSheetItem(
-                            label = LocalStrings.current.shareAsUrl,
+            if (shareModeBottomSheetOpened) {
+                CustomModalBottomSheet(
+                    title = LocalStrings.current.actionShare,
+                    items =
+                        listOf(
+                            CustomModalBottomSheetItem(
+                                label = LocalStrings.current.shareAsUrl,
+                            ),
+                            CustomModalBottomSheetItem(
+                                label = LocalStrings.current.shareAsFile,
+                            ),
                         ),
-                        CustomModalBottomSheetItem(
-                            label = LocalStrings.current.shareAsFile,
-                        ),
-                    ),
-                onSelected = { index ->
-                    shareModeBottomSheetOpened = false
-                    if (index != null) {
-                        model.reduce(
-                            when (index) {
-                                1 -> ImageDetailMviModel.Intent.ShareAsFile
-                                else -> ImageDetailMviModel.Intent.ShareAsUrl
-                            },
-                        )
-                    }
-                },
-            )
+                    onSelected = { index ->
+                        shareModeBottomSheetOpened = false
+                        if (index != null) {
+                            model.reduce(
+                                when (index) {
+                                    1 -> ImageDetailMviModel.Intent.ShareAsFile
+                                    else -> ImageDetailMviModel.Intent.ShareAsUrl
+                                },
+                            )
+                        }
+                    },
+                )
+            }
         }
     }
 }

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
@@ -572,6 +572,7 @@ class SettingsScreen : Screen {
                 listOf(
                     UrlOpeningMode.External,
                     UrlOpeningMode.CustomTabs,
+                    UrlOpeningMode.Internal,
                 )
             CustomModalBottomSheet(
                 title = LocalStrings.current.settingsItemUrlOpeningMode,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ androidx-splashscreen = "1.0.1"
 androidx-sqlite = "2.5.0-alpha11"
 androidx-work = "2.9.1"
 bouncycastle = "1.79"
+calf = "0.6.1"
 coil = "3.0.2"
 compose-colorpicker = "1.1.2"
 compose-plugin = "1.7.0"
@@ -48,11 +49,14 @@ androidx-work-runtime = { module = "androidx.work:work-runtime-ktx", version.ref
 
 bouncycastle = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
 
+calf = { module = "com.mohamedrejeb.calf:calf-webview", version.ref = "calf" }
+
 coil = { module = "io.coil-kt.coil3:coil", version.ref = "coil" }
 coil-network-ktor = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose-core", version.ref = "coil" }
 coil-gif = { module = "io.coil-kt.coil3:coil-gif", version.ref = "coil" }
 
+compose-colorpicker = { module = "com.github.skydoves:colorpicker-compose", version.ref = "compose-colorpicker" }
 compose-multiplatform-media-player = { module = "network.chaintech:compose-multiplatform-media-player", version.ref = "compose-multiplatform-media-player" }
 
 compose-ui-test = { module = "androidx.compose.ui:ui-test-junit4-android", version.ref = "compose-ui-test" }
@@ -60,8 +64,6 @@ compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", ve
 
 connectivity-core = { module = "dev.jordond.connectivity:connectivity-core", version.ref = "connectivity" }
 connectivity-device = { module = "dev.jordond.connectivity:connectivity-device", version.ref = "connectivity" }
-
-multiplatform-settings = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatform-settings" }
 
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
@@ -86,18 +88,25 @@ ktorfit-converters-response = { module = "de.jensklingenberg.ktorfit:ktorfit-con
 ksoup-html = { module = "com.mohamedrejeb.ksoup:ksoup-html", version.ref = "ksoup" }
 ksoup-entities = { module = "com.mohamedrejeb.ksoup:ksoup-entities", version.ref = "ksoup" }
 
-materialKolor = { module = "com.materialkolor:material-kolor", version.ref = "materialKolor" }
-compose-colorpicker = { module = "com.github.skydoves:colorpicker-compose", version.ref = "compose-colorpicker" }
-
 lyricist = { module = "cafe.adriel.lyricist:lyricist", version.ref = "lyricist" }
 
+materialKolor = { module = "com.materialkolor:material-kolor", version.ref = "materialKolor" }
+
+multiplatform-settings = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatform-settings" }
+
 sentry = { module = "io.sentry:sentry-kotlin-multiplatform", version.ref = "sentry" }
+
 stately-common = { module = "co.touchlab:stately-common", version.ref = "stately" }
+
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
 room-sqlite = { module = "androidx.sqlite:sqlite-bundled", version.ref = "androidx-sqlite" }
 room-ksp = { module = "androidx.room:room-compiler", version.ref = "room" }
 room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
+
+turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
+
+unifiedpush = { module = "org.unifiedpush.android:connector", version.ref = "unifiedpush" }
 
 voyager-navigator = { module = "cafe.adriel.voyager:voyager-navigator", version.ref = "voyager" }
 voyager-screenmodel = { module = "cafe.adriel.voyager:voyager-screenmodel", version.ref = "voyager" }
@@ -105,19 +114,21 @@ voyager-tab = { module = "cafe.adriel.voyager:voyager-tab-navigator", version.re
 voyager-transition = { module = "cafe.adriel.voyager:voyager-transitions", version.ref = "voyager" }
 voyager-koin = { module = "cafe.adriel.voyager:voyager-koin", version.ref = "voyager" }
 
-turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
-
-unifiedpush = { module = "org.unifiedpush.android:connector", version.ref = "unifiedpush" }
-
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
+
 jetbrains-compose = { id = "org.jetbrains.compose", version.ref = "compose-plugin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+
 ktorfit = { id = "de.jensklingenberg.ktorfit", version.ref = "ktorfit" }
+
 mokkery = { id = "dev.mokkery", version.ref = "mokkery" }
+
 room = { id = "androidx.room", version.ref = "room" }


### PR DESCRIPTION
This PR adds an option to open web links in an internal web view, to avoid leaving the app and open a browser. This can be beneficial to #470 which depends on the process being killed and scroll state not being restored.