### PR TITLE
fix: resolve custom emojis inside poll options

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/PollCard.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/PollCard.kt
@@ -43,6 +43,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillary
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.getDurationFromNowToDate
 import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.getPrettyDuration
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EmojiModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.PollModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.PollOptionModel
 import kotlin.math.roundToInt
@@ -59,6 +60,7 @@ fun PollCard(
     poll: PollModel,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    emojis: List<EmojiModel> = emptyList(),
     onVote: ((List<Int>) -> Unit)? = null,
 ) {
     val canVote = enabled && !poll.expired && poll.ownVotes.isEmpty()
@@ -78,6 +80,7 @@ fun PollCard(
             PollCardOption(
                 modifier = Modifier.fillMaxWidth(),
                 title = option.title,
+                emojis = emojis,
                 percentage = percentage,
                 enabled = canVote,
                 reactToClickEnabled = !showingResults,
@@ -152,6 +155,7 @@ private fun PollCardOption(
     isScoreHigher: Boolean = false,
     isOwnVote: Boolean = false,
     isShowingResults: Boolean = false,
+    emojis: List<EmojiModel> = emptyList(),
     onVote: (() -> Unit)? = null,
 ) {
     val shape = RoundedCornerShape(CornerSize.xl)
@@ -222,11 +226,12 @@ private fun PollCardOption(
         }
 
         // option title
-        Text(
+        TextWithCustomEmojis(
             modifier = Modifier.weight(1f).padding(start = Spacing.xxs),
             text = title,
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onBackground,
+            emojis = emojis,
         )
 
         // trailing part

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
@@ -255,6 +255,7 @@ fun TimelineItem(
                         PollCard(
                             modifier = Modifier.fillMaxWidth(),
                             poll = poll,
+                            emojis = entryToDisplay.emojis,
                             enabled = pollEnabled,
                             onVote = { choices ->
                                 onPollVote?.invoke(entryToDisplay, choices)


### PR DESCRIPTION
Custom emojis in poll options were not rendered due to two issues:
- the backend does not always return them in the response, when custom emojis occur inside poll options;
- the UI component used in app for poll options did not support inline contents.

This PR solves both issues, making it possible to have custom emojis in poll options, e.g. [here](https://hellions.cloud/@dannotdaniel/113457309209971514)

![poll_with_emojis](https://github.com/user-attachments/assets/5d7ae582-4f24-4a7e-8c82-c97a6d867d90)
