### PR TITLE
fix: HTML syntax in app full_description.txt

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -33,7 +33,7 @@
     <li>
         and, of course, much more (see the official documentation)…
     </li>
-<ul>
+</ul>
 <p>
     The web interface is great to access all of these features but on a mobile device there are
     different constraints for usability and readability, so it comes in handy to have an app to

--- a/fastlane/metadata/android/it-IT/full_description.txt
+++ b/fastlane/metadata/android/it-IT/full_description.txt
@@ -33,7 +33,7 @@
     <li>
         e ovviamente molto altro (fare riferimento alla documentazione ufficiale)…
     </li>
-<ul>
+</ul>
 <p>
     L'interfaccia web è ottima per accedere a tutte queste funzionalità, ma su un dispositivo mobile
     ci sono vincoli diversi per usabilità e leggibilità, quindi è utile avere un'app per utilizzare


### PR DESCRIPTION
This PR fixes a bug in the HTML syntax in the app description in Fastlane metadata.