### PR TITLE
refactor: remove useless navigators

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/App.kt
@@ -22,6 +22,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.AppTheme
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.di.getL10nManager
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.ProvideStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.DrawerEvent
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.ScreenContent
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.VoyagerNavigator
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDrawerCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
@@ -140,7 +141,7 @@ fun App(onLoadingFinished: (() -> Unit)? = null) {
                         gesturesEnabled = drawerGesturesEnabled,
                         drawerContent = {
                             ModalDrawerSheet {
-                                Navigator(DrawerContent())
+                                ScreenContent(DrawerContent())
                             }
                         },
                     ) {

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/bottomnavigation/ExploreTab.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/bottomnavigation/ExploreTab.kt
@@ -1,9 +1,9 @@
 package com.livefast.eattrash.raccoonforfriendica.bottomnavigation
 
 import androidx.compose.runtime.Composable
-import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.navigator.tab.Tab
 import cafe.adriel.voyager.navigator.tab.TabOptions
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.ScreenContent
 import com.livefast.eattrash.raccoonforfriendica.feature.explore.ExploreScreen
 
 object ExploreTab : Tab {
@@ -17,6 +17,6 @@ object ExploreTab : Tab {
 
     @Composable
     override fun Content() {
-        Navigator(ExploreScreen())
+        ScreenContent(ExploreScreen())
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/bottomnavigation/HomeTab.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/bottomnavigation/HomeTab.kt
@@ -1,9 +1,9 @@
 package com.livefast.eattrash.raccoonforfriendica.bottomnavigation
 
 import androidx.compose.runtime.Composable
-import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.navigator.tab.Tab
 import cafe.adriel.voyager.navigator.tab.TabOptions
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.ScreenContent
 import com.livefast.eattrash.raccoonforfriendica.feature.timeline.TimelineScreen
 
 object HomeTab : Tab {
@@ -17,6 +17,6 @@ object HomeTab : Tab {
 
     @Composable
     override fun Content() {
-        Navigator(TimelineScreen())
+        ScreenContent(TimelineScreen())
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/bottomnavigation/InboxTab.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/bottomnavigation/InboxTab.kt
@@ -1,9 +1,9 @@
 package com.livefast.eattrash.raccoonforfriendica.bottomnavigation
 
 import androidx.compose.runtime.Composable
-import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.navigator.tab.Tab
 import cafe.adriel.voyager.navigator.tab.TabOptions
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.ScreenContent
 import com.livefast.eattrash.raccoonforfriendica.feature.inbox.InboxScreen
 
 object InboxTab : Tab {
@@ -17,6 +17,6 @@ object InboxTab : Tab {
 
     @Composable
     override fun Content() {
-        Navigator(InboxScreen())
+        ScreenContent(InboxScreen())
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/bottomnavigation/ProfileTab.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/bottomnavigation/ProfileTab.kt
@@ -1,9 +1,9 @@
 package com.livefast.eattrash.raccoonforfriendica.bottomnavigation
 
 import androidx.compose.runtime.Composable
-import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.navigator.tab.Tab
 import cafe.adriel.voyager.navigator.tab.TabOptions
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.ScreenContent
 import com.livefast.eattrash.raccoonforfriendica.feature.profile.ProfileScreen
 
 object ProfileTab : Tab {
@@ -17,6 +17,6 @@ object ProfileTab : Tab {
 
     @Composable
     override fun Content() {
-        Navigator(ProfileScreen())
+        ScreenContent(ProfileScreen())
     }
 }


### PR DESCRIPTION
In an attempt to reduce the coupling with Voyager's navigators, this PR replaces the ones which are never use to push/pop anything with plain screen contents.