### PR TITLE
fix: rendering images of different heights

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentAttachments.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentAttachments.kt
@@ -142,8 +142,6 @@ private fun AttachmentElement(
     autoload: Boolean = true,
     sensitive: Boolean = false,
     onClick: (() -> Unit)? = null,
-    minHeight: Dp = Dp.Unspecified,
-    maxHeight: Dp = Dp.Unspecified,
 ) {
     val attachmentWidth = attachment.originalWidth ?: 0
     val attachmentHeight = attachment.originalHeight ?: 0
@@ -159,8 +157,6 @@ private fun AttachmentElement(
                 originalHeight = attachmentHeight,
                 sensitive = blurNsfw && sensitive,
                 autoload = autoload,
-                minHeight = minHeight,
-                maxHeight = maxHeight,
                 contentScale = contentScale,
                 onClick = onClick,
             )

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentAttachments.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentAttachments.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.AttachmentModel
@@ -59,9 +58,9 @@ fun ContentAttachments(
             initialPage = 0,
             pageCount = { filteredAttachments.size },
         )
-    val maxHeightAspectRatio =
+    val referenceAspectRatio =
         filteredAttachments
-            .maxBy { it.originalHeight ?: 0 }
+            .minBy { it.originalHeight ?: 0 }
             .aspectRatio
             .takeIf { it > 0 } ?: (16 / 9f)
     val hasMultipleElements = filteredAttachments.size > 1
@@ -73,7 +72,7 @@ fun ContentAttachments(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .aspectRatio(maxHeightAspectRatio),
+                    .aspectRatio(referenceAspectRatio),
             state = pagerState,
             beyondViewportPageCount = 1,
         ) { index ->

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentImage.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentImage.kt
@@ -6,8 +6,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -90,22 +89,9 @@ fun ContentImage(
         CustomImage(
             modifier =
                 Modifier
+                    .fillMaxSize()
                     .clip(RoundedCornerShape(CornerSize.xl))
-                    .then(
-                        when {
-                            minHeight == Dp.Unspecified && maxHeight == Dp.Unspecified -> {
-                                Modifier.fillMaxHeight()
-                            }
-
-                            originalWidth > 0 && originalHeight > 0 -> {
-                                Modifier.aspectRatio(originalWidth / originalHeight.toFloat())
-                            }
-
-                            else -> {
-                                Modifier.heightIn(min = minHeight, max = maxHeight)
-                            }
-                        },
-                    ).clickable {
+                    .clickable {
                         onClick?.invoke()
                     },
             url = url,


### PR DESCRIPTION
If an image carousel in a feed had images with very different aspect ratios, some "vertical gaps" may be present which highly deteriorate the UI of the app.

Moreover, under some circumstances, unbound images could expand too much, overlapping the rest of the post view.

This PR fixed both issues and cleans up some code that is not needed any more after attachment grids were gone.