### PR TITLE
fix: typo in en-US full_description.txt

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -10,7 +10,7 @@
         rich text editing, long posts, support for titles and spoilers;
     </li>
     <li>
-        native support for ActivityPub <b>groups<b>;
+        native support for ActivityPub <b>groups</b>;
     </li>
     <li>
         <b>direct messages</b>;


### PR DESCRIPTION
Fix closing `</b>` tag in English app full description.