### PR TITLE
fix: retain screen state on navigation from top-level screens

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/App.kt
@@ -22,7 +22,6 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.AppTheme
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.di.getL10nManager
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.ProvideStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.DrawerEvent
-import com.livefast.eattrash.raccoonforfriendica.core.navigation.ScreenContent
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.VoyagerNavigator
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDrawerCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
@@ -141,7 +140,7 @@ fun App(onLoadingFinished: (() -> Unit)? = null) {
                         gesturesEnabled = drawerGesturesEnabled,
                         drawerContent = {
                             ModalDrawerSheet {
-                                ScreenContent(DrawerContent())
+                                Navigator(DrawerContent())
                             }
                         },
                     ) {

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/bottomnavigation/ExploreTab.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/bottomnavigation/ExploreTab.kt
@@ -1,9 +1,9 @@
 package com.livefast.eattrash.raccoonforfriendica.bottomnavigation
 
 import androidx.compose.runtime.Composable
+import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.navigator.tab.Tab
 import cafe.adriel.voyager.navigator.tab.TabOptions
-import com.livefast.eattrash.raccoonforfriendica.core.navigation.ScreenContent
 import com.livefast.eattrash.raccoonforfriendica.feature.explore.ExploreScreen
 
 object ExploreTab : Tab {
@@ -17,6 +17,6 @@ object ExploreTab : Tab {
 
     @Composable
     override fun Content() {
-        ScreenContent(ExploreScreen())
+        Navigator(ExploreScreen())
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/bottomnavigation/HomeTab.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/bottomnavigation/HomeTab.kt
@@ -1,9 +1,9 @@
 package com.livefast.eattrash.raccoonforfriendica.bottomnavigation
 
 import androidx.compose.runtime.Composable
+import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.navigator.tab.Tab
 import cafe.adriel.voyager.navigator.tab.TabOptions
-import com.livefast.eattrash.raccoonforfriendica.core.navigation.ScreenContent
 import com.livefast.eattrash.raccoonforfriendica.feature.timeline.TimelineScreen
 
 object HomeTab : Tab {
@@ -17,6 +17,6 @@ object HomeTab : Tab {
 
     @Composable
     override fun Content() {
-        ScreenContent(TimelineScreen())
+        Navigator(TimelineScreen())
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/bottomnavigation/InboxTab.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/bottomnavigation/InboxTab.kt
@@ -1,9 +1,9 @@
 package com.livefast.eattrash.raccoonforfriendica.bottomnavigation
 
 import androidx.compose.runtime.Composable
+import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.navigator.tab.Tab
 import cafe.adriel.voyager.navigator.tab.TabOptions
-import com.livefast.eattrash.raccoonforfriendica.core.navigation.ScreenContent
 import com.livefast.eattrash.raccoonforfriendica.feature.inbox.InboxScreen
 
 object InboxTab : Tab {
@@ -17,6 +17,6 @@ object InboxTab : Tab {
 
     @Composable
     override fun Content() {
-        ScreenContent(InboxScreen())
+        Navigator(InboxScreen())
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/bottomnavigation/ProfileTab.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/bottomnavigation/ProfileTab.kt
@@ -1,9 +1,9 @@
 package com.livefast.eattrash.raccoonforfriendica.bottomnavigation
 
 import androidx.compose.runtime.Composable
+import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.navigator.tab.Tab
 import cafe.adriel.voyager.navigator.tab.TabOptions
-import com.livefast.eattrash.raccoonforfriendica.core.navigation.ScreenContent
 import com.livefast.eattrash.raccoonforfriendica.feature.profile.ProfileScreen
 
 object ProfileTab : Tab {
@@ -17,6 +17,6 @@ object ProfileTab : Tab {
 
     @Composable
     override fun Content() {
-        ScreenContent(ProfileScreen())
+        Navigator(ProfileScreen())
     }
 }

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/ScreenContent.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/ScreenContent.kt
@@ -1,9 +1,0 @@
-package com.livefast.eattrash.raccoonforfriendica.core.navigation
-
-import androidx.compose.runtime.Composable
-import cafe.adriel.voyager.core.screen.Screen
-
-@Composable
-fun ScreenContent(screen: Screen) {
-    screen.Content()
-}

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
@@ -45,7 +45,6 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.Placeh
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ProgressHud
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
-import com.livefast.eattrash.raccoonforfriendica.core.navigation.ScreenContent
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDrawerCoordinator
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
 import com.livefast.eattrash.raccoonforfriendica.feature.profile.loginintro.LoginIntroScreen
@@ -137,11 +136,13 @@ class ProfileScreen : Screen {
                                     },
                                 ),
                     ) {
-                        if (uiState.currentUserId != null) {
-                            ScreenContent(MyAccountScreen)
-                        } else {
-                            ScreenContent(LoginIntroScreen())
-                        }
+                        val screen =
+                            if (uiState.currentUserId != null) {
+                                MyAccountScreen
+                            } else {
+                                LoginIntroScreen()
+                            }
+                        screen.Content()
                     }
                 },
             )

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/newaccount/NewAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/newaccount/NewAccountScreen.kt
@@ -18,9 +18,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.navigator.Navigator
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
-import com.livefast.eattrash.raccoonforfriendica.core.navigation.ScreenContent
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.feature.profile.loginintro.LoginIntroScreen
 
@@ -66,7 +66,7 @@ class NewAccountScreen : Screen {
                         .padding(padding)
                         .fillMaxWidth(),
             ) {
-                ScreenContent(LoginIntroScreen())
+                Navigator(LoginIntroScreen())
             }
         }
     }


### PR DESCRIPTION
## Technical details
This fixes a bug introduced in #502 due to which, after removing some `Navigator`s the lifecycle of some screens has changed (Home, Explore, Inbox and Profile) and they are reinitialized when navigating to a detail and back.
