### PR TITLE
enhancement: show app icon current state

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SettingsColorRow.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SettingsColorRow.kt
@@ -37,7 +37,7 @@ fun SettingsColorRow(
         modifier =
             modifier
                 .clip(
-                    shape = RoundedCornerShape(CornerSize.l),
+                    shape = RoundedCornerShape(CornerSize.xl),
                 ).then(
                     if (onTap != null) {
                         Modifier.clickable {

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SettingsImageInfo.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SettingsImageInfo.kt
@@ -42,7 +42,7 @@ fun SettingsImageInfo(
             modifier
                 .fillMaxWidth()
                 .clip(
-                    shape = RoundedCornerShape(CornerSize.l),
+                    shape = RoundedCornerShape(CornerSize.xl),
                 ).then(
                     if (onEdit != null) {
                         Modifier.clickable {

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SettingsRow.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SettingsRow.kt
@@ -45,7 +45,7 @@ fun SettingsRow(
         modifier =
             modifier
                 .clip(
-                    shape = RoundedCornerShape(CornerSize.l),
+                    shape = RoundedCornerShape(CornerSize.xl),
                 ).then(
                     if (onTap != null) {
                         Modifier.clickable {

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SettingsSwitchRow.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/SettingsSwitchRow.kt
@@ -28,7 +28,7 @@ fun SettingsSwitchRow(
         modifier =
             Modifier
                 .clip(
-                    shape = RoundedCornerShape(CornerSize.l),
+                    shape = RoundedCornerShape(CornerSize.xl),
                 ).clickable {
                     onValueChanged(!value)
                 }.padding(horizontal = Spacing.m),

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/appicon/DefaultAppIconManager.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/appicon/DefaultAppIconManager.kt
@@ -3,10 +3,15 @@ package com.livefast.eattrash.raccoonforfriendica.core.utils.appicon
 import android.content.ComponentName
 import android.content.Context
 import android.content.pm.PackageManager
+import com.livefast.eattrash.raccoonforfriendica.core.preferences.TemporaryKeyStore
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
 
 class DefaultAppIconManager(
     private val context: Context,
+    private val keyStore: TemporaryKeyStore,
 ) : AppIconManager {
+    override val current = MutableStateFlow<AppIconVariant>(AppIconVariant.Default)
     private val allComponentNames =
         listOf(
             "com.livefast.eattrash.raccoonforfriendica.MainActivity",
@@ -14,6 +19,11 @@ class DefaultAppIconManager(
         )
 
     override val supportsMultipleIcons = allComponentNames.isNotEmpty()
+
+    init {
+        val lastUsedVariant = keyStore[KEY_APP_ICON_VARIANT, 0].toAppIconVariant()
+        current.update { lastUsedVariant }
+    }
 
     override fun changeIcon(variant: AppIconVariant) {
         val indexToEnable = variant.toInt()
@@ -32,5 +42,11 @@ class DefaultAppIconManager(
                 )
             }
         }
+        keyStore.save(KEY_APP_ICON_VARIANT, variant.toInt())
+        current.update { variant }
+    }
+
+    companion object {
+        private const val KEY_APP_ICON_VARIANT = "AppIconManager.APP_ICON_VARIANT"
     }
 }

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/Utils.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/Utils.kt
@@ -141,6 +141,9 @@ actual val coreUtilsCalendarModule =
 actual val coreAppIconModule =
     module {
         single<AppIconManager> {
-            DefaultAppIconManager(context = get())
+            DefaultAppIconManager(
+                context = get(),
+                keyStore = get(),
+            )
         }
     }

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/appicon/AppIconManager.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/appicon/AppIconManager.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.core.utils.appicon
 
 import androidx.compose.runtime.Composable
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
+import kotlinx.coroutines.flow.StateFlow
 
 sealed interface AppIconVariant {
     data object Default : AppIconVariant
@@ -11,6 +12,7 @@ sealed interface AppIconVariant {
 
 interface AppIconManager {
     val supportsMultipleIcons: Boolean
+    val current: StateFlow<AppIconVariant>
 
     fun changeIcon(variant: AppIconVariant)
 }

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/appicon/DefaultAppIconManager.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/appicon/DefaultAppIconManager.kt
@@ -1,7 +1,10 @@
 package com.livefast.eattrash.raccoonforfriendica.core.utils.appicon
 
+import kotlinx.coroutines.flow.MutableStateFlow
+
 class DefaultAppIconManager : AppIconManager {
     override val supportsMultipleIcons = false
+    override val current = MutableStateFlow(AppIconVariant.Default)
 
     override fun changeIcon(variant: AppIconVariant) {
         // no-op

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsMviModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsMviModel.kt
@@ -151,6 +151,7 @@ interface SettingsMviModel :
         val crashReportRestartRequired: Boolean = false,
         val hideNavigationBarWhileScrolling: Boolean = true,
         val appIconChangeSupported: Boolean = true,
+        val appIconVariant: AppIconVariant = AppIconVariant.Default,
         val appIconRestartRequired: Boolean = false,
     )
 

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
@@ -342,6 +342,7 @@ class SettingsScreen : Screen {
                                     } else {
                                         null
                                     },
+                                value = uiState.appIconVariant.toReadableName(),
                                 onTap = {
                                     appIconBottomSheetOpened = true
                                 },

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsViewModel.kt
@@ -145,6 +145,11 @@ class SettingsViewModel(
                     updateState { it.copy(crashReportRestartRequired = value) }
                 }.launchIn(this)
 
+            appIconManager.current
+                .onEach { variant ->
+                    updateState { it.copy(appIconVariant = variant) }
+                }.launchIn(this)
+
             settingsRepository.current
                 .onEach { settings ->
                     if (settings != null) {


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds the current app icon variant as an observable state in `AppIconManager`, registers for observation in settings and shows the value in the UI.

## Additional notes
<!-- Anything to declare for code review? -->
The value is persisted using `TemporaryKeyStore` so it is backed by `EnEncryptedSharedPreferences` on Android.
