### PR TITLE
feat: implement settings import/export

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -71,4 +71,4 @@ practices, please contact us at livefast.eattrash.raccoon@gmail.com.
 
 --- 
 
-Last updated: 2024-10-16
+Last updated: 2024-11-16

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
@@ -449,4 +449,6 @@ internal val DeStrings =
         override val settingsItemAppIcon = "Anwendungssymbol"
         override val appIconDefault = "Standard"
         override val appIconClassical = "Klassisch"
+        override val settingsItemExport = "Einstellungen exportieren"
+        override val settingsItemImport = "Einstellungen importieren"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -444,4 +444,6 @@ internal open class DefaultStrings : Strings {
     override val settingsItemAppIcon = "Application icon"
     override val appIconDefault = "Default"
     override val appIconClassical = "Classical"
+    override val settingsItemExport = "Export settings"
+    override val settingsItemImport = "Import settings"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/EsStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/EsStrings.kt
@@ -449,4 +449,6 @@ internal val EsStrings =
         override val settingsItemAppIcon = "Icono de la aplicación"
         override val appIconDefault = "Estandar"
         override val appIconClassical = "Clásico"
+        override val settingsItemExport = "Exportar configuración"
+        override val settingsItemImport = "Importar configuración"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/FrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/FrStrings.kt
@@ -454,4 +454,6 @@ internal val FrStrings =
         override val settingsItemAppIcon = "Icône de l'application"
         override val appIconDefault = "Défaut"
         override val appIconClassical = "Classique"
+        override val settingsItemExport = "Exporter les paramètres"
+        override val settingsItemImport = "Importer les paramètres"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -449,4 +449,6 @@ internal val ItStrings =
         override val settingsItemAppIcon = "Icona applicazione"
         override val appIconDefault = "Predefinita"
         override val appIconClassical = "Classica"
+        override val settingsItemExport = "Esporta impostazioni"
+        override val settingsItemImport = "Importa impostazioni"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/PlStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/PlStrings.kt
@@ -447,4 +447,6 @@ internal val PlStrings =
         override val settingsItemAppIcon = "Ikona aplikacji"
         override val appIconDefault = "Domyślny"
         override val appIconClassical = "Klasyczny"
+        override val settingsItemExport = "Eksportowanie ustawień"
+        override val settingsItemImport = "Importowanie ustawień"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/PtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/PtStrings.kt
@@ -453,4 +453,6 @@ internal val PtStrings =
         override val settingsItemAppIcon = "Ícone da aplicação"
         override val appIconDefault = "Predefinição"
         override val appIconClassical = "Clássico"
+        override val settingsItemExport = "Exportar as definições"
+        override val settingsItemImport = "Importar as definições"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -396,6 +396,8 @@ interface Strings {
     val settingsItemAppIcon: String
     val appIconDefault: String
     val appIconClassical: String
+    val settingsItemExport: String
+    val settingsItemImport: String
 }
 
 object Locales {

--- a/docs/manual/it/main.md
+++ b/docs/manual/it/main.md
@@ -656,6 +656,8 @@ costituita dalle seguenti sezioni:
   - **Colore tema** permette di selezionare un colore a partire dal quale verrà generata una palette
     di colori Material 3;
   - **Material You** genera una palette di colori a partire dall'immagine di sfondo;
+  - **Icona applicatione** permette di selezionare un'icona per l'applicazione (predefinita o "
+    classica");
 - **NSFW**
   - **Gestione filtri** apre la schermata di [gestione](#gestione-filtri) degli utenti bloccati e
     silenziati;
@@ -666,7 +668,11 @@ costituita dalle seguenti sezioni:
 - **Debug**
   - **Abilita segnalazioni anonime arresti anomali** determina se abilitare o meno le segnalazioni
     anonime inviate in caso di arresto anomalo per tutti gli account (affinché la modifica sia
-    effettiva sarà necessario riavviare l'applicazione).
+    effettiva sarà necessario riavviare l'applicazione);
+- **Altro**
+  - **Esporta impostazioni** salva le impostazioni attuali in un file JSON (per poterle importare
+    nuovamente se cambi account o cancelli i dati dell'applicazione);
+  - **Importa impostazioni** carica le impostazioni dell'app da un file JSON;
 
 <p id="markdown-formatting">
 * scegliere con cautela: <em>Markdown</em> è supportato solo da alcune versioni di Mastodon (es.

--- a/docs/manual/main.md
+++ b/docs/manual/main.md
@@ -610,6 +610,7 @@ sections:
   - **Font size** configures the scale factor applied to fonts in the UI
   - **Theme color** allows to choose a color to generate a Material 3 palette from;
   - **Material You** generate a color palette based on the launcher image;
+  - **Application icon** change the application icon (default or "classic" one);
 - **NSFW**
   - **Manage filters** opens the ban and [filter management](#manage-filters) screen;
   - **Include NSFW contents** enables a client-side filter to exclude sensitive posts;
@@ -617,7 +618,11 @@ sections:
     when they occur in timelines;
 - **Debug**
   - **Enable anonymous crash reports** determines whether anonymous crash reports are enabled for
-    all accounts (changing this option requires the app to be restarted afterwards).
+    all accounts (changing this option requires the app to be restarted afterwards);
+- **Other**
+  - **Export settings** export the current settings to a JSON file (which can be imported if you
+    change account or clear the app data);
+  - **Import settings** import application settings from a JSON file;
 
 <p id="markdown-formatting">
 * please choose wisely: <em>Markdown</em> is supported only by some versions of Mastodon (e.g.

--- a/domain/identity/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/data/ImageLoadingMode.kt
+++ b/domain/identity/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/data/ImageLoadingMode.kt
@@ -18,3 +18,17 @@ fun ImageLoadingMode.toReadableName(): String =
         ImageLoadingMode.Always -> LocalStrings.current.imageLoadingModeAlways
         ImageLoadingMode.OnDemand -> LocalStrings.current.imageLoadingModeOnDemand
     }
+
+fun ImageLoadingMode.toInt(): Int =
+    when (this) {
+        ImageLoadingMode.Always -> 1
+        ImageLoadingMode.OnWifi -> 2
+        else -> 0
+    }
+
+fun Int.toImageLoadingMode(): ImageLoadingMode =
+    when (this) {
+        2 -> ImageLoadingMode.OnWifi
+        1 -> ImageLoadingMode.Always
+        else -> ImageLoadingMode.OnDemand
+    }

--- a/domain/identity/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/data/MarkupMode.kt
+++ b/domain/identity/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/data/MarkupMode.kt
@@ -31,3 +31,19 @@ fun MarkupMode.toReadableName() =
         MarkupMode.Markdown -> LocalStrings.current.markupModeMarkdown
         MarkupMode.PlainText -> LocalStrings.current.markupModePlainText
     }
+
+fun Int.toMarkupMode(): MarkupMode =
+    when (this) {
+        1 -> MarkupMode.HTML
+        2 -> MarkupMode.BBCode
+        3 -> MarkupMode.Markdown
+        else -> MarkupMode.PlainText
+    }
+
+fun MarkupMode.toInt() =
+    when (this) {
+        MarkupMode.HTML -> 1
+        MarkupMode.BBCode -> 2
+        MarkupMode.Markdown -> 3
+        MarkupMode.PlainText -> 0
+    }

--- a/domain/identity/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/data/NotificationMode.kt
+++ b/domain/identity/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/data/NotificationMode.kt
@@ -18,3 +18,17 @@ fun NotificationMode.toReadableName(): String =
         NotificationMode.Pull -> LocalStrings.current.settingsNotificationModePull
         NotificationMode.Push -> LocalStrings.current.settingsNotificationModePush
     }
+
+fun Int.toNotificationMode(): NotificationMode =
+    when (this) {
+        1 -> NotificationMode.Pull
+        2 -> NotificationMode.Push
+        else -> NotificationMode.Disabled
+    }
+
+fun NotificationMode.toInt() =
+    when (this) {
+        NotificationMode.Pull -> 1
+        NotificationMode.Push -> 2
+        else -> 0
+    }

--- a/domain/identity/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/data/SettingsModel.kt
+++ b/domain/identity/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/data/SettingsModel.kt
@@ -30,3 +30,16 @@ data class SettingsModel(
     val autoloadImages: ImageLoadingMode = ImageLoadingMode.Always,
     val hideNavigationBarWhileScrolling: Boolean = true,
 )
+
+fun Int.toDomainMaxLines(): Int =
+    when (this) {
+        // interpret null values as unlimited
+        0 -> Int.MAX_VALUE
+        else -> this
+    }
+
+fun Int.toSerialMaxLines(): Int =
+    when (this) {
+        Int.MAX_VALUE -> 0
+        else -> this
+    }

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultSettingsRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultSettingsRepository.kt
@@ -6,11 +6,13 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.toUiFontSc
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.toUiTheme
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.dao.SettingsDao
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.entities.SettingsEntity
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.ImageLoadingMode
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.MarkupMode
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.NotificationMode
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.toDomainMaxLines
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.toImageLoadingMode
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.toInt
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.toMarkupMode
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.toNotificationMode
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.toSerialMaxLines
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.toUrlOpeningMode
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
@@ -86,67 +88,10 @@ private fun SettingsModel.toEntity() =
         excludeRepliesFromTimeline = excludeRepliesFromTimeline,
         openGroupsInForumModeByDefault = openGroupsInForumModeByDefault,
         markupMode = markupMode.toInt(),
-        maxPostBodyLines = maxPostBodyLines.toEntityMaxLines(),
+        maxPostBodyLines = maxPostBodyLines.toSerialMaxLines(),
         defaultTimelineId = defaultTimelineId,
         notificationMode = notificationMode.toInt(),
         pullNotificationCheckInterval = pullNotificationCheckInterval?.inWholeSeconds,
         autoloadImages = autoloadImages.toInt(),
         hideNavigationBarWhileScrolling = hideNavigationBarWhileScrolling,
     )
-
-private fun Int.toMarkupMode(): MarkupMode =
-    when (this) {
-        1 -> MarkupMode.HTML
-        2 -> MarkupMode.BBCode
-        3 -> MarkupMode.Markdown
-        else -> MarkupMode.PlainText
-    }
-
-private fun MarkupMode.toInt() =
-    when (this) {
-        MarkupMode.HTML -> 1
-        MarkupMode.BBCode -> 2
-        MarkupMode.Markdown -> 3
-        MarkupMode.PlainText -> 0
-    }
-
-private fun Int.toDomainMaxLines(): Int =
-    when (this) {
-        // interpret null values as unlimited
-        0 -> Int.MAX_VALUE
-        else -> this
-    }
-
-private fun Int.toEntityMaxLines(): Int =
-    when (this) {
-        Int.MAX_VALUE -> 0
-        else -> this
-    }
-
-private fun Int.toNotificationMode(): NotificationMode =
-    when (this) {
-        1 -> NotificationMode.Pull
-        2 -> NotificationMode.Push
-        else -> NotificationMode.Disabled
-    }
-
-private fun NotificationMode.toInt() =
-    when (this) {
-        NotificationMode.Pull -> 1
-        NotificationMode.Push -> 2
-        else -> 0
-    }
-
-private fun ImageLoadingMode.toInt(): Int =
-    when (this) {
-        ImageLoadingMode.Always -> 1
-        ImageLoadingMode.OnWifi -> 2
-        else -> 0
-    }
-
-private fun Int.toImageLoadingMode(): ImageLoadingMode =
-    when (this) {
-        2 -> ImageLoadingMode.OnWifi
-        1 -> ImageLoadingMode.Always
-        else -> ImageLoadingMode.OnDemand
-    }

--- a/domain/identity/usecase/build.gradle.kts
+++ b/domain/identity/usecase/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.kotlinx.serialization)
     alias(libs.plugins.mokkery)
 }
 
@@ -39,6 +40,7 @@ kotlin {
 
                 implementation(libs.koin.core)
                 implementation(libs.kotlinx.coroutines)
+                implementation(libs.kotlinx.serialization.json)
 
                 implementation(projects.core.appearance)
                 implementation(projects.core.l10n)

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultExportSettingsUseCase.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultExportSettingsUseCase.kt
@@ -1,0 +1,19 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
+
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.encodeToString
+
+internal class DefaultExportSettingsUseCase(
+    private val settingsRepository: SettingsRepository,
+) : ExportSettingsUseCase {
+    override suspend fun invoke(): String {
+        val settings = settingsRepository.current.value ?: return ""
+        return withContext(Dispatchers.IO) {
+            val data = settings.toData()
+            jsonSerializationStrategy.encodeToString(data)
+        }
+    }
+}

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultImportSettingsUseCase.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultImportSettingsUseCase.kt
@@ -1,0 +1,24 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
+
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
+
+internal class DefaultImportSettingsUseCase(
+    private val settingsRepository: SettingsRepository,
+) : ImportSettingsUseCase {
+    override suspend fun invoke(content: String) {
+        val current = settingsRepository.current.value ?: return
+        withContext(Dispatchers.IO) {
+            val data: SerializableSettings = jsonSerializationStrategy.decodeFromString(content)
+            val settings =
+                data.toModel().copy(
+                    id = current.id,
+                    accountId = current.accountId,
+                )
+            settingsRepository.update(settings)
+            settingsRepository.changeCurrent(settings)
+        }
+    }
+}

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/ExportSettingsUseCase.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/ExportSettingsUseCase.kt
@@ -1,0 +1,5 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
+
+interface ExportSettingsUseCase {
+    suspend operator fun invoke(): String
+}

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/ImportSettingsUseCase.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/ImportSettingsUseCase.kt
@@ -1,0 +1,5 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
+
+interface ImportSettingsUseCase {
+    suspend operator fun invoke(content: String)
+}

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/SerializableSettings.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/SerializableSettings.kt
@@ -1,0 +1,98 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
+
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.toInt
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.toUiFontFamily
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.toUiFontScale
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.toUiTheme
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.toDomainMaxLines
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.toImageLoadingMode
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.toInt
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.toMarkupMode
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.toNotificationMode
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.toSerialMaxLines
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.toUrlOpeningMode
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlin.time.Duration.Companion.seconds
+
+internal val jsonSerializationStrategy =
+    Json {
+        encodeDefaults = true
+        prettyPrint = true
+    }
+
+@Serializable
+internal data class SerializableSettings(
+    val lang: String = "en",
+    val theme: Int = 0,
+    val fontFamily: Int = 0,
+    val fontScale: Int = 0,
+    val dynamicColors: Boolean = false,
+    val customSeedColor: Int? = null,
+    val defaultTimelineType: Int = 0,
+    val defaultTimelineId: String? = null,
+    val includeNsfw: Boolean = false,
+    val blurNsfw: Boolean = true,
+    val urlOpeningMode: Int = 0,
+    val defaultPostVisibility: Int = 0,
+    val defaultReplyVisibility: Int = 1,
+    val excludeRepliesFromTimeline: Boolean = false,
+    val openGroupsInForumModeByDefault: Boolean = true,
+    val markupMode: Int = 0,
+    val maxPostBodyLines: Int = Int.MAX_VALUE,
+    val notificationMode: Int = 0,
+    val pullNotificationCheckInterval: Long? = null,
+    val autoloadImages: Int = 1,
+    val hideNavigationBarWhileScrolling: Boolean = true,
+)
+
+internal fun SerializableSettings.toModel() =
+    SettingsModel(
+        lang = lang,
+        theme = theme.toUiTheme(),
+        fontFamily = fontFamily.toUiFontFamily(),
+        fontScale = fontScale.toUiFontScale(),
+        dynamicColors = dynamicColors,
+        customSeedColor = customSeedColor,
+        defaultTimelineType = defaultTimelineType,
+        blurNsfw = blurNsfw,
+        includeNsfw = includeNsfw,
+        urlOpeningMode = urlOpeningMode.toUrlOpeningMode(),
+        defaultPostVisibility = defaultPostVisibility,
+        defaultReplyVisibility = defaultReplyVisibility,
+        excludeRepliesFromTimeline = excludeRepliesFromTimeline,
+        openGroupsInForumModeByDefault = openGroupsInForumModeByDefault,
+        markupMode = markupMode.toMarkupMode(),
+        maxPostBodyLines = maxPostBodyLines.toDomainMaxLines(),
+        defaultTimelineId = defaultTimelineId,
+        notificationMode = notificationMode.toNotificationMode(),
+        pullNotificationCheckInterval = pullNotificationCheckInterval?.seconds,
+        autoloadImages = autoloadImages.toImageLoadingMode(),
+        hideNavigationBarWhileScrolling = hideNavigationBarWhileScrolling,
+    )
+
+internal fun SettingsModel.toData() =
+    SerializableSettings(
+        lang = lang,
+        theme = theme.toInt(),
+        fontFamily = fontFamily.toInt(),
+        fontScale = fontScale.toInt(),
+        dynamicColors = dynamicColors,
+        customSeedColor = customSeedColor,
+        defaultTimelineType = defaultTimelineType,
+        includeNsfw = includeNsfw,
+        blurNsfw = blurNsfw,
+        urlOpeningMode = urlOpeningMode.toInt(),
+        defaultPostVisibility = defaultPostVisibility,
+        defaultReplyVisibility = defaultReplyVisibility,
+        excludeRepliesFromTimeline = excludeRepliesFromTimeline,
+        openGroupsInForumModeByDefault = openGroupsInForumModeByDefault,
+        markupMode = markupMode.toInt(),
+        maxPostBodyLines = maxPostBodyLines.toSerialMaxLines(),
+        defaultTimelineId = defaultTimelineId,
+        notificationMode = notificationMode.toInt(),
+        pullNotificationCheckInterval = pullNotificationCheckInterval?.inWholeSeconds,
+        autoloadImages = autoloadImages.toInt(),
+        hideNavigationBarWhileScrolling = hideNavigationBarWhileScrolling,
+    )

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
@@ -6,12 +6,16 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.Default
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultContentPreloadManager
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultDeleteAccountUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultEntryActionRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultExportSettingsUseCase
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultImportSettingsUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultLoginUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultLogoutUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultSetupAccountUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultSwitchAccountUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DeleteAccountUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.EntryActionRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.ExportSettingsUseCase
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.ImportSettingsUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.LoginUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.LogoutUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.SetupAccountUseCase
@@ -80,6 +84,16 @@ val domainIdentityUseCaseModule =
                 timelineEntryRepository = get(),
                 trendingRepository = get(),
                 notificationRepository = get(),
+            )
+        }
+        single<ImportSettingsUseCase> {
+            DefaultImportSettingsUseCase(
+                settingsRepository = get(),
+            )
+        }
+        single<ExportSettingsUseCase> {
+            DefaultExportSettingsUseCase(
+                settingsRepository = get(),
             )
         }
     }

--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultExportSettingsUseCaseTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultExportSettingsUseCaseTest.kt
@@ -1,0 +1,51 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
+
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.UiTheme
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import dev.mokkery.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DefaultExportSettingsUseCaseTest {
+    private val settingsRepository = mock<SettingsRepository>(MockMode.autoUnit)
+    private val sut = DefaultExportSettingsUseCase(settingsRepository)
+
+    @Test
+    fun `when invoked then interactions are as expected`() =
+        runTest {
+            val settings =
+                SettingsModel(
+                    theme = UiTheme.Dark,
+                )
+            every { settingsRepository.current } returns MutableStateFlow(settings)
+            val expected = jsonSerializationStrategy.encodeToString(settings.toData())
+
+            val res = sut()
+            assertEquals(expected, res)
+
+            verify {
+                settingsRepository.current
+            }
+        }
+
+    @Test
+    fun `given no settings when invoked then interactions are as expected`() =
+        runTest {
+            every { settingsRepository.current } returns MutableStateFlow(null)
+
+            val res = sut()
+            assertEquals("", res)
+
+            verify {
+                settingsRepository.current
+            }
+        }
+}

--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultImportSettingsUseCaseTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultImportSettingsUseCaseTest.kt
@@ -1,0 +1,57 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
+
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.UiTheme
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import kotlin.test.Test
+
+class DefaultImportSettingsUseCaseTest {
+    private val settingsRepository = mock<SettingsRepository>(MockMode.autoUnit)
+    private val sut = DefaultImportSettingsUseCase(settingsRepository)
+
+    @Test
+    fun `when invoked then interactions are as expected`() =
+        runTest {
+            val settings =
+                SettingsModel(
+                    theme = UiTheme.Dark,
+                )
+            val currentSettings = SettingsModel()
+            every { settingsRepository.current } returns MutableStateFlow(currentSettings)
+
+            val serialized = jsonSerializationStrategy.encodeToString(settings.toData())
+            sut(serialized)
+
+            verifySuspend {
+                settingsRepository.update(settings)
+                settingsRepository.changeCurrent(settings)
+            }
+        }
+
+    @Test
+    fun `given no settings when invoked then interactions are as expected`() =
+        runTest {
+            val settings =
+                SettingsModel(
+                    theme = UiTheme.Dark,
+                )
+            every { settingsRepository.current } returns MutableStateFlow(null)
+
+            val serialized = jsonSerializationStrategy.encodeToString(settings.toData())
+            sut(serialized)
+
+            verifySuspend(VerifyMode.not) {
+                settingsRepository.update(settings)
+                settingsRepository.changeCurrent(settings)
+            }
+        }
+}

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsMviModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsMviModel.kt
@@ -114,6 +114,12 @@ interface SettingsMviModel :
         data class ChangeAppIcon(
             val variant: AppIconVariant,
         ) : Intent
+
+        data object ExportSettings : Intent
+
+        data class ImportSettings(
+            val content: String,
+        ) : Intent
     }
 
     data class State(
@@ -153,7 +159,13 @@ interface SettingsMviModel :
         val appIconChangeSupported: Boolean = true,
         val appIconVariant: AppIconVariant = AppIconVariant.Default,
         val appIconRestartRequired: Boolean = false,
+        val loading: Boolean = false,
+        val supportSettingsImportExport: Boolean = true,
     )
 
-    sealed interface Effect
+    sealed interface Effect {
+        data class SaveSettings(
+            val content: String,
+        ) : Effect
+    }
 }

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/di/SettingsModule.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/di/SettingsModule.kt
@@ -22,6 +22,9 @@ val featureSettingsModule =
                 pushNotificationManager = get(),
                 crashReportManager = get(),
                 appIconManager = get(),
+                fileSystemManager = get(),
+                importSettings = get(),
+                exportSettings = get(),
             )
         }
         factory<UserFeedbackMviModel> {


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR introduces the possibility to export settings to a JSON file and reimport them. This can be useful to transfer settings from one account to another or re-import a previous configuration if the app is uninstalled or its data are wiped from the device.

## Additional notes
<!-- Anything to declare for code review? -->
Since a lot of converters methods were private in `DefaultSettingsRepository` but were now needed to serialize/deserialize settings to/from `SerializableSettings`, all these methods have been moved to a shared module (`:domain:identity:data`) in order to be accessible both from `:repository `and from `:usecase` modules.
