### PR TITLE
fix: newlines after titles in Markdown preview

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Technical details
 <!-- Describe the motivation and scope of your changes -->
-This PR…
+This PR …
 
 ## Additional notes
 <!-- Anything to declare for code review? -->

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/utils/DefaultPrepareForPreviewUseCase.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/utils/DefaultPrepareForPreviewUseCase.kt
@@ -79,32 +79,32 @@ internal class DefaultPrepareForPreviewUseCase(
         }.run {
             Regex("^# (?<title>.*?)($|\n)").substituteAllOccurrences(this) { match ->
                 val content = match.groups["title"]?.value.orEmpty()
-                append("<h1>$content</h1>")
+                append("<h1>$content</h1><br />")
             }
         }.run {
             Regex("^## (?<title>.*?)($|\n)").substituteAllOccurrences(this) { match ->
                 val content = match.groups["title"]?.value.orEmpty()
-                append("<h2>$content</h2>")
+                append("<h2>$content</h2><br />")
             }
         }.run {
             Regex("^### (?<title>.*?)($|\n)").substituteAllOccurrences(this) { match ->
                 val content = match.groups["title"]?.value.orEmpty()
-                append("<h3>$content</h3>")
+                append("<h3>$content</h3><br />")
             }
         }.run {
             Regex("^#### (?<title>.*?)($|\n)").substituteAllOccurrences(this) { match ->
                 val content = match.groups["title"]?.value.orEmpty()
-                append("<h4>$content</h4>")
+                append("<h4>$content</h4><br />")
             }
         }.run {
             Regex("^##### (?<title>.*?)($|\n)").substituteAllOccurrences(this) { match ->
                 val content = match.groups["title"]?.value.orEmpty()
-                append("<h5>$content</h5>")
+                append("<h5>$content</h5><br />")
             }
         }.replace("<ul>", "\n")
-            .replace("</ul>", "\n")
+            .replace("</ul>", "\n\n")
             .replace("<ol>", "\n")
-            .replace("</ol>", "\n")
+            .replace("</ol>", "\n\n")
             .run {
                 Regex("^- (?<content>.*?)$").substituteAllOccurrences(this) { match ->
                     val content = match.groups["content"]?.value.orEmpty()


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes a small bug when using Markdown as formatting mode, due to which newlines after headlines were not appearing the in-app preview (but were still rendered correctly when posted).

## Additional notes
<!-- Anything to declare for code review? -->
The in-app preview is a best-effort attempt to show what posts will look like and is not 100% reliable.