### PR TITLE
fix: avoid self mention when replying to a post

### DIFF
--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
@@ -275,14 +275,14 @@ class ComposerViewModel(
                 screenModelScope.launch {
                     val mentions =
                         buildList {
-                            val initialValue = intent.initialHandle.orEmpty()
-                            if (initialValue.isNotEmpty()) {
-                                this += initialValue
-                            }
                             val currentUserHandle =
                                 identityRepository.currentUser.value
                                     ?.handle
                                     .orEmpty()
+                            val initialValue = intent.initialHandle.orEmpty()
+                            if (initialValue.isNotEmpty() && initialValue != currentUserHandle) {
+                                this += initialValue
+                            }
                             val mentions =
                                 inReplyToId
                                     ?.let { entryCache.get(it) }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes a bug due to which it was still possible to self-mention when adding a reply.

## Additional notes
<!-- Anything to declare for code review? -->
Nothing to declare.
