### PR TITLE
fix: make sure to retrieve post source when editing

### DIFF
--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
@@ -1284,7 +1284,7 @@ class ComposerViewModel(
             }
 
         val reference =
-            if (!uiState.value.supportsRichEditing) {
+            if (uiState.value.supportsRichEditing) {
                 // retrieve field values from source to strip down all formatting
                 timelineEntryRepository.getSource(entry.id) ?: entry
             } else {

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
@@ -12,6 +12,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate.HapticFeedba
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.blurHashParamsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationSpecification
@@ -208,7 +209,7 @@ class MyAccountViewModel(
         }
 
         updateState { it.copy(loading = true) }
-        val entries = paginationManager.loadNextPage()
+        val entries = paginationManager.loadNextPage().distinctBy { it.safeKey }
         entries.preloadImages()
         updateState {
             it.copy(


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes a bug due to which the post source was retrieved for editing only if the selected markup mode was plain text. The condition was inverted, the source should be retrieve only if the markup mode was anything other than plain text.

## Additional notes
<!-- Anything to declare for code review? -->
Added _a posteriori_ deduplication in my account posts because there was a weird crash trying to reproduce the original issue.
