### PR TITLE
feat: allowing change markup mode in create post screen

### DIFF
--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
@@ -452,4 +452,7 @@ internal val DeStrings =
         override val settingsItemExport = "Einstellungen exportieren"
         override val settingsItemImport = "Einstellungen importieren"
         override val actionExport = "Exportieren"
+        override val actionChangeMarkupMode = "Auszeichnungsart ändern"
+        override val confirmChangeMarkupMode =
+            "Wenn Sie den Markup-Typ ändern, gehen alle Formatierungen verloren. Trotzdem weitermachen?"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -447,4 +447,7 @@ internal open class DefaultStrings : Strings {
     override val settingsItemExport = "Export settings"
     override val settingsItemImport = "Import settings"
     override val actionExport = "Export"
+    override val actionChangeMarkupMode = "Change markup type"
+    override val confirmChangeMarkupMode =
+        "If you change the markup type, all the formatting will be lost. Proceed anyway?"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/EsStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/EsStrings.kt
@@ -452,4 +452,7 @@ internal val EsStrings =
         override val settingsItemExport = "Exportar configuración"
         override val settingsItemImport = "Importar configuración"
         override val actionExport = "Exportar"
+        override val actionChangeMarkupMode = "Cambiar tipo de marcado"
+        override val confirmChangeMarkupMode =
+            "Si cambia el tipo de marcado, se perderá todo el formato. ¿Proceder de todos modos?"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/FrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/FrStrings.kt
@@ -457,4 +457,7 @@ internal val FrStrings =
         override val settingsItemExport = "Exporter les paramètres"
         override val settingsItemImport = "Importer les paramètres"
         override val actionExport = "Exporter"
+        override val actionChangeMarkupMode = "Modifier type de balisage"
+        override val confirmChangeMarkupMode =
+            "Si vous modifiez le type de balisage, toutes les mises en forme seront perdues. Poursuivre quand même ?"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -452,4 +452,7 @@ internal val ItStrings =
         override val settingsItemExport = "Esporta impostazioni"
         override val settingsItemImport = "Importa impostazioni"
         override val actionExport = "Esporta"
+        override val actionChangeMarkupMode = "Cambia il tipo di markup"
+        override val confirmChangeMarkupMode =
+            "Se si cambia il tipo di markup, tutta la formattazione andrà persa. Procedere comunque?"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/PlStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/PlStrings.kt
@@ -450,4 +450,7 @@ internal val PlStrings =
         override val settingsItemExport = "Eksportowanie ustawień"
         override val settingsItemImport = "Importowanie ustawień"
         override val actionExport = "Eksportuj"
+        override val actionChangeMarkupMode = "Zmiana typu znaczników"
+        override val confirmChangeMarkupMode =
+            "Jeśli zmienisz typ znaczników, całe formatowanie zostanie utracone. Kontynuować mimo to?"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/PtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/PtStrings.kt
@@ -456,4 +456,7 @@ internal val PtStrings =
         override val settingsItemExport = "Exportar as definições"
         override val settingsItemImport = "Importar as definições"
         override val actionExport = "Exportar"
+        override val actionChangeMarkupMode = "Alterar tipo de marcação"
+        override val confirmChangeMarkupMode =
+            "Se alterar o tipo de marcação, toda a formatação se perderá. Continuar na mesma?"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -399,6 +399,8 @@ interface Strings {
     val settingsItemExport: String
     val settingsItemImport: String
     val actionExport: String
+    val actionChangeMarkupMode: String
+    val confirmChangeMarkupMode: String
 }
 
 object Locales {

--- a/feature/composer/build.gradle.kts
+++ b/feature/composer/build.gradle.kts
@@ -44,6 +44,7 @@ kotlin {
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
                 implementation(projects.core.commonui.content)
+                implementation(projects.core.htmlparse)
                 implementation(projects.core.l10n)
                 implementation(projects.core.navigation)
                 implementation(projects.core.notifications)

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
@@ -11,6 +11,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.PollModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.Visibility
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.MarkupMode
 
 sealed interface ComposerFieldType {
     data object Spoiler : ComposerFieldType
@@ -191,6 +192,10 @@ interface ComposerMviModel :
         data object CreatePreview : Intent
 
         data object InsertList : Intent
+
+        data class ChangeMarkupMode(
+            val mode: MarkupMode,
+        ) : Intent
     }
 
     data class State(
@@ -229,9 +234,10 @@ interface ComposerMviModel :
         val shouldShowMentionSuggestions: Boolean = false,
         val mentionSuggestionsLoading: Boolean = false,
         val mentionSuggestions: List<UserModel> = emptyList(),
-        val supportsRichEditing: Boolean = false,
         val autoloadImages: Boolean = true,
         val inReplyTo: TimelineEntryModel? = null,
+        val markupMode: MarkupMode = MarkupMode.PlainText,
+        val availableMarkupModes: List<MarkupMode> = emptyList(),
     )
 
     sealed interface Effect {
@@ -262,3 +268,6 @@ interface ComposerMviModel :
         ) : ValidationError
     }
 }
+
+internal val ComposerMviModel.State.supportsRichEditing: Boolean
+    get() = markupMode.supportsRichEditing

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/di/ComposerModule.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/di/ComposerModule.kt
@@ -3,7 +3,9 @@ package com.livefast.eattrash.raccoonforfriendica.feature.composer.di
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.ComposerMviModel
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.ComposerViewModel
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.utils.DefaultPrepareForPreviewUseCase
+import com.livefast.eattrash.raccoonforfriendica.feature.composer.utils.DefaultStripMarkupUseCase
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.utils.PrepareForPreviewUseCase
+import com.livefast.eattrash.raccoonforfriendica.feature.composer.utils.StripMarkupUseCase
 import org.koin.dsl.module
 
 val featureComposerModule =
@@ -11,6 +13,11 @@ val featureComposerModule =
         single<PrepareForPreviewUseCase> {
             DefaultPrepareForPreviewUseCase(
                 apiConfigurationRepository = get(),
+            )
+        }
+        single<StripMarkupUseCase> {
+            DefaultStripMarkupUseCase(
+                prepareForPreview = get(),
             )
         }
         factory<ComposerMviModel> { params ->
@@ -33,6 +40,7 @@ val featureComposerModule =
                 emojiRepository = get(),
                 userRepository = get(),
                 prepareForPreview = get(),
+                stripMarkup = get(),
                 notificationCenter = get(),
             )
         }

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/utils/DefaultPrepareForPreviewUseCase.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/utils/DefaultPrepareForPreviewUseCase.kt
@@ -77,29 +77,29 @@ internal class DefaultPrepareForPreviewUseCase(
                 append("<a href=\"$url\">$anchor</a>")
             }
         }.run {
-            Regex("^# (?<title>.*?)($|\n)").substituteAllOccurrences(this) { match ->
+            Regex("(?<=^|\n)# (?<title>.*?)(?=$|\n)").substituteAllOccurrences(this) { match ->
                 val content = match.groups["title"]?.value.orEmpty()
-                append("<h1>$content</h1><br />")
+                append("<h1>$content</h1>\n")
             }
         }.run {
-            Regex("^## (?<title>.*?)($|\n)").substituteAllOccurrences(this) { match ->
+            Regex("(?<=^|\n)## (?<title>.*?)(?=\$|\n)").substituteAllOccurrences(this) { match ->
                 val content = match.groups["title"]?.value.orEmpty()
-                append("<h2>$content</h2><br />")
+                append("<h2>$content</h2>\n")
             }
         }.run {
-            Regex("^### (?<title>.*?)($|\n)").substituteAllOccurrences(this) { match ->
+            Regex("(?<=^|\n)### (?<title>.*?)(?=$|\n)").substituteAllOccurrences(this) { match ->
                 val content = match.groups["title"]?.value.orEmpty()
-                append("<h3>$content</h3><br />")
+                append("<h3>$content</h3>\n")
             }
         }.run {
-            Regex("^#### (?<title>.*?)($|\n)").substituteAllOccurrences(this) { match ->
+            Regex("(?<=^|\n)#### (?<title>.*?)(?=\$|\n)").substituteAllOccurrences(this) { match ->
                 val content = match.groups["title"]?.value.orEmpty()
-                append("<h4>$content</h4><br />")
+                append("<h4>$content</h4>\n")
             }
         }.run {
-            Regex("^##### (?<title>.*?)($|\n)").substituteAllOccurrences(this) { match ->
+            Regex("(?<=^|\n)##### (?<title>.*?)(?=\$|\n)").substituteAllOccurrences(this) { match ->
                 val content = match.groups["title"]?.value.orEmpty()
-                append("<h5>$content</h5><br />")
+                append("<h5>$content</h5>\n")
             }
         }.replace("<ul>", "\n")
             .replace("</ul>", "\n\n")

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/utils/DefaultStripMarkupUseCase.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/utils/DefaultStripMarkupUseCase.kt
@@ -1,0 +1,18 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.composer.utils
+
+import androidx.compose.ui.graphics.Color
+import com.livefast.eattrash.raccoonforfriendica.core.htmlparse.parseHtml
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.MarkupMode
+
+internal class DefaultStripMarkupUseCase(
+    private val prepareForPreview: PrepareForPreviewUseCase,
+) : StripMarkupUseCase {
+    override fun invoke(
+        text: String,
+        mode: MarkupMode,
+    ): String {
+        val rendered = prepareForPreview(text = text, mode = mode)
+        val html = rendered.parseHtml(Color.Unspecified)
+        return html.toString()
+    }
+}

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/utils/StripMarkupUseCase.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/utils/StripMarkupUseCase.kt
@@ -1,0 +1,10 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.composer.utils
+
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.MarkupMode
+
+interface StripMarkupUseCase {
+    operator fun invoke(
+        text: String,
+        mode: MarkupMode,
+    ): String
+}


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds the possibility to change the markup mode in the composer,  just for the current post being edited. All current markup has to be stripped down, so a confirmation by the user is requested.

## Additional notes
<!-- Anything to declare for code review? -->
The process for removing markup has two steps:
- first everything is converted to HTML (for BBCode and Markdown)
- then the markup is stripped down.

Since there were still issues with titles in markdown being properly captured and converted to HTML headlines (even after #524) a different approached using lookahead and lookbehind in regexes has been adopted.
