### PR TITLE
fix: notification type serialization for filtering and subscription 

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/NotificationService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/NotificationService.kt
@@ -1,7 +1,6 @@
 package com.livefast.eattrash.raccoonforfriendica.core.api.service
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Notification
-import com.livefast.eattrash.raccoonforfriendica.core.api.dto.NotificationType
 import de.jensklingenberg.ktorfit.Response
 import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.POST
@@ -11,7 +10,8 @@ import de.jensklingenberg.ktorfit.http.Query
 interface NotificationService {
     @GET("v1/notifications")
     suspend fun get(
-        @Query("types") types: List<NotificationType>,
+        @Query("types[]") types: List<String>,
+        @Query("exclude_types[]") excludeTypes: List<String>? = null,
         @Query("max_id") maxId: String? = null,
         @Query("min_id") minId: String? = null,
         @Query("include_all") includeAll: Boolean = false,

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNotificationRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNotificationRepository.kt
@@ -3,8 +3,8 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationType
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toDto
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toRawValue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.sync.Mutex
@@ -34,7 +34,7 @@ internal class DefaultNotificationRepository(
             runCatching {
                 val response =
                     provider.notifications.get(
-                        types = types.mapNotNull { it.toDto() },
+                        types = types.mapNotNull { it.toRawValue() },
                         maxId = pageCursor,
                         limit = DEFAULT_PAGE_SIZE,
                     )

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPushNotificationRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPushNotificationRepository.kt
@@ -4,6 +4,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvid
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationPolicy
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toDto
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toRawValue
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.http.parameters
 import kotlinx.coroutines.Dispatchers
@@ -30,7 +31,7 @@ internal class DefaultPushNotificationRepository(
                             append("subscription[keys][auth]", auth)
                             for (type in NotificationType.ALL) {
                                 append(
-                                    "data[alerts][${type.toDto()}]",
+                                    "data[alerts][${type.toRawValue()}]",
                                     (type in types).toString(),
                                 )
                             }
@@ -52,7 +53,7 @@ internal class DefaultPushNotificationRepository(
                         parameters {
                             for (type in NotificationType.ALL) {
                                 append(
-                                    "data[alerts][${type.toDto()}]",
+                                    "data[alerts][${type.toRawValue()}]",
                                     (type in types).toString(),
                                 )
                             }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
@@ -277,16 +277,16 @@ internal fun Tag.toModel() =
         url = url,
     )
 
-internal fun NotificationType.toDto(): NotificationTypeDto? =
+internal fun NotificationType.toRawValue(): String? =
     when (this) {
-        NotificationType.Entry -> NotificationTypeDto.STATUS
-        NotificationType.Favorite -> NotificationTypeDto.FAVOURITE
-        NotificationType.Follow -> NotificationTypeDto.FOLLOW
-        NotificationType.FollowRequest -> NotificationTypeDto.FOLLOW_REQUEST
-        NotificationType.Mention -> NotificationTypeDto.MENTION
-        NotificationType.Poll -> NotificationTypeDto.POLL
-        NotificationType.Reblog -> NotificationTypeDto.REBLOG
-        NotificationType.Update -> NotificationTypeDto.UPDATE
+        NotificationType.Entry -> "status"
+        NotificationType.Favorite -> "favourite"
+        NotificationType.Follow -> "follow"
+        NotificationType.FollowRequest -> "follow_request"
+        NotificationType.Mention -> "mention"
+        NotificationType.Poll -> "poll"
+        NotificationType.Reblog -> "reblog"
+        NotificationType.Update -> "update"
         else -> null
     }
 


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes the `NotificationType` to data-transfer-object mapping, because I forgot enum values (even if `Serializable` and with `@SerialName`) are not automatically serialized when used as query parameters by Ktorfit.

This is also one of the reasons why push notifications were not working: when creating or updating a subscription "data" object in the payload used serialized event types as keys, which were not recognized by the backend.

Moreover, trailing brackets are needed to pass multiple parameters under the same key.

## Additional notes
<!-- Anything to declare for code review? -->
After the changes in this PR, filtering works seamlessly on Mastodon but on Friendica it is still not working: all results seem to be returned no matter what values are passed in query as `types[]` / `exclude_types[]`.

I'll open an issue upstream and keep this linked.
