### PR TITLE
feat: compose post with shared content

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -47,6 +47,13 @@
 
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:mimeType="text/plain" />
+            </intent-filter>
         </activity>
 
         <!-- alias with traditional icon -->
@@ -74,6 +81,13 @@
                 <action android:name="dev.zwander.mastodonredirect.intent.action.OPEN_FEDI_LINK" />
 
                 <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:mimeType="text/plain" />
             </intent-filter>
         </activity-alias>
 

--- a/composeApp/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/MainActivity.kt
@@ -10,6 +10,7 @@ import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
 import com.livefast.eattrash.raccoonforfriendica.auth.DefaultAuthManager
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.BottomNavigationSection
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDetailOpener
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDrawerCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di.getAuthManager
@@ -86,15 +87,26 @@ class MainActivity : ComponentActivity() {
             )
         }
 
-        intent.data?.also {
-            handleIncomingUrl(it)
-        }
+        handleIntent(intent)
     }
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        intent.data?.also {
-            handleIncomingUrl(it)
+        handleIntent(intent)
+    }
+
+    private fun handleIntent(intent: Intent) {
+        when {
+            intent.action == Intent.ACTION_SEND ->
+                intent.getStringExtra(Intent.EXTRA_TEXT)?.let { content ->
+                    val detailOpener = getDetailOpener()
+                    detailOpener.openComposer(initialText = content.trim('"'))
+                }
+
+            else ->
+                intent.data?.also {
+                    handleIncomingUrl(it)
+                }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
@@ -205,6 +205,7 @@ class DefaultDetailOpener(
         editedPostId: String?,
         urlToShare: String?,
         inGroup: Boolean,
+        initialText: String?,
     ) {
         if (!isLogged) {
             return
@@ -226,6 +227,7 @@ class DefaultDetailOpener(
                     groupHandle = inReplyToUser?.handle.takeIf { isGroup },
                     editedPostId = editedPostId,
                     urlToShare = urlToShare,
+                    initialText = initialText,
                 )
             navigationCoordinator.push(screen)
         }

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DetailOpener.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DetailOpener.kt
@@ -56,6 +56,7 @@ interface DetailOpener {
         editedPostId: String? = null,
         urlToShare: String? = null,
         inGroup: Boolean = false,
+        initialText: String? = null,
     )
 
     fun openEditUnpublished(

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
@@ -109,6 +110,7 @@ class ComposerScreen(
     private val scheduledPostId: String? = null,
     private val draftId: String? = null,
     private val urlToShare: String? = null,
+    private val initialText: String? = null,
 ) : Screen {
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
@@ -179,6 +181,14 @@ class ComposerScreen(
 
                 !urlToShare.isNullOrEmpty() ->
                     model.reduce(ComposerMviModel.Intent.AddShareUrl(urlToShare))
+
+                !initialText.isNullOrEmpty() ->
+                    model.reduce(
+                        ComposerMviModel.Intent.SetFieldValue(
+                            value = TextFieldValue(text = initialText),
+                            fieldType = ComposerFieldType.Body,
+                        ),
+                    )
 
                 inReplyToId != null ->
                     model.reduce(


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds the ability to receive textual data from external applications using the system "Share" action. The incoming text is then used to pre-populate the body field in the post creation form.

## Additional notes
<!-- Anything to declare for code review? -->
The intent-filter uses the `SEND` action and treats everything as text. Further refinement needs to be done to receive images or other kinds of data.

#### Related issues
- #540 
