### PR TITLE
fix: anonymous account settings load

### DIFF
--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitor.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitor.kt
@@ -76,7 +76,11 @@ internal class DefaultActiveAccountMonitor(
 
             identityRepository.refreshCurrentUser(null)
 
-            settingsRepository.changeCurrent(defaultSettings)
+            val accountSettings =
+                accountRepository.getBy(handle = "")?.let {
+                    settingsRepository.get(it.id)
+                } ?: defaultSettings
+            settingsRepository.changeCurrent(accountSettings)
 
             notificationCoordinator.setupAnonymousUser()
         } else {

--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitorTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitorTest.kt
@@ -70,8 +70,10 @@ class DefaultActiveAccountMonitorTest {
             val account: AccountModel? = null
             val accountChannel = Channel<AccountModel?>()
             every { accountRepository.getActiveAsFlow() } returns accountChannel.receiveAsFlow()
+            everySuspend { accountRepository.getBy(handle = any()) } returns AccountModel(id = 1)
             everySuspend { accountRepository.getActive() } returns account
             val settings = SettingsModel()
+            everySuspend { settingsRepository.get(any()) } returns settings
 
             sut.start()
             accountChannel.send(account)
@@ -84,6 +86,8 @@ class DefaultActiveAccountMonitorTest {
                 identityRepository.refreshCurrentUser(null)
                 supportedFeatureRepository.refresh()
                 contentPreloadManager.preload()
+                accountRepository.getBy(handle = "")
+                settingsRepository.get(accountId = 1)
                 settingsRepository.changeCurrent(settings)
                 notificationCoordinator.setupAnonymousUser()
             }

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsViewModel.kt
@@ -466,11 +466,6 @@ class SettingsViewModel(
         saveSettings(newSettings)
     }
 
-    private suspend fun saveSettings(newSettings: SettingsModel) {
-        settingsRepository.update(newSettings)
-        settingsRepository.changeCurrent(newSettings)
-    }
-
     private suspend fun changeNotificationMode(mode: NotificationMode) {
         val currentSettings = settingsRepository.current.value ?: return
         val newSettings = currentSettings.copy(notificationMode = mode)
@@ -522,5 +517,10 @@ class SettingsViewModel(
             updateState { it.copy(loading = false) }
             emitEffect(SettingsMviModel.Effect.SaveSettings(content))
         }
+    }
+
+    private suspend fun saveSettings(newSettings: SettingsModel) {
+        settingsRepository.update(newSettings)
+        settingsRepository.changeCurrent(newSettings)
     }
 }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes a bug due to which for anonymous accounts the default values were selected at app startup or logout, instead of loading the actual settings of the anonymous account.

