### PR TITLE
feat: add announcements • part 2

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -81,6 +81,7 @@ kotlin {
             implementation(projects.domain.pushnotifications)
             implementation(projects.domain.urlhandler)
 
+            implementation(projects.feature.announcements)
             implementation(projects.feature.calendar)
             implementation(projects.feature.circles)
             implementation(projects.feature.composer)

--- a/composeApp/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/DiHelper.kt
+++ b/composeApp/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/DiHelper.kt
@@ -27,6 +27,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.doma
 import com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications.di.domainPullNotificationModule
 import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.di.domainPushNotificationsModule
 import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.di.domainUrlHandlerModule
+import com.livefast.eattrash.raccoonforfriendica.feature.announcements.di.featureAnnouncementsModule
 import com.livefast.eattrash.raccoonforfriendica.feature.calendar.di.featureCalendarModule
 import com.livefast.eattrash.raccoonforfriendica.feature.circles.di.featureCirclesModule
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.di.featureComposerModule
@@ -85,6 +86,7 @@ val sharedHelperModule =
             domainPullNotificationModule,
             domainPushNotificationsModule,
             domainUrlHandlerModule,
+            featureAnnouncementsModule,
             featureCalendarModule,
             featureCirclesModule,
             featureComposerModule,

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
@@ -16,6 +16,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toInt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.LocalItemCache
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
+import com.livefast.eattrash.raccoonforfriendica.feature.announcements.AnnouncementsScreen
 import com.livefast.eattrash.raccoonforfriendica.feature.calendar.detail.EventDetailScreen
 import com.livefast.eattrash.raccoonforfriendica.feature.calendar.list.CalendarScreen
 import com.livefast.eattrash.raccoonforfriendica.feature.circles.editmembers.CircleMembersScreen
@@ -405,6 +406,11 @@ class DefaultDetailOpener(
 
     override fun openInternalWebView(url: String) {
         val screen = WebViewScreen(url)
+        navigationCoordinator.push(screen)
+    }
+
+    override fun openAnnouncements() {
+        val screen = AnnouncementsScreen()
         navigationCoordinator.push(screen)
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpenerTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpenerTest.kt
@@ -13,6 +13,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Local
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
+import com.livefast.eattrash.raccoonforfriendica.feature.announcements.AnnouncementsScreen
 import com.livefast.eattrash.raccoonforfriendica.feature.calendar.detail.EventDetailScreen
 import com.livefast.eattrash.raccoonforfriendica.feature.calendar.list.CalendarScreen
 import com.livefast.eattrash.raccoonforfriendica.feature.circles.editmembers.CircleMembersScreen
@@ -486,6 +487,15 @@ class DefaultDetailOpenerTest {
 
         verify {
             navigationCoordinator.push(any<WebViewScreen>())
+        }
+    }
+
+    @Test
+    fun `when openAnnouncements then interactions are as expected`() {
+        sut.openAnnouncements()
+
+        verify {
+            navigationCoordinator.push(any<AnnouncementsScreen>())
         }
     }
 }

--- a/composeApp/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/DiHelper.kt
+++ b/composeApp/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/DiHelper.kt
@@ -27,6 +27,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.doma
 import com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications.di.domainPullNotificationModule
 import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.di.domainPushNotificationsModule
 import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.di.domainUrlHandlerModule
+import com.livefast.eattrash.raccoonforfriendica.feature.announcements.di.featureAnnouncementsModule
 import com.livefast.eattrash.raccoonforfriendica.feature.calendar.di.featureCalendarModule
 import com.livefast.eattrash.raccoonforfriendica.feature.circles.di.featureCirclesModule
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.di.featureComposerModule
@@ -87,6 +88,7 @@ fun initKoin(): Koin {
                 domainPullNotificationModule,
                 domainPushNotificationsModule,
                 domainUrlHandlerModule,
+                featureAnnouncementsModule,
                 featureCalendarModule,
                 featureCirclesModule,
                 featureComposerModule,

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/StatusReaction.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/StatusReaction.kt
@@ -8,6 +8,6 @@ data class StatusReaction(
     @SerialName("count") val count: Int = 0,
     @SerialName("me") val me: Boolean? = null,
     @SerialName("name") val name: String,
-    @SerialName("static_url") val staticUrl: String,
-    @SerialName("url") val url: String,
+    @SerialName("static_url") val staticUrl: String? = null,
+    @SerialName("url") val url: String? = null,
 )

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DeStrings.kt
@@ -458,4 +458,5 @@ internal val DeStrings =
         override val actionEditMembers = "Mitglieder bearbeiten"
         override val settingsItemBarTheme = "Thema der Status- und Navigationsleiste"
         override val barThemeSolid = "Solide"
+        override val announcementsTitle = "Ankündigungen"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -454,4 +454,5 @@ internal open class DefaultStrings : Strings {
     override val actionEditMembers = "Edit members"
     override val settingsItemBarTheme = "Status and navigation bar theme"
     override val barThemeSolid = "Solid"
+    override val announcementsTitle = "Announcements"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/EsStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/EsStrings.kt
@@ -458,4 +458,5 @@ internal val EsStrings =
         override val actionEditMembers = "Editar miembros"
         override val settingsItemBarTheme = "Tema de la barra de estado y navegación"
         override val barThemeSolid = "Sólido"
+        override val announcementsTitle = "Anuncios"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/FrStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/FrStrings.kt
@@ -463,4 +463,5 @@ internal val FrStrings =
         override val actionEditMembers = "Modifier les membres"
         override val settingsItemBarTheme = "Thème de la barre d'état et de navigation"
         override val barThemeSolid = "Solide"
+        override val announcementsTitle = "Annonces"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/ItStrings.kt
@@ -458,4 +458,5 @@ internal val ItStrings =
         override val actionEditMembers = "Modifica membri"
         override val settingsItemBarTheme = "Tema barra di stato e di navigazione"
         override val barThemeSolid = "Pieno"
+        override val announcementsTitle = "Annunci"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/PlStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/PlStrings.kt
@@ -456,4 +456,5 @@ internal val PlStrings =
         override val actionEditMembers = "Edytuj członków"
         override val settingsItemBarTheme = "Motyw paska stanu i nawigacji"
         override val barThemeSolid = "Solidny"
+        override val announcementsTitle = "Ogłoszenia"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/PtStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/PtStrings.kt
@@ -462,4 +462,5 @@ internal val PtStrings =
         override val actionEditMembers = "Editar membros"
         override val settingsItemBarTheme = "Tema da barra de estado e de navegação"
         override val barThemeSolid = "Sólido"
+        override val announcementsTitle = "Anúncios"
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -406,6 +406,7 @@ interface Strings {
     val actionEditMembers: String
     val settingsItemBarTheme: String
     val barThemeSolid: String
+    val announcementsTitle: String
 }
 
 object Locales {

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/UaStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/UaStrings.kt
@@ -465,4 +465,5 @@ internal val UaStrings =
         override val actionEditMembers = "Редагувати учасників"
         override val settingsItemBarTheme = "Тема для статусу та навігаційної панелі"
         override val barThemeSolid = "Суцільна"
+        override val announcementsTitle = "Оголошення"
     }

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DetailOpener.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DetailOpener.kt
@@ -120,4 +120,6 @@ interface DetailOpener {
     fun openLicences()
 
     fun openInternalWebView(url: String)
+
+    fun openAnnouncements()
 }

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/calendar/DefaultCalendarHelper.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/calendar/DefaultCalendarHelper.kt
@@ -32,10 +32,6 @@ class DefaultCalendarHelper(
             }
         runCatching {
             context.startActivity(intent)
-        }.also {
-            it.exceptionOrNull()?.also { e ->
-                e.printStackTrace()
-            }
         }
     }
 }

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NodeFeatures.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NodeFeatures.kt
@@ -11,4 +11,5 @@ data class NodeFeatures(
     val supportsMarkdown: Boolean = false,
     val supportsEntryShare: Boolean = false,
     val supportsCalendar: Boolean = false,
+    val supportsAnnouncements: Boolean = false,
 )

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/ReactionModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/ReactionModel.kt
@@ -4,6 +4,6 @@ data class ReactionModel(
     val count: Int = 0,
     val isMe: Boolean = false,
     val name: String,
-    val url: String,
-    val staticUrl: String,
+    val url: String? = null,
+    val staticUrl: String? = null,
 )

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultAnnouncementRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultAnnouncementRepository.kt
@@ -23,7 +23,8 @@ internal class DefaultAnnouncementRepository(
                 }
             }
             if (cachedValues.isNotEmpty()) {
-                return@withContext cachedValues
+                // map to a new immutable list or Compose freaks out
+                return@withContext cachedValues.map { it }
             }
             runCatching {
                 val response = provider.announcements.getAll()

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepository.kt
@@ -14,16 +14,17 @@ internal class DefaultSupportedFeatureRepository(
         val info = nodeInfoRepository.getInfo()
         features.update {
             it.copy(
-                supportsPhotoGallery = info?.isFriendica == true,
-                supportsDirectMessages = info?.isFriendica == true,
-                supportsEntryTitles = info?.isFriendica == true,
-                supportsCustomCircles = info?.isFriendica == true,
-                supportReportCategoryRuleViolation = info?.isFriendica == false,
-                supportsPolls = info?.isFriendica == false,
-                supportsBBCode = info?.isFriendica == true,
-                supportsMarkdown = info?.isFriendica == false,
-                supportsEntryShare = info?.isFriendica == true,
-                supportsCalendar = info?.isFriendica == true,
+                supportsPhotoGallery = info.isFriendica,
+                supportsDirectMessages = info.isFriendica,
+                supportsEntryTitles = info.isFriendica,
+                supportsCustomCircles = info.isFriendica,
+                supportReportCategoryRuleViolation = info.isMastodon,
+                supportsPolls = info.isMastodon,
+                supportsBBCode = info.isFriendica,
+                supportsMarkdown = info.isMastodon,
+                supportsEntryShare = info.isFriendica,
+                supportsCalendar = info.isFriendica,
+                supportsAnnouncements = info.isMastodon,
             )
         }
     }
@@ -32,8 +33,8 @@ internal class DefaultSupportedFeatureRepository(
 private val FRIENDICA_REGEX =
     Regex("\\(compatible; Friendica (?<version>[a-zA-Z0-9.-_]*)\\)")
 
-private val NodeInfoModel.isFriendica: Boolean
-    get() =
-        version
-            .orEmpty()
-            .contains(FRIENDICA_REGEX)
+private val NodeInfoModel?.isFriendica: Boolean
+    get() = this?.version?.contains(FRIENDICA_REGEX) ?: false
+
+private val NodeInfoModel?.isMastodon: Boolean
+    get() = !isFriendica

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepository.kt
@@ -104,10 +104,6 @@ internal class DefaultUserRepository(
                             limit = DEFAULT_PAGE_SIZE,
                         ).map { it.user.toModel() }
                 }
-            }.apply {
-                exceptionOrNull()?.also {
-                    it.printStackTrace()
-                }
             }.getOrNull()
         }
 

--- a/feature/announcements/build.gradle.kts
+++ b/feature/announcements/build.gradle.kts
@@ -1,0 +1,72 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.jetbrains.compose)
+    alias(libs.plugins.compose.compiler)
+}
+
+@OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
+kotlin {
+    applyDefaultHierarchyTemplate()
+    androidTarget {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_1_8)
+        }
+    }
+    listOf(
+        iosX64(),
+        iosArm64(),
+        iosSimulatorArm64(),
+    ).forEach {
+        it.binaries.framework {
+            baseName = "feature.announcements"
+            isStatic = true
+        }
+    }
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(compose.runtime)
+                implementation(compose.foundation)
+                implementation(compose.material)
+                implementation(compose.material3)
+                implementation(compose.materialIconsExtended)
+
+                implementation(libs.koin.core)
+                implementation(libs.voyager.navigator)
+                implementation(libs.voyager.screenmodel)
+                implementation(libs.voyager.koin)
+
+                implementation(projects.core.appearance)
+                implementation(projects.core.architecture)
+                implementation(projects.core.commonui.components)
+                implementation(projects.core.commonui.content)
+                implementation(projects.core.l10n)
+                implementation(projects.core.navigation)
+                implementation(projects.core.utils)
+
+                implementation(projects.domain.content.data)
+                implementation(projects.domain.content.repository)
+                implementation(projects.domain.identity.data)
+                implementation(projects.domain.identity.repository)
+            }
+        }
+    }
+}
+
+android {
+    namespace = "com.livefast.eattrash.raccoonforfriendica.feature.announcements"
+    compileSdk =
+        libs.versions.android.targetSdk
+            .get()
+            .toInt()
+    defaultConfig {
+        minSdk =
+            libs.versions.android.minSdk
+                .get()
+                .toInt()
+    }
+}

--- a/feature/announcements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/announcements/AnnouncementsMviModel.kt
+++ b/feature/announcements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/announcements/AnnouncementsMviModel.kt
@@ -1,0 +1,26 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.announcements
+
+import cafe.adriel.voyager.core.model.ScreenModel
+import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.AnnouncementModel
+
+interface AnnouncementsMviModel :
+    ScreenModel,
+    MviModel<AnnouncementsMviModel.Intent, AnnouncementsMviModel.State, AnnouncementsMviModel.Effect> {
+    sealed interface Intent {
+        data object Refresh : Intent
+    }
+
+    data class State(
+        val currentUserId: String? = null,
+        val refreshing: Boolean = false,
+        val initial: Boolean = true,
+        val items: List<AnnouncementModel> = emptyList(),
+        val autoloadImages: Boolean = true,
+        val hideNavigationBarWhileScrolling: Boolean = true,
+    )
+
+    sealed interface Effect {
+        data object BackToTop : Effect
+    }
+}

--- a/feature/announcements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/announcements/AnnouncementsScreen.kt
+++ b/feature/announcements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/announcements/AnnouncementsScreen.kt
@@ -1,0 +1,201 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.announcements
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.koin.getScreenModel
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.GenericPlaceholder
+import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.LocalStrings
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
+import com.livefast.eattrash.raccoonforfriendica.feature.announcements.components.AnnouncementCard
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+
+class AnnouncementsScreen : Screen {
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    override fun Content() {
+        val model = getScreenModel<AnnouncementsMviModel>()
+        val uiState by model.uiState.collectAsState()
+        val navigationCoordinator = remember { getNavigationCoordinator() }
+        val topAppBarState = rememberTopAppBarState()
+        val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
+        val connection = navigationCoordinator.getBottomBarScrollConnection()
+        val uriHandler = LocalUriHandler.current
+        val scope = rememberCoroutineScope()
+        val snackbarHostState = remember { SnackbarHostState() }
+        val lazyListState = rememberLazyListState()
+
+        suspend fun goBackToTop() {
+            runCatching {
+                lazyListState.scrollToItem(0)
+                topAppBarState.heightOffset = 0f
+                topAppBarState.contentOffset = 0f
+            }
+        }
+
+        LaunchedEffect(model) {
+            model.effects
+                .onEach { event ->
+                    when (event) {
+                        AnnouncementsMviModel.Effect.BackToTop -> goBackToTop()
+                    }
+                }.launchIn(this)
+        }
+
+        Scaffold(
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
+            topBar = {
+                TopAppBar(
+                    modifier = Modifier.clickable { scope.launch { goBackToTop() } },
+                    windowInsets = topAppBarState.toWindowInsets(),
+                    scrollBehavior = scrollBehavior,
+                    title = {
+                        Text(
+                            text = LocalStrings.current.announcementsTitle,
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                    },
+                    navigationIcon = {
+                        if (navigationCoordinator.canPop.value) {
+                            IconButton(
+                                onClick = {
+                                    navigationCoordinator.pop()
+                                },
+                            ) {
+                                Icon(
+                                    imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                                    contentDescription = null,
+                                )
+                            }
+                        }
+                    },
+                )
+            },
+            snackbarHost = {
+                SnackbarHost(
+                    hostState = snackbarHostState,
+                ) { data ->
+                    Snackbar(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        snackbarData = data,
+                    )
+                }
+            },
+        ) { padding ->
+            PullToRefreshBox(
+                modifier =
+                    Modifier
+                        .padding(padding)
+                        .fillMaxWidth()
+                        .then(
+                            if (connection != null && uiState.hideNavigationBarWhileScrolling) {
+                                Modifier.nestedScroll(connection)
+                            } else {
+                                Modifier
+                            },
+                        ).then(
+                            if (connection != null && uiState.hideNavigationBarWhileScrolling) {
+                                Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
+                            } else {
+                                Modifier
+                            },
+                        ),
+                isRefreshing = uiState.refreshing,
+                onRefresh = {
+                    model.reduce(AnnouncementsMviModel.Intent.Refresh)
+                },
+            ) {
+                LazyColumn(
+                    state = lazyListState,
+                ) {
+                    if (uiState.initial) {
+                        val placeholderCount = 5
+                        items(placeholderCount) { idx ->
+                            GenericPlaceholder(
+                                modifier = Modifier.fillMaxWidth(),
+                                height = 200.dp,
+                            )
+                            if (idx < placeholderCount - 1) {
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(vertical = Spacing.s),
+                                )
+                            }
+                        }
+                    }
+
+                    if (!uiState.initial && !uiState.refreshing && uiState.items.isEmpty()) {
+                        item {
+                            Text(
+                                modifier = Modifier.fillMaxWidth().padding(top = Spacing.m),
+                                text = LocalStrings.current.messageEmptyList,
+                                textAlign = TextAlign.Center,
+                                style = MaterialTheme.typography.bodyLarge,
+                            )
+                        }
+                    }
+
+                    itemsIndexed(
+                        items = uiState.items,
+                        key = { _, e -> "announcements-${e.id}" },
+                    ) { idx, announcement ->
+                        AnnouncementCard(
+                            announcement = announcement,
+                            autoloadImages = uiState.autoloadImages,
+                            onOpenUrl = { url ->
+                                uriHandler.openUri(url)
+                            },
+                        )
+                        if (idx < uiState.items.lastIndex) {
+                            HorizontalDivider(
+                                modifier = Modifier.padding(vertical = Spacing.s),
+                            )
+                        }
+                    }
+
+                    item {
+                        Spacer(modifier = Modifier.height(Spacing.xxxl))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/feature/announcements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/announcements/AnnouncementsViewModel.kt
+++ b/feature/announcements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/announcements/AnnouncementsViewModel.kt
@@ -1,0 +1,117 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.announcements
+
+import cafe.adriel.voyager.core.model.screenModelScope
+import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.AnnouncementModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.AnnouncementRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.AnnouncementsManager
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ImageAutoloadObserver
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+
+class AnnouncementsViewModel(
+    private val identityRepository: IdentityRepository,
+    private val settingsRepository: SettingsRepository,
+    private val announcementRepository: AnnouncementRepository,
+    private val announcementsManager: AnnouncementsManager,
+    private val imageAutoloadObserver: ImageAutoloadObserver,
+) : DefaultMviModel<AnnouncementsMviModel.Intent, AnnouncementsMviModel.State, AnnouncementsMviModel.Effect>(
+        initialState = AnnouncementsMviModel.State(),
+    ),
+    AnnouncementsMviModel {
+    init {
+        screenModelScope.launch {
+            imageAutoloadObserver.enabled
+                .onEach { autoloadImages ->
+                    updateState {
+                        it.copy(
+                            autoloadImages = autoloadImages,
+                        )
+                    }
+                }.launchIn(this)
+
+            identityRepository.currentUser
+                .onEach { currentUser ->
+                    updateState {
+                        it.copy(currentUserId = currentUser?.id)
+                    }
+                }.launchIn(this)
+
+            settingsRepository.current
+                .onEach { settings ->
+                    updateState {
+                        it.copy(
+                            hideNavigationBarWhileScrolling =
+                                settings?.hideNavigationBarWhileScrolling ?: true,
+                        )
+                    }
+                }.launchIn(this)
+
+            if (uiState.value.initial) {
+                refresh(initial = true)
+            }
+        }
+    }
+
+    override fun reduce(intent: AnnouncementsMviModel.Intent) {
+        when (intent) {
+            AnnouncementsMviModel.Intent.Refresh ->
+                screenModelScope.launch {
+                    refresh()
+                }
+        }
+    }
+
+    private suspend fun refresh(initial: Boolean = false) {
+        updateState {
+            it.copy(initial = initial, refreshing = !initial)
+        }
+        if (!initial) {
+            markAllAsRead()
+        }
+
+        val items = announcementRepository.getAll(refresh = !initial).orEmpty()
+        updateState {
+            it.copy(
+                items = items,
+                initial = false,
+                refreshing = false,
+            )
+        }
+        if (initial) {
+            emitEffect(AnnouncementsMviModel.Effect.BackToTop)
+        }
+    }
+
+    private suspend fun updateItemInState(
+        id: String,
+        block: (AnnouncementModel) -> AnnouncementModel,
+    ) {
+        updateState {
+            it.copy(
+                items =
+                    it.items.map { item ->
+                        if (item.id == id) {
+                            item.let(block)
+                        } else {
+                            item
+                        }
+                    },
+            )
+        }
+    }
+
+    private suspend fun markAllAsRead() {
+        val items = uiState.value.items.filter { !it.read }
+        items.forEach { item ->
+            val success = announcementRepository.markAsRead(item.id)
+            if (success) {
+                updateItemInState(item.id) { it.copy(read = true) }
+                announcementsManager.decrementUnreadCount()
+            }
+        }
+    }
+}

--- a/feature/announcements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/announcements/components/AnnouncementCard.kt
+++ b/feature/announcements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/announcements/components/AnnouncementCard.kt
@@ -1,0 +1,86 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.announcements.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ContentBody
+import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.prettifyDate
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.AnnouncementModel
+
+@Composable
+internal fun AnnouncementCard(
+    announcement: AnnouncementModel,
+    modifier: Modifier = Modifier,
+    autoloadImages: Boolean = true,
+    onOpenUrl: ((String) -> Unit)? = null,
+) {
+    val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha)
+
+    Column(
+        modifier =
+            modifier.padding(
+                vertical = Spacing.xxs,
+                horizontal = Spacing.s,
+            ),
+        verticalArrangement = Arrangement.spacedBy(Spacing.s),
+    ) {
+        Row {
+            Spacer(Modifier.weight(1f))
+            // unread indicator
+            if (!announcement.read) {
+                Box(
+                    modifier =
+                        Modifier
+                            .size(IconSize.xs)
+                            .padding(2.dp)
+                            .background(
+                                color = MaterialTheme.colorScheme.onBackground,
+                                shape = CircleShape,
+                            ),
+                )
+            }
+        }
+
+        val body = announcement.content
+        if (body.isNotBlank()) {
+            ContentBody(
+                modifier = Modifier.fillMaxWidth(),
+                content = body,
+                autoloadImages = autoloadImages,
+                emojis = announcement.emojis,
+                onOpenUrl = onOpenUrl,
+            )
+        }
+
+        Row {
+            Spacer(Modifier.weight(1f))
+            // publish date
+            val date = announcement.published
+            Text(
+                text =
+                    buildString {
+                        if (!date.isNullOrBlank()) {
+                            append(date.prettifyDate())
+                        }
+                    },
+                style = MaterialTheme.typography.bodySmall,
+                color = ancillaryColor,
+            )
+        }
+    }
+}

--- a/feature/announcements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/announcements/di/AnnouncementsModule.kt
+++ b/feature/announcements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/announcements/di/AnnouncementsModule.kt
@@ -1,0 +1,18 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.announcements.di
+
+import com.livefast.eattrash.raccoonforfriendica.feature.announcements.AnnouncementsMviModel
+import com.livefast.eattrash.raccoonforfriendica.feature.announcements.AnnouncementsViewModel
+import org.koin.dsl.module
+
+val featureAnnouncementsModule =
+    module {
+        factory<AnnouncementsMviModel> {
+            AnnouncementsViewModel(
+                identityRepository = get(),
+                settingsRepository = get(),
+                announcementRepository = get(),
+                announcementsManager = get(),
+                imageAutoloadObserver = get(),
+            )
+        }
+    }

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerContent.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerContent.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.automirrored.filled.ContactSupport
 import androidx.compose.material.icons.filled.Bookmarks
 import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.Campaign
 import androidx.compose.material.icons.filled.Dashboard
 import androidx.compose.material.icons.filled.Drafts
 import androidx.compose.material.icons.filled.Favorite
@@ -172,7 +173,15 @@ class DrawerContent : Screen {
                             handleAction { detailOpener.openCircles() }
                         },
                     )
-
+                    if (uiState.hasAnnouncements) {
+                        DrawerShortcut(
+                            title = LocalStrings.current.announcementsTitle,
+                            icon = Icons.Default.Campaign,
+                            onSelected = {
+                                handleAction { detailOpener.openAnnouncements() }
+                            },
+                        )
+                    }
                     if (uiState.hasDirectMessages) {
                         DrawerShortcut(
                             title = LocalStrings.current.directMessagesTitle,

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerMviModel.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerMviModel.kt
@@ -29,6 +29,7 @@ interface DrawerMviModel :
         val hasDirectMessages: Boolean = false,
         val hasGallery: Boolean = false,
         val hasCalendar: Boolean = false,
+        val hasAnnouncements: Boolean = false,
         val anonymousChangeNodeName: String = "",
         val anonymousChangeNodeValidationInProgress: Boolean = false,
         val anonymousChangeNodeNameError: ValidationError? = null,

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerViewModel.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerViewModel.kt
@@ -62,6 +62,7 @@ class DrawerViewModel(
                             hasDirectMessages = features.supportsDirectMessages,
                             hasGallery = features.supportsPhotoGallery,
                             hasCalendar = features.supportsCalendar,
+                            hasAnnouncements = features.supportsAnnouncements,
                         )
                     }
                 }.launchIn(this)

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineMviModel.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineMviModel.kt
@@ -75,6 +75,7 @@ interface TimelineMviModel :
         val maxBodyLines: Int = Int.MAX_VALUE,
         val autoloadImages: Boolean = true,
         val hideNavigationBarWhileScrolling: Boolean = true,
+        val unreadAnnouncements: Int = 0,
     )
 
     sealed interface Effect {

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
@@ -16,8 +16,11 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Campaign
 import androidx.compose.material.icons.filled.Create
 import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
@@ -49,6 +52,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.sp
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Dimensions
@@ -181,6 +185,41 @@ class TimelineScreen : Screen {
                                 imageVector = Icons.Default.Menu,
                                 contentDescription = null,
                             )
+                        }
+                    },
+                    actions = {
+                        if (uiState.unreadAnnouncements > 0) {
+                            IconButton(
+                                onClick = {
+                                    scope.launch {
+                                        detailOpener.openAnnouncements()
+                                    }
+                                },
+                            ) {
+                                BadgedBox(
+                                    badge = {
+                                        val unreadCount = uiState.unreadAnnouncements
+                                        if (unreadCount > 0) {
+                                            Badge(
+                                                modifier = Modifier.align(Alignment.TopEnd),
+                                            ) {
+                                                Text(
+                                                    text = if (unreadCount <= 10) "$unreadCount" else "10+",
+                                                    style =
+                                                        MaterialTheme.typography.labelSmall.copy(
+                                                            fontSize = 8.sp,
+                                                        ),
+                                                )
+                                            }
+                                        }
+                                    },
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Default.Campaign,
+                                        contentDescription = null,
+                                    )
+                                }
+                            }
                         }
                     },
                 )

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
@@ -16,6 +16,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toTimelineT
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationSpecification
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.AnnouncementsManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.CirclesRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
@@ -49,6 +50,7 @@ class TimelineViewModel(
     private val imagePreloadManager: ImagePreloadManager,
     private val blurHashRepository: BlurHashRepository,
     private val imageAutoloadObserver: ImageAutoloadObserver,
+    private val announcementsManager: AnnouncementsManager,
 ) : DefaultMviModel<TimelineMviModel.Intent, TimelineMviModel.State, TimelineMviModel.Effect>(
         initialState = TimelineMviModel.State(),
     ),
@@ -98,6 +100,11 @@ class TimelineViewModel(
                 .subscribe(TimelineEntryUpdatedEvent::class)
                 .onEach { event ->
                     updateEntryInState(event.entry.id) { event.entry }
+                }.launchIn(this)
+
+            announcementsManager.unreadCount
+                .onEach { count ->
+                    updateState { it.copy(unreadAnnouncements = count) }
                 }.launchIn(this)
 
             combine(

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/di/TimelineModule.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/di/TimelineModule.kt
@@ -21,6 +21,7 @@ val featureTimelineModule =
                 imagePreloadManager = get(),
                 blurHashRepository = get(),
                 imageAutoloadObserver = get(),
+                announcementsManager = get(),
             )
         }
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -55,6 +55,7 @@ include(":domain:pullnotifications")
 include(":domain:pushnotifications")
 include(":domain:urlhandler")
 
+include(":feature:announcements")
 include(":feature:calendar")
 include(":feature:circles")
 include(":feature:composer")


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds a bare bone "Announcements" screen with the list of communications from the instance admins. Each item can be read/unread and all items are marked as read when refreshing the list. 

## Additional notes
<!-- Anything to declare for code review? -->
Reactions are neither visible nor editable, because this feature will be implemented in a future PR.

<details><summary>Related issues:</summary>

- #542 
</details>

<details><summary>Related PRs:</summary>

- #553
</details>

