### PR TITLE
feat: handle incoming images from system share

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -54,6 +54,13 @@
 
                 <data android:mimeType="text/plain" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:mimeType="image/*" />
+            </intent-filter>
         </activity>
 
         <!-- alias with traditional icon -->

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
@@ -207,6 +207,7 @@ class DefaultDetailOpener(
         urlToShare: String?,
         inGroup: Boolean,
         initialText: String?,
+        initialAttachment: ByteArray?,
     ) {
         if (!isLogged) {
             return
@@ -229,6 +230,7 @@ class DefaultDetailOpener(
                     editedPostId = editedPostId,
                     urlToShare = urlToShare,
                     initialText = initialText,
+                    initialAttachment = initialAttachment,
                 )
             navigationCoordinator.push(screen)
         }

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DetailOpener.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DetailOpener.kt
@@ -57,6 +57,7 @@ interface DetailOpener {
         urlToShare: String? = null,
         inGroup: Boolean = false,
         initialText: String? = null,
+        initialAttachment: ByteArray? = null,
     )
 
     fun openEditUnpublished(

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
@@ -113,6 +113,7 @@ class ComposerScreen(
     private val draftId: String? = null,
     private val urlToShare: String? = null,
     private val initialText: String? = null,
+    private val initialAttachment: ByteArray? = null,
 ) : Screen {
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
@@ -191,6 +192,9 @@ class ComposerScreen(
                             fieldType = ComposerFieldType.Body,
                         ),
                     )
+
+                initialAttachment != null ->
+                    model.reduce(ComposerMviModel.Intent.AddAttachment(initialAttachment))
 
                 inReplyToId != null ->
                     model.reduce(


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR updates the management of incoming attachments to handle images: the stream is read and passed to the composer, which in turns uploads it as a regular image from gallery.

## Additional notes
<!-- Anything to declare for code review? -->
This was an occasion to refactor the management of intents with `Intent.ACTION_SEND` action in `MainActivity`. The delay is added because unless a root navigator is set, it is not possible to navigate to the composer.

<details><summary>Related issues</summary>

- #540 
</details>
