### PR TITLE
fix: avoid resetting contentWindowInsets if bottom bar is present

### DIFF
--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -256,7 +255,6 @@ class ComposerScreen(
         }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             modifier =
                 Modifier
                     .background(MaterialTheme.colorScheme.surfaceVariant)

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationScreen.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -124,7 +123,6 @@ class ConversationScreen(
         }
 
         Scaffold(
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
             modifier =
                 Modifier
                     .background(MaterialTheme.colorScheme.surface)


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR avoids setting null WindowInsets for scaffolds where a bottom bar is used (apart from the main one).

## Additional notes
<!-- Anything to declare for code review? -->
This is a tentative fix for a bug introduced in #548 on devices running  Android <= 9 versions.
