### PR TITLE
enhancement: hide legacy login

### DIFF
--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/CustomModalBottomSheet.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/CustomModalBottomSheet.kt
@@ -62,7 +62,9 @@ fun CustomModalBottomSheet(
             onSelected?.invoke(null)
         },
         content = {
-            Column {
+            Column(
+                modifier = Modifier.padding(bottom = Spacing.xs),
+            ) {
                 Text(
                     modifier = Modifier.fillMaxWidth(),
                     textAlign = TextAlign.Center,

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ConfirmMuteUserBottomSheet.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ConfirmMuteUserBottomSheet.kt
@@ -78,6 +78,7 @@ fun ConfirmMuteUserBottomSheet(
         },
     ) {
         Column(
+            modifier = Modifier.padding(bottom = Spacing.xs),
             verticalArrangement = Arrangement.spacedBy(Spacing.xs),
         ) {
             Text(

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/InsertEmojiBottomSheet.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/InsertEmojiBottomSheet.kt
@@ -65,7 +65,9 @@ fun InsertEmojiBottomSheet(
             onClose?.invoke()
         },
     ) {
-        Column {
+        Column(
+            modifier = Modifier.padding(bottom = Spacing.xs),
+        ) {
             Text(
                 modifier = Modifier.fillMaxWidth(),
                 textAlign = TextAlign.Center,

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/components/GalleryPickerDialog.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/components/GalleryPickerDialog.kt
@@ -101,7 +101,9 @@ fun GalleryPickerDialog(
             onClose?.invoke(null)
         },
         content = {
-            Column {
+            Column(
+                modifier = Modifier.padding(bottom = Spacing.xs),
+            ) {
                 Box {
                     Text(
                         modifier = Modifier.fillMaxWidth().align(Alignment.Center),

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/loginintro/LoginIntroScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/loginintro/LoginIntroScreen.kt
@@ -172,7 +172,9 @@ internal class LoginIntroScreen : Screen {
                     moreInfoBottomSheetOpened = false
                 },
             ) {
-                Column {
+                Column(
+                    modifier = Modifier.padding(bottom = Spacing.xs),
+                ) {
                     Text(
                         modifier = Modifier.fillMaxWidth(),
                         textAlign = TextAlign.Center,


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR makes the "legacy login" (HTTP Basic auth) less visible, it is now required to open a drop-down menu to access it.

## Additional notes
<!-- Anything to declare for code review? -->
The reason is that I received an extremely impolite report from a user complaining that having to "login in the browser" (_that's how OAuth2 works and it's for your safety duh!_) makes an app useless because what's the point of using an app if it opens the browser? Moreover they tried to use the basic auth screen without success and said the app was not working and definitely not production ready.

The only "constructive" point I get from this criticism is that leaving in plain sight the possibility to login with basic auth is BAD and MISLEADING and users should not be confused by it.
