### PR TITLE
enhancement: Improve timeline a11y

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentFooter.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentFooter.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.dp
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
@@ -54,37 +55,41 @@ fun ContentFooter(
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         FooterItem(
-            modifier = Modifier.width(baseItemWidth),
+            modifier = Modifier.clearAndSetSemantics { }
+            .width(baseItemWidth),
             icon = Icons.AutoMirrored.Default.Reply,
-            contentDescription = LocalStrings.current.actionReply,
+            contentDescription = null,
             value = replyCount,
             onClick = onReply,
         )
         FooterItem(
-            modifier = Modifier.width(baseItemWidth),
+            modifier = Modifier.clearAndSetSemantics { }
+            .width(baseItemWidth),
             icon = Icons.Outlined.RocketLaunch,
             toggledIcon = Icons.Filled.RocketLaunch,
-            contentDescription = LocalStrings.current.actionReblog,
+            contentDescription = null,
             value = reblogCount,
             toggled = reblogged,
             loading = reblogLoading,
             onClick = onReblog,
         )
         FooterItem(
-            modifier = Modifier.width(baseItemWidth),
+            modifier = Modifier.clearAndSetSemantics { }
+            .width(baseItemWidth),
             icon = Icons.Default.FavoriteBorder,
             toggledIcon = Icons.Default.Favorite,
-            contentDescription = LocalStrings.current.actionAddToFavorites,
+            contentDescription = null,
             value = favoriteCount,
             toggled = favorite,
             loading = favoriteLoading,
             onClick = onFavorite,
         )
         FooterItem(
-            modifier = Modifier.width(baseItemWidth),
+            modifier = Modifier.clearAndSetSemantics { }
+            .width(baseItemWidth),
             icon = Icons.Default.BookmarkBorder,
             toggledIcon = Icons.Default.Bookmark,
-            contentDescription = LocalStrings.current.actionAddToBookmarks,
+            contentDescription = null,
             toggled = bookmarked,
             loading = bookmarkLoading,
             onClick = onBookmark,

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentHeader.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentHeader.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.unit.Dp
@@ -48,7 +49,8 @@ fun ContentHeader(
     val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha)
     val onOpenUserModifier =
         if (onOpenUser != null) {
-            Modifier.clickable(
+            Modifier.clearAndSetSemantics { }
+            .clickable(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = null,
             ) {
@@ -57,7 +59,7 @@ fun ContentHeader(
                 }
             }
         } else {
-            Modifier
+            Modifier.clearAndSetSemantics { }
         }
 
     Row(

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/InReplyToInfo.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/InReplyToInfo.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
@@ -43,7 +44,8 @@ internal fun InReplyToInfo(
     val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha)
     val onOpenUserModifier =
         if (onOpenUser != null) {
-            Modifier.clickable(
+            Modifier.clearAndSetSemantics { }
+            .clickable(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = null,
             ) {
@@ -52,7 +54,7 @@ internal fun InReplyToInfo(
                 }
             }
         } else {
-            Modifier
+            Modifier.clearAndSetSemantics { }
         }
 
     Row(
@@ -63,7 +65,7 @@ internal fun InReplyToInfo(
         Icon(
             modifier = Modifier.size(iconSize),
             imageVector = Icons.AutoMirrored.Default.Reply,
-            contentDescription = LocalStrings.current.actionReply,
+            contentDescription = null,
             tint = ancillaryColor,
         )
         Text(

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ReblogInfo.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ReblogInfo.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
@@ -43,7 +44,8 @@ internal fun ReblogInfo(
     val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha)
     val onOpenUserModifier =
         if (onOpenUser != null) {
-            Modifier.clickable(
+            Modifier.clearAndSetSemantics { }
+            .clickable(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = null,
             ) {
@@ -60,10 +62,11 @@ internal fun ReblogInfo(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(Spacing.s),
     ) {
+        // There is no need for a contentDescription here as this is decorative image with no click handler
         Icon(
             modifier = Modifier.size(iconSize),
             imageVector = Icons.Default.Repeat,
-            contentDescription = LocalStrings.current.actionReblog,
+            contentDescription = null,
             tint = ancillaryColor,
         )
         Text(

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
@@ -28,6 +28,10 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.DpOffset
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
@@ -72,6 +76,63 @@ fun TimelineItem(
     val spoiler = entryToDisplay.spoiler.orEmpty()
     val contentHorizontalPadding = Spacing.s
 
+    val replyActionLabel = buildString {
+        append(LocalStrings.current.actionReply)
+    if (entryToDisplay.replyCount > 0) {
+        append(": ")
+        append(entryToDisplay.replyCount)
+   }
+    }
+    val reblogActionLabel = buildString {
+        append(LocalStrings.current.actionReblog)
+    if (entryToDisplay.reblogCount > 0) {
+        append(": ")
+        append(entryToDisplay.reblogCount)
+   }
+    }
+    val favoriteActionLabel = buildString {
+    if (entryToDisplay.favorite) {
+            append(LocalStrings.current.actionRemoveFromFavorites)
+   } else {
+            append(LocalStrings.current.actionAddToFavorites)
+   }
+    if (entryToDisplay.favoriteCount > 0) {
+        append(": ")
+        append(entryToDisplay.favoriteCount)
+   }
+    }
+    val bookmarkActionLabel = buildString {
+    if (entryToDisplay.bookmarked) {
+            append(LocalStrings.current.actionRemoveFromBookmarks)
+   } else {
+            append(LocalStrings.current.actionAddToBookmarks)
+   }
+    }
+    val inReplyToActionLabel = buildString {
+    append(entry.inReplyTo?.creator?.let { it.displayName ?: it.handle }.orEmpty())
+    if (isNotEmpty()) {
+        append(": ")
+   }
+        append(LocalStrings.current.timelineEntryInReplyTo)
+    }
+    val rebloggedActionLabel = buildString {
+    append(entry.creator?.let { it.displayName ?: it.handle }.orEmpty())
+    if (isNotEmpty()) {
+        append(": ")
+   }
+        append(LocalStrings.current.timelineEntryRebloggedBy)
+    }
+    val userActionLabel = buildString {
+    append(entryToDisplay.creator?.let { it.displayName ?: it.handle }.orEmpty())
+    if (isNotEmpty()) {
+        append(": ")
+   }
+        append(LocalStrings.current.postTitle)
+        append(" ")
+        append(LocalStrings.current.postBy)
+    }
+    val optionsActionLabel = LocalStrings.current.actionOpenOptions
+
     Column(
         modifier =
             modifier
@@ -80,7 +141,53 @@ fun TimelineItem(
                     indication = null,
                 ) {
                     onClick?.invoke(entryToDisplay)
-                },
+                }
+                .semantics(mergeDescendants = true) {
+                    var helperActions: List<CustomAccessibilityAction> = emptyList()
+                    if (actionsEnabled) {
+                        helperActions += CustomAccessibilityAction(
+                            label = replyActionLabel,
+                            action = { onReply?.invoke(entryToDisplay); true }
+                        )
+                        helperActions += CustomAccessibilityAction(
+                            label = reblogActionLabel,
+                            action = { onReblog?.invoke(entryToDisplay); true }
+                        )
+                        helperActions += CustomAccessibilityAction(
+                            label = favoriteActionLabel,
+                            action = { onFavorite?.invoke(entryToDisplay); true }
+                        )
+                        helperActions += CustomAccessibilityAction(
+                            label = bookmarkActionLabel,
+                            action = { onBookmark?.invoke(entryToDisplay); true }
+                        )
+                    }
+                    if (reshareAndReplyVisible and isReblog) {
+                        helperActions += CustomAccessibilityAction(
+                            label = rebloggedActionLabel,
+                            action = { entry.creator?.let { onOpenUser?.invoke(it) }; true }
+                        )
+                    }
+                    if (reshareAndReplyVisible and isReply) {
+                        helperActions += CustomAccessibilityAction(
+                            label = inReplyToActionLabel,
+                            action = { entry.inReplyTo?.creator?.let { onOpenUser?.invoke(it) }; true }
+                        )
+                    }
+                    helperActions += CustomAccessibilityAction(
+                        label = userActionLabel,
+                        action = { entryToDisplay.creator?.let { onOpenUser?.invoke(it) }; true }
+                    )
+                    if (options.isNotEmpty()) {
+                        helperActions += CustomAccessibilityAction(
+                            label = optionsActionLabel,
+                            action = { optionsMenuOpen = true; true }
+                        )
+                        if (helperActions.isNotEmpty()) {
+                            customActions = helperActions
+                        }
+                    }
+},
         verticalArrangement = Arrangement.spacedBy(Spacing.s),
     ) {
         Column(
@@ -132,7 +239,8 @@ fun TimelineItem(
                             modifier =
                                 Modifier.onGloballyPositioned {
                                     optionsOffset = it.positionInParent()
-                                },
+                                }
+                                .clearAndSetSemantics { },
                             onClick = {
                                 optionsMenuOpen = true
                             },
@@ -140,7 +248,7 @@ fun TimelineItem(
                             Icon(
                                 modifier = Modifier.size(IconSize.s),
                                 imageVector = Icons.Default.MoreVert,
-                                contentDescription = LocalStrings.current.actionOpenOptions,
+                                contentDescription = null,
                                 tint = MaterialTheme.colorScheme.onBackground,
                             )
                         }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/DefaultStrings.kt
@@ -489,4 +489,6 @@ internal open class DefaultStrings : Strings {
     override val formatStrikethrough = "Strikethrough"
     override val formatUnderlined = "Underlined"
     override val formatMonospace = "Monospace"
+    override val actionRemoveFromFavorites = "Remove from favorites"
+    override val actionRemoveFromBookmarks = "Remove from bookmarks"
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/messages/Strings.kt
@@ -441,6 +441,8 @@ interface Strings {
     val formatStrikethrough: String
     val formatUnderlined: String
     val formatMonospace: String
+    val actionRemoveFromFavorites: String
+    val actionRemoveFromBookmarks: String
 }
 
 object Locales {


### PR DESCRIPTION
## Technical details

There are two common navigation techniques used by screen reader users. Explore by touch and gesture navigation. With gesture navigation performing a gesture moves to previous or next actionable element on the screen. If there are many actionable elements within a list item it becomes quite involving to navigate from one active item to another one.

As a follow up to #557 I have done the following:

* Cleared semantic of all the clickable elements except attachments and urls within posts effectivelly hiding these from screen reader users
* Reimplemented these hidden features as an accessibility actions so they can be activated when screen reader is running on demand.
* Now moving from a timeline item to the next or previous one only takes single screen reader gesture for simple text content posts


## Additional notes

This is my first attempt at kotlin / jetpack compose contribution, so please bear with me and let me know what to improve please.

If this turns to be usefull I might be able to try working on more accessibility related improvements in the future.