### PR TITLE
fix: skips custom emojis for accessibility

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TextWithCustomEmojis.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TextWithCustomEmojis.kt
@@ -76,7 +76,7 @@ fun TextWithCustomEmojis(
                     foundImages[id] = ImageData(url = url, description = alt)
                     appendInlineContent(
                         id = id,
-                        alternateText = occurrence.value,
+                        alternateText = alt ?: occurrence.value,
                     )
                 }
             }
@@ -94,7 +94,7 @@ fun TextWithCustomEmojis(
                     CustomImage(
                         modifier = Modifier.fillMaxSize(),
                         url = emoji.url,
-                        contentDescription = emoji.code,
+                        contentDescription = null,
                         contentScale = ContentScale.FillWidth,
                     )
                 }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR makes sure image alt text is used for embedded images in `TextWithCustomEmojis`. This does not apply to emojis for which it is ok to replace them with the code.
