### PR TITLE
chore: add tests for favourites and hashtags pagination

### DIFF
--- a/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFavoritesPaginationManagerTest.kt
+++ b/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFavoritesPaginationManagerTest.kt
@@ -1,0 +1,179 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
+
+import com.livefast.eattrash.raccoonforfriendica.core.notifications.NotificationCenter
+import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.NotificationCenterEvent
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.ReplyHelper
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.returnsArgAt
+import dev.mokkery.answering.sequentiallyReturns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.reflect.KClass
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DefaultFavoritesPaginationManagerTest {
+    private val timelineEntryRepository = mock<TimelineEntryRepository>()
+    private val emojiHelper =
+        mock<EmojiHelper> {
+            everySuspend { any<UserModel>().withEmojisIfMissing() } returnsArgAt 0
+            everySuspend { any<TimelineEntryModel>().withEmojisIfMissing() } returnsArgAt 0
+        }
+    private val replyHelper =
+        mock<ReplyHelper> {
+            everySuspend { any<TimelineEntryModel>().withInReplyToIfMissing() } returnsArgAt 0
+        }
+    private val notificationCenter =
+        mock<NotificationCenter> {
+            every { subscribe(any<KClass<NotificationCenterEvent>>()) } returns MutableSharedFlow()
+        }
+
+    private val sut =
+        DefaultFavoritesPaginationManager(
+            timelineEntryRepository = timelineEntryRepository,
+            emojiHelper = emojiHelper,
+            replyHelper = replyHelper,
+            notificationCenter = notificationCenter,
+            dispatcher = UnconfinedTestDispatcher(),
+        )
+
+    // region Bookmarks
+    @Test
+    fun `given no results when loadNextPage with Bookmarks specification then result is as expected`() =
+        runTest {
+            everySuspend {
+                timelineEntryRepository.getBookmarks(pageCursor = any())
+            } returns emptyList()
+
+            sut.reset(FavoritesPaginationSpecification.Bookmarks(includeNsfw = false))
+            val res = sut.loadNextPage()
+
+            assertTrue(res.isEmpty())
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                timelineEntryRepository.getBookmarks(pageCursor = null)
+            }
+        }
+
+    @Test
+    fun `given results when loadNextPage with Bookmarks specification then result is as expected`() =
+        runTest {
+            val list =
+                listOf(
+                    TimelineEntryModel(id = "1", content = "", creator = UserModel(id = "2")),
+                )
+            everySuspend {
+                timelineEntryRepository.getBookmarks(pageCursor = any())
+            } returns list
+
+            sut.reset(FavoritesPaginationSpecification.Bookmarks(includeNsfw = false))
+            val res = sut.loadNextPage()
+
+            assertEquals(list, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                timelineEntryRepository.getBookmarks(pageCursor = null)
+            }
+        }
+
+    @Test
+    fun `given no more results when loadNextPage twice with Bookmarks specification then result is as expected`() =
+        runTest {
+            val list =
+                listOf(
+                    TimelineEntryModel(id = "1", content = "", creator = UserModel(id = "2")),
+                )
+            everySuspend {
+                timelineEntryRepository.getBookmarks(pageCursor = any())
+            } sequentiallyReturns listOf(list, emptyList())
+
+            sut.reset(FavoritesPaginationSpecification.Bookmarks(includeNsfw = false))
+            sut.loadNextPage()
+            val res = sut.loadNextPage()
+
+            assertEquals(list, res)
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                timelineEntryRepository.getBookmarks(pageCursor = null)
+                timelineEntryRepository.getBookmarks(pageCursor = "1")
+            }
+        }
+    // endregion
+
+    // region Favorites
+    @Test
+    fun `given no results when loadNextPage with Favorites specification then result is as expected`() =
+        runTest {
+            everySuspend {
+                timelineEntryRepository.getFavorites(pageCursor = any())
+            } returns emptyList()
+
+            sut.reset(FavoritesPaginationSpecification.Favorites(includeNsfw = false))
+            val res = sut.loadNextPage()
+
+            assertTrue(res.isEmpty())
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                timelineEntryRepository.getFavorites(pageCursor = null)
+            }
+        }
+
+    @Test
+    fun `given results when loadNextPage with Favorites specification then result is as expected`() =
+        runTest {
+            val list =
+                listOf(
+                    TimelineEntryModel(id = "1", content = "", creator = UserModel(id = "2")),
+                )
+            everySuspend {
+                timelineEntryRepository.getFavorites(pageCursor = any())
+            } returns list
+
+            sut.reset(FavoritesPaginationSpecification.Favorites(includeNsfw = false))
+            val res = sut.loadNextPage()
+
+            assertEquals(list, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                timelineEntryRepository.getFavorites(pageCursor = null)
+            }
+        }
+
+    @Test
+    fun `given no more results when loadNextPage twice with Favorites specification then result is as expected`() =
+        runTest {
+            val list =
+                listOf(
+                    TimelineEntryModel(id = "1", content = "", creator = UserModel(id = "2")),
+                )
+            everySuspend {
+                timelineEntryRepository.getFavorites(pageCursor = any())
+            } sequentiallyReturns listOf(list, emptyList())
+
+            sut.reset(FavoritesPaginationSpecification.Favorites(includeNsfw = false))
+            sut.loadNextPage()
+            val res = sut.loadNextPage()
+
+            assertEquals(list, res)
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                timelineEntryRepository.getFavorites(pageCursor = null)
+                timelineEntryRepository.getFavorites(pageCursor = "1")
+            }
+        }
+    // endregion
+}

--- a/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFollowedHashtagsPaginationManagerTest.kt
+++ b/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFollowedHashtagsPaginationManagerTest.kt
@@ -1,0 +1,83 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TagModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TagRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.ListWithPageCursor
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.sequentiallyReturns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DefaultFollowedHashtagsPaginationManagerTest {
+    private val tagRepository = mock<TagRepository>()
+    private val sut = DefaultFollowedHashtagsPaginationManager(tagRepository = tagRepository)
+
+    @Test
+    fun `given no results when loadNextPage then result is as expected`() =
+        runTest {
+            everySuspend { tagRepository.getFollowed(any()) } returns ListWithPageCursor()
+
+            sut.reset()
+            val res = sut.loadNextPage()
+
+            assertTrue(res.isEmpty())
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                tagRepository.getFollowed(pageCursor = null)
+            }
+        }
+
+    @Test
+    fun `given results when loadNextPage then result is as expected`() =
+        runTest {
+            val elements =
+                listOf(
+                    TagModel(url = "fake-url", name = "fake-name", following = true),
+                )
+            everySuspend { tagRepository.getFollowed(any()) } returns
+                ListWithPageCursor(list = elements, cursor = "1")
+
+            sut.reset()
+            val res = sut.loadNextPage()
+
+            assertEquals(elements, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                tagRepository.getFollowed(pageCursor = null)
+            }
+        }
+
+    @Test
+    fun `given can not fetch more when loadNextPage twice then result is as expected`() =
+        runTest {
+            val elements =
+                listOf(
+                    TagModel(url = "fake-url", name = "fake-name", following = true),
+                )
+            everySuspend {
+                tagRepository.getFollowed(any())
+            } sequentiallyReturns
+                listOf(
+                    ListWithPageCursor(list = elements, cursor = "1"),
+                    ListWithPageCursor(),
+                )
+
+            sut.reset()
+            sut.loadNextPage()
+            val res = sut.loadNextPage()
+
+            assertEquals(elements, res)
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                tagRepository.getFollowed(pageCursor = null)
+                tagRepository.getFollowed(pageCursor = "1")
+            }
+        }
+}


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds the tests for `DefaultFavoritesPaginationManager` and `DefaultFollowedHashtagsPaginationManager`.
