### PR TITLE
chore: add tests for pagination follow requests and inbox

### DIFF
--- a/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultExplorePaginationManagerTest.kt
+++ b/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultExplorePaginationManagerTest.kt
@@ -100,6 +100,60 @@ class DefaultExplorePaginationManagerTest {
         }
 
     @Test
+    fun `given sensitive results when loadNextPage with Posts specification and not includeNsfw then result is as expected`() =
+        runTest {
+            val list =
+                listOf(
+                    TimelineEntryModel(id = "1", content = "", creator = UserModel(id = "2")),
+                    TimelineEntryModel(
+                        id = "3",
+                        content = "",
+                        creator = UserModel(id = "2"),
+                        sensitive = true,
+                    ),
+                )
+            everySuspend {
+                trendingRepository.getEntries(offset = any())
+            } returns list
+
+            sut.reset(ExplorePaginationSpecification.Posts(includeNsfw = false))
+            val res = sut.loadNextPage()
+
+            assertEquals(list.subList(0, 1).map { ExploreItemModel.Entry(it) }, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                trendingRepository.getEntries(offset = 0)
+            }
+        }
+
+    @Test
+    fun `given sensitive results when loadNextPage with Posts specification then result is as expected`() =
+        runTest {
+            val list =
+                listOf(
+                    TimelineEntryModel(id = "1", content = "", creator = UserModel(id = "2")),
+                    TimelineEntryModel(
+                        id = "3",
+                        content = "",
+                        creator = UserModel(id = "2"),
+                        sensitive = true,
+                    ),
+                )
+            everySuspend {
+                trendingRepository.getEntries(offset = any())
+            } returns list
+
+            sut.reset(ExplorePaginationSpecification.Posts(includeNsfw = true))
+            val res = sut.loadNextPage()
+
+            assertEquals(list.map { ExploreItemModel.Entry(it) }, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                trendingRepository.getEntries(offset = 0)
+            }
+        }
+
+    @Test
     fun `given no more results when loadNextPage twice with Posts specification then result is as expected`() =
         runTest {
             val list =

--- a/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFavoritesPaginationManagerTest.kt
+++ b/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFavoritesPaginationManagerTest.kt
@@ -91,6 +91,60 @@ class DefaultFavoritesPaginationManagerTest {
         }
 
     @Test
+    fun `given sensitive results when loadNextPage with Bookmarks specification and not includeNsfw then result is as expected`() =
+        runTest {
+            val list =
+                listOf(
+                    TimelineEntryModel(id = "1", content = "", creator = UserModel(id = "2")),
+                    TimelineEntryModel(
+                        id = "3",
+                        content = "",
+                        creator = UserModel(id = "2"),
+                        sensitive = true,
+                    ),
+                )
+            everySuspend {
+                timelineEntryRepository.getBookmarks(pageCursor = any())
+            } returns list
+
+            sut.reset(FavoritesPaginationSpecification.Bookmarks(includeNsfw = false))
+            val res = sut.loadNextPage()
+
+            assertEquals(list.subList(0, 1), res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                timelineEntryRepository.getBookmarks(pageCursor = null)
+            }
+        }
+
+    @Test
+    fun `given sensitive results when loadNextPage with Bookmarks specification then result is as expected`() =
+        runTest {
+            val list =
+                listOf(
+                    TimelineEntryModel(id = "1", content = "", creator = UserModel(id = "2")),
+                    TimelineEntryModel(
+                        id = "3",
+                        content = "",
+                        creator = UserModel(id = "2"),
+                        sensitive = true,
+                    ),
+                )
+            everySuspend {
+                timelineEntryRepository.getBookmarks(pageCursor = any())
+            } returns list
+
+            sut.reset(FavoritesPaginationSpecification.Bookmarks(includeNsfw = true))
+            val res = sut.loadNextPage()
+
+            assertEquals(list, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                timelineEntryRepository.getBookmarks(pageCursor = null)
+            }
+        }
+
+    @Test
     fun `given no more results when loadNextPage twice with Bookmarks specification then result is as expected`() =
         runTest {
             val list =

--- a/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFollowRequestPaginationManagerTest.kt
+++ b/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFollowRequestPaginationManagerTest.kt
@@ -1,0 +1,93 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.ListWithPageCursor
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.returnsArgAt
+import dev.mokkery.answering.sequentiallyReturns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DefaultFollowRequestPaginationManagerTest {
+    private val userRepository = mock<UserRepository>()
+    private val emojiHelper =
+        mock<EmojiHelper> {
+            everySuspend { any<UserModel>().withEmojisIfMissing() } returnsArgAt 0
+        }
+    private val sut =
+        DefaultFollowRequestPaginationManager(
+            userRepository = userRepository,
+            emojiHelper = emojiHelper,
+        )
+
+    @Test
+    fun `given no results when loadNextPage then result is as expected`() =
+        runTest {
+            everySuspend { userRepository.getFollowRequests(any()) } returns ListWithPageCursor()
+
+            sut.reset()
+            val res = sut.loadNextPage()
+
+            assertTrue(res.isEmpty())
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                userRepository.getFollowRequests(pageCursor = null)
+            }
+        }
+
+    @Test
+    fun `given results when loadNextPage then result is as expected`() =
+        runTest {
+            val elements = listOf(UserModel(id = "1"))
+            everySuspend { userRepository.getFollowRequests(any()) } returns
+                ListWithPageCursor(
+                    list = elements,
+                    cursor = "1",
+                )
+
+            sut.reset()
+            val res = sut.loadNextPage()
+
+            assertEquals(elements, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                userRepository.getFollowRequests(pageCursor = null)
+            }
+        }
+
+    @Test
+    fun `given can not fetch more when loadNextPage twice then result is as expected`() =
+        runTest {
+            val elements = listOf(UserModel(id = "1"))
+            everySuspend {
+                userRepository.getFollowRequests(any())
+            } sequentiallyReturns
+                listOf(
+                    ListWithPageCursor(
+                        list = elements,
+                        cursor = "1",
+                    ),
+                    ListWithPageCursor(),
+                )
+
+            sut.reset()
+            sut.loadNextPage()
+            val res = sut.loadNextPage()
+
+            assertEquals(elements, res)
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                userRepository.getFollowRequests(pageCursor = null)
+                userRepository.getFollowRequests(pageCursor = "1")
+            }
+        }
+}

--- a/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultNotificationsPaginationManagerTest.kt
+++ b/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultNotificationsPaginationManagerTest.kt
@@ -1,0 +1,258 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationType
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.NotificationRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.ReplyHelper
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.returnsArgAt
+import dev.mokkery.answering.sequentiallyReturns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DefaultNotificationsPaginationManagerTest {
+    private val notificationRepository = mock<NotificationRepository>()
+    private val userRepository =
+        mock<UserRepository> {
+            everySuspend { getRelationships(any()) } returns emptyList()
+        }
+    private val emojiHelper =
+        mock<EmojiHelper> {
+            everySuspend { any<UserModel>().withEmojisIfMissing() } returnsArgAt 0
+            everySuspend { any<TimelineEntryModel>().withEmojisIfMissing() } returnsArgAt 0
+        }
+    private val replyHelper =
+        mock<ReplyHelper> {
+            everySuspend { any<TimelineEntryModel>().withInReplyToIfMissing() } returnsArgAt 0
+        }
+    private val sut =
+        DefaultNotificationsPaginationManager(
+            notificationRepository = notificationRepository,
+            userRepository = userRepository,
+            emojiHelper = emojiHelper,
+            replyHelper = replyHelper,
+        )
+
+    @Test
+    fun `given no results when loadNextPage then result is as expected`() =
+        runTest {
+            everySuspend {
+                notificationRepository.getAll(
+                    types = any(),
+                    pageCursor = any(),
+                    refresh = any(),
+                )
+            } returns emptyList()
+
+            sut.reset(
+                NotificationsPaginationSpecification.Default(
+                    types = NotificationType.ALL,
+                    includeNsfw = false,
+                ),
+            )
+            val res = sut.loadNextPage()
+
+            assertTrue(res.isEmpty())
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                notificationRepository.getAll(
+                    types = NotificationType.ALL,
+                    pageCursor = null,
+                    refresh = false,
+                )
+            }
+        }
+
+    @Test
+    fun `given results when loadNextPage then result is as expected`() =
+        runTest {
+            val elements = listOf(NotificationModel(id = "1"))
+            everySuspend {
+                notificationRepository.getAll(
+                    types = any(),
+                    pageCursor = any(),
+                    refresh = any(),
+                )
+            } returns elements
+
+            sut.reset(
+                NotificationsPaginationSpecification.Default(
+                    types = NotificationType.ALL,
+                    includeNsfw = false,
+                ),
+            )
+            val res = sut.loadNextPage()
+
+            assertEquals(elements, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                notificationRepository.getAll(
+                    types = NotificationType.ALL,
+                    pageCursor = null,
+                    refresh = false,
+                )
+            }
+        }
+
+    @Test
+    fun `given results when loadNextPage with refresh then result is as expected`() =
+        runTest {
+            val elements = listOf(NotificationModel(id = "1"))
+            everySuspend {
+                notificationRepository.getAll(
+                    types = any(),
+                    pageCursor = any(),
+                    refresh = any(),
+                )
+            } returns elements
+
+            sut.reset(
+                NotificationsPaginationSpecification.Default(
+                    types = NotificationType.ALL,
+                    includeNsfw = false,
+                    refresh = true,
+                ),
+            )
+            val res = sut.loadNextPage()
+
+            assertEquals(elements, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                notificationRepository.getAll(
+                    types = NotificationType.ALL,
+                    pageCursor = null,
+                    refresh = true,
+                )
+            }
+        }
+
+    @Test
+    fun `given sensitive results when loadNextPage without includeNsfw then result is as expected`() =
+        runTest {
+            val elements =
+                listOf(
+                    NotificationModel(id = "1"),
+                    NotificationModel(
+                        id = "2",
+                        entry = TimelineEntryModel(id = "3", content = "", sensitive = true),
+                    ),
+                )
+            everySuspend {
+                notificationRepository.getAll(
+                    types = any(),
+                    pageCursor = any(),
+                    refresh = any(),
+                )
+            } returns elements
+
+            sut.reset(
+                NotificationsPaginationSpecification.Default(
+                    types = NotificationType.ALL,
+                    includeNsfw = false,
+                    refresh = true,
+                ),
+            )
+            val res = sut.loadNextPage()
+
+            assertEquals(elements.subList(0, 1), res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                notificationRepository.getAll(
+                    types = NotificationType.ALL,
+                    pageCursor = null,
+                    refresh = true,
+                )
+            }
+        }
+
+    @Test
+    fun `given sensitive results when loadNextPage then result is as expected`() =
+        runTest {
+            val elements =
+                listOf(
+                    NotificationModel(id = "1"),
+                    NotificationModel(
+                        id = "2",
+                        entry = TimelineEntryModel(id = "3", content = "", sensitive = true),
+                    ),
+                )
+            everySuspend {
+                notificationRepository.getAll(
+                    types = any(),
+                    pageCursor = any(),
+                    refresh = any(),
+                )
+            } returns elements
+
+            sut.reset(
+                NotificationsPaginationSpecification.Default(
+                    types = NotificationType.ALL,
+                    includeNsfw = true,
+                    refresh = true,
+                ),
+            )
+            val res = sut.loadNextPage()
+
+            assertEquals(elements, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                notificationRepository.getAll(
+                    types = NotificationType.ALL,
+                    pageCursor = null,
+                    refresh = true,
+                )
+            }
+        }
+
+    @Test
+    fun `given can not fetch more when loadNextPage twice then result is as expected`() =
+        runTest {
+            val elements = listOf(NotificationModel(id = "1"))
+            everySuspend {
+                notificationRepository.getAll(
+                    types = any(),
+                    pageCursor = any(),
+                    refresh = any(),
+                )
+            } sequentiallyReturns
+                listOf(
+                    elements,
+                    emptyList(),
+                )
+
+            sut.reset(
+                NotificationsPaginationSpecification.Default(
+                    types = NotificationType.ALL,
+                    includeNsfw = false,
+                ),
+            )
+            sut.loadNextPage()
+            val res = sut.loadNextPage()
+
+            assertEquals(elements, res)
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                notificationRepository.getAll(
+                    types = NotificationType.ALL,
+                    pageCursor = null,
+                    refresh = false,
+                )
+                notificationRepository.getAll(
+                    types = NotificationType.ALL,
+                    pageCursor = "1",
+                    refresh = false,
+                )
+            }
+        }
+}


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds the tests for `DefaultFollowRequestPaginationManager` and `DefaultNotificationsPaginationManager`.

## Additional notes
<!-- Anything to declare for code review? -->
More test for sensitive contents with/without the `includeNsfw` flag have been added to `DefaultFavoritesPaginationManager` and `DefaultExplorePaginationManager`.
