### PR TITLE
chore: add test for search result and user pagination

### DIFF
--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUserPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUserPaginationManager.kt
@@ -112,7 +112,11 @@ internal class DefaultUserPaginationManager(
                             offset =
                                 history
                                     .indexOfLast { it.id == pageCursor }
-                                    .takeIf { it >= 0 } ?: 0,
+                                    .takeIf { it >= 0 }
+                                    ?.let {
+                                        // offset is count, not index
+                                        it + 1
+                                    } ?: 0,
                         )?.deduplicate()
                         ?.let {
                             if (specification.withRelationship) {

--- a/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultAlbumPhotoPaginationManagerTest.kt
+++ b/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultAlbumPhotoPaginationManagerTest.kt
@@ -40,10 +40,7 @@ class DefaultAlbumPhotoPaginationManagerTest {
     @Test
     fun `given photos when loadNextPage then result is as expected`() =
         runTest {
-            val elements =
-                listOf(
-                    AttachmentModel(id = "1", url = ""),
-                )
+            val elements = listOf(AttachmentModel(id = "1", url = ""))
             everySuspend { albumRepository.getPhotos(any(), any(), any()) } returns elements
 
             sut.reset(AlbumPhotoPaginationSpecification.Default(album = ALBUM_NAME))
@@ -63,10 +60,7 @@ class DefaultAlbumPhotoPaginationManagerTest {
     @Test
     fun `given can not fetch more when loadNextPage twice then result is as expected`() =
         runTest {
-            val elements =
-                listOf(
-                    AttachmentModel(id = "1", url = ""),
-                )
+            val elements = listOf(AttachmentModel(id = "1", url = ""))
             everySuspend {
                 albumRepository.getPhotos(
                     any(),

--- a/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultEventPaginationManagerTest.kt
+++ b/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultEventPaginationManagerTest.kt
@@ -36,10 +36,7 @@ class DefaultEventPaginationManagerTest {
     @Test
     fun `given photos when loadNextPage then result is as expected`() =
         runTest {
-            val elements =
-                listOf(
-                    EventModel(id = "1", uri = "", title = "", startTime = "0"),
-                )
+            val elements = listOf(EventModel(id = "1", uri = "", title = "", startTime = "0"))
             everySuspend { eventRepository.getAll(any()) } returns elements
 
             sut.reset(EventsPaginationSpecification.All)
@@ -55,10 +52,7 @@ class DefaultEventPaginationManagerTest {
     @Test
     fun `given can not fetch more when loadNextPage twice then result is as expected`() =
         runTest {
-            val elements =
-                listOf(
-                    EventModel(id = "1", uri = "", title = "", startTime = "0"),
-                )
+            val elements = listOf(EventModel(id = "1", uri = "", title = "", startTime = "0"))
             everySuspend {
                 eventRepository.getAll(any())
             } sequentiallyReturns

--- a/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultSearchPaginationManagerTest.kt
+++ b/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultSearchPaginationManagerTest.kt
@@ -1,0 +1,418 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
+
+import com.livefast.eattrash.raccoonforfriendica.core.notifications.NotificationCenter
+import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.NotificationCenterEvent
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.ExploreItemModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.SearchResultType
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TagModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.ReplyHelper
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SearchRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.returnsArgAt
+import dev.mokkery.answering.sequentiallyReturns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.reflect.KClass
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DefaultSearchPaginationManagerTest {
+    private val searchRepository = mock<SearchRepository>()
+    private val userRepository =
+        mock<UserRepository> {
+            everySuspend { getRelationships(any()) } returns emptyList()
+        }
+    private val emojiHelper =
+        mock<EmojiHelper> {
+            everySuspend { any<UserModel>().withEmojisIfMissing() } returnsArgAt 0
+            everySuspend { any<TimelineEntryModel>().withEmojisIfMissing() } returnsArgAt 0
+        }
+    private val replyHelper =
+        mock<ReplyHelper> {
+            everySuspend { any<TimelineEntryModel>().withInReplyToIfMissing() } returnsArgAt 0
+        }
+    private val notificationCenter =
+        mock<NotificationCenter> {
+            every { subscribe(any<KClass<NotificationCenterEvent>>()) } returns MutableSharedFlow()
+        }
+
+    private val sut =
+        DefaultSearchPaginationManager(
+            searchRepository = searchRepository,
+            userRepository = userRepository,
+            emojiHelper = emojiHelper,
+            replyHelper = replyHelper,
+            notificationCenter = notificationCenter,
+            dispatcher = UnconfinedTestDispatcher(),
+        )
+
+    // region Posts
+    @Test
+    fun `given no results when loadNextPage with Posts specification then result is as expected`() =
+        runTest {
+            everySuspend {
+                searchRepository.search(
+                    query = any(),
+                    type = any(),
+                    pageCursor = any(),
+                    resolve = any(),
+                )
+            } returns emptyList()
+
+            sut.reset(SearchPaginationSpecification.Entries(query = "query", includeNsfw = false))
+            val res = sut.loadNextPage()
+
+            assertTrue(res.isEmpty())
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                searchRepository.search(
+                    query = "query",
+                    type = SearchResultType.Entries,
+                    pageCursor = null,
+                    resolve = false,
+                )
+            }
+        }
+
+    @Test
+    fun `given results when loadNextPage with Posts specification then result is as expected`() =
+        runTest {
+            val list =
+                listOf(
+                    TimelineEntryModel(id = "1", content = "", creator = UserModel(id = "2")),
+                )
+            everySuspend {
+                searchRepository.search(
+                    query = any(),
+                    type = any(),
+                    pageCursor = any(),
+                    resolve = any(),
+                )
+            } returns list.map { ExploreItemModel.Entry(it) }
+
+            sut.reset(SearchPaginationSpecification.Entries(query = "query", includeNsfw = false))
+            val res = sut.loadNextPage()
+
+            assertEquals(list.map { ExploreItemModel.Entry(it) }, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                searchRepository.search(
+                    query = "query",
+                    type = SearchResultType.Entries,
+                    pageCursor = null,
+                    resolve = false,
+                )
+            }
+        }
+
+    @Test
+    fun `given sensitive results when loadNextPage with Posts specification and not includeNsfw then result is as expected`() =
+        runTest {
+            val list =
+                listOf(
+                    TimelineEntryModel(id = "1", content = "", creator = UserModel(id = "2")),
+                    TimelineEntryModel(
+                        id = "3",
+                        content = "",
+                        creator = UserModel(id = "2"),
+                        sensitive = true,
+                    ),
+                )
+            everySuspend {
+                searchRepository.search(
+                    query = any(),
+                    type = any(),
+                    pageCursor = any(),
+                    resolve = any(),
+                )
+            } returns list.map { ExploreItemModel.Entry(it) }
+
+            sut.reset(SearchPaginationSpecification.Entries(query = "query", includeNsfw = false))
+            val res = sut.loadNextPage()
+
+            assertEquals(list.subList(0, 1).map { ExploreItemModel.Entry(it) }, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                searchRepository.search(
+                    query = "query",
+                    type = SearchResultType.Entries,
+                    pageCursor = null,
+                    resolve = false,
+                )
+            }
+        }
+
+    @Test
+    fun `given sensitive results when loadNextPage with Posts specification then result is as expected`() =
+        runTest {
+            val list =
+                listOf(
+                    TimelineEntryModel(id = "1", content = "", creator = UserModel(id = "2")),
+                    TimelineEntryModel(
+                        id = "3",
+                        content = "",
+                        creator = UserModel(id = "2"),
+                        sensitive = true,
+                    ),
+                )
+            everySuspend {
+                searchRepository.search(
+                    query = any(),
+                    type = any(),
+                    pageCursor = any(),
+                    resolve = any(),
+                )
+            } returns list.map { ExploreItemModel.Entry(it) }
+
+            sut.reset(SearchPaginationSpecification.Entries(query = "query", includeNsfw = true))
+            val res = sut.loadNextPage()
+
+            assertEquals(list.map { ExploreItemModel.Entry(it) }, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                searchRepository.search(
+                    query = "query",
+                    type = SearchResultType.Entries,
+                    pageCursor = null,
+                    resolve = false,
+                )
+            }
+        }
+
+    @Test
+    fun `given no more results when loadNextPage twice with Posts specification then result is as expected`() =
+        runTest {
+            val list =
+                listOf(
+                    TimelineEntryModel(id = "1", content = "", creator = UserModel(id = "2")),
+                )
+            everySuspend {
+                searchRepository.search(
+                    query = any(),
+                    type = any(),
+                    pageCursor = any(),
+                    resolve = any(),
+                )
+            } sequentiallyReturns listOf(list.map { ExploreItemModel.Entry(it) }, emptyList())
+
+            sut.reset(SearchPaginationSpecification.Entries(query = "query", includeNsfw = false))
+            sut.loadNextPage()
+            val res = sut.loadNextPage()
+
+            assertEquals(list.map { ExploreItemModel.Entry(it) }, res)
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                searchRepository.search(
+                    query = "query",
+                    type = SearchResultType.Entries,
+                    pageCursor = null,
+                    resolve = false,
+                )
+                searchRepository.search(
+                    query = "query",
+                    type = SearchResultType.Entries,
+                    pageCursor = "1",
+                    resolve = false,
+                )
+            }
+        }
+    // endregion
+
+    // region Hashtags
+    @Test
+    fun `given no results when loadNextPage with Hashtags specification then result is as expected`() =
+        runTest {
+            everySuspend {
+                searchRepository.search(
+                    query = any(),
+                    type = any(),
+                    pageCursor = any(),
+                    resolve = any(),
+                )
+            } returns emptyList()
+
+            sut.reset(SearchPaginationSpecification.Hashtags(query = "query"))
+            val res = sut.loadNextPage()
+
+            assertTrue(res.isEmpty())
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                searchRepository.search(
+                    query = "query",
+                    type = SearchResultType.Hashtags,
+                    pageCursor = null,
+                    resolve = false,
+                )
+            }
+        }
+
+    @Test
+    fun `given results when loadNextPage with Hashtags specification then result is as expected`() =
+        runTest {
+            val list = listOf(TagModel(name = "", url = ""))
+            everySuspend {
+                searchRepository.search(
+                    query = any(),
+                    type = any(),
+                    pageCursor = any(),
+                    resolve = any(),
+                )
+            } returns list.map { ExploreItemModel.HashTag(it) }
+
+            sut.reset(SearchPaginationSpecification.Hashtags(query = "query"))
+            val res = sut.loadNextPage()
+
+            assertEquals(list.map { ExploreItemModel.HashTag(it) }, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                searchRepository.search(
+                    query = "query",
+                    type = SearchResultType.Hashtags,
+                    pageCursor = null,
+                    resolve = false,
+                )
+            }
+        }
+
+    @Test
+    fun `given no more results when loadNextPage twice with Hashtags specification then result is as expected`() =
+        runTest {
+            val list = listOf(TagModel(name = "", url = ""))
+            everySuspend {
+                searchRepository.search(
+                    query = any(),
+                    type = any(),
+                    pageCursor = any(),
+                    resolve = any(),
+                )
+            } sequentiallyReturns listOf(list.map { ExploreItemModel.HashTag(it) }, emptyList())
+
+            sut.reset(SearchPaginationSpecification.Hashtags(query = "query"))
+            sut.loadNextPage()
+            val res = sut.loadNextPage()
+
+            assertEquals(list.map { ExploreItemModel.HashTag(it) }, res)
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                searchRepository.search(
+                    query = "query",
+                    type = SearchResultType.Hashtags,
+                    pageCursor = null,
+                    resolve = false,
+                )
+                searchRepository.search(
+                    query = "query",
+                    type = SearchResultType.Hashtags,
+                    pageCursor = null,
+                    resolve = false,
+                )
+            }
+        }
+    // endregion
+
+    // region Users
+    @Test
+    fun `given no results when loadNextPage with Users specification then result is as expected`() =
+        runTest {
+            everySuspend {
+                searchRepository.search(
+                    query = any(),
+                    type = any(),
+                    pageCursor = any(),
+                    resolve = any(),
+                )
+            } returns emptyList()
+
+            sut.reset(SearchPaginationSpecification.Users(query = "query"))
+            val res = sut.loadNextPage()
+
+            assertTrue(res.isEmpty())
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                searchRepository.search(
+                    query = "query",
+                    type = SearchResultType.Users,
+                    pageCursor = null,
+                    resolve = false,
+                )
+            }
+        }
+
+    @Test
+    fun `given results when loadNextPage with Users specification then result is as expected`() =
+        runTest {
+            val list = listOf(UserModel(id = "1"))
+            everySuspend {
+                searchRepository.search(
+                    query = any(),
+                    type = any(),
+                    pageCursor = any(),
+                    resolve = any(),
+                )
+            } returns list.map { ExploreItemModel.User(it) }
+
+            sut.reset(SearchPaginationSpecification.Users(query = "query"))
+            val res = sut.loadNextPage()
+
+            assertEquals(list.map { ExploreItemModel.User(it) }, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                searchRepository.search(
+                    query = "query",
+                    type = SearchResultType.Users,
+                    pageCursor = null,
+                    resolve = false,
+                )
+            }
+        }
+
+    @Test
+    fun `given no more results when loadNextPage twice with Users specification then result is as expected`() =
+        runTest {
+            val list = listOf(UserModel(id = "1"))
+            everySuspend {
+                searchRepository.search(
+                    query = any(),
+                    type = any(),
+                    pageCursor = any(),
+                    resolve = any(),
+                )
+            } sequentiallyReturns listOf(list.map { ExploreItemModel.User(it) }, emptyList())
+
+            sut.reset(SearchPaginationSpecification.Users(query = "query"))
+            sut.loadNextPage()
+            val res = sut.loadNextPage()
+
+            assertEquals(list.map { ExploreItemModel.User(it) }, res)
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                searchRepository.search(
+                    query = "query",
+                    type = SearchResultType.Users,
+                    pageCursor = null,
+                    resolve = false,
+                )
+                searchRepository.search(
+                    query = "query",
+                    type = SearchResultType.Users,
+                    pageCursor = "1",
+                    resolve = false,
+                )
+            }
+        }
+    // endregion
+}

--- a/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUserPaginationManagerTest.kt
+++ b/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUserPaginationManagerTest.kt
@@ -1,0 +1,713 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
+
+import com.livefast.eattrash.raccoonforfriendica.core.notifications.NotificationCenter
+import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.NotificationCenterEvent
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.CirclesRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.returnsArgAt
+import dev.mokkery.answering.sequentiallyReturns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.reflect.KClass
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DefaultUserPaginationManagerTest {
+    private val userRepository =
+        mock<UserRepository> {
+            everySuspend { getRelationships(any()) } returns emptyList()
+        }
+    private val timelineEntryRepository = mock<TimelineEntryRepository>()
+    private val circlesRepository = mock<CirclesRepository>()
+    private val emojiHelper =
+        mock<EmojiHelper> {
+            everySuspend { any<UserModel>().withEmojisIfMissing() } returnsArgAt 0
+            everySuspend { any<TimelineEntryModel>().withEmojisIfMissing() } returnsArgAt 0
+        }
+    private val notificationCenter =
+        mock<NotificationCenter> {
+            every { subscribe(any<KClass<NotificationCenterEvent>>()) } returns MutableSharedFlow()
+        }
+    private val sut =
+        DefaultUserPaginationManager(
+            userRepository = userRepository,
+            timelineEntryRepository = timelineEntryRepository,
+            circlesRepository = circlesRepository,
+            emojiHelper = emojiHelper,
+            notificationCenter = notificationCenter,
+            dispatcher = UnconfinedTestDispatcher(),
+        )
+
+    // region Follower
+    @Test
+    fun `given no results when loadNextPage with Follower then result is as expected`() =
+        runTest {
+            everySuspend {
+                userRepository.getFollowers(
+                    id = any(),
+                    pageCursor = any(),
+                )
+            } returns emptyList()
+
+            sut.reset(UserPaginationSpecification.Follower(userId = "1"))
+            val res = sut.loadNextPage()
+
+            assertTrue(res.isEmpty())
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                userRepository.getFollowers(id = "1", pageCursor = null)
+            }
+        }
+
+    @Test
+    fun `given results when loadNextPage with Follower then result is as expected`() =
+        runTest {
+            val list = listOf(UserModel(id = "2"))
+            everySuspend {
+                userRepository.getFollowers(
+                    id = any(),
+                    pageCursor = any(),
+                )
+            } returns list
+
+            sut.reset(UserPaginationSpecification.Follower(userId = "1"))
+            val res = sut.loadNextPage()
+
+            assertEquals(list, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                userRepository.getFollowers(id = "1", pageCursor = null)
+            }
+        }
+
+    @Test
+    fun `given can not fetch more results when loadNextPage with Follower twice then result is as expected`() =
+        runTest {
+            val list = listOf(UserModel(id = "2"))
+            everySuspend {
+                userRepository.getFollowers(
+                    id = any(),
+                    pageCursor = any(),
+                )
+            } sequentiallyReturns
+                listOf(
+                    list,
+                    emptyList(),
+                )
+
+            sut.reset(UserPaginationSpecification.Follower(userId = "1"))
+            sut.loadNextPage()
+            val res = sut.loadNextPage()
+
+            assertEquals(list, res)
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                userRepository.getFollowers(id = "1", pageCursor = null)
+                userRepository.getFollowers(id = "1", pageCursor = "2")
+            }
+        }
+    // endregion
+
+    // region Following
+    @Test
+    fun `given no results when loadNextPage with Following then result is as expected`() =
+        runTest {
+            everySuspend {
+                userRepository.getFollowing(
+                    id = any(),
+                    pageCursor = any(),
+                )
+            } returns emptyList()
+
+            sut.reset(UserPaginationSpecification.Following(userId = "1"))
+            val res = sut.loadNextPage()
+
+            assertTrue(res.isEmpty())
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                userRepository.getFollowing(id = "1", pageCursor = null)
+            }
+        }
+
+    @Test
+    fun `given results when loadNextPage with Following then result is as expected`() =
+        runTest {
+            val list = listOf(UserModel(id = "2"))
+            everySuspend {
+                userRepository.getFollowing(
+                    id = any(),
+                    pageCursor = any(),
+                )
+            } returns list
+
+            sut.reset(UserPaginationSpecification.Following(userId = "1"))
+            val res = sut.loadNextPage()
+
+            assertEquals(list, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                userRepository.getFollowing(id = "1", pageCursor = null)
+            }
+        }
+
+    @Test
+    fun `given can not fetch more results when loadNextPage with Following twice then result is as expected`() =
+        runTest {
+            val list = listOf(UserModel(id = "2"))
+            everySuspend {
+                userRepository.getFollowing(
+                    id = any(),
+                    pageCursor = any(),
+                )
+            } sequentiallyReturns
+                listOf(
+                    list,
+                    emptyList(),
+                )
+
+            sut.reset(UserPaginationSpecification.Following(userId = "1"))
+            sut.loadNextPage()
+            val res = sut.loadNextPage()
+
+            assertEquals(list, res)
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                userRepository.getFollowing(id = "1", pageCursor = null)
+                userRepository.getFollowing(id = "1", pageCursor = "2")
+            }
+        }
+    // endregion
+
+    // region EntryUsersReblog
+    @Test
+    fun `given no results when loadNextPage with EntryUsersReblog then result is as expected`() =
+        runTest {
+            everySuspend {
+                timelineEntryRepository.getUsersWhoReblogged(
+                    id = any(),
+                    pageCursor = any(),
+                )
+            } returns emptyList()
+
+            sut.reset(UserPaginationSpecification.EntryUsersReblog(entryId = "1"))
+            val res = sut.loadNextPage()
+
+            assertTrue(res.isEmpty())
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                timelineEntryRepository.getUsersWhoReblogged(
+                    id = "1",
+                    pageCursor = null,
+                )
+            }
+        }
+
+    @Test
+    fun `given results when loadNextPage with EntryUsersReblog then result is as expected`() =
+        runTest {
+            val list = listOf(UserModel(id = "2"))
+            everySuspend {
+                timelineEntryRepository.getUsersWhoReblogged(
+                    id = any(),
+                    pageCursor = any(),
+                )
+            } returns list
+
+            sut.reset(UserPaginationSpecification.EntryUsersReblog(entryId = "1"))
+            val res = sut.loadNextPage()
+
+            assertEquals(list, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                timelineEntryRepository.getUsersWhoReblogged(
+                    id = "1",
+                    pageCursor = null,
+                )
+            }
+        }
+
+    @Test
+    fun `given can not fetch more results when loadNextPage with EntryUsersReblog twice then result is as expected`() =
+        runTest {
+            val list = listOf(UserModel(id = "2"))
+            everySuspend {
+                timelineEntryRepository.getUsersWhoReblogged(
+                    id = any(),
+                    pageCursor = any(),
+                )
+            } sequentiallyReturns
+                listOf(
+                    list,
+                    emptyList(),
+                )
+
+            sut.reset(UserPaginationSpecification.EntryUsersReblog(entryId = "1"))
+            sut.loadNextPage()
+            val res = sut.loadNextPage()
+
+            assertEquals(list, res)
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                timelineEntryRepository.getUsersWhoReblogged(
+                    id = "1",
+                    pageCursor = null,
+                )
+                timelineEntryRepository.getUsersWhoReblogged(
+                    id = "1",
+                    pageCursor = "2",
+                )
+            }
+        }
+    // endregion
+
+    // region EntryUsersFavorite
+    @Test
+    fun `given no results when loadNextPage with EntryUsersFavorite then result is as expected`() =
+        runTest {
+            everySuspend {
+                timelineEntryRepository.getUsersWhoFavorited(
+                    id = any(),
+                    pageCursor = any(),
+                )
+            } returns emptyList()
+
+            sut.reset(UserPaginationSpecification.EntryUsersFavorite(entryId = "1"))
+            val res = sut.loadNextPage()
+
+            assertTrue(res.isEmpty())
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                timelineEntryRepository.getUsersWhoFavorited(
+                    id = "1",
+                    pageCursor = null,
+                )
+            }
+        }
+
+    @Test
+    fun `given results when loadNextPage with EntryUsersFavorite then result is as expected`() =
+        runTest {
+            val list = listOf(UserModel(id = "2"))
+            everySuspend {
+                timelineEntryRepository.getUsersWhoFavorited(
+                    id = any(),
+                    pageCursor = any(),
+                )
+            } returns list
+
+            sut.reset(UserPaginationSpecification.EntryUsersFavorite(entryId = "1"))
+            val res = sut.loadNextPage()
+
+            assertEquals(list, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                timelineEntryRepository.getUsersWhoFavorited(
+                    id = "1",
+                    pageCursor = null,
+                )
+            }
+        }
+
+    @Test
+    fun `given can not fetch more results when loadNextPage with EntryUsersFavorite twice then result is as expected`() =
+        runTest {
+            val list = listOf(UserModel(id = "2"))
+            everySuspend {
+                timelineEntryRepository.getUsersWhoFavorited(
+                    id = any(),
+                    pageCursor = any(),
+                )
+            } sequentiallyReturns
+                listOf(
+                    list,
+                    emptyList(),
+                )
+
+            sut.reset(UserPaginationSpecification.EntryUsersFavorite(entryId = "1"))
+            sut.loadNextPage()
+            val res = sut.loadNextPage()
+
+            assertEquals(list, res)
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                timelineEntryRepository.getUsersWhoFavorited(
+                    id = "1",
+                    pageCursor = null,
+                )
+                timelineEntryRepository.getUsersWhoFavorited(
+                    id = "1",
+                    pageCursor = "2",
+                )
+            }
+        }
+    // endregion
+
+    // region Search
+    @Test
+    fun `given no results when loadNextPage with Search then result is as expected`() =
+        runTest {
+            everySuspend {
+                userRepository.search(
+                    query = any(),
+                    offset = any(),
+                    following = any(),
+                )
+            } returns emptyList()
+
+            sut.reset(UserPaginationSpecification.Search(query = "query"))
+            val res = sut.loadNextPage()
+
+            assertTrue(res.isEmpty())
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                userRepository.search(
+                    query = "query",
+                    offset = 0,
+                    following = false,
+                )
+            }
+        }
+
+    @Test
+    fun `given results when loadNextPage with Search then result is as expected`() =
+        runTest {
+            val list = listOf(UserModel(id = "2"))
+            everySuspend {
+                userRepository.search(
+                    query = any(),
+                    offset = any(),
+                    following = any(),
+                )
+            } returns list
+
+            sut.reset(UserPaginationSpecification.Search(query = "query"))
+            val res = sut.loadNextPage()
+
+            assertEquals(list, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                userRepository.search(
+                    query = "query",
+                    offset = 0,
+                    following = false,
+                )
+            }
+        }
+
+    @Test
+    fun `given can not fetch more results when loadNextPage with Search twice then result is as expected`() =
+        runTest {
+            val list = listOf(UserModel(id = "2"))
+            everySuspend {
+                userRepository.search(
+                    query = any(),
+                    offset = any(),
+                    following = any(),
+                )
+            } sequentiallyReturns
+                listOf(
+                    list,
+                    emptyList(),
+                )
+
+            sut.reset(UserPaginationSpecification.Search(query = "query"))
+            sut.loadNextPage()
+            val res = sut.loadNextPage()
+
+            assertEquals(list, res)
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                userRepository.search(
+                    query = "query",
+                    offset = 0,
+                    following = false,
+                )
+                userRepository.search(
+                    query = "query",
+                    offset = 1,
+                    following = false,
+                )
+            }
+        }
+    // endregion
+
+    // region SearchFollowing
+    @Test
+    fun `given no results when loadNextPage with SearchFollowing then result is as expected`() =
+        runTest {
+            everySuspend {
+                userRepository.searchMyFollowing(
+                    query = any(),
+                    pageCursor = any(),
+                )
+            } returns emptyList()
+
+            sut.reset(UserPaginationSpecification.SearchFollowing(query = "query"))
+            val res = sut.loadNextPage()
+
+            assertTrue(res.isEmpty())
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                userRepository.searchMyFollowing(
+                    query = "query",
+                    pageCursor = null,
+                )
+            }
+        }
+
+    @Test
+    fun `given results when loadNextPage with SearchFollowing then result is as expected`() =
+        runTest {
+            val list = listOf(UserModel(id = "2"))
+            everySuspend {
+                userRepository.searchMyFollowing(
+                    query = any(),
+                    pageCursor = any(),
+                )
+            } returns list
+
+            sut.reset(UserPaginationSpecification.SearchFollowing(query = "query"))
+            val res = sut.loadNextPage()
+
+            assertEquals(list, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                userRepository.searchMyFollowing(
+                    query = "query",
+                    pageCursor = null,
+                )
+            }
+        }
+
+    @Test
+    fun `given can not fetch more results when loadNextPage with SearchFollowing twice then result is as expected`() =
+        runTest {
+            val list = listOf(UserModel(id = "2"))
+            everySuspend {
+                userRepository.searchMyFollowing(
+                    query = any(),
+                    pageCursor = any(),
+                )
+            } sequentiallyReturns
+                listOf(
+                    list,
+                    emptyList(),
+                )
+
+            sut.reset(UserPaginationSpecification.SearchFollowing(query = "query"))
+            sut.loadNextPage()
+            val res = sut.loadNextPage()
+
+            assertEquals(list, res)
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                userRepository.searchMyFollowing(
+                    query = "query",
+                    pageCursor = null,
+                )
+                userRepository.searchMyFollowing(
+                    query = "query",
+                    pageCursor = "2",
+                )
+            }
+        }
+    // endregion
+
+    // region Muted
+    @Test
+    fun `given no results when loadNextPage with Muted then result is as expected`() =
+        runTest {
+            everySuspend { userRepository.getMuted(pageCursor = any()) } returns emptyList()
+
+            sut.reset(UserPaginationSpecification.Muted)
+            val res = sut.loadNextPage()
+
+            assertTrue(res.isEmpty())
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                userRepository.getMuted(pageCursor = null)
+            }
+        }
+
+    @Test
+    fun `given results when loadNextPage with Muted then result is as expected`() =
+        runTest {
+            val list = listOf(UserModel(id = "2"))
+            everySuspend { userRepository.getMuted(pageCursor = any()) } returns list
+
+            sut.reset(UserPaginationSpecification.Muted)
+            val res = sut.loadNextPage()
+
+            assertEquals(list, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                userRepository.getMuted(pageCursor = null)
+            }
+        }
+
+    @Test
+    fun `given can not fetch more results when loadNextPage with Muted twice then result is as expected`() =
+        runTest {
+            val list = listOf(UserModel(id = "2"))
+            everySuspend { userRepository.getMuted(pageCursor = any()) } sequentiallyReturns
+                listOf(
+                    list,
+                    emptyList(),
+                )
+
+            sut.reset(UserPaginationSpecification.Muted)
+            sut.loadNextPage()
+            val res = sut.loadNextPage()
+
+            assertEquals(list, res)
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                userRepository.getMuted(pageCursor = null)
+                userRepository.getMuted(pageCursor = "2")
+            }
+        }
+    // endregion
+
+    // region Blocked
+    @Test
+    fun `given no results when loadNextPage with Blocked then result is as expected`() =
+        runTest {
+            everySuspend { userRepository.getBlocked(pageCursor = any()) } returns emptyList()
+
+            sut.reset(UserPaginationSpecification.Blocked)
+            val res = sut.loadNextPage()
+
+            assertTrue(res.isEmpty())
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                userRepository.getBlocked(pageCursor = null)
+            }
+        }
+
+    @Test
+    fun `given results when loadNextPage with Blocked then result is as expected`() =
+        runTest {
+            val list = listOf(UserModel(id = "2"))
+            everySuspend { userRepository.getBlocked(pageCursor = any()) } returns list
+
+            sut.reset(UserPaginationSpecification.Blocked)
+            val res = sut.loadNextPage()
+
+            assertEquals(list, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                userRepository.getBlocked(pageCursor = null)
+            }
+        }
+
+    @Test
+    fun `given can not fetch more results when loadNextPage with Blocked twice then result is as expected`() =
+        runTest {
+            val list = listOf(UserModel(id = "2"))
+            everySuspend { userRepository.getBlocked(pageCursor = any()) } sequentiallyReturns
+                listOf(
+                    list,
+                    emptyList(),
+                )
+
+            sut.reset(UserPaginationSpecification.Blocked)
+            sut.loadNextPage()
+            val res = sut.loadNextPage()
+
+            assertEquals(list, res)
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                userRepository.getBlocked(pageCursor = null)
+                userRepository.getBlocked(pageCursor = "2")
+            }
+        }
+    // endregion
+
+    // region CircleMembers
+    @Test
+    fun `given no results when loadNextPage with CircleMembers then result is as expected`() =
+        runTest {
+            everySuspend {
+                circlesRepository.getMembers(id = any(), pageCursor = any())
+            } returns emptyList()
+
+            sut.reset(UserPaginationSpecification.CircleMembers(id = "1", query = "query"))
+            val res = sut.loadNextPage()
+
+            assertTrue(res.isEmpty())
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                circlesRepository.getMembers(
+                    id = "1",
+                    pageCursor = null,
+                )
+            }
+        }
+
+    @Test
+    fun `given results when loadNextPage with CircleMembers then result is as expected`() =
+        runTest {
+            val list = listOf(UserModel(id = "2", displayName = "query"))
+            everySuspend {
+                circlesRepository.getMembers(id = any(), pageCursor = any())
+            } returns list
+
+            sut.reset(UserPaginationSpecification.CircleMembers(id = "1", query = "query"))
+            val res = sut.loadNextPage()
+
+            assertEquals(list, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                circlesRepository.getMembers(
+                    id = "1",
+                    pageCursor = null,
+                )
+            }
+        }
+
+    @Test
+    fun `given can not fetch more results when loadNextPage with CircleMembers twice then result is as expected`() =
+        runTest {
+            val list = listOf(UserModel(id = "2", displayName = "query"))
+            everySuspend {
+                circlesRepository.getMembers(id = any(), pageCursor = any())
+            } sequentiallyReturns
+                listOf(
+                    list,
+                    emptyList(),
+                )
+
+            sut.reset(UserPaginationSpecification.CircleMembers(id = "1", query = "query"))
+            sut.loadNextPage()
+            val res = sut.loadNextPage()
+
+            assertEquals(list, res)
+            assertFalse(sut.canFetchMore)
+            verifySuspend {
+                circlesRepository.getMembers(
+                    id = "1",
+                    pageCursor = null,
+                )
+                circlesRepository.getMembers(
+                    id = "1",
+                    pageCursor = "2",
+                )
+            }
+        }
+    // endregion
+}


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds the tests for `DefaultSearchPaginationManager` and `DefaultUserPaginagionManager`.

## Additional notes
<!-- Anything to declare for code review? -->
There was a bug in the offset parameters passed to the `v1/accounts/:id/statuses` endpoint discovered in this test.
