### PR TITLE
fix: embedded images accessibility

### DIFF
--- a/core/commonui/content/build.gradle.kts
+++ b/core/commonui/content/build.gradle.kts
@@ -37,6 +37,7 @@ kotlin {
 
                 implementation(libs.calf)
                 implementation(libs.koin.core)
+                implementation(libs.ksoup.html)
                 implementation(libs.voyager.navigator)
 
                 implementation(projects.core.appearance)


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR makes sure the alternate text for an embedded image inside a post is read from the `alt` attribute of the `img` HTML element.

## Additional notes
<!-- Anything to declare for code review? -->
This is an iteration over #570.
