### PR TITLE
chore: add more tests for notification center and main view model

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/main/MainMviModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/main/MainMviModel.kt
@@ -15,7 +15,6 @@ interface MainMviModel :
 
     data class UiState(
         val bottomBarOffsetHeightPx: Float = 0f,
-        val isLogged: Boolean = false,
         val bottomNavigationSections: List<BottomNavigationSection> = emptyList(),
     )
 

--- a/composeApp/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/main/MainViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/main/MainViewModelTest.kt
@@ -1,0 +1,72 @@
+package com.livefast.eattrash.raccoonforfriendica.main
+
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.BottomNavigationSection
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.InboxManager
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.setMain
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MainViewModelTest {
+    private val unreadCountFlow = MutableStateFlow(0)
+    private val inboxManager =
+        mock<InboxManager> { every { unreadCount } returns unreadCountFlow }
+    private lateinit var sut: MainViewModel
+
+    @BeforeTest
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun setup() {
+        Dispatchers.run { setMain(UnconfinedTestDispatcher()) }
+        sut = viewModelFactory()
+    }
+
+    @Test
+    fun `when initialized then state is as expected`() {
+        val state = sut.uiState.value
+        val sections =
+            listOf(
+                BottomNavigationSection.Home,
+                BottomNavigationSection.Explore,
+                BottomNavigationSection.Inbox(unreadItems = 0),
+                BottomNavigationSection.Profile,
+            )
+        assertEquals(sections, state.bottomNavigationSections)
+        assertEquals(0f, state.bottomBarOffsetHeightPx)
+    }
+
+    @Test
+    fun `when unread count changes then state is as expected`() {
+        val count = 1
+        unreadCountFlow.update { count }
+        val state = sut.uiState.value
+
+        val inboxSection =
+            state.bottomNavigationSections.firstNotNullOf {
+                it as? BottomNavigationSection.Inbox
+            }
+        assertEquals(count, inboxSection.unreadItems)
+    }
+
+    @Test
+    fun `when SetBottomBarOffsetHeightPx then state is as expected`() {
+        val bottomBarOffsetHeightPx = 2f
+        sut.reduce(MainMviModel.Intent.SetBottomBarOffsetHeightPx(bottomBarOffsetHeightPx))
+
+        val state = sut.uiState.value
+
+        assertEquals(bottomBarOffsetHeightPx, state.bottomBarOffsetHeightPx)
+    }
+
+    private fun viewModelFactory() =
+        MainViewModel(
+            inboxManager = inboxManager,
+        )
+}

--- a/core/notifications/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/core/notifications/DefaultNotificationCenterTest.kt
+++ b/core/notifications/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/core/notifications/DefaultNotificationCenterTest.kt
@@ -1,8 +1,16 @@
 package com.livefast.eattrash.raccoonforfriendica.core.notifications
 
 import app.cash.turbine.test
+import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.AlbumsUpdatedEvent
+import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.DraftDeletedEvent
+import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.TagUpdatedEvent
+import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.TimelineEntryCreatedEvent
+import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.TimelineEntryDeletedEvent
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.TimelineEntryUpdatedEvent
+import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.UserUpdatedEvent
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TagModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
@@ -33,12 +41,48 @@ class DefaultNotificationCenterTest {
     }
 
     @Test
-    fun `given subscription when send event then event is received just once`() =
+    fun `given subscription when send UserUpdatedEvent then event is received just once`() =
         runTest {
             val expected =
-                TimelineEntryUpdatedEvent(
-                    entry = TimelineEntryModel(id = "0", content = ""),
-                )
+                UserUpdatedEvent(user = UserModel(id = "0"))
+            launch {
+                sut.send(expected)
+            }
+
+            sut.subscribe(UserUpdatedEvent::class).test {
+                val actual = awaitItem()
+                assertEquals(expected, actual)
+            }
+
+            sut.subscribe(UserUpdatedEvent::class).test {
+                expectNoEvents()
+            }
+        }
+
+    @Test
+    fun `given subscription when send TimelineEntryCreatedEvent then event is received just once`() =
+        runTest {
+            val expected =
+                TimelineEntryCreatedEvent(entry = TimelineEntryModel(id = "0", content = ""))
+            launch {
+                sut.send(expected)
+            }
+
+            sut.subscribe(TimelineEntryCreatedEvent::class).test {
+                val actual = awaitItem()
+                assertEquals(expected, actual)
+            }
+
+            sut.subscribe(TimelineEntryCreatedEvent::class).test {
+                expectNoEvents()
+            }
+        }
+
+    @Test
+    fun `given subscription when send TimelineEntryUpdatedEvent then event is received just once`() =
+        runTest {
+            val expected =
+                TimelineEntryUpdatedEvent(entry = TimelineEntryModel(id = "0", content = ""))
             launch {
                 sut.send(expected)
             }
@@ -49,6 +93,78 @@ class DefaultNotificationCenterTest {
             }
 
             sut.subscribe(TimelineEntryUpdatedEvent::class).test {
+                expectNoEvents()
+            }
+        }
+
+    @Test
+    fun `given subscription when send TimelineEntryDeletedEvent then event is received just once`() =
+        runTest {
+            val expected = TimelineEntryDeletedEvent(id = "0")
+            launch {
+                sut.send(expected)
+            }
+
+            sut.subscribe(TimelineEntryDeletedEvent::class).test {
+                val actual = awaitItem()
+                assertEquals(expected, actual)
+            }
+
+            sut.subscribe(TimelineEntryDeletedEvent::class).test {
+                expectNoEvents()
+            }
+        }
+
+    @Test
+    fun `given subscription when send TagUpdatedEvent then event is received just once`() =
+        runTest {
+            val expected = TagUpdatedEvent(tag = TagModel(name = "tag"))
+            launch {
+                sut.send(expected)
+            }
+
+            sut.subscribe(TagUpdatedEvent::class).test {
+                val actual = awaitItem()
+                assertEquals(expected, actual)
+            }
+
+            sut.subscribe(TagUpdatedEvent::class).test {
+                expectNoEvents()
+            }
+        }
+
+    @Test
+    fun `given subscription when send AlbumsUpdatedEvent then event is received just once`() =
+        runTest {
+            val expected = AlbumsUpdatedEvent
+            launch {
+                sut.send(expected)
+            }
+
+            sut.subscribe(AlbumsUpdatedEvent::class).test {
+                val actual = awaitItem()
+                assertEquals(expected, actual)
+            }
+
+            sut.subscribe(AlbumsUpdatedEvent::class).test {
+                expectNoEvents()
+            }
+        }
+
+    @Test
+    fun `given subscription when send DraftDeletedEvent then event is received just once`() =
+        runTest {
+            val expected = DraftDeletedEvent(id = "0")
+            launch {
+                sut.send(expected)
+            }
+
+            sut.subscribe(DraftDeletedEvent::class).test {
+                val actual = awaitItem()
+                assertEquals(expected, actual)
+            }
+
+            sut.subscribe(DraftDeletedEvent::class).test {
                 expectNoEvents()
             }
         }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds some more test for `DefaultNotificationCenter` and creates a test for `MainViewModel`.

