### PR TITLE
chore: add friendica.myportal.social to default instances

### DIFF
--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/FriendicaInstance.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/FriendicaInstance.kt
@@ -17,6 +17,12 @@ val DefaultFriendicaInstances =
         this +=
             FriendicaInstance(
                 lang = "🇬🇧",
+                mau = 14,
+                value = "friendica.myportal.social",
+            )
+        this +=
+            FriendicaInstance(
+                lang = "🇬🇧",
                 mau = 18,
                 value = "friendica.world",
             )


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds `friendica.myportal.social` to the list of default instances.

--- 
Original request [on Friendica](https://friendica.myportal.social/display/e65e1095-4367-44a3-381a-fe1006360066).
