### PR TITLE
chore: add test for announcement repository

### DIFF
--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultAnnouncementRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultAnnouncementRepositoryTest.kt
@@ -1,0 +1,171 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Announcement
+import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.AnnouncementService
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DefaultAnnouncementRepositoryTest {
+    private val announcementService = mock<AnnouncementService>()
+    private val serviceProvider =
+        mock<ServiceProvider> {
+            every { announcements } returns announcementService
+        }
+    private val sut = DefaultAnnouncementRepository(provider = serviceProvider)
+
+    @Test
+    fun `when getAll then result is as expected`() =
+        runTest {
+            val list = listOf(Announcement(id = "1", content = "lorem ipsum"))
+            everySuspend { announcementService.getAll() } returns list
+
+            val res = sut.getAll()
+
+            assertEquals(list.map { it.toModel() }, res)
+            verifySuspend {
+                announcementService.getAll()
+            }
+        }
+
+    @Test
+    fun `when getAll twice with no refresh then result is as expected`() =
+        runTest {
+            val list = listOf(Announcement(id = "1", content = "lorem ipsum"))
+            everySuspend { announcementService.getAll() } returns list
+
+            sut.getAll()
+            val res = sut.getAll()
+
+            assertEquals(list.map { it.toModel() }, res)
+            verifySuspend(VerifyMode.exactly(1)) {
+                announcementService.getAll()
+            }
+        }
+
+    @Test
+    fun `when getAll twice with refresh then result is as expected`() =
+        runTest {
+            val list = listOf(Announcement(id = "1", content = "lorem ipsum"))
+            everySuspend { announcementService.getAll() } returns list
+
+            sut.getAll()
+            val res = sut.getAll(refresh = true)
+
+            assertEquals(list.map { it.toModel() }, res)
+            verifySuspend(VerifyMode.exactly(2)) {
+                announcementService.getAll()
+            }
+        }
+
+    @Test
+    fun `given success when markAsRead then result is as expected`() =
+        runTest {
+            everySuspend { announcementService.dismiss(any()) } returns mockResponse(res = Unit)
+
+            val res = sut.markAsRead(id = "1")
+
+            assertTrue(res)
+            verifySuspend {
+                announcementService.dismiss("1")
+            }
+        }
+
+    @Test
+    fun `given error when markAsRead then result is as expected`() =
+        runTest {
+            everySuspend { announcementService.dismiss(any()) } returns
+                mockResponse(statusCode = HttpStatusCode.InternalServerError)
+
+            val res = sut.markAsRead(id = "1")
+
+            assertFalse(res)
+            verifySuspend {
+                announcementService.dismiss("1")
+            }
+        }
+
+    @Test
+    fun `given success when addReaction then result is as expected`() =
+        runTest {
+            everySuspend {
+                announcementService.addReaction(
+                    id = any(),
+                    name = any(),
+                )
+            } returns mockResponse(res = Unit)
+
+            val res = sut.addReaction(id = "1", reaction = "🦝")
+
+            assertTrue(res)
+            verifySuspend {
+                announcementService.addReaction("1", name = "🦝")
+            }
+        }
+
+    @Test
+    fun `given error when addReaction then result is as expected`() =
+        runTest {
+            everySuspend {
+                announcementService.addReaction(
+                    id = any(),
+                    name = any(),
+                )
+            } returns mockResponse(statusCode = HttpStatusCode.InternalServerError)
+
+            val res = sut.addReaction(id = "1", reaction = "🦝")
+
+            assertFalse(res)
+            verifySuspend {
+                announcementService.addReaction("1", name = "🦝")
+            }
+        }
+
+    @Test
+    fun `given success when removeReaction then result is as expected`() =
+        runTest {
+            everySuspend {
+                announcementService.removeReaction(
+                    id = any(),
+                    name = any(),
+                )
+            } returns mockResponse(res = Unit)
+
+            val res = sut.removeReaction(id = "1", reaction = "🦝")
+
+            assertTrue(res)
+            verifySuspend {
+                announcementService.removeReaction("1", name = "🦝")
+            }
+        }
+
+    @Test
+    fun `given error when removeReaction then result is as expected`() =
+        runTest {
+            everySuspend {
+                announcementService.removeReaction(
+                    id = any(),
+                    name = any(),
+                )
+            } returns mockResponse(statusCode = HttpStatusCode.InternalServerError)
+
+            val res = sut.removeReaction(id = "1", reaction = "🦝")
+
+            assertFalse(res)
+            verifySuspend {
+                announcementService.removeReaction("1", name = "🦝")
+            }
+        }
+}

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/TestUtils.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/TestUtils.kt
@@ -1,0 +1,55 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import de.jensklingenberg.ktorfit.Response
+import io.ktor.client.call.HttpClientCall
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.Headers
+import io.ktor.http.HttpProtocolVersion
+import io.ktor.http.HttpStatusCode
+import io.ktor.util.date.GMTDate
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.InternalAPI
+import kotlin.coroutines.CoroutineContext
+import kotlin.test.fail
+
+internal fun <T> mockResponse(
+    statusCode: HttpStatusCode = HttpStatusCode.OK,
+    res: T? = null,
+): Response<T> {
+    val rawResponse =
+        object : HttpResponse() {
+            override val call: HttpClientCall
+                get() = fail("not implemented")
+            override val coroutineContext: CoroutineContext
+                get() = fail("not implemented")
+            override val headers: Headers
+                get() = fail("not implemented")
+
+            @InternalAPI
+            override val rawContent: ByteReadChannel
+                get() = fail("not implemented")
+            override val requestTime: GMTDate
+                get() = fail("not implemented")
+            override val responseTime: GMTDate
+                get() = fail("not implemented")
+            override val status: HttpStatusCode
+                get() = statusCode
+            override val version: HttpProtocolVersion
+                get() = fail("not implemented")
+        }
+    val response =
+        if (res != null) {
+            Response.success<T>(
+                body = res,
+                rawResponse = rawResponse,
+            )
+        } else {
+            Response.error(
+                body = object {},
+                rawResponse = rawResponse,
+            )
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    return response as Response<T>
+}


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds a test for `DefaultAnnouncementRepository`.

## Additional notes
<!-- Anything to declare for code review? -->
A utility function to mock network responses for service methods returning `Response<T>` is being created. This is a surprise tool that will help us later. 

<div align="center">
<img alt="mickey mouse meme: it's a surprise tool that will help us later" src="https://i.redd.it/dqk6ibyv84d11.jpg" />
</div>
