### PR TITLE
fix: strip down HTML before editing posts

### DIFF
--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
@@ -668,7 +668,7 @@ class ComposerScreen(
                         visibility = uiState.visibility,
                         availableVisibilities = uiState.availableVisibilities,
                         // visibility change is not possible when editing a post
-                        changeVisibilityEnabled = editedPostId == null,
+                        changeVisibilityEnabled = !isBeingEdited,
                         onChangeVisibility = { visibility ->
                             if (visibility is Visibility.Circle) {
                                 selectCircleDialogOpen = true

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
@@ -1,10 +1,12 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.composer
 
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.getSelectedText
 import cafe.adriel.voyager.core.model.screenModelScope
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
+import com.livefast.eattrash.raccoonforfriendica.core.htmlparse.parseHtml
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.NotificationCenter
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.DraftDeletedEvent
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.TimelineEntryCreatedEvent
@@ -598,7 +600,12 @@ class ComposerViewModel(
                         },
                     offsetAfter = before.length,
                 )
-            updateState { it.copy(bodyValue = newValue, hasUnsavedChanges = true) }
+            updateState {
+                it.copy(
+                    bodyValue = newValue,
+                    hasUnsavedChanges = true
+                )
+            }
         }
     }
 
@@ -623,7 +630,12 @@ class ComposerViewModel(
                     additionalPart = additionalPart,
                     offsetAfter = additionalPart.length,
                 )
-            updateState { it.copy(bodyValue = newValue, hasUnsavedChanges = true) }
+            updateState {
+                it.copy(
+                    bodyValue = newValue,
+                    hasUnsavedChanges = true
+                )
+            }
         }
     }
 
@@ -683,7 +695,12 @@ class ComposerViewModel(
                     additionalPart = additionalPart,
                     offsetAfter = additionalPart.length,
                 )
-            updateState { it.copy(bodyValue = newValue, hasUnsavedChanges = true) }
+            updateState {
+                it.copy(
+                    bodyValue = newValue,
+                    hasUnsavedChanges = true
+                )
+            }
         }
     }
 
@@ -1086,7 +1103,12 @@ class ComposerViewModel(
                         },
                     offsetAfter = before.length,
                 )
-            updateState { it.copy(bodyValue = newValue, hasUnsavedChanges = true) }
+            updateState {
+                it.copy(
+                    bodyValue = newValue,
+                    hasUnsavedChanges = true
+                )
+            }
         }
     }
 
@@ -1304,12 +1326,10 @@ class ComposerViewModel(
             }
 
         val reference =
-            if (uiState.value.supportsRichEditing) {
-                // retrieve field values from source to strip down all formatting
-                timelineEntryRepository.getSource(entry.id) ?: entry
-            } else {
-                entry
-            }
+            // retrieve field values from source to strip down all formatting
+            timelineEntryRepository.getSource(entry.id) ?: entry.copy(
+                content = entry.content.parseHtml(Color.Black).text
+            )
 
         updateState {
             it.copy(


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR makes sure HTML markup is stripped off before loading a post for editing in the composer.

## Additional notes
<!-- Anything to declare for code review? -->
The main source of the bug was relying on the state `markupMode` property before it was actually populated and its default value `PlainText` disabling getting the post source in the loading process.
