### PR TITLE
enhancement: enable excludeRepliesFromTimeline on Friendica by default

### DIFF
--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultLoginUseCase.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultLoginUseCase.kt
@@ -55,17 +55,19 @@ internal class DefaultLoginUseCase(
             if (oldSettings == null) {
                 supportedFeatureRepository.refresh()
                 val supportsBBCode = supportedFeatureRepository.features.value.supportsBBCode
-                val defaultMarkupMode =
-                    if (supportsBBCode) {
-                        MarkupMode.BBCode
-                    } else {
-                        MarkupMode.PlainText
-                    }
                 settingsRepository.create(
                     defaultSettings.copy(
                         id = 0,
                         accountId = account.id,
-                        markupMode = defaultMarkupMode,
+                        // on Friendica, enable BBCode by default
+                        markupMode =
+                            if (supportsBBCode) {
+                                MarkupMode.BBCode
+                            } else {
+                                MarkupMode.PlainText
+                            },
+                        // on Friendica, enable excludeRepliesFromTimeline
+                        excludeRepliesFromTimeline = supportsBBCode,
                     ),
                 )
             }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR makes sure `excludeRepliesFromTimeline` is set to `true` for new users who log in on a Friendica backend.

## Additional notes
<!-- Anything to declare for code review? -->
Since Friendica is the only backend supporting BBCode markup, the `supportsBBCode` value from the current features is used as discriminatory criterion.

This is documented and a test is added to make sure the behaviour is as expected.
