### PR TITLE
fix: update suggestion source values for Mastodon >= 4.3.0

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/SuggestionSource.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/SuggestionSource.kt
@@ -3,12 +3,30 @@ package com.livefast.eattrash.raccoonforfriendica.core.api.dto
 import kotlinx.serialization.SerialName
 
 enum class SuggestionSource {
+    @Deprecated("Replaced by FEATURED")
     @SerialName("staff")
     STAFF,
 
+    @Deprecated("Replaced by one of SIMILAR_TO_RECENTLY_FOLLOWED, FRIENDS_OF_FRIENDS")
     @SerialName("past_interactions")
     PAST_INTERACTIONS,
 
+    @Deprecated("Replaced by one of MOST_FOLLOWED, MOST_INTERACTIONS")
     @SerialName("global")
     GLOBAL,
+
+    @SerialName("similar_to_recently_followed")
+    SIMILAR_TO_RECENTLY_FOLLOWED,
+
+    @SerialName("friends_of_friends")
+    FRIENDS_OF_FRIENDS,
+
+    @SerialName("most_followed")
+    MOST_FOLLOWED,
+
+    @SerialName("most_interactions")
+    MOST_INTERACTIONS,
+
+    @SerialName("featured")
+    FEATURED,
 }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR updates the possible values for the `SuggestionSource` enum, considering the values have been renamed or replaced by more specific ones on Mastodon >= 4.3.0.

## Additional notes
<!-- Anything to declare for code review? -->
Old values are kept for backwards compatibility with Friendica or older Mastodon instances.