### PR TITLE
fix: partial revert of `d79937cd` for attempt to remove markup locally

### DIFF
--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
@@ -1,12 +1,10 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.composer
 
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.getSelectedText
 import cafe.adriel.voyager.core.model.screenModelScope
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
-import com.livefast.eattrash.raccoonforfriendica.core.htmlparse.parseHtml
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.NotificationCenter
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.DraftDeletedEvent
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.events.TimelineEntryCreatedEvent
@@ -1325,11 +1323,8 @@ class ComposerViewModel(
                 }
             }
 
-        val reference =
-            // retrieve field values from source to strip down all formatting
-            timelineEntryRepository.getSource(entry.id) ?: entry.copy(
-                content = entry.content.parseHtml(Color.Black).text
-            )
+        // retrieve field values from source to strip down all formatting
+        val reference = timelineEntryRepository.getSource(entry.id) ?: entry
 
         updateState {
             it.copy(


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR partially reverts d79937cd because trying to remove all markup locally apparently breaks more things than the ones it fixes.

## Additional notes
<!-- Anything to declare for code review? -->
We have a saying for it:

> Pezo el tacón del sbrego
