### PR TITLE
chore: add tests for event and marker repository

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -204,6 +204,7 @@ dependencies {
     kover(projects.core.preferences)
     kover(projects.core.utils)
     kover(projects.domain.content.pagination)
+    kover(projects.domain.content.repository)
     kover(projects.domain.content.usecase)
     kover(projects.domain.identity.repository)
     kover(projects.domain.identity.usecase)

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Event.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Event.kt
@@ -5,15 +5,15 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class Event(
-    @SerialName("id") val id: Long,
-    @SerialName("uid") val uid: Long,
-    @SerialName("cid") val cid: Long,
-    @SerialName("uri") val uri: String,
-    @SerialName("name") val name: String,
+    @SerialName("cid") val cid: Long? = null,
     @SerialName("desc") val description: String,
-    @SerialName("start_time") val startTime: String,
     @SerialName("end_time") val endTime: String? = null,
-    @SerialName("type") val type: String,
+    @SerialName("id") val id: Long,
+    @SerialName("name") val name: String,
     @SerialName("nofinish") val noFinish: Int = 0,
     @SerialName("place") val place: String? = null,
+    @SerialName("start_time") val startTime: String,
+    @SerialName("type") val type: String? = null,
+    @SerialName("uid") val uid: Long? = 0,
+    @SerialName("uri") val uri: String,
 )

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
@@ -543,7 +543,7 @@ internal fun Markers.toModel(): List<MarkerModel> =
         }
     }
 
-private fun String.toEventType(): EventType =
+private fun String?.toEventType(): EventType =
     when (this) {
         "birthday" -> EventType.Birthday
         else -> EventType.Event

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEventRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEventRepositoryTest.kt
@@ -1,0 +1,51 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Event
+import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.EventService
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DefaultEventRepositoryTest {
+    private val eventService = mock<EventService>()
+    private val serviceProvider =
+        mock<ServiceProvider> { every { events } returns eventService }
+    private val sut =
+        DefaultEventRepository(
+            provider = serviceProvider,
+        )
+
+    @Test
+    fun `when getAll then result is as expected`() =
+        runTest {
+            val list =
+                listOf(
+                    Event(
+                        id = 1,
+                        uri = "",
+                        name = "",
+                        description = "",
+                        startTime = "",
+                    ),
+                )
+            everySuspend { eventService.getAll(any(), any()) } returns list
+
+            val res = sut.getAll(pageCursor = "0")
+
+            assertEquals(list.map { it.toModel() }, res)
+            verifySuspend {
+                eventService.getAll(
+                    maxId = 0,
+                    count = 20,
+                )
+            }
+        }
+}

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultLocalItemCacheTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultLocalItemCacheTest.kt
@@ -1,0 +1,57 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class DefaultLocalItemCacheTest {
+    private val sut = DefaultLocalItemCache<TimelineEntryModel>()
+
+    @Test
+    fun `given item not present when get then result is as expected`() =
+        runTest {
+            val res = sut.get("1")
+            assertNull(res)
+        }
+
+    @Test
+    fun `given item present when get then result is as expected`() =
+        runTest {
+            val item = TimelineEntryModel(id = "1", content = "")
+
+            sut.put(item.id, item)
+            val res = sut.get("1")
+
+            assertEquals(item, res)
+        }
+
+    @Test
+    fun `when remove then result is as expected`() =
+        runTest {
+            val item = TimelineEntryModel(id = "1", content = "")
+
+            sut.put(item.id, item)
+            val res1 = sut.get("1")
+            sut.remove("1")
+            val res2 = sut.get("1")
+
+            assertEquals(item, res1)
+            assertNull(res2)
+        }
+
+    @Test
+    fun `when clear then result is as expected`() =
+        runTest {
+            val item = TimelineEntryModel(id = "1", content = "")
+
+            sut.put(item.id, item)
+            val res1 = sut.get("1")
+            sut.clear()
+            val res2 = sut.get("1")
+
+            assertEquals(item, res1)
+            assertNull(res2)
+        }
+}

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMarkerRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMarkerRepositoryTest.kt
@@ -1,0 +1,92 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.MarkerItem
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Markers
+import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.MarkerService
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MarkerModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MarkerType
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.matcher.matching
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DefaultMarkerRepositoryTest {
+    private val markerService = mock<MarkerService>()
+    private val serviceProvider = mock<ServiceProvider> { every { markers } returns markerService }
+    private val sut =
+        DefaultMarkerRepository(
+            provider = serviceProvider,
+        )
+
+    @Test
+    fun `when get then result is as expected`() =
+        runTest {
+            everySuspend { markerService.get(any()) } returns Markers(notifications = MarkerItem("1"))
+
+            val res = sut.get(type = MarkerType.Notifications)
+
+            assertEquals(expected = MarkerModel(type = MarkerType.Notifications, "1"), actual = res)
+            verifySuspend {
+                markerService.get(listOf("notifications"))
+            }
+        }
+
+    @Test
+    fun `when get twice then result is as expected`() =
+        runTest {
+            everySuspend { markerService.get(any()) } returns Markers(notifications = MarkerItem("1"))
+
+            sut.get(type = MarkerType.Notifications)
+            val res = sut.get(type = MarkerType.Notifications)
+
+            assertEquals(expected = MarkerModel(type = MarkerType.Notifications, "1"), actual = res)
+            verifySuspend(VerifyMode.exactly(1)) {
+                markerService.get(listOf("notifications"))
+            }
+        }
+
+    @Test
+    fun `when get twice refreshing then result is as expected`() =
+        runTest {
+            everySuspend { markerService.get(any()) } returns Markers(notifications = MarkerItem("1"))
+
+            sut.get(type = MarkerType.Notifications)
+            val res = sut.get(type = MarkerType.Notifications, refresh = true)
+
+            assertEquals(expected = MarkerModel(type = MarkerType.Notifications, "1"), actual = res)
+            verifySuspend(VerifyMode.exactly(2)) {
+                markerService.get(listOf("notifications"))
+            }
+        }
+
+    @Test
+    fun `when update then result is as expected`() =
+        runTest {
+            everySuspend { markerService.update(any()) } returns
+                Markers(
+                    notifications =
+                        MarkerItem(
+                            "2",
+                        ),
+                )
+
+            val res = sut.update(MarkerType.Notifications, id = "2")
+
+            assertEquals(expected = MarkerModel(type = MarkerType.Notifications, "2"), actual = res)
+            verifySuspend {
+                markerService.update(
+                    matching {
+                        it.formData["notifications[last_read_id]"] == "2"
+                    },
+                )
+            }
+        }
+}


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds more unit tests for content repositories, in particular:
- `DefaultEventRepository`;
- `DefaultMarkerRepository`;
- `DefaultLocalItemCache`.

## Additional notes
<!-- Anything to declare for code review? -->
Coverage is expected to decrease, because the `:domain:content:repository` subproject was not included in the consolidated report and it is only partially covered. Future PRs will take care of adding more tests.
