### PR TITLE
enhancement: always make Markdown option available

### DIFF
--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepository.kt
@@ -21,7 +21,7 @@ internal class DefaultSupportedFeatureRepository(
                 supportReportCategoryRuleViolation = info.isMastodon,
                 supportsPolls = info.isMastodon,
                 supportsBBCode = info.isFriendica,
-                supportsMarkdown = info.isMastodon,
+                supportsMarkdown = true,
                 supportsEntryShare = info.isFriendica,
                 supportsCalendar = info.isFriendica,
                 supportsAnnouncements = info.isMastodon,


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR makes it possible to select Markdown as markup mode even on Friendica nodes.
