### PR TITLE
fix: avoid app crashing due to alt text being empty string in embedded image

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TextWithCustomEmojis.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TextWithCustomEmojis.kt
@@ -79,7 +79,8 @@ fun TextWithCustomEmojis(
                         foundImages[id] = imageData
                         appendInlineContent(
                             id = id,
-                            alternateText = imageData.description ?: rawString,
+                            alternateText =
+                                imageData.description.takeIf { !it.isNullOrEmpty() } ?: rawString,
                         )
                     }
                 }


### PR DESCRIPTION
…d images

## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR solved a crash (from Sentry console) due to `alternateText` being an empty string in an embedded image inside `TextWithCustomEmojis`.

