### PR TITLE
fix: avoid retrieving post source for editing in BBCode and Markdown

### DIFF
--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
@@ -1323,8 +1323,14 @@ class ComposerViewModel(
                 }
             }
 
-        // retrieve field values from source to strip down all formatting
-        val reference = timelineEntryRepository.getSource(entry.id) ?: entry
+        // retrieve field values from source to strip down all formatting (if HTML)
+        val markupMode = settingsRepository.current.value?.markupMode ?: MarkupMode.PlainText
+        val reference =
+            if (markupMode == MarkupMode.HTML) {
+                timelineEntryRepository.getSource(entry.id) ?: entry
+            } else {
+                entry
+            }
 
         updateState {
             it.copy(


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR changes the policy for retrieving post source before editing, allowing to do so only for HTML. This is due to a "bug" (intended but undesired) behaviour due to which BBCode and Markdown formatting is lost on Friendica.
