### PR TITLE
fix: post preview best-effort rendering

### DIFF
--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/converters/DefaultBBCodeConverter.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/converters/DefaultBBCodeConverter.kt
@@ -2,13 +2,22 @@ package com.livefast.eattrash.raccoonforfriendica.feature.composer.converters
 
 import com.livefast.eattrash.raccoonforfriendica.core.utils.substituteAllOccurrences
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.utils.ComposerRegexes
-import com.livefast.eattrash.raccoonforfriendica.feature.composer.utils.replaceNewlines
 import com.mohamedrejeb.ksoup.html.parser.KsoupHtmlHandler
 import com.mohamedrejeb.ksoup.html.parser.KsoupHtmlParser
 
 internal class DefaultBBCodeConverter : BBCodeConverter {
     override fun toHtml(value: String) =
         value
+            .replace("[h1]", "<h1>")
+            .replace("[/h1]", "</h1>")
+            .replace("[h2]", "<h2>")
+            .replace("[/h2]", "</h2>")
+            .replace("[h3]", "<h3>")
+            .replace("[/h3]", "</h3>")
+            .replace("[h4]", "<h4>")
+            .replace("[/h4]", "</h4>")
+            .replace("[h5]", "<h5>")
+            .replace("[/h5]", "</h5>")
             .replace("[u]", "<u>")
             .replace("[/u]", "</u>")
             .replace("[s]", "<s>")
@@ -98,3 +107,5 @@ internal class DefaultBBCodeConverter : BBCodeConverter {
         return builder.toString()
     }
 }
+
+private fun String.replaceNewlines(): String = replace("\n", "<br />")

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/converters/DefaultMarkdownConverter.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/converters/DefaultMarkdownConverter.kt
@@ -2,7 +2,6 @@ package com.livefast.eattrash.raccoonforfriendica.feature.composer.converters
 
 import com.livefast.eattrash.raccoonforfriendica.core.utils.substituteAllOccurrences
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.utils.ComposerRegexes
-import com.livefast.eattrash.raccoonforfriendica.feature.composer.utils.replaceNewlines
 
 internal class DefaultMarkdownConverter : MarkdownConverter {
     override fun toHtml(value: String) =
@@ -58,21 +57,12 @@ internal class DefaultMarkdownConverter : MarkdownConverter {
                     val content = match.groups["title"]?.value.orEmpty()
                     append("<h5>$content</h5>\n")
                 }
-            }.replace("<ul>", "\n")
-            .replace("</ul>", "\n\n")
-            .replace("<ol>", "\n")
-            .replace("</ol>", "\n\n")
-            .run {
-                Regex("^- (?<content>.*?)$").substituteAllOccurrences(this) { match ->
-                    val content = match.groups["content"]?.value.orEmpty()
-                    append("<li>$content</li>")
-                }
             }.run {
                 ComposerRegexes.BBCODE_SHARE.substituteAllOccurrences(this) { match ->
                     val url = match.groups["url"]?.value.orEmpty()
                     append(url)
                 }
-            }.replaceNewlines()
+            }
 
     override fun fromHtml(value: String) = value
 }

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/usecase/DefaultPrepareForPreviewUseCase.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/usecase/DefaultPrepareForPreviewUseCase.kt
@@ -8,7 +8,6 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiC
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.converters.BBCodeConverter
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.converters.MarkdownConverter
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.utils.ComposerRegexes
-import com.livefast.eattrash.raccoonforfriendica.feature.composer.utils.replaceNewlines
 
 internal class DefaultPrepareForPreviewUseCase(
     private val apiConfigurationRepository: ApiConfigurationRepository,
@@ -22,7 +21,7 @@ internal class DefaultPrepareForPreviewUseCase(
         when (mode) {
             MarkupMode.BBCode -> bbCodeConverter.toHtml(text)
             MarkupMode.Markdown -> markdownConverter.toHtml(text)
-            else -> text.replaceNewlines()
+            else -> text
         }.withMentions().withHashtags()
 
     private fun String.withMentions(): String =

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/utils/ComposerRegexes.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/utils/ComposerRegexes.kt
@@ -9,6 +9,4 @@ internal object ComposerRegexes {
         Regex("#(?<hashtag>.+?)(?=\\b)")
     val BBCODE_URL =
         Regex("\\[url=(?<url>.*?)](?<anchor>.*?)\\[/url]")
-    val HTML_URL =
-        Regex("<a \"href\"=(?<url>.*?)>(?<anchor>.*?)</a>")
 }

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/utils/Extension.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/utils/Extension.kt
@@ -1,5 +1,0 @@
-package com.livefast.eattrash.raccoonforfriendica.feature.composer.utils
-
-internal fun String.replaceNewlines(): String =
-    replace(Regex("\n\n"), "<br /><br />")
-        .replace("\n", " ")


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR solves a series of issues reported by @informapirata, more in detail:
- BBCode did not support headlines (of any level);
- block quotes were not rendered (this already worked after #597 but double-checked);
- Markdown preview did not render correctly lists.

## Additional notes
<!-- Anything to declare for code review? -->
Unfortunately, the conversion from Markdown to HTML (needed because post preview internally renders HTML only) is not trivial when lists are involved. I've remove all attempts to process them and left the post text as-is as far as ordered or unordered lists are concerned.
