### PR TITLE
fix: ensure proper deduplication in content pagination

### DIFF
--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultEventPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultEventPaginationManager.kt
@@ -31,16 +31,18 @@ internal class DefaultEventPaginationManager(
                     eventRepository.getAll(
                         pageCursor = pageCursor,
                     )
-            }?.updatePaginationData()
+            }
+
+        return mutex.withLock {
+            results
+                ?.updatePaginationData()
                 ?.deduplicate()
-                .orEmpty()
-
-        mutex.withLock {
-            history.addAll(results)
+                ?.also {
+                    history.addAll(it)
+                }
+            // return a copy
+            history.map { it }
         }
-
-        // return a copy
-        return history.map { it }
     }
 
     private fun List<EventModel>.updatePaginationData(): List<EventModel> =

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultExplorePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultExplorePaginationManager.kt
@@ -128,17 +128,18 @@ internal class DefaultExplorePaginationManager(
                         ?.map {
                             ExploreItemModel.User(it)
                         }?.determineUserRelationshipStatus()
-            }?.deduplicate()
-                ?.updatePaginationData()
-                ?.fixupCreatorEmojis()
-                ?.fixupInReplyTo()
-                .orEmpty()
-        mutex.withLock {
-            history.addAll(results)
-        }
+            }.orEmpty()
 
-        // return a copy
-        return history.map { it }
+        return mutex.withLock {
+            results
+                .deduplicate()
+                .updatePaginationData()
+                .fixupCreatorEmojis()
+                .fixupInReplyTo()
+                .also { history.addAll(it) }
+            // return a copy
+            history.map { it }
+        }
     }
 
     private fun List<ExploreItemModel>.updatePaginationData(): List<ExploreItemModel> =

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFollowedHashtagsPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFollowedHashtagsPaginationManager.kt
@@ -3,6 +3,8 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TagModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TagRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.ListWithPageCursor
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 internal class DefaultFollowedHashtagsPaginationManager(
     private val tagRepository: TagRepository,
@@ -10,25 +12,27 @@ internal class DefaultFollowedHashtagsPaginationManager(
     private var pageCursor: String? = null
     override var canFetchMore: Boolean = true
     private val history = mutableListOf<TagModel>()
+    private val mutex = Mutex()
 
     override suspend fun reset() {
         pageCursor = null
-        history.clear()
+        mutex.withLock {
+            history.clear()
+        }
         canFetchMore = true
     }
 
     override suspend fun loadNextPage(): List<TagModel> {
-        val results =
-            tagRepository
-                .getFollowed(pageCursor)
+        val results = tagRepository.getFollowed(pageCursor)
+
+        return mutex.withLock {
+            results
                 ?.updatePaginationData()
                 ?.deduplicate()
-                .orEmpty()
-
-        history.addAll(results)
-
-        // return a copy
-        return history.map { it }
+                ?.also { history.addAll(it) }
+            // return a copy
+            history.map { it }
+        }
     }
 
     private fun ListWithPageCursor<TagModel>.updatePaginationData(): List<TagModel> =

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUnpublishedPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUnpublishedPaginationManager.kt
@@ -73,16 +73,16 @@ internal class DefaultUnpublishedPaginationManager(
 
                 UnpublishedPaginationSpecification.Drafts ->
                     draftRepository.getAll(page = page)
-            }?.updatePaginationData()
-                ?.deduplicate()
-                .orEmpty()
+            }.orEmpty()
 
-        mutex.withLock {
-            history.addAll(results)
+        return mutex.withLock {
+            results
+                .updatePaginationData()
+                .deduplicate()
+                .also { history.addAll(it) }
+            // return a copy
+            history.map { it }
         }
-
-        // return a copy
-        return history.map { it }
     }
 
     private fun List<TimelineEntryModel>.updatePaginationData(): List<TimelineEntryModel> =

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/usecase/DefaultPopulateThreadUseCase.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/usecase/DefaultPopulateThreadUseCase.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.feature.thread.usecase
 
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.feature.thread.data.ConversationNode
@@ -76,15 +77,7 @@ internal class DefaultPopulateThreadUseCase(
         }
     }
 
-    private fun List<TimelineEntryModel>.deduplicate(): List<TimelineEntryModel> {
-        val res = mutableListOf<TimelineEntryModel>()
-        for (e in this) {
-            if (res.none { it.id == e.id }) {
-                res += e
-            }
-        }
-        return res
-    }
+    private fun List<TimelineEntryModel>.deduplicate(): List<TimelineEntryModel> = distinctBy { it.safeKey }
 
     private fun List<TimelineEntryModel>.populateLoadMore() =
         mapIndexed { idx, entry ->


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes a bug due to which multiple elements with the same ID were accidentally added to post (or other content) lists, making the app crash because IDs have to be unique to ensure proper state management in lazy containers.

## Additional notes
<!-- Anything to declare for code review? -->
The root cause was the concurrency model adopted in pagination managers: having a single writer and multiple readers was ok-ish unless the read was a consistency check performed before write in order to avoid writing possibly duplicated content.

The deduplication and subsequent write have to be atomic, so this PR makes sure to do so by extending the critical section.
