### PR TITLE
fix: trending link deserialization

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/TrendsLink.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/TrendsLink.kt
@@ -10,4 +10,8 @@ data class TrendsLink(
     @SerialName("image") val image: String? = null,
     @SerialName("title") val title: String? = null,
     @SerialName("url") val url: String?,
-)
+) {
+    companion object {
+        fun fromJson(value: String): List<TrendsLink> = JsonSerializer.decodeFromString<List<TrendsLink>>(value)
+    }
+}

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/TrendsService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/TrendsService.kt
@@ -2,7 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.core.api.service
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Status
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Tag
-import com.livefast.eattrash.raccoonforfriendica.core.api.dto.TrendsLink
+import de.jensklingenberg.ktorfit.Response
 import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.Query
 
@@ -23,5 +23,5 @@ interface TrendsService {
     suspend fun getLinks(
         @Query("offset") offset: Int,
         @Query("limit") limit: Int = 20,
-    ): List<TrendsLink>
+    ): Response<Any>
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTrendingRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTrendingRepository.kt
@@ -1,11 +1,13 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.TrendsLink
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.LinkModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TagModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModelWithReply
+import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.sync.Mutex
@@ -72,7 +74,10 @@ internal class DefaultTrendingRepository(
                             offset = offset,
                             limit = DEFAULT_PAGE_SIZE,
                         )
-                response.map { it.toModel() }
+                // workaround for a server bug which inserts empty arrays "[]," among valid results
+                // (at least on some Friendica versions)
+                val body = response.raw().bodyAsText().replace("[],", "")
+                TrendsLink.fromJson(body).map { it.toModel() }
             }.getOrNull()
         }
 


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR makes it possible to deserialize the list of links from the raw request body, because invalid results (e.g. empty arrays `[]`) appear in the GET v1/trens/links response interweaved with valid results.

## Additional notes
<!-- Anything to declare for code review? -->
This is a temporary workaround waiting for server-side resolution.
