### PR TITLE
chore: add unit tests for media, node info and notification repositories

### DIFF
--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMediaRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMediaRepositoryTest.kt
@@ -1,0 +1,87 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.MediaAttachment
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.MediaType
+import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.MediaService
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DefaultMediaRepositoryTest {
+    private val mediaService = mock<MediaService>()
+    private val serviceProvider = mock<ServiceProvider> { every { media } returns mediaService }
+    private val sut = DefaultMediaRepository(provider = serviceProvider)
+
+    @Test
+    fun `when getBy then result is as expected`() =
+        runTest {
+            val attachment =
+                MediaAttachment(
+                    id = "1",
+                    type = MediaType.IMAGE,
+                )
+            everySuspend { mediaService.getBy(any()) } returns attachment
+
+            val res = sut.getBy("1")
+
+            assertEquals(attachment.toModel(), res)
+            verifySuspend {
+                mediaService.getBy("1")
+            }
+        }
+
+    @Test
+    fun `when create then result is as expected`() =
+        runTest {
+            val attachment =
+                MediaAttachment(
+                    id = "1",
+                    type = MediaType.IMAGE,
+                )
+            everySuspend { mediaService.create(any()) } returns attachment
+
+            val bytes = byteArrayOf(0x00.toByte(), 0x01.toByte(), 0x00.toByte())
+            val res =
+                sut.create(
+                    bytes = bytes,
+                    album = "fake-album",
+                    alt = "fake-description",
+                )
+
+            assertEquals(attachment.toModel(), res)
+            verifySuspend {
+                mediaService.create(any())
+            }
+        }
+
+    @Test
+    fun `when update then result is as expected`() =
+        runTest {
+            val attachment =
+                MediaAttachment(
+                    id = "1",
+                    type = MediaType.IMAGE,
+                )
+            everySuspend { mediaService.update(id = any(), content = any()) } returns attachment
+
+            val res =
+                sut.update(
+                    id = "1",
+                    alt = "fake-description",
+                )
+
+            assertTrue(res)
+            verifySuspend {
+                mediaService.update(id = any(), content = any())
+            }
+        }
+}

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNodeInfoRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNodeInfoRepositoryTest.kt
@@ -1,0 +1,47 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Instance
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.InstanceRule
+import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.InstanceService
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DefaultNodeInfoRepositoryTest {
+    private val instanceService = mock<InstanceService>()
+    private val serviceProvider =
+        mock<ServiceProvider> { every { instance } returns instanceService }
+    private val sut = DefaultNodeInfoRepository(provider = serviceProvider)
+
+    @Test
+    fun `when getInfo then result is as expected`() =
+        runTest {
+            val instance = Instance(domain = "example.com")
+            everySuspend { instanceService.getInfo() } returns instance
+
+            val res = sut.getInfo()
+
+            assertEquals(instance.toModel(), res)
+        }
+
+    @Test
+    fun `when getRules then result is as expected`() =
+        runTest {
+            val list =
+                listOf(
+                    InstanceRule(id = "1", text = "rule 1"),
+                    InstanceRule(id = "2", text = "rule 2"),
+                )
+            everySuspend { instanceService.getRules() } returns list
+
+            val res = sut.getRules()
+
+            assertEquals(list.map { it.toModel() }, res)
+        }
+}

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNotificationRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNotificationRepositoryTest.kt
@@ -1,0 +1,232 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Notification
+import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.NotificationService
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationType
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.matcher.matching
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.NotificationType as NotificationTypeDto
+
+class DefaultNotificationRepositoryTest {
+    private val notificationService = mock<NotificationService>()
+    private val serviceProvider =
+        mock<ServiceProvider> { every { notifications } returns notificationService }
+    private val sut = DefaultNotificationRepository(provider = serviceProvider)
+
+    @Test
+    fun `given no results when getAll then result is as expected`() =
+        runTest {
+            everySuspend {
+                notificationService.get(
+                    types = any(),
+                    excludeTypes = any(),
+                    maxId = any(),
+                    minId = any(),
+                    includeAll = any(),
+                    limit = any(),
+                )
+            } returns emptyList()
+
+            val res = sut.getAll(types = NotificationType.ALL)
+
+            assertEquals(emptyList(), res)
+            verifySuspend {
+                notificationService.get(
+                    types = matching { it.contains("mention") },
+                    excludeTypes = null,
+                    maxId = null,
+                    minId = null,
+                    includeAll = false,
+                    limit = 20,
+                )
+            }
+        }
+
+    @Test
+    fun `when getAll then result is as expected`() =
+        runTest {
+            val list = listOf(Notification(id = "1", type = NotificationTypeDto.MENTION))
+            everySuspend {
+                notificationService.get(
+                    types = any(),
+                    excludeTypes = any(),
+                    maxId = any(),
+                    minId = any(),
+                    includeAll = any(),
+                    limit = any(),
+                )
+            } returns list
+
+            val res = sut.getAll(types = NotificationType.ALL)
+
+            assertEquals(list.map { it.toModel() }, res)
+            verifySuspend {
+                notificationService.get(
+                    types = matching { it.contains("mention") },
+                    excludeTypes = null,
+                    maxId = null,
+                    minId = null,
+                    includeAll = false,
+                    limit = 20,
+                )
+            }
+        }
+
+    @Test
+    fun `when getAll with page cursor then result is as expected`() =
+        runTest {
+            val list = listOf(Notification(id = "1", type = NotificationTypeDto.MENTION))
+            everySuspend {
+                notificationService.get(
+                    types = any(),
+                    excludeTypes = any(),
+                    maxId = any(),
+                    minId = any(),
+                    includeAll = any(),
+                    limit = any(),
+                )
+            } returns list
+
+            val res = sut.getAll(types = NotificationType.ALL, pageCursor = "0")
+
+            assertEquals(list.map { it.toModel() }, res)
+            verifySuspend {
+                notificationService.get(
+                    types = matching { it.contains("mention") },
+                    excludeTypes = null,
+                    maxId = "0",
+                    minId = null,
+                    includeAll = false,
+                    limit = 20,
+                )
+            }
+        }
+
+    @Test
+    fun `when getAll twice with no refresh then result is as expected`() =
+        runTest {
+            val list = listOf(Notification(id = "1", type = NotificationTypeDto.MENTION))
+            everySuspend {
+                notificationService.get(
+                    types = any(),
+                    excludeTypes = any(),
+                    maxId = any(),
+                    minId = any(),
+                    includeAll = any(),
+                    limit = any(),
+                )
+            } returns list
+
+            sut.getAll(types = NotificationType.ALL)
+            val res = sut.getAll(types = NotificationType.ALL)
+
+            assertEquals(list.map { it.toModel() }, res)
+            verifySuspend(VerifyMode.exactly(1)) {
+                notificationService.get(
+                    types = matching { it.contains("mention") },
+                    excludeTypes = null,
+                    maxId = null,
+                    minId = null,
+                    includeAll = false,
+                    limit = 20,
+                )
+            }
+        }
+
+    @Test
+    fun `when getAll twice with refresh then result is as expected`() =
+        runTest {
+            val list = listOf(Notification(id = "1", type = NotificationTypeDto.MENTION))
+            everySuspend {
+                notificationService.get(
+                    types = any(),
+                    excludeTypes = any(),
+                    maxId = any(),
+                    minId = any(),
+                    includeAll = any(),
+                    limit = any(),
+                )
+            } returns list
+
+            sut.getAll(types = NotificationType.ALL)
+            val res = sut.getAll(types = NotificationType.ALL, refresh = true)
+
+            assertEquals(list.map { it.toModel() }, res)
+            verifySuspend(VerifyMode.exactly(2)) {
+                notificationService.get(
+                    types = matching { it.contains("mention") },
+                    excludeTypes = null,
+                    maxId = null,
+                    minId = null,
+                    includeAll = false,
+                    limit = 20,
+                )
+            }
+        }
+
+    @Test
+    fun `when dismiss then result is as expected`() =
+        runTest {
+            everySuspend { notificationService.dismiss(any()) } returns mockResponse(res = Unit)
+
+            val res = sut.dismiss("1")
+
+            assertTrue(res)
+            verifySuspend {
+                notificationService.dismiss("1")
+            }
+        }
+
+    @Test
+    fun `given error when dismiss then result is as expected`() =
+        runTest {
+            everySuspend { notificationService.dismiss(any()) } returns mockResponse(statusCode = HttpStatusCode.InternalServerError)
+
+            val res = sut.dismiss("1")
+
+            assertFalse(res)
+            verifySuspend {
+                notificationService.dismiss("1")
+            }
+        }
+
+    @Test
+    fun `when dismissAll then result is as expected`() =
+        runTest {
+            everySuspend { notificationService.clear() } returns mockResponse(res = Unit)
+
+            val res = sut.dismissAll()
+
+            assertTrue(res)
+            verifySuspend {
+                notificationService.clear()
+            }
+        }
+
+    @Test
+    fun `given error when dismissAll then result is as expected`() =
+        runTest {
+            everySuspend { notificationService.clear() } returns mockResponse(statusCode = HttpStatusCode.InternalServerError)
+
+            val res = sut.dismissAll()
+
+            assertFalse(res)
+            verifySuspend {
+                notificationService.clear()
+            }
+        }
+}


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds unit tests for `DefaultMediaRepository`, `DefaultNodeInfoRepository` and `DefaultNotificationRepository`.
