### PR TITLE
refactor(di): make expect modules internal

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/DiHelper.kt
+++ b/composeApp/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/DiHelper.kt
@@ -9,16 +9,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.coreNavigati
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.di.coreNotificationsModule
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.di.corePersistenceModule
 import com.livefast.eattrash.raccoonforfriendica.core.preferences.di.corePreferencesModule
-import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreAppIconModule
-import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreCrashReportModule
-import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreHapticFeedbackModule
-import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreUtilsCalendarModule
-import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreUtilsDebugModule
-import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreUtilsFileSystemModule
-import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreUtilsGalleryModule
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreUtilsModule
-import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreUtilsShareModule
-import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreUtilsUrlModule
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.di.domainContentPaginationModule
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.di.domainContentRepositoryModule
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.di.domainContentUseCaseModule
@@ -60,24 +51,15 @@ val sharedHelperModule =
         includes(
             sharedModule,
             coreApiModule,
-            coreAppIconModule,
             coreAppearanceModule,
             coreCommonUiComponentsModule,
-            coreCrashReportModule,
-            coreHapticFeedbackModule,
             coreL10nModule,
             corePersistenceModule,
             corePreferencesModule,
             coreNavigationModule,
             coreNotificationsModule,
             coreResourceModule,
-            coreUtilsCalendarModule,
-            coreUtilsDebugModule,
-            coreUtilsFileSystemModule,
-            coreUtilsGalleryModule,
             coreUtilsModule,
-            coreUtilsShareModule,
-            coreUtilsUrlModule,
             domainContentPaginationModule,
             domainContentRepositoryModule,
             domainContentUseCaseModule,

--- a/composeApp/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/DiHelper.kt
+++ b/composeApp/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/DiHelper.kt
@@ -9,16 +9,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.coreNavigati
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.di.coreNotificationsModule
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.di.corePersistenceModule
 import com.livefast.eattrash.raccoonforfriendica.core.preferences.di.corePreferencesModule
-import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreAppIconModule
-import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreCrashReportModule
-import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreHapticFeedbackModule
-import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreUtilsCalendarModule
-import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreUtilsDebugModule
-import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreUtilsFileSystemModule
-import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreUtilsGalleryModule
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreUtilsModule
-import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreUtilsShareModule
-import com.livefast.eattrash.raccoonforfriendica.core.utils.di.coreUtilsUrlModule
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.di.domainContentPaginationModule
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.di.domainContentRepositoryModule
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.di.domainContentUseCaseModule
@@ -62,24 +53,15 @@ fun initKoin(): Koin {
             modules(
                 sharedModule,
                 coreApiModule,
-                coreAppIconModule,
                 coreAppearanceModule,
                 coreCommonUiComponentsModule,
-                coreCrashReportModule,
-                coreHapticFeedbackModule,
                 coreL10nModule,
                 corePersistenceModule,
                 corePreferencesModule,
                 coreNavigationModule,
                 coreNotificationsModule,
                 coreResourceModule,
-                coreUtilsCalendarModule,
-                coreUtilsDebugModule,
-                coreUtilsFileSystemModule,
-                coreUtilsGalleryModule,
                 coreUtilsModule,
-                coreUtilsShareModule,
-                coreUtilsUrlModule,
                 domainContentPaginationModule,
                 domainContentRepositoryModule,
                 domainContentUseCaseModule,

--- a/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/di/Utils.kt
+++ b/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/di/Utils.kt
@@ -13,7 +13,7 @@ actual fun getThemeRepository(): ThemeRepository {
     return res
 }
 
-actual val nativeAppearanceModule =
+internal actual val nativeAppearanceModule =
     module {
         single<ColorSchemeProvider> {
             DefaultColorSchemeProvider(context = get())

--- a/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/di/Utils.kt
+++ b/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/di/Utils.kt
@@ -5,7 +5,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.BarColorP
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ColorSchemeProvider
 import org.koin.core.module.Module
 
-expect val nativeAppearanceModule: Module
+internal expect val nativeAppearanceModule: Module
 
 expect fun getThemeRepository(): ThemeRepository
 

--- a/core/appearance/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/di/Utils.kt
+++ b/core/appearance/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/di/Utils.kt
@@ -11,7 +11,7 @@ import org.koin.dsl.module
 
 actual fun getThemeRepository(): ThemeRepository = CoreAppearanceHelper.repository
 
-actual val nativeAppearanceModule =
+internal actual val nativeAppearanceModule =
     module {
         single<ColorSchemeProvider> {
             DefaultColorSchemeProvider()

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/Utils.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/Utils.kt
@@ -65,7 +65,7 @@ actual fun getNetworkStateObserver(): NetworkStateObserver {
     return res
 }
 
-actual val coreUtilsFileSystemModule =
+internal actual val nativeFileSystemModule =
     module {
         single<FileSystemManager> {
             DefaultFileSystemManager(
@@ -74,7 +74,7 @@ actual val coreUtilsFileSystemModule =
         }
     }
 
-actual val coreUtilsGalleryModule =
+internal actual val nativeGalleryModule =
     module {
         single<GalleryHelper> {
             DefaultGalleryHelper(
@@ -83,7 +83,7 @@ actual val coreUtilsGalleryModule =
         }
     }
 
-actual val coreUtilsShareModule =
+internal actual val nativeShareModule =
     module {
         single<ShareHelper> {
             DefaultShareHelper(
@@ -92,7 +92,7 @@ actual val coreUtilsShareModule =
         }
     }
 
-actual val coreUtilsUrlModule =
+internal actual val nativeUrlModule =
     module {
         single<CustomTabsHelper> {
             DefaultCustomTabsHelper(
@@ -101,7 +101,7 @@ actual val coreUtilsUrlModule =
         }
     }
 
-actual val coreUtilsDebugModule =
+internal actual val nativeDebugModule =
     module {
         single<AppInfoRepository> {
             DefaultAppInfoRepository(
@@ -110,7 +110,7 @@ actual val coreUtilsDebugModule =
         }
     }
 
-actual val coreHapticFeedbackModule =
+internal actual val nativeHapticFeedbackModule =
     module {
         single<HapticFeedback> {
             DefaultHapticFeedback(
@@ -119,7 +119,7 @@ actual val coreHapticFeedbackModule =
         }
     }
 
-actual val coreCrashReportModule =
+internal actual val nativeCrashReportModule =
     module {
         single<CrashReportManager> {
             DefaultCrashReportManager(
@@ -129,7 +129,7 @@ actual val coreCrashReportModule =
         }
     }
 
-actual val coreUtilsCalendarModule =
+internal actual val nativeCalendarModule =
     module {
         single<CalendarHelper> {
             DefaultCalendarHelper(
@@ -138,7 +138,7 @@ actual val coreUtilsCalendarModule =
         }
     }
 
-actual val coreAppIconModule =
+internal actual val nativeAppIconModule =
     module {
         single<AppIconManager> {
             DefaultAppIconManager(

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/Utils.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/Utils.kt
@@ -26,20 +26,20 @@ expect fun getCalendarHelper(): CalendarHelper
 
 expect fun getNetworkStateObserver(): NetworkStateObserver
 
-expect val coreUtilsFileSystemModule: Module
+internal expect val nativeFileSystemModule: Module
 
-expect val coreUtilsGalleryModule: Module
+internal expect val nativeGalleryModule: Module
 
-expect val coreUtilsShareModule: Module
+internal expect val nativeShareModule: Module
 
-expect val coreUtilsUrlModule: Module
+internal expect val nativeUrlModule: Module
 
-expect val coreUtilsDebugModule: Module
+internal expect val nativeDebugModule: Module
 
-expect val coreHapticFeedbackModule: Module
+internal expect val nativeHapticFeedbackModule: Module
 
-expect val coreCrashReportModule: Module
+internal expect val nativeCrashReportModule: Module
 
-expect val coreUtilsCalendarModule: Module
+internal expect val nativeCalendarModule: Module
 
-expect val coreAppIconModule: Module
+internal expect val nativeAppIconModule: Module

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/UtilsModule.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/UtilsModule.kt
@@ -14,6 +14,18 @@ import org.koin.dsl.module
 
 val coreUtilsModule =
     module {
+        includes(
+            nativeFileSystemModule,
+            nativeGalleryModule,
+            nativeShareModule,
+            nativeUrlModule,
+            nativeDebugModule,
+            nativeHapticFeedbackModule,
+            nativeCrashReportModule,
+            nativeCalendarModule,
+            nativeAppIconModule,
+        )
+
         single<ImageLoaderProvider> {
             DefaultImageLoaderProvider(
                 context = get(),

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/Utils.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/Utils.kt
@@ -41,49 +41,49 @@ actual fun getCalendarHelper(): CalendarHelper = CoreUtilsDiHelper.calendarHelpe
 
 actual fun getNetworkStateObserver(): NetworkStateObserver = CoreUtilsDiHelper.networkStateObserver
 
-actual val coreUtilsFileSystemModule =
+internal actual val nativeFileSystemModule =
     module {
         single<FileSystemManager> {
             DefaultFileSystemManager()
         }
     }
 
-actual val coreUtilsGalleryModule =
+internal actual val nativeGalleryModule =
     module {
         single<GalleryHelper> {
             DefaultGalleryHelper()
         }
     }
 
-actual val coreUtilsShareModule =
+internal actual val nativeShareModule =
     module {
         single<ShareHelper> {
             DefaultShareHelper()
         }
     }
 
-actual val coreUtilsUrlModule =
+internal actual val nativeUrlModule =
     module {
         single<CustomTabsHelper> {
             DefaultCustomTabsHelper()
         }
     }
 
-actual val coreUtilsDebugModule =
+internal actual val nativeDebugModule =
     module {
         single<AppInfoRepository> {
             DefaultAppInfoRepository()
         }
     }
 
-actual val coreHapticFeedbackModule =
+internal actual val nativeHapticFeedbackModule =
     module {
         single<HapticFeedback> {
             DefaultHapticFeedback()
         }
     }
 
-actual val coreCrashReportModule =
+internal actual val nativeCrashReportModule =
     module {
         single<CrashReportManager> {
             DefaultCrashReportManager(
@@ -92,14 +92,14 @@ actual val coreCrashReportModule =
         }
     }
 
-actual val coreUtilsCalendarModule =
+internal actual val nativeCalendarModule =
     module {
         single<CalendarHelper> {
             DefaultCalendarHelper()
         }
     }
 
-actual val coreAppIconModule =
+internal actual val nativeAppIconModule =
     module {
         single<AppIconManager> {
             DefaultAppIconManager()


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR makes `expect` Koin modules internal to the container subproject and include them in the main module exported to the main project.

In this way, the internal "structure" of the DI modules is entirely responsibility of the subproject which exposes a single module to its clients (hiding all DI setup).

## Additional notes
<!-- Anything to declare for code review? -->
This is in preparation to further DI refactoring, such as introducing Koin annotations.
