### PR TITLE
chore: add test for photo and album repository

### DIFF
--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoAlbumRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoAlbumRepository.kt
@@ -47,7 +47,7 @@ internal class DefaultPhotoAlbumRepository(
                             append("album", name)
                         },
                     )
-                val res = provider.photoAlbum.update(data)
+                val res = provider.photoAlbum.delete(data)
                 res.result == "deleted"
             }.getOrElse { false }
         }

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoAlbumRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoAlbumRepositoryTest.kt
@@ -1,0 +1,125 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaApiResult
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaPhoto
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaPhotoAlbum
+import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.PhotoAlbumService
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.matcher.matching
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DefaultPhotoAlbumRepositoryTest {
+    private val photoAlbumService = mock<PhotoAlbumService>()
+    private val serviceProvider =
+        mock<ServiceProvider> { every { photoAlbum } returns photoAlbumService }
+    private val sut = DefaultPhotoAlbumRepository(provider = serviceProvider)
+
+    @Test
+    fun `when getAll then result is as expected`() =
+        runTest {
+            val list = listOf(FriendicaPhotoAlbum(name = "fake-album"))
+            everySuspend { photoAlbumService.getAll() } returns list
+
+            val res = sut.getAll()
+
+            assertEquals(list.map { it.toModel() }, res)
+            verifySuspend {
+                photoAlbumService.getAll()
+            }
+        }
+
+    @Test
+    fun `when update then result is as expected`() =
+        runTest {
+            everySuspend { photoAlbumService.update(any()) } returns
+                FriendicaApiResult(result = "updated")
+
+            val res = sut.update(oldName = "fake-album", newName = "fake-album-new")
+
+            assertTrue(res)
+            verifySuspend {
+                photoAlbumService.update(
+                    matching {
+                        it.formData["album"] == "fake-album" && it.formData["album_new"] == "fake-album-new"
+                    },
+                )
+            }
+        }
+
+    @Test
+    fun `given error when update then result is as expected`() =
+        runTest {
+            everySuspend { photoAlbumService.update(any()) } returns
+                FriendicaApiResult(result = "ko")
+
+            val res = sut.update(oldName = "fake-album", newName = "fake-album-new")
+
+            assertFalse(res)
+        }
+
+    @Test
+    fun `when delete then result is as expected`() =
+        runTest {
+            everySuspend { photoAlbumService.delete(any()) } returns
+                FriendicaApiResult(result = "deleted")
+
+            val res = sut.delete(name = "fake-album")
+
+            assertTrue(res)
+            verifySuspend {
+                photoAlbumService.delete(
+                    matching {
+                        it.formData["album"] == "fake-album"
+                    },
+                )
+            }
+        }
+
+    @Test
+    fun `given error when delete then result is as expected`() =
+        runTest {
+            everySuspend { photoAlbumService.delete(any()) } returns
+                FriendicaApiResult(result = "ko")
+
+            val res = sut.delete(name = "fake-album")
+
+            assertFalse(res)
+        }
+
+    @Test
+    fun `when getPhotos then result is as expected`() =
+        runTest {
+            val list = listOf(FriendicaPhoto(id = "0"))
+            everySuspend {
+                photoAlbumService.getPhotos(
+                    album = any(),
+                    maxId = any(),
+                    latestFirst = any(),
+                    limit = any(),
+                )
+            } returns list
+
+            val res = sut.getPhotos(album = "fake-album", pageCursor = null)
+
+            assertEquals(list.map { it.toModel() }, res)
+            verifySuspend {
+                photoAlbumService.getPhotos(
+                    album = "fake-album",
+                    maxId = null,
+                    latestFirst = false,
+                    limit = 20,
+                )
+            }
+        }
+}

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoRepositoryTest.kt
@@ -1,0 +1,124 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaApiResult
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaPhoto
+import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.PhotoService
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.IOException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DefaultPhotoRepositoryTest {
+    private val photoService = mock<PhotoService>()
+    private val serviceProvider = mock<ServiceProvider> { every { photo } returns photoService }
+    private val sut = DefaultPhotoRepository(provider = serviceProvider)
+
+    @Test
+    fun `when create then result is as expected`() =
+        runTest {
+            val photo = FriendicaPhoto(id = "1")
+            everySuspend { photoService.create(any()) } returns photo
+
+            val bytes = byteArrayOf(0x00.toByte(), 0x01.toByte(), 0x00.toByte())
+            val res =
+                sut.create(
+                    bytes = bytes,
+                    album = "fake-album",
+                    alt = "fake-description",
+                )
+
+            assertEquals(photo.toModel(), res)
+            verifySuspend {
+                photoService.create(any())
+            }
+        }
+
+    @Test
+    fun `given error when create then result is as expected`() =
+        runTest {
+            everySuspend { photoService.create(any()) } throws IOException("Network error")
+
+            val bytes = byteArrayOf(0x00.toByte(), 0x01.toByte(), 0x00.toByte())
+            val res =
+                sut.create(
+                    bytes = bytes,
+                    album = "fake-album",
+                    alt = "fake-description",
+                )
+
+            assertNull(res)
+            verifySuspend {
+                photoService.create(any())
+            }
+        }
+
+    @Test
+    fun `when update then result is as expected`() =
+        runTest {
+            everySuspend { photoService.update(content = any()) } returns
+                FriendicaApiResult(result = "updated")
+
+            val res =
+                sut.update(
+                    id = "1",
+                    alt = "fake-description",
+                )
+
+            assertTrue(res)
+            verifySuspend {
+                photoService.update(content = any())
+            }
+        }
+
+    @Test
+    fun `given error when update then result is as expected`() =
+        runTest {
+            everySuspend { photoService.update(content = any()) } returns
+                FriendicaApiResult(result = "ko")
+
+            val res =
+                sut.update(
+                    id = "1",
+                    alt = "fake-description",
+                )
+
+            assertFalse(res)
+        }
+
+    @Test
+    fun `when delete then result is as expected`() =
+        runTest {
+            everySuspend { photoService.delete(content = any()) } returns
+                FriendicaApiResult(result = "deleted")
+
+            val res = sut.delete(id = "1")
+
+            assertTrue(res)
+            verifySuspend {
+                photoService.delete(content = any())
+            }
+        }
+
+    @Test
+    fun `given error when delete then result is as expected`() =
+        runTest {
+            everySuspend { photoService.delete(content = any()) } returns
+                FriendicaApiResult(result = "ko")
+
+            val res = sut.delete(id = "1")
+
+            assertFalse(res)
+        }
+}


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds the tests for `DefaultPhotoAlbumRepository` and `DefaultPhotoRepository`.

## Additional notes
<!-- Anything to declare for code review? -->
An error which prevented albums from being deleted was fixed in `DefaultPhotoAlbumRepository`.
