### PR TITLE
chore: remove useless KSP plugin from :core:persistence

### DIFF
--- a/core/persistence/build.gradle.kts
+++ b/core/persistence/build.gradle.kts
@@ -65,7 +65,6 @@ room {
 }
 
 dependencies {
-    add("kspCommonMainMetadata", libs.ktorfit.ksp)
     add("kspAndroid", libs.room.ksp)
     add("kspIosX64", libs.room.ksp)
     add("kspIosArm64", libs.room.ksp)


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR prevents an unnecessary KSP plugin from being applied in `:core:persistence`.

## Additional notes
<!-- Anything to declare for code review? -->
This error was probably due to a copy-paste from `:core:api`. I found it while trying (unsuccessfully) to migrate some module to Koin with annotations.
