### PR TITLE
chore: further KSP simplification

### DIFF
--- a/core/api/build.gradle.kts
+++ b/core/api/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.google.devtools.ksp.gradle.KspTaskMetadata
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -75,5 +74,7 @@ kotlin.sourceSets.commonMain {
 }
 
 tasks.withType<KotlinCompile> {
-    dependsOn(tasks.withType<KspTaskMetadata>())
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
+    }
 }

--- a/core/persistence/build.gradle.kts
+++ b/core/persistence/build.gradle.kts
@@ -1,6 +1,4 @@
-import com.google.devtools.ksp.gradle.KspTaskMetadata
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
@@ -73,8 +71,4 @@ dependencies {
 
 kotlin.sourceSets.commonMain {
     kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
-}
-
-tasks.withType<KotlinCompile> {
-    dependsOn(tasks.withType<KspTaskMetadata>())
 }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR removes the workaround for having task on `androidMain` and `iosMain` source sets depend on the `commonMain` one in` :core:persistence` which is not needed. Moreover, even in `:core:api` where it is (temporarily) needed, it adds a check on the task name to avoid circularities.

## Additional notes
<!-- Anything to declare for code review? -->
This workaround is going to be dropped eventually, because the way KSP works in KMP project is undergoing major or minor changes release after release.

![things are constantly happening and I would like for it to stop, please](https://img.ifunny.co/images/3585051046a1f3a91d8a9ae96a0b3e6443a83f6dfac2da54239a14a83d330fda_1.jpg)
