### PR TITLE
refactor(di): migrate to koin annotations • 1

### DIFF
--- a/core/api/build.gradle.kts
+++ b/core/api/build.gradle.kts
@@ -1,5 +1,5 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
@@ -32,6 +32,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.kotlinx.serialization.json)
                 implementation(libs.ktor.contentnegotiation)
                 implementation(libs.ktor.auth)
@@ -67,13 +68,18 @@ dependencies {
     add("kspIosX64", libs.ktorfit.ksp)
     add("kspIosArm64", libs.ktorfit.ksp)
     add("kspIosSimulatorArm64", libs.ktorfit.ksp)
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
 }
 
 kotlin.sourceSets.commonMain {
     kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
 }
 
-tasks.withType<KotlinCompile> {
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
     if (name != "kspCommonMainKotlinMetadata") {
         dependsOn("kspCommonMainKotlinMetadata")
     }

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/di/ApiModule.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/di/ApiModule.kt
@@ -2,19 +2,23 @@ package com.livefast.eattrash.raccoonforfriendica.core.api.di
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.DefaultServiceProvider
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
-import org.koin.core.qualifier.named
-import org.koin.dsl.module
+import com.livefast.eattrash.raccoonforfriendica.core.utils.debug.AppInfoRepository
+import org.koin.core.annotation.Module
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
+import org.koin.ksp.generated.module
 
-val coreApiModule =
-    module {
-        single<ServiceProvider>(named("default")) {
-            DefaultServiceProvider(
-                appInfoRepository = get(),
-            )
-        }
-        factory<ServiceProvider>(named("other")) {
-            DefaultServiceProvider(
-                appInfoRepository = get(),
-            )
-        }
-    }
+@Module
+internal class ApiModule {
+    @Single
+    @Named("default")
+    fun provideLocalServiceProvider(appInfoRepository: AppInfoRepository): ServiceProvider =
+        DefaultServiceProvider(appInfoRepository = appInfoRepository)
+
+    @Single
+    @Named("other")
+    fun provideOtherServiceProvider(appInfoRepository: AppInfoRepository): ServiceProvider =
+        DefaultServiceProvider(appInfoRepository = appInfoRepository)
+}
+
+val coreApiModule = ApiModule().module

--- a/core/appearance/build.gradle.kts
+++ b/core/appearance/build.gradle.kts
@@ -1,16 +1,16 @@
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
-    alias(libs.plugins.mokkery)
     alias(libs.plugins.kotlinx.kover)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.mokkery)
 }
 
-@OptIn(ExperimentalKotlinGradlePluginApi::class)
 kotlin {
     applyDefaultHierarchyTemplate()
     androidTarget {
@@ -43,6 +43,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.materialKolor)
 
                 implementation(projects.core.l10n)
@@ -57,6 +58,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.core.appearance"
     compileSdk =
@@ -68,5 +77,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/di/NativeAppearanceModule.kt
+++ b/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/di/NativeAppearanceModule.kt
@@ -1,0 +1,8 @@
+package com.livefast.eattrash.raccoonforfriendica.core.appearance.di
+
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.appearance.theme")
+internal class NativeAppearanceModule

--- a/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/di/Utils.kt
+++ b/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/di/Utils.kt
@@ -3,25 +3,16 @@ package com.livefast.eattrash.raccoonforfriendica.core.appearance.di
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.repository.ThemeRepository
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.BarColorProvider
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ColorSchemeProvider
-import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.DefaultBarColorProvider
-import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.DefaultColorSchemeProvider
-import org.koin.dsl.module
+import org.koin.core.module.Module
 import org.koin.java.KoinJavaComponent.inject
+import org.koin.ksp.generated.module
+
+internal actual val nativeAppearanceModule: Module = NativeAppearanceModule().module
 
 actual fun getThemeRepository(): ThemeRepository {
     val res: ThemeRepository by inject(ThemeRepository::class.java)
     return res
 }
-
-internal actual val nativeAppearanceModule =
-    module {
-        single<ColorSchemeProvider> {
-            DefaultColorSchemeProvider(context = get())
-        }
-        single<BarColorProvider> {
-            DefaultBarColorProvider()
-        }
-    }
 
 actual fun getColorSchemeProvider(): ColorSchemeProvider {
     val res by inject<ColorSchemeProvider>(ColorSchemeProvider::class.java)

--- a/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/DefaultBarColorProvider.kt
+++ b/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/DefaultBarColorProvider.kt
@@ -11,7 +11,9 @@ import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.UiBarTheme
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.UiTheme
+import org.koin.core.annotation.Single
 
+@Single
 class DefaultBarColorProvider : BarColorProvider {
     @Composable
     override fun setBarColorAccordingToTheme(

--- a/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/DefaultColorSchemeProvider.kt
+++ b/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/DefaultColorSchemeProvider.kt
@@ -11,7 +11,9 @@ import androidx.compose.ui.graphics.Color
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.UiTheme
 import com.materialkolor.PaletteStyle
 import com.materialkolor.dynamicColorScheme
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultColorSchemeProvider(
     private val context: Context,
 ) : ColorSchemeProvider {

--- a/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/di/AppearanceModule.kt
+++ b/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/di/AppearanceModule.kt
@@ -1,20 +1,19 @@
 package com.livefast.eattrash.raccoonforfriendica.core.appearance.di
 
-import com.livefast.eattrash.raccoonforfriendica.core.appearance.repository.DefaultThemeColorRepository
-import com.livefast.eattrash.raccoonforfriendica.core.appearance.repository.DefaultThemeRepository
-import com.livefast.eattrash.raccoonforfriendica.core.appearance.repository.ThemeColorRepository
-import com.livefast.eattrash.raccoonforfriendica.core.appearance.repository.ThemeRepository
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
 import org.koin.dsl.module
+import org.koin.ksp.generated.module
+import org.koin.core.module.Module as KoinModule
 
-val coreAppearanceModule =
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.appearance.repository")
+internal class AppearanceRepositoryModule
+
+val coreAppearanceModule: KoinModule =
     module {
-        includes(nativeAppearanceModule)
-
-        single<ThemeRepository> {
-            DefaultThemeRepository()
-        }
-
-        single<ThemeColorRepository> {
-            DefaultThemeColorRepository()
-        }
+        includes(
+            nativeAppearanceModule,
+            AppearanceRepositoryModule().module,
+        )
     }

--- a/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/repository/DefaultThemeColorRepository.kt
+++ b/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/repository/DefaultThemeColorRepository.kt
@@ -1,7 +1,9 @@
 package com.livefast.eattrash.raccoonforfriendica.core.appearance.repository
 
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.ThemeColor
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultThemeColorRepository : ThemeColorRepository {
     override fun getColors(): List<ThemeColor> =
         listOf(

--- a/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/repository/DefaultThemeRepository.kt
+++ b/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/repository/DefaultThemeRepository.kt
@@ -6,7 +6,9 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.UiFontScal
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.UiTheme
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultThemeRepository : ThemeRepository {
     override val theme = MutableStateFlow<UiTheme>(UiTheme.Default)
     override val fontFamily = MutableStateFlow<UiFontFamily>(UiFontFamily.Default)

--- a/core/appearance/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/di/Utils.kt
+++ b/core/appearance/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/di/Utils.kt
@@ -9,8 +9,6 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.koin.dsl.module
 
-actual fun getThemeRepository(): ThemeRepository = CoreAppearanceHelper.repository
-
 internal actual val nativeAppearanceModule =
     module {
         single<ColorSchemeProvider> {
@@ -20,6 +18,8 @@ internal actual val nativeAppearanceModule =
             DefaultBarColorProvider()
         }
     }
+
+actual fun getThemeRepository(): ThemeRepository = CoreAppearanceHelper.repository
 
 actual fun getColorSchemeProvider(): ColorSchemeProvider = CoreAppearanceHelper.colorSchemeProvider
 

--- a/core/appearance/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/DefaultBarColorProvider.kt
+++ b/core/appearance/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/DefaultBarColorProvider.kt
@@ -5,11 +5,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.UiBarTheme
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.UiTheme
+import org.koin.core.annotation.Single
 import platform.UIKit.UIApplication
 import platform.UIKit.UIStatusBarStyleDarkContent
 import platform.UIKit.UIStatusBarStyleLightContent
 import platform.UIKit.setStatusBarStyle
 
+@Single
 class DefaultBarColorProvider : BarColorProvider {
     @Composable
     override fun setBarColorAccordingToTheme(

--- a/core/appearance/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/DefaultColorSchemeProvider.kt
+++ b/core/appearance/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/DefaultColorSchemeProvider.kt
@@ -5,7 +5,9 @@ import androidx.compose.ui.graphics.Color
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.UiTheme
 import com.materialkolor.PaletteStyle
 import com.materialkolor.dynamicColorScheme
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultColorSchemeProvider : ColorSchemeProvider {
     override val supportsDynamicColors = false
 

--- a/core/commonui/components/build.gradle.kts
+++ b/core/commonui/components/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.coil.compose)
                 implementation(libs.compose.colorpicker)
                 implementation(libs.compose.multiplatform.media.player)
@@ -60,5 +63,23 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
+kotlin.sourceSets.commonMain {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/DefaultFabNestedScrollConnection.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/DefaultFabNestedScrollConnection.kt
@@ -1,0 +1,42 @@
+package com.livefast.eattrash.raccoonforfriendica.core.commonui.components
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import org.koin.core.annotation.Single
+
+private const val THRESHOLD = 1f
+
+@Single
+internal class DefaultFabNestedScrollConnection(
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob()),
+) : FabNestedScrollConnection {
+    private val fabVisible = MutableStateFlow(true)
+
+    override val isFabVisible: StateFlow<Boolean>
+        get() =
+            fabVisible
+                .stateIn(
+                    scope = scope,
+                    started = SharingStarted.WhileSubscribed(5_000),
+                    initialValue = true,
+                )
+
+    override fun onPreScroll(
+        available: Offset,
+        source: NestedScrollSource,
+    ): Offset {
+        if (available.y < -THRESHOLD) {
+            fabVisible.value = false
+        }
+        if (available.y > THRESHOLD) {
+            fabVisible.value = true
+        }
+        return Offset.Zero
+    }
+}

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/FabNestedScrollConnection.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/FabNestedScrollConnection.kt
@@ -1,47 +1,10 @@
 package com.livefast.eattrash.raccoonforfriendica.core.commonui.components
 
 import androidx.compose.runtime.Stable
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
-import androidx.compose.ui.input.nestedscroll.NestedScrollSource
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.stateIn
-
-private const val THRESHOLD = 1f
 
 @Stable
 interface FabNestedScrollConnection : NestedScrollConnection {
     val isFabVisible: StateFlow<Boolean>
-}
-
-internal class DefaultFabNestedScrollConnection(
-    private val scope: CoroutineScope = CoroutineScope(SupervisorJob()),
-) : FabNestedScrollConnection {
-    private val fabVisible = MutableStateFlow(true)
-
-    override val isFabVisible: StateFlow<Boolean>
-        get() =
-            fabVisible
-                .stateIn(
-                    scope = scope,
-                    started = SharingStarted.WhileSubscribed(5_000),
-                    initialValue = true,
-                )
-
-    override fun onPreScroll(
-        available: Offset,
-        source: NestedScrollSource,
-    ): Offset {
-        if (available.y < -THRESHOLD) {
-            fabVisible.value = false
-        }
-        if (available.y > THRESHOLD) {
-            fabVisible.value = true
-        }
-        return Offset.Zero
-    }
 }

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/di/ComponentsModule.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/di/ComponentsModule.kt
@@ -1,12 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di
 
-import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.DefaultFabNestedScrollConnection
-import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.FabNestedScrollConnection
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val coreCommonUiComponentsModule =
-    module {
-        factory<FabNestedScrollConnection> {
-            DefaultFabNestedScrollConnection()
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.commonui.components")
+internal class CommonUiComponentsModule
+
+val coreCommonUiComponentsModule = CommonUiComponentsModule().module

--- a/core/l10n/build.gradle.kts
+++ b/core/l10n/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,10 +38,19 @@ kotlin {
                 implementation(compose.material3)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.lyricist)
             }
         }
     }
+}
+
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
 }
 
 android {
@@ -53,5 +64,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/DefaultL10nManager.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/DefaultL10nManager.kt
@@ -4,7 +4,9 @@ import cafe.adriel.lyricist.Lyricist
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.Locales
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.Strings
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.messages.localizableStrings
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultL10nManager : L10nManager {
     override val lyricist: Lyricist<Strings> =
         Lyricist(

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/di/L10nModule.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/di/L10nModule.kt
@@ -1,12 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.core.l10n.di
 
-import com.livefast.eattrash.raccoonforfriendica.core.l10n.DefaultL10nManager
-import com.livefast.eattrash.raccoonforfriendica.core.l10n.L10nManager
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val coreL10nModule =
-    module {
-        single<L10nManager> {
-            DefaultL10nManager()
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.l10n")
+internal class L10nModule
+
+val coreL10nModule = L10nModule().module

--- a/core/navigation/build.gradle.kts
+++ b/core/navigation/build.gradle.kts
@@ -1,16 +1,16 @@
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
-    alias(libs.plugins.mokkery)
     alias(libs.plugins.kotlinx.kover)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.mokkery)
 }
 
-@OptIn(ExperimentalKotlinGradlePluginApi::class)
 kotlin {
     applyDefaultHierarchyTemplate()
     androidTarget {
@@ -36,6 +36,7 @@ kotlin {
             implementation(compose.material3)
 
             implementation(libs.koin.core)
+            api(libs.koin.annotations)
             implementation(libs.stately.common)
             implementation(libs.voyager.navigator)
             implementation(libs.voyager.tab)
@@ -56,6 +57,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.core.navigation"
     compileSdk =
@@ -67,5 +76,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/core/navigation/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/di/Utils.kt
+++ b/core/navigation/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/di/Utils.kt
@@ -3,16 +3,15 @@ package com.livefast.eattrash.raccoonforfriendica.core.navigation.di
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.DrawerCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.NavigationCoordinator
-import org.koin.java.KoinJavaComponent
 import org.koin.java.KoinJavaComponent.inject
 
 actual fun getNavigationCoordinator(): NavigationCoordinator {
-    val res by KoinJavaComponent.inject<NavigationCoordinator>(NavigationCoordinator::class.java)
+    val res by inject<NavigationCoordinator>(NavigationCoordinator::class.java)
     return res
 }
 
 actual fun getDetailOpener(): DetailOpener {
-    val res by KoinJavaComponent.inject<DetailOpener>(DetailOpener::class.java)
+    val res by inject<DetailOpener>(DetailOpener::class.java)
     return res
 }
 

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultDrawerCoordinator.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultDrawerCoordinator.kt
@@ -2,7 +2,9 @@ package com.livefast.eattrash.raccoonforfriendica.core.navigation
 
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import org.koin.core.annotation.Single
 
+@Single
 class DefaultDrawerCoordinator : DrawerCoordinator {
     override val events = MutableSharedFlow<DrawerEvent>()
     override val gesturesEnabled = MutableStateFlow(true)

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationCoordinator.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationCoordinator.kt
@@ -12,7 +12,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.getAndUpdate
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultNavigationCoordinator(
     dispatcher: CoroutineDispatcher = Dispatchers.Main,
 ) : NavigationCoordinator {

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/di/NavigationModule.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/di/NavigationModule.kt
@@ -1,17 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.core.navigation.di
 
-import com.livefast.eattrash.raccoonforfriendica.core.navigation.DefaultDrawerCoordinator
-import com.livefast.eattrash.raccoonforfriendica.core.navigation.DefaultNavigationCoordinator
-import com.livefast.eattrash.raccoonforfriendica.core.navigation.DrawerCoordinator
-import com.livefast.eattrash.raccoonforfriendica.core.navigation.NavigationCoordinator
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val coreNavigationModule =
-    module {
-        single<NavigationCoordinator> {
-            DefaultNavigationCoordinator()
-        }
-        single<DrawerCoordinator> {
-            DefaultDrawerCoordinator()
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.navigation")
+internal class NavigationModule
+
+val coreNavigationModule = NavigationModule().module

--- a/core/notifications/build.gradle.kts
+++ b/core/notifications/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
@@ -6,6 +7,7 @@ plugins {
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.kotlinx.kover)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -34,6 +36,7 @@ kotlin {
                 implementation(compose.foundation)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
 
                 implementation(projects.core.utils)
                 implementation(projects.domain.content.data)
@@ -49,6 +52,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.core.notifications"
     compileSdk =
@@ -60,5 +71,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/core/notifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/notifications/DefaultNotificationCenter.kt
+++ b/core/notifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/notifications/DefaultNotificationCenter.kt
@@ -9,9 +9,11 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Single
 import kotlin.reflect.KClass
 import kotlin.reflect.safeCast
 
+@Single
 internal class DefaultNotificationCenter(
     dispatcher: CoroutineDispatcher = Dispatchers.Main,
 ) : NotificationCenter {

--- a/core/notifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/notifications/di/NotificationsModule.kt
+++ b/core/notifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/notifications/di/NotificationsModule.kt
@@ -1,12 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.core.notifications.di
 
-import com.livefast.eattrash.raccoonforfriendica.core.notifications.DefaultNotificationCenter
-import com.livefast.eattrash.raccoonforfriendica.core.notifications.NotificationCenter
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val coreNotificationsModule =
-    module {
-        single<NotificationCenter> {
-            DefaultNotificationCenter()
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.notifications")
+class NotificationsModule
+
+val coreNotificationsModule = NotificationsModule().module

--- a/core/persistence/build.gradle.kts
+++ b/core/persistence/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
@@ -33,6 +34,7 @@ kotlin {
                 implementation(libs.kotlinx.coroutines)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.room.sqlite)
                 implementation(libs.room.runtime)
 
@@ -67,8 +69,19 @@ dependencies {
     add("kspIosX64", libs.room.ksp)
     add("kspIosArm64", libs.room.ksp)
     add("kspIosSimulatorArm64", libs.room.ksp)
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
 }
 
 kotlin.sourceSets.commonMain {
     kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
+    }
 }

--- a/core/persistence/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/builder/DefaultDatabaseBuilderProvider.kt
+++ b/core/persistence/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/builder/DefaultDatabaseBuilderProvider.kt
@@ -1,9 +1,13 @@
-package com.livefast.eattrash.raccoonforfriendica.core.persistence
+package com.livefast.eattrash.raccoonforfriendica.core.persistence.builder
 
 import android.content.Context
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import com.livefast.eattrash.raccoonforfriendica.core.persistence.AppDatabase
+import com.livefast.eattrash.raccoonforfriendica.core.persistence.builder.DatabaseBuilderProvider
+import org.koin.core.annotation.Single
 
+@Single
 class DefaultDatabaseBuilderProvider(
     private val context: Context,
 ) : DatabaseBuilderProvider {

--- a/core/persistence/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/di/Utils.kt
+++ b/core/persistence/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/di/Utils.kt
@@ -1,14 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.core.persistence.di
 
-import com.livefast.eattrash.raccoonforfriendica.core.persistence.DatabaseBuilderProvider
-import com.livefast.eattrash.raccoonforfriendica.core.persistence.DefaultDatabaseBuilderProvider
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-actual val nativePersistenceModule =
-    module {
-        single<DatabaseBuilderProvider> {
-            DefaultDatabaseBuilderProvider(
-                context = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.persistence.builder")
+internal class NativePersistenceModule
+
+actual val nativePersistenceModule: org.koin.core.module.Module = NativePersistenceModule().module

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/DatabaseBuilderProvider.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/DatabaseBuilderProvider.kt
@@ -1,7 +1,0 @@
-package com.livefast.eattrash.raccoonforfriendica.core.persistence
-
-import androidx.room.RoomDatabase
-
-internal interface DatabaseBuilderProvider {
-    fun provideDatabaseBuilder(): RoomDatabase.Builder<AppDatabase>
-}

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/DatabaseProvider.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/DatabaseProvider.kt
@@ -1,5 +1,0 @@
-package com.livefast.eattrash.raccoonforfriendica.core.persistence
-
-internal interface DatabaseProvider {
-    fun provideDatabase(): AppDatabase
-}

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/builder/DatabaseBuilderProvider.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/builder/DatabaseBuilderProvider.kt
@@ -1,0 +1,8 @@
+package com.livefast.eattrash.raccoonforfriendica.core.persistence.builder
+
+import androidx.room.RoomDatabase
+import com.livefast.eattrash.raccoonforfriendica.core.persistence.AppDatabase
+
+internal interface DatabaseBuilderProvider {
+    fun provideDatabaseBuilder(): RoomDatabase.Builder<AppDatabase>
+}

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/di/PersistenceModule.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/di/PersistenceModule.kt
@@ -1,33 +1,29 @@
 package com.livefast.eattrash.raccoonforfriendica.core.persistence.di
 
-import com.livefast.eattrash.raccoonforfriendica.core.persistence.DatabaseProvider
-import com.livefast.eattrash.raccoonforfriendica.core.persistence.DefaultDatabaseProvider
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.dao.AccountDao
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.dao.DraftDao
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.dao.SettingsDao
+import com.livefast.eattrash.raccoonforfriendica.core.persistence.provider.DatabaseProvider
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.core.annotation.Single
 import org.koin.dsl.module
+import org.koin.ksp.generated.module
+
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.persistence.provider")
+internal class PersistenceModule {
+    @Single
+    fun provideAccountDao(dbProvider: DatabaseProvider): AccountDao = dbProvider.provideDatabase().getAccountDao()
+
+    @Single
+    fun provideSettingsDao(dbProvider: DatabaseProvider): SettingsDao = dbProvider.provideDatabase().getSettingsDao()
+
+    @Single
+    fun provideDraftDao(dbProvider: DatabaseProvider): DraftDao = dbProvider.provideDatabase().getDraftDao()
+}
 
 val corePersistenceModule =
     module {
-        includes(nativePersistenceModule)
-
-        single<DatabaseProvider> {
-            DefaultDatabaseProvider(
-                builderProvider = get(),
-            )
-        }
-
-        single<AccountDao> {
-            val dbProvider: DatabaseProvider = get()
-            dbProvider.provideDatabase().getAccountDao()
-        }
-
-        single<SettingsDao> {
-            val dbProvider: DatabaseProvider = get()
-            dbProvider.provideDatabase().getSettingsDao()
-        }
-        single<DraftDao> {
-            val dbProvider: DatabaseProvider = get()
-            dbProvider.provideDatabase().getDraftDao()
-        }
+        includes(nativePersistenceModule, PersistenceModule().module)
     }

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/provider/DatabaseProvider.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/provider/DatabaseProvider.kt
@@ -1,0 +1,7 @@
+package com.livefast.eattrash.raccoonforfriendica.core.persistence.provider
+
+import com.livefast.eattrash.raccoonforfriendica.core.persistence.AppDatabase
+
+internal interface DatabaseProvider {
+    fun provideDatabase(): AppDatabase
+}

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/provider/DefaultDatabaseProvider.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/provider/DefaultDatabaseProvider.kt
@@ -1,9 +1,13 @@
-package com.livefast.eattrash.raccoonforfriendica.core.persistence
+package com.livefast.eattrash.raccoonforfriendica.core.persistence.provider
 
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import com.livefast.eattrash.raccoonforfriendica.core.persistence.AppDatabase
+import com.livefast.eattrash.raccoonforfriendica.core.persistence.builder.DatabaseBuilderProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultDatabaseProvider(
     private val builderProvider: DatabaseBuilderProvider,
 ) : DatabaseProvider {

--- a/core/persistence/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/builder/DefaultDatabaseBuilderProvider.kt
+++ b/core/persistence/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/builder/DefaultDatabaseBuilderProvider.kt
@@ -1,12 +1,15 @@
-package com.livefast.eattrash.raccoonforfriendica.core.persistence
+package com.livefast.eattrash.raccoonforfriendica.core.persistence.builder
 
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import com.livefast.eattrash.raccoonforfriendica.core.persistence.AppDatabase
 import kotlinx.cinterop.ExperimentalForeignApi
+import org.koin.core.annotation.Single
 import platform.Foundation.NSDocumentDirectory
 import platform.Foundation.NSFileManager
 import platform.Foundation.NSUserDomainMask
 
+@Single
 class DefaultDatabaseBuilderProvider : DatabaseBuilderProvider {
     override fun provideDatabaseBuilder(): RoomDatabase.Builder<AppDatabase> {
         val dbFilePath = documentDirectory() + "/raccoonforfriendica.db"

--- a/core/persistence/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/di/Utils.kt
+++ b/core/persistence/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/di/Utils.kt
@@ -1,7 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.core.persistence.di
 
-import com.livefast.eattrash.raccoonforfriendica.core.persistence.DatabaseBuilderProvider
-import com.livefast.eattrash.raccoonforfriendica.core.persistence.DefaultDatabaseBuilderProvider
+import com.livefast.eattrash.raccoonforfriendica.core.persistence.builder.DatabaseBuilderProvider
+import com.livefast.eattrash.raccoonforfriendica.core.persistence.builder.DefaultDatabaseBuilderProvider
 import org.koin.dsl.module
 
 actual val nativePersistenceModule =

--- a/core/preferences/build.gradle.kts
+++ b/core/preferences/build.gradle.kts
@@ -1,12 +1,14 @@
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlinx.serialization)
-    alias(libs.plugins.mokkery)
     alias(libs.plugins.kotlinx.kover)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.mokkery)
 }
 
 @OptIn(ExperimentalKotlinGradlePluginApi::class)
@@ -38,6 +40,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.multiplatform.settings)
             }
         }
@@ -51,6 +54,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.core.preferences"
     compileSdk =
@@ -62,5 +73,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/core/preferences/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/di/Utils.kt
+++ b/core/preferences/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/di/Utils.kt
@@ -1,53 +1,23 @@
 package com.livefast.eattrash.raccoonforfriendica.core.preferences.di
 
-import android.content.Context
-import android.content.SharedPreferences
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKeys
-import com.livefast.eattrash.raccoonforfriendica.core.preferences.DefaultSettingsWrapper
-import com.livefast.eattrash.raccoonforfriendica.core.preferences.SettingsWrapper
+import com.livefast.eattrash.raccoonforfriendica.core.preferences.provider.SharedPreferencesProvider
 import com.russhwolf.settings.Settings
 import com.russhwolf.settings.SharedPreferencesSettings
-import org.koin.core.parameter.parametersOf
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.core.annotation.Single
 import org.koin.dsl.module
+import org.koin.ksp.generated.module
 
-internal actual val nativePreferencesModule =
-    module {
-        single { params ->
-            SharedPreferencesProvider(
-                name = params[0],
-                context = get(),
-            )
-        }
-        single<Settings> { params ->
-            val sharedPreferencesProvider: SharedPreferencesProvider =
-                get(
-                    parameters = { parametersOf(params[0]) },
-                )
-            SharedPreferencesSettings(
-                delegate = sharedPreferencesProvider.sharedPreferences,
-                commit = false,
-            )
-        }
-        single<SettingsWrapper> {
-            DefaultSettingsWrapper(settings = get(parameters = { parametersOf(PREFERENCES_NAME) }))
-        }
-    }
-
-private const val PREFERENCES_NAME = "secret_shared_prefs"
-
-private class SharedPreferencesProvider(
-    name: String,
-    context: Context,
-) {
-    private val masterKeyAlias: String = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
-
-    val sharedPreferences: SharedPreferences =
-        EncryptedSharedPreferences.create(
-            name,
-            masterKeyAlias,
-            context,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.preferences.provider")
+internal class NativePreferencesModule {
+    @Single
+    fun provideSettings(sharedPreferencesProvider: SharedPreferencesProvider): Settings =
+        SharedPreferencesSettings(
+            delegate = sharedPreferencesProvider.sharedPreferences,
+            commit = false,
         )
 }
+
+internal actual val nativePreferencesModule = NativePreferencesModule().module

--- a/core/preferences/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/provider/SharedPreferencesProvider.kt
+++ b/core/preferences/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/provider/SharedPreferencesProvider.kt
@@ -1,0 +1,27 @@
+package com.livefast.eattrash.raccoonforfriendica.core.preferences.provider
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
+import org.koin.core.annotation.Single
+
+@Single
+internal class SharedPreferencesProvider(
+    context: Context,
+) {
+    private val masterKeyAlias: String = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+
+    val sharedPreferences: SharedPreferences =
+        EncryptedSharedPreferences.create(
+            PREFERENCES_NAME,
+            masterKeyAlias,
+            context,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+        )
+
+    companion object {
+        private const val PREFERENCES_NAME = "secret_shared_prefs"
+    }
+}

--- a/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/DefaultSettingsWrapper.kt
+++ b/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/DefaultSettingsWrapper.kt
@@ -3,7 +3,9 @@ package com.livefast.eattrash.raccoonforfriendica.core.preferences
 import com.russhwolf.settings.Settings
 import com.russhwolf.settings.get
 import com.russhwolf.settings.set
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultSettingsWrapper(
     private val settings: Settings,
 ) : SettingsWrapper {

--- a/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/DefaultTemporaryKeyStore.kt
+++ b/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/DefaultTemporaryKeyStore.kt
@@ -1,5 +1,8 @@
 package com.livefast.eattrash.raccoonforfriendica.core.preferences
 
+import org.koin.core.annotation.Single
+
+@Single
 internal class DefaultTemporaryKeyStore(
     private val settings: SettingsWrapper,
 ) : TemporaryKeyStore {

--- a/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/di/PreferencesModule.kt
+++ b/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/di/PreferencesModule.kt
@@ -1,16 +1,18 @@
 package com.livefast.eattrash.raccoonforfriendica.core.preferences.di
 
-import com.livefast.eattrash.raccoonforfriendica.core.preferences.DefaultTemporaryKeyStore
-import com.livefast.eattrash.raccoonforfriendica.core.preferences.TemporaryKeyStore
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
 import org.koin.dsl.module
+import org.koin.ksp.generated.module
+
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.preferences")
+class PreferencesModule
 
 val corePreferencesModule =
     module {
-        includes(nativePreferencesModule)
-
-        single<TemporaryKeyStore> {
-            DefaultTemporaryKeyStore(
-                settings = get(),
-            )
-        }
+        includes(
+            nativePreferencesModule,
+            PreferencesModule().module,
+        )
     }

--- a/core/preferences/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/di/Utils.kt
+++ b/core/preferences/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/di/Utils.kt
@@ -1,23 +1,16 @@
 package com.livefast.eattrash.raccoonforfriendica.core.preferences.di
 
-import com.livefast.eattrash.raccoonforfriendica.core.preferences.DefaultSettingsWrapper
-import com.livefast.eattrash.raccoonforfriendica.core.preferences.SettingsWrapper
 import com.russhwolf.settings.ExperimentalSettingsImplementation
 import com.russhwolf.settings.KeychainSettings
 import com.russhwolf.settings.Settings
-import org.koin.core.parameter.parametersOf
 import org.koin.dsl.module
 
 private const val DEFAULT_NAME = "secret_shared_prefs"
 
 internal actual val nativePreferencesModule =
     module {
-        single<Settings> { params ->
-            val name: String? = params[0]
+        single<Settings> {
             @OptIn(ExperimentalSettingsImplementation::class)
-            KeychainSettings(service = name ?: DEFAULT_NAME)
-        }
-        single<SettingsWrapper> {
-            DefaultSettingsWrapper(settings = get(parameters = { parametersOf(DEFAULT_NAME) }))
+            KeychainSettings(service = DEFAULT_NAME)
         }
     }

--- a/core/utils/build.gradle.kts
+++ b/core/utils/build.gradle.kts
@@ -1,5 +1,5 @@
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 import java.util.Properties
 
 plugins {
@@ -7,11 +7,11 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
-    alias(libs.plugins.mokkery)
     alias(libs.plugins.kotlinx.kover)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.mokkery)
 }
 
-@OptIn(ExperimentalKotlinGradlePluginApi::class)
 kotlin {
     applyDefaultHierarchyTemplate()
     androidTarget {
@@ -73,6 +73,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.core.utils"
     compileSdk =
@@ -94,4 +102,17 @@ android {
     }
 }
 
-private fun loadProperties(name: String): Properties = File("$projectDir/$name").inputStream().use { Properties().apply { load(it) } }
+private fun loadProperties(name: String): Properties =
+    File("$projectDir/$name").inputStream().use {
+        Properties().apply { load(it) }
+    }
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
+    }
+}

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/appicon/DefaultAppIconManager.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/appicon/DefaultAppIconManager.kt
@@ -6,7 +6,9 @@ import android.content.pm.PackageManager
 import com.livefast.eattrash.raccoonforfriendica.core.preferences.TemporaryKeyStore
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
+import org.koin.core.annotation.Single
 
+@Single
 class DefaultAppIconManager(
     private val context: Context,
     private val keyStore: TemporaryKeyStore,

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/calendar/DefaultCalendarHelper.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/calendar/DefaultCalendarHelper.kt
@@ -3,7 +3,9 @@ package com.livefast.eattrash.raccoonforfriendica.core.utils.calendar
 import android.content.Intent
 import android.provider.CalendarContract
 import io.sentry.kotlin.multiplatform.Context
+import org.koin.core.annotation.Single
 
+@Single
 class DefaultCalendarHelper(
     private val context: Context,
 ) : CalendarHelper {

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/debug/DefaultAppInfoRepository.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/debug/DefaultAppInfoRepository.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.os.Build
 import kotlinx.coroutines.flow.MutableStateFlow
+import org.koin.core.annotation.Single
 
+@Single
 class DefaultAppInfoRepository(
     private val context: Context,
 ) : AppInfoRepository {

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/debug/DefaultCrashReportManager.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/debug/DefaultCrashReportManager.kt
@@ -7,7 +7,9 @@ import io.sentry.kotlin.multiplatform.Sentry
 import io.sentry.kotlin.multiplatform.protocol.UserFeedback
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultCrashReportManager(
     private val context: Context,
     private val keyStore: TemporaryKeyStore,

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeUtilsModule.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeUtilsModule.kt
@@ -1,0 +1,36 @@
+package com.livefast.eattrash.raccoonforfriendica.core.utils.di
+
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.utils.appicon")
+internal class AppIconModule
+
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.utils.calendar")
+internal class CalendarModule
+
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.utils.debug")
+internal class DebugModule
+
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.utils.fs")
+internal class FileSystemModule
+
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.utils.gallery")
+internal class GalleryModule
+
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.utils.share")
+internal class ShareModule
+
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.utils.url")
+internal class UrlModule
+
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate")
+internal class VibrateModule

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/Utils.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/Utils.kt
@@ -1,28 +1,16 @@
 package com.livefast.eattrash.raccoonforfriendica.core.utils.di
 
-import com.livefast.eattrash.raccoonforfriendica.core.utils.appicon.AppIconManager
-import com.livefast.eattrash.raccoonforfriendica.core.utils.appicon.DefaultAppIconManager
 import com.livefast.eattrash.raccoonforfriendica.core.utils.calendar.CalendarHelper
-import com.livefast.eattrash.raccoonforfriendica.core.utils.calendar.DefaultCalendarHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.debug.AppInfoRepository
 import com.livefast.eattrash.raccoonforfriendica.core.utils.debug.CrashReportManager
-import com.livefast.eattrash.raccoonforfriendica.core.utils.debug.DefaultAppInfoRepository
-import com.livefast.eattrash.raccoonforfriendica.core.utils.debug.DefaultCrashReportManager
-import com.livefast.eattrash.raccoonforfriendica.core.utils.fs.DefaultFileSystemManager
-import com.livefast.eattrash.raccoonforfriendica.core.utils.fs.FileSystemManager
-import com.livefast.eattrash.raccoonforfriendica.core.utils.gallery.DefaultGalleryHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.gallery.GalleryHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.BlurHashRepository
 import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.ImageLoaderProvider
 import com.livefast.eattrash.raccoonforfriendica.core.utils.network.NetworkStateObserver
-import com.livefast.eattrash.raccoonforfriendica.core.utils.share.DefaultShareHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.share.ShareHelper
-import com.livefast.eattrash.raccoonforfriendica.core.utils.url.CustomTabsHelper
-import com.livefast.eattrash.raccoonforfriendica.core.utils.url.DefaultCustomTabsHelper
-import com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate.DefaultHapticFeedback
-import com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate.HapticFeedback
 import org.koin.dsl.module
 import org.koin.java.KoinJavaComponent
+import org.koin.ksp.generated.module
 
 actual fun getImageLoaderProvider(): ImageLoaderProvider {
     val inject = KoinJavaComponent.inject<ImageLoaderProvider>(ImageLoaderProvider::class.java)
@@ -65,85 +53,16 @@ actual fun getNetworkStateObserver(): NetworkStateObserver {
     return res
 }
 
-internal actual val nativeFileSystemModule =
+internal actual val nativeUtilsModule =
     module {
-        single<FileSystemManager> {
-            DefaultFileSystemManager(
-                context = get(),
-            )
-        }
-    }
-
-internal actual val nativeGalleryModule =
-    module {
-        single<GalleryHelper> {
-            DefaultGalleryHelper(
-                context = get(),
-            )
-        }
-    }
-
-internal actual val nativeShareModule =
-    module {
-        single<ShareHelper> {
-            DefaultShareHelper(
-                context = get(),
-            )
-        }
-    }
-
-internal actual val nativeUrlModule =
-    module {
-        single<CustomTabsHelper> {
-            DefaultCustomTabsHelper(
-                context = get(),
-            )
-        }
-    }
-
-internal actual val nativeDebugModule =
-    module {
-        single<AppInfoRepository> {
-            DefaultAppInfoRepository(
-                context = get(),
-            )
-        }
-    }
-
-internal actual val nativeHapticFeedbackModule =
-    module {
-        single<HapticFeedback> {
-            DefaultHapticFeedback(
-                context = get(),
-            )
-        }
-    }
-
-internal actual val nativeCrashReportModule =
-    module {
-        single<CrashReportManager> {
-            DefaultCrashReportManager(
-                context = get(),
-                keyStore = get(),
-            )
-        }
-    }
-
-internal actual val nativeCalendarModule =
-    module {
-        single<CalendarHelper> {
-            DefaultCalendarHelper(
-                context = get(),
-            )
-        }
-    }
-
-internal actual val nativeAppIconModule =
-    module {
-        single<AppIconManager> {
-            DefaultAppIconManager(
-                context = get(),
-                keyStore = get(),
-            )
-        }
+        includes(
+            AppIconModule().module,
+            CalendarModule().module,
+            DebugModule().module,
+            FileSystemModule().module,
+            GalleryModule().module,
+            ShareModule().module,
+            UrlModule().module,
+            VibrateModule().module,
+        )
     }

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/fs/DefaultFileSystemManager.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/fs/DefaultFileSystemManager.kt
@@ -7,10 +7,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import okio.FileSystem
 import okio.Path
+import org.koin.core.annotation.Single
 import org.koin.java.KoinJavaComponent
 import java.io.InputStreamReader
 import java.io.OutputStreamWriter
 
+@Single
 class DefaultFileSystemManager(
     private val context: Context,
 ) : FileSystemManager {

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/gallery/DefaultGalleryHelper.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/gallery/DefaultGalleryHelper.kt
@@ -13,9 +13,11 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Single
 
 private const val DEFAULT_BASE_PATH = "RaccoonForFriendica"
 
+@Single
 internal class DefaultGalleryHelper(
     private val context: Context,
 ) : GalleryHelper {

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/ImageUtils.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/ImageUtils.kt
@@ -19,8 +19,8 @@ actual fun IntArray.toComposeImageBitmap(
 actual fun getNativeDecoders(): List<Decoder.Factory> =
     buildList {
         if (Build.VERSION.SDK_INT >= 28) {
-            AnimatedImageDecoder.Factory()
+            this += AnimatedImageDecoder.Factory()
         } else {
-            GifDecoder.Factory()
+            this += GifDecoder.Factory()
         }
     }

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/share/ShareHelper.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/share/ShareHelper.kt
@@ -3,7 +3,9 @@ package com.livefast.eattrash.raccoonforfriendica.core.utils.share
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import org.koin.core.annotation.Single
 
+@Single
 class DefaultShareHelper(
     private val context: Context,
 ) : ShareHelper {

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/url/DefaultCustomTabsHelper.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/url/DefaultCustomTabsHelper.kt
@@ -5,7 +5,9 @@ import android.content.Intent
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsClient
 import androidx.browser.customtabs.CustomTabsIntent
+import org.koin.core.annotation.Single
 
+@Single
 class DefaultCustomTabsHelper(
     private val context: Context,
 ) : CustomTabsHelper {

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/vibrate/DefaultHapticFeedback.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/vibrate/DefaultHapticFeedback.kt
@@ -5,7 +5,9 @@ import android.content.Context
 import android.os.Build
 import android.os.VibrationEffect
 import android.os.Vibrator
+import org.koin.core.annotation.Single
 
+@Single
 class DefaultHapticFeedback(
     private val context: Context,
 ) : HapticFeedback {

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/Utils.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/Utils.kt
@@ -26,20 +26,4 @@ expect fun getCalendarHelper(): CalendarHelper
 
 expect fun getNetworkStateObserver(): NetworkStateObserver
 
-internal expect val nativeFileSystemModule: Module
-
-internal expect val nativeGalleryModule: Module
-
-internal expect val nativeShareModule: Module
-
-internal expect val nativeUrlModule: Module
-
-internal expect val nativeDebugModule: Module
-
-internal expect val nativeHapticFeedbackModule: Module
-
-internal expect val nativeCrashReportModule: Module
-
-internal expect val nativeCalendarModule: Module
-
-internal expect val nativeAppIconModule: Module
+internal expect val nativeUtilsModule: Module

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/UtilsModule.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/UtilsModule.kt
@@ -1,53 +1,23 @@
 package com.livefast.eattrash.raccoonforfriendica.core.utils.di
 
-import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.BlurHashDecoder
-import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.BlurHashRepository
-import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.DefaultBlurHashDecoder
-import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.DefaultBlurHashRepository
-import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.DefaultImageLoaderProvider
-import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.DefaultImagePreloadManager
-import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.ImageLoaderProvider
-import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.ImagePreloadManager
-import com.livefast.eattrash.raccoonforfriendica.core.utils.network.DefaultNetworkStateObserver
-import com.livefast.eattrash.raccoonforfriendica.core.utils.network.NetworkStateObserver
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
 import org.koin.dsl.module
+import org.koin.ksp.generated.module
+
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.utils.imageload")
+class ImageLoadModule
+
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.utils.network")
+class NetworkStateModule
 
 val coreUtilsModule =
     module {
         includes(
-            nativeFileSystemModule,
-            nativeGalleryModule,
-            nativeShareModule,
-            nativeUrlModule,
-            nativeDebugModule,
-            nativeHapticFeedbackModule,
-            nativeCrashReportModule,
-            nativeCalendarModule,
-            nativeAppIconModule,
+            nativeUtilsModule,
+            ImageLoadModule().module,
+            NetworkStateModule().module,
         )
-
-        single<ImageLoaderProvider> {
-            DefaultImageLoaderProvider(
-                context = get(),
-                fileSystemManager = get(),
-            )
-        }
-
-        single<ImagePreloadManager> {
-            DefaultImagePreloadManager(
-                context = get(),
-                imageLoaderProvider = get(),
-            )
-        }
-        single<BlurHashDecoder> {
-            DefaultBlurHashDecoder()
-        }
-        single<BlurHashRepository> {
-            DefaultBlurHashRepository(
-                decoder = get(),
-            )
-        }
-        single<NetworkStateObserver> {
-            DefaultNetworkStateObserver()
-        }
     }

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/DefaultBlurHashDecoder.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/DefaultBlurHashDecoder.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.toArgb
 import com.livefast.eattrash.raccoonforfriendica.core.utils.cache.LruCache
+import org.koin.core.annotation.Single
 import kotlin.math.PI
 import kotlin.math.cos
 import kotlin.math.pow
@@ -18,6 +19,7 @@ private const val MAX_CACHE_SIZE = 10
  * The original code has been modified here to work with Compose (multiplatform) ImageBitmap
  * and Color in order to be used in common source set and shared across platforms.
  */
+@Single
 internal class DefaultBlurHashDecoder : BlurHashDecoder {
     private val cacheCosinesX = LruCache<Int, DoubleArray>(MAX_CACHE_SIZE)
     private val cacheCosinesY = LruCache<Int, DoubleArray>(MAX_CACHE_SIZE)

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/DefaultBlurHashRepository.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/DefaultBlurHashRepository.kt
@@ -6,7 +6,9 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultBlurHashRepository(
     private val decoder: BlurHashDecoder,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/DefaultImageLoaderProvider.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/DefaultImageLoaderProvider.kt
@@ -6,7 +6,9 @@ import coil3.disk.DiskCache
 import coil3.memory.MemoryCache
 import coil3.request.crossfade
 import com.livefast.eattrash.raccoonforfriendica.core.utils.fs.FileSystemManager
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultImageLoaderProvider(
     private val context: PlatformContext,
     private val fileSystemManager: FileSystemManager,

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/DefaultImagePreloadManager.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/DefaultImagePreloadManager.kt
@@ -3,7 +3,9 @@ package com.livefast.eattrash.raccoonforfriendica.core.utils.imageload
 import coil3.PlatformContext
 import coil3.memory.MemoryCache
 import coil3.request.ImageRequest
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultImagePreloadManager(
     private val context: PlatformContext,
     private val imageLoaderProvider: ImageLoaderProvider,

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/network/DefaultNetworkStateObserver.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/network/DefaultNetworkStateObserver.kt
@@ -9,7 +9,9 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultNetworkStateObserver(
     private val connectivity: Connectivity = Connectivity(),
     dispatcher: CoroutineDispatcher = Dispatchers.IO,

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/appicon/DefaultAppIconManager.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/appicon/DefaultAppIconManager.kt
@@ -1,7 +1,9 @@
 package com.livefast.eattrash.raccoonforfriendica.core.utils.appicon
 
 import kotlinx.coroutines.flow.MutableStateFlow
+import org.koin.core.annotation.Single
 
+@Single
 class DefaultAppIconManager : AppIconManager {
     override val supportsMultipleIcons = false
     override val current = MutableStateFlow(AppIconVariant.Default)

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/calendar/DefaultCalendarHelper.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/calendar/DefaultCalendarHelper.kt
@@ -1,5 +1,8 @@
 package com.livefast.eattrash.raccoonforfriendica.core.utils.calendar
 
+import org.koin.core.annotation.Single
+
+@Single
 class DefaultCalendarHelper : CalendarHelper {
     override val supportsExport: Boolean = false
 

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/debug/DefaultAppInfoRepository.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/debug/DefaultAppInfoRepository.kt
@@ -1,9 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.core.utils.debug
 
 import kotlinx.coroutines.flow.MutableStateFlow
+import org.koin.core.annotation.Single
 import platform.Foundation.NSBundle
 import kotlin.experimental.ExperimentalNativeApi
 
+@Single
 class DefaultAppInfoRepository : AppInfoRepository {
     override val appInfo = MutableStateFlow(getInfo())
 

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/debug/DefaultCrashReportManager.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/debug/DefaultCrashReportManager.kt
@@ -5,8 +5,10 @@ import io.sentry.kotlin.multiplatform.Sentry
 import io.sentry.kotlin.multiplatform.protocol.UserFeedback
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
+import org.koin.core.annotation.Single
 import platform.Foundation.NSBundle
 
+@Single
 internal class DefaultCrashReportManager(
     private val keyStore: TemporaryKeyStore,
 ) : CrashReportManager {

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/Utils.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/Utils.kt
@@ -41,66 +41,34 @@ actual fun getCalendarHelper(): CalendarHelper = CoreUtilsDiHelper.calendarHelpe
 
 actual fun getNetworkStateObserver(): NetworkStateObserver = CoreUtilsDiHelper.networkStateObserver
 
-internal actual val nativeFileSystemModule =
+internal actual val nativeUtilsModule =
     module {
         single<FileSystemManager> {
             DefaultFileSystemManager()
         }
-    }
-
-internal actual val nativeGalleryModule =
-    module {
         single<GalleryHelper> {
             DefaultGalleryHelper()
         }
-    }
-
-internal actual val nativeShareModule =
-    module {
         single<ShareHelper> {
             DefaultShareHelper()
         }
-    }
-
-internal actual val nativeUrlModule =
-    module {
         single<CustomTabsHelper> {
             DefaultCustomTabsHelper()
         }
-    }
-
-internal actual val nativeDebugModule =
-    module {
         single<AppInfoRepository> {
             DefaultAppInfoRepository()
         }
-    }
-
-internal actual val nativeHapticFeedbackModule =
-    module {
         single<HapticFeedback> {
             DefaultHapticFeedback()
         }
-    }
-
-internal actual val nativeCrashReportModule =
-    module {
         single<CrashReportManager> {
             DefaultCrashReportManager(
                 keyStore = get(),
             )
         }
-    }
-
-internal actual val nativeCalendarModule =
-    module {
         single<CalendarHelper> {
             DefaultCalendarHelper()
         }
-    }
-
-internal actual val nativeAppIconModule =
-    module {
         single<AppIconManager> {
             DefaultAppIconManager()
         }

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/fs/DefaultFileSystemManager.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/fs/DefaultFileSystemManager.kt
@@ -3,9 +3,11 @@ package com.livefast.eattrash.raccoonforfriendica.core.utils.fs
 import androidx.compose.runtime.Composable
 import okio.FileSystem
 import okio.Path
+import org.koin.core.annotation.Single
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
+@Single
 class DefaultFileSystemManager : FileSystemManager {
     override val isSupported = false
 

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/gallery/DefaultGalleryHelper.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/gallery/DefaultGalleryHelper.kt
@@ -6,11 +6,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.interop.LocalUIViewController
+import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.allocArrayOf
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.usePinned
+import org.koin.core.annotation.Single
 import platform.Foundation.NSData
 import platform.Foundation.create
 import platform.PhotosUI.PHPickerConfiguration
@@ -25,7 +27,7 @@ import platform.posix.memcpy
 
 typealias ImageBytes = NSData
 
-@OptIn(ExperimentalForeignApi::class)
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
 fun ByteArray.toImageBytes(): ImageBytes =
     memScoped {
         return NSData.create(
@@ -42,6 +44,7 @@ fun ImageBytes.toByteArray(): ByteArray =
         }
     }
 
+@Single
 internal class DefaultGalleryHelper : GalleryHelper {
     override val supportsCustomPath: Boolean = false
 

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/share/ShareHelper.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/share/ShareHelper.kt
@@ -1,9 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.core.utils.share
 
+import org.koin.core.annotation.Single
 import platform.UIKit.UIActivityViewController
 import platform.UIKit.UIApplication
 import platform.UIKit.UIImage
 
+@Single
 class DefaultShareHelper : ShareHelper {
     override val supportsShareImage = false
 

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/url/DefaultCustomTabsHelper.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/url/DefaultCustomTabsHelper.kt
@@ -1,5 +1,8 @@
 package com.livefast.eattrash.raccoonforfriendica.core.utils.url
 
+import org.koin.core.annotation.Single
+
+@Single
 class DefaultCustomTabsHelper : CustomTabsHelper {
     override val isSupported = false
 

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/vibrate/DefaultHapticFeedback.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/vibrate/DefaultHapticFeedback.kt
@@ -1,7 +1,9 @@
 package com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate
 
+import org.koin.core.annotation.Single
 import platform.UIKit.UIImpactFeedbackGenerator
 
+@Single
 class DefaultHapticFeedback : HapticFeedback {
     override fun vibrate() {
         UIImpactFeedbackGenerator().apply {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ compose-ui-test = "1.7.5"
 connectivity = "1.1.3"
 compose-multiplatform-media-player = "1.0.26"
 koin = "4.0.0"
+koin-annotations = "2.0.0-Beta2"
 kotlin = "2.1.0"
 kotlinx-coroutines = "1.9.0"
 kotlinx-serialization-json = "1.7.3"
@@ -69,6 +70,8 @@ connectivity-device = { module = "dev.jordond.connectivity:connectivity-device",
 
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
+koin-annotations = { module = "io.insert-koin:koin-annotations", version.ref = "koin-annotations" }
+koin-ksp = { module = "io.insert-koin:koin-ksp-compiler", version.ref = "koin-annotations" }
 
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR removes (wherever possible, see notes below) manually defined Koin modules and relies on the ones autogenerated via KSP in all subprojects inside `:core`.

## Additional notes
<!-- Anything to declare for code review? -->
Since Koin KSP plugin is [compatible with KSP 2.0.20-1.0.25](https://insert-koin.io/docs/setup/annotations/#ksp-plugin) (and this project is using KSP 2.1.0-1.0.29 something was definitely and undoubtedly bound to break. It did. What I found is not working is generating sources for iOS, despite the plugin being applied to iOS source sets. It also looks like [I'm not the only one](https://stackoverflow.com/questions/78809435/kmp-kotlin-2-0-with-ksp-koin-annotations-doesnt-find-generated-modules-on-ios).

Considering the version of Koin annotations (and of the KSP plugin) is still a beta (2.0.0-Beta2) this was expected and it is likely to change (and possibly be resolved) in the future.

The only impact of this is that, whenever there were native bindings on the `iosMain` source set, it is not possible to use autogenerated modules like I'm doing on Android but module definitions need to be done manually like done until now. 

Considering all autogenerated modules can be used in a manually-defined module because the two styles (manual/annotation-based) are interoperable, I'm keeping native modules as manually defined on iOS.

--- 
Documentation [reference](https://insert-koin.io/docs/reference/koin-annotations/start)
