### PR TITLE
refactor(di): migrate to Koin annotations • 2

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/DiHelper.kt
+++ b/composeApp/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/DiHelper.kt
@@ -46,7 +46,7 @@ import com.livefast.eattrash.raccoonforfriendica.feaure.search.di.featureSearchM
 import com.livefast.eattrash.raccoonforfriendica.unit.licences.di.featureLicenceModule
 import org.koin.dsl.module
 
-val sharedHelperModule =
+internal val sharedHelperModule =
     module {
         includes(
             sharedModule,

--- a/core/persistence/build.gradle.kts
+++ b/core/persistence/build.gradle.kts
@@ -43,6 +43,9 @@ kotlin {
                 implementation(projects.core.utils)
             }
         }
+        val iosMain by getting {
+            kotlin.srcDir("build/generated/ksp/metadata")
+        }
     }
 }
 

--- a/core/persistence/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/builder/DefaultDatabaseBuilderProvider.kt
+++ b/core/persistence/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/builder/DefaultDatabaseBuilderProvider.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.core.persistence.builder
 
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.util.findDatabaseConstructorAndInitDatabaseImpl
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.AppDatabase
 import kotlinx.cinterop.ExperimentalForeignApi
 import org.koin.core.annotation.Single
@@ -17,7 +18,7 @@ class DefaultDatabaseBuilderProvider : DatabaseBuilderProvider {
             .databaseBuilder<AppDatabase>(
                 name = dbFilePath,
                 factory = {
-                    AppDatabase::class.instantiateImpl()
+                    findDatabaseConstructorAndInitDatabaseImpl(AppDatabase::class)
                 },
             )
     }

--- a/domain/content/pagination/build.gradle.kts
+++ b/domain/content/pagination/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
-    alias(libs.plugins.mokkery)
     alias(libs.plugins.kotlinx.kover)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.mokkery)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -51,6 +53,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.domain.content.pagination"
     compileSdk =
@@ -62,5 +72,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultAlbumPhotoPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultAlbumPhotoPaginationManager.kt
@@ -4,7 +4,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.AttachmentM
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.PhotoAlbumRepository
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultAlbumPhotoPaginationManager(
     private val albumRepository: PhotoAlbumRepository,
 ) : AlbumPhotoPaginationManager {

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultDirectMessagesPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultDirectMessagesPaginationManager.kt
@@ -5,7 +5,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Direc
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultDirectMessagesPaginationManager(
     private val directMessageRepository: DirectMessageRepository,
     private val emojiHelper: EmojiHelper,

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultEventPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultEventPaginationManager.kt
@@ -4,7 +4,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EventModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EventRepository
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultEventPaginationManager(
     private val eventRepository: EventRepository,
 ) : EventPaginationManager {

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultExplorePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultExplorePaginationManager.kt
@@ -22,7 +22,9 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultExplorePaginationManager(
     private val trendingRepository: TrendingRepository,
     private val userRepository: UserRepository,

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFavoritesPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFavoritesPaginationManager.kt
@@ -17,7 +17,9 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultFavoritesPaginationManager(
     private val timelineEntryRepository: TimelineEntryRepository,
     private val emojiHelper: EmojiHelper,

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFollowRequestPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFollowRequestPaginationManager.kt
@@ -6,7 +6,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserR
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.ListWithPageCursor
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultFollowRequestPaginationManager(
     private val userRepository: UserRepository,
     private val emojiHelper: EmojiHelper,

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFollowedHashtagsPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFollowedHashtagsPaginationManager.kt
@@ -5,7 +5,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TagRe
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.ListWithPageCursor
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultFollowedHashtagsPaginationManager(
     private val tagRepository: TagRepository,
 ) : FollowedHashtagsPaginationManager {

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultNotificationsPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultNotificationsPaginationManager.kt
@@ -10,7 +10,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Reply
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultNotificationsPaginationManager(
     private val notificationRepository: NotificationRepository,
     private val userRepository: UserRepository,

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultSearchPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultSearchPaginationManager.kt
@@ -23,7 +23,9 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultSearchPaginationManager(
     private val searchRepository: SearchRepository,
     private val userRepository: UserRepository,

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
@@ -21,7 +21,9 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultTimelinePaginationManager(
     private val timelineRepository: TimelineRepository,
     private val timelineEntryRepository: TimelineEntryRepository,

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUnpublishedPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUnpublishedPaginationManager.kt
@@ -15,7 +15,9 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultUnpublishedPaginationManager(
     private val scheduledEntryRepository: ScheduledEntryRepository,
     private val draftRepository: DraftRepository,

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUserPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUserPaginationManager.kt
@@ -18,7 +18,9 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultUserPaginationManager(
     private val userRepository: UserRepository,
     private val timelineEntryRepository: TimelineEntryRepository,

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
@@ -1,117 +1,12 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.di
 
-import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.AlbumPhotoPaginationManager
-import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultAlbumPhotoPaginationManager
-import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultDirectMessagesPaginationManager
-import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultEventPaginationManager
-import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultExplorePaginationManager
-import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultFavoritesPaginationManager
-import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultFollowRequestPaginationManager
-import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultFollowedHashtagsPaginationManager
-import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultNotificationsPaginationManager
-import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultSearchPaginationManager
-import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultTimelinePaginationManager
-import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultUnpublishedPaginationManager
-import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultUserPaginationManager
-import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DirectMessagesPaginationManager
-import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.EventPaginationManager
-import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.ExplorePaginationManager
-import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.FavoritesPaginationManager
-import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.FollowRequestPaginationManager
-import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.FollowedHashtagsPaginationManager
-import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.NotificationsPaginationManager
-import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.SearchPaginationManager
-import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationManager
-import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.UnpublishedPaginationManager
-import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.UserPaginationManager
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
 import org.koin.dsl.module
+import org.koin.ksp.generated.module
 
-val domainContentPaginationModule =
-    module {
-        factory<TimelinePaginationManager> {
-            DefaultTimelinePaginationManager(
-                timelineRepository = get(),
-                timelineEntryRepository = get(),
-                emojiHelper = get(),
-                replyHelper = get(),
-                notificationCenter = get(),
-            )
-        }
-        factory<NotificationsPaginationManager> {
-            DefaultNotificationsPaginationManager(
-                notificationRepository = get(),
-                emojiHelper = get(),
-                replyHelper = get(),
-                userRepository = get(),
-            )
-        }
-        factory<ExplorePaginationManager> {
-            DefaultExplorePaginationManager(
-                trendingRepository = get(),
-                userRepository = get(),
-                emojiHelper = get(),
-                replyHelper = get(),
-                notificationCenter = get(),
-            )
-        }
-        factory<UserPaginationManager> {
-            DefaultUserPaginationManager(
-                userRepository = get(),
-                timelineEntryRepository = get(),
-                circlesRepository = get(),
-                emojiHelper = get(),
-                notificationCenter = get(),
-            )
-        }
-        factory<FavoritesPaginationManager> {
-            DefaultFavoritesPaginationManager(
-                timelineEntryRepository = get(),
-                emojiHelper = get(),
-                replyHelper = get(),
-                notificationCenter = get(),
-            )
-        }
-        factory<FollowedHashtagsPaginationManager> {
-            DefaultFollowedHashtagsPaginationManager(
-                tagRepository = get(),
-            )
-        }
-        factory<SearchPaginationManager> {
-            DefaultSearchPaginationManager(
-                searchRepository = get(),
-                userRepository = get(),
-                emojiHelper = get(),
-                replyHelper = get(),
-                notificationCenter = get(),
-            )
-        }
-        factory<FollowRequestPaginationManager> {
-            DefaultFollowRequestPaginationManager(
-                userRepository = get(),
-                emojiHelper = get(),
-            )
-        }
-        factory<DirectMessagesPaginationManager> {
-            DefaultDirectMessagesPaginationManager(
-                directMessageRepository = get(),
-                emojiHelper = get(),
-            )
-        }
-        factory<AlbumPhotoPaginationManager> {
-            DefaultAlbumPhotoPaginationManager(
-                albumRepository = get(),
-            )
-        }
-        factory<UnpublishedPaginationManager> {
-            DefaultUnpublishedPaginationManager(
-                scheduledEntryRepository = get(),
-                draftRepository = get(),
-                notificationCenter = get(),
-            )
-        }
-        factory<EventPaginationManager> {
-            DefaultEventPaginationManager(
-                eventRepository = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.domain.content.pagination")
+internal class ContentPaginationModule
+
+val domainContentPaginationModule = ContentPaginationModule().module

--- a/domain/content/repository/build.gradle.kts
+++ b/domain/content/repository/build.gradle.kts
@@ -1,14 +1,14 @@
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
-    alias(libs.plugins.mokkery)
     alias(libs.plugins.kotlinx.kover)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.mokkery)
 }
 
-@OptIn(ExperimentalKotlinGradlePluginApi::class)
 kotlin {
     applyDefaultHierarchyTemplate()
     androidTarget {
@@ -31,6 +31,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.ktorfit.lib)
                 implementation(libs.ktorfit.converters.response)
 
@@ -50,6 +51,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.domain.content.repository"
     compileSdk =
@@ -61,5 +70,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultAnnouncementRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultAnnouncementRepository.kt
@@ -8,9 +8,12 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultAnnouncementRepository(
-    private val provider: ServiceProvider,
+    @Named("default") private val provider: ServiceProvider,
 ) : AnnouncementRepository {
     private val mutex = Mutex()
     private val cachedValues: MutableList<AnnouncementModel> = mutableListOf()

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultAnnouncementsManager.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultAnnouncementsManager.kt
@@ -3,7 +3,9 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.getAndUpdate
 import kotlinx.coroutines.flow.update
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultAnnouncementsManager(
     private val announcementRepository: AnnouncementRepository,
 ) : AnnouncementsManager {

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultCirclesRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultCirclesRepository.kt
@@ -11,9 +11,12 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultCirclesRepository(
-    private val provider: ServiceProvider,
+    @Named("default") private val provider: ServiceProvider,
 ) : CirclesRepository {
     override suspend fun getAll(): List<CircleModel>? =
         withContext(Dispatchers.IO) {

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultDirectMessageRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultDirectMessageRepository.kt
@@ -8,9 +8,12 @@ import io.ktor.http.Parameters
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultDirectMessageRepository(
-    private val provider: ServiceProvider,
+    @Named("default") private val provider: ServiceProvider,
 ) : DirectMessageRepository {
     override suspend fun getAll(
         page: Int,

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultDraftRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultDraftRepository.kt
@@ -13,10 +13,13 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultDraftRepository(
     private val draftDao: DraftDao,
-    private val provider: ServiceProvider,
+    @Named("default") private val provider: ServiceProvider,
 ) : DraftRepository {
     override suspend fun getAll(page: Int): List<TimelineEntryModel>? =
         withContext(Dispatchers.IO) {

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEmojiHelper.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEmojiHelper.kt
@@ -4,7 +4,9 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.nodeName
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EmojiModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultEmojiHelper(
     private val repository: EmojiRepository,
 ) : EmojiHelper {

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEmojiRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEmojiRepository.kt
@@ -7,10 +7,13 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultEmojiRepository(
-    private val provider: ServiceProvider,
-    private val otherProvider: ServiceProvider,
+    @Named("default") private val provider: ServiceProvider,
+    @Named("other") private val otherProvider: ServiceProvider,
     private val cache: LruCache<String, List<EmojiModel>> = LruCache(20),
 ) : EmojiRepository {
     override suspend fun getAll(

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEventRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEventRepository.kt
@@ -6,9 +6,12 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultEventRepository(
-    private val provider: ServiceProvider,
+    @Named("default") private val provider: ServiceProvider,
 ) : EventRepository {
     override suspend fun getAll(pageCursor: String?): List<EventModel>? =
         withContext(Dispatchers.IO) {

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultInboxManager.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultInboxManager.kt
@@ -5,7 +5,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.hasLaterIdT
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.getAndUpdate
 import kotlinx.coroutines.flow.update
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultInboxManager(
     private val notificationRepository: NotificationRepository,
     private val markerRepository: MarkerRepository,

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMarkerRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMarkerRepository.kt
@@ -10,9 +10,12 @@ import io.ktor.http.Parameters
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultMarkerRepository(
-    private val provider: ServiceProvider,
+    @Named("default") private val provider: ServiceProvider,
 ) : MarkerRepository {
     private val cachedValues = mutableMapOf<MarkerType, MarkerModel>()
 

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMediaRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMediaRepository.kt
@@ -12,9 +12,12 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultMediaRepository(
-    private val provider: ServiceProvider,
+    @Named("default") private val provider: ServiceProvider,
 ) : MediaRepository {
     override suspend fun getBy(id: String): AttachmentModel? =
         withContext(Dispatchers.IO) {

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNodeInfoRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNodeInfoRepository.kt
@@ -7,9 +7,12 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultNodeInfoRepository(
-    private val provider: ServiceProvider,
+    @Named("default") private val provider: ServiceProvider,
 ) : NodeInfoRepository {
     override suspend fun getInfo(): NodeInfoModel? =
         withContext(Dispatchers.IO) {

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNotificationRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNotificationRepository.kt
@@ -10,9 +10,12 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultNotificationRepository(
-    private val provider: ServiceProvider,
+    @Named("default") private val provider: ServiceProvider,
 ) : NotificationRepository {
     private val mutex = Mutex()
     private val cachedValues: MutableList<NotificationModel> = mutableListOf()

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoAlbumRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoAlbumRepository.kt
@@ -9,9 +9,12 @@ import io.ktor.http.Parameters
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultPhotoAlbumRepository(
-    private val provider: ServiceProvider,
+    @Named("default") private val provider: ServiceProvider,
 ) : PhotoAlbumRepository {
     override suspend fun getAll(): List<MediaAlbumModel>? =
         withContext(Dispatchers.IO) {

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoRepository.kt
@@ -10,9 +10,12 @@ import io.ktor.http.HttpHeaders
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultPhotoRepository(
-    private val provider: ServiceProvider,
+    @Named("default") private val provider: ServiceProvider,
 ) : PhotoRepository {
     override suspend fun create(
         bytes: ByteArray,

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPushNotificationRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPushNotificationRepository.kt
@@ -10,9 +10,12 @@ import io.ktor.http.parameters
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultPushNotificationRepository(
-    private val provider: ServiceProvider,
+    @Named("default") private val provider: ServiceProvider,
 ) : PushNotificationRepository {
     override suspend fun create(
         endpoint: String,

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultReplyHelper.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultReplyHelper.kt
@@ -2,7 +2,9 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 
 import com.livefast.eattrash.raccoonforfriendica.core.utils.cache.LruCache
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultReplyHelper(
     private val entryRepository: TimelineEntryRepository,
     private val entryCache: LruCache<String, TimelineEntryModel> = LruCache(100),

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultReportRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultReportRepository.kt
@@ -8,9 +8,12 @@ import io.ktor.http.Parameters
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultReportRepository(
-    private val provider: ServiceProvider,
+    @Named("default") private val provider: ServiceProvider,
 ) : ReportRepository {
     override suspend fun create(
         userId: String,

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultScheduledEntryRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultScheduledEntryRepository.kt
@@ -8,9 +8,12 @@ import io.ktor.http.parameters
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultScheduledEntryRepository(
-    private val provider: ServiceProvider,
+    @Named("default") private val provider: ServiceProvider,
 ) : ScheduledEntryRepository {
     override suspend fun getAll(pageCursor: String?): List<TimelineEntryModel>? =
         withContext(Dispatchers.IO) {

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSearchRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSearchRepository.kt
@@ -9,9 +9,12 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultSearchRepository(
-    private val provider: ServiceProvider,
+    @Named("default") private val provider: ServiceProvider,
 ) : SearchRepository {
     override suspend fun search(
         query: String,
@@ -31,9 +34,20 @@ internal class DefaultSearchRepository(
                             resolve = resolve,
                         )
                 when (type) {
-                    SearchResultType.Entries -> response.statuses.map { ExploreItemModel.Entry(it.toModelWithReply()) }
-                    SearchResultType.Hashtags -> response.hashtags.map { ExploreItemModel.HashTag(it.toModel()) }
-                    SearchResultType.Users -> response.accounts.map { ExploreItemModel.User(it.toModel()) }
+                    SearchResultType.Entries ->
+                        response.statuses.map {
+                            ExploreItemModel.Entry(it.toModelWithReply())
+                        }
+
+                    SearchResultType.Hashtags ->
+                        response.hashtags.map {
+                            ExploreItemModel.HashTag(it.toModel())
+                        }
+
+                    SearchResultType.Users ->
+                        response.accounts.map {
+                            ExploreItemModel.User(it.toModel())
+                    }
                 }
             }.getOrNull()
         }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepository.kt
@@ -4,7 +4,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NodeFeature
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NodeInfoModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultSupportedFeatureRepository(
     private val nodeInfoRepository: NodeInfoRepository,
 ) : SupportedFeatureRepository {

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTagRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTagRepository.kt
@@ -8,9 +8,12 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultTagRepository(
-    private val provider: ServiceProvider,
+    @Named("default") private val provider: ServiceProvider,
 ) : TagRepository {
     override suspend fun getFollowed(pageCursor: String?): ListWithPageCursor<TagModel>? =
         withContext(Dispatchers.IO) {

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTimelineEntryRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTimelineEntryRepository.kt
@@ -22,10 +22,13 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
 import kotlin.time.Duration
 
+@Single
 internal class DefaultTimelineEntryRepository(
-    private val provider: ServiceProvider,
+    @Named("default") private val provider: ServiceProvider,
 ) : TimelineEntryRepository {
     private val mutex = Mutex()
     private val cachedValues: MutableList<TimelineEntryModel> = mutableListOf()

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTimelineRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTimelineRepository.kt
@@ -10,9 +10,12 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultTimelineRepository(
-    private val provider: ServiceProvider,
+    @Named("default") private val provider: ServiceProvider,
 ) : TimelineRepository {
     private val mutex = Mutex()
     private val cachedValues: MutableList<TimelineEntryModel> = mutableListOf()

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTrendingRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTrendingRepository.kt
@@ -13,9 +13,12 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultTrendingRepository(
-    private val provider: ServiceProvider,
+    @Named("default") private val provider: ServiceProvider,
 ) : TrendingRepository {
     private val mutex = Mutex()
     private val cachedTags: MutableList<TagModel> = mutableListOf()

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepository.kt
@@ -20,9 +20,12 @@ import io.ktor.http.parameters
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultUserRepository(
-    private val provider: ServiceProvider,
+    @Named("default") private val provider: ServiceProvider,
 ) : UserRepository {
     private var cachedUser: UserModel? = null
 

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
@@ -4,208 +4,31 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.CircleModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EventModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.AnnouncementRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.AnnouncementsManager
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.CirclesRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultAnnouncementRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultAnnouncementsManager
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultCirclesRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultDirectMessageRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultDraftRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultEmojiHelper
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultEmojiRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultEventRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultInboxManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultLocalItemCache
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultMarkerRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultMediaRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultNodeInfoRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultNotificationRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultPhotoAlbumRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultPhotoRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultPushNotificationRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultReplyHelper
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultReportRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultScheduledEntryRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultSearchRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultSupportedFeatureRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultTagRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultTimelineEntryRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultTimelineRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultTrendingRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultUserRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DirectMessageRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DraftRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EventRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.InboxManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.LocalItemCache
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.MarkerRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.MediaRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.NodeInfoRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.NotificationRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.PhotoAlbumRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.PhotoRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.PushNotificationRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.ReplyHelper
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.ReportRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.ScheduledEntryRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SearchRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SupportedFeatureRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TagRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TrendingRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
-import org.koin.core.qualifier.named
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.core.annotation.Single
+import org.koin.ksp.generated.module
 
-val domainContentRepositoryModule =
-    module {
-        single<TimelineRepository> {
-            DefaultTimelineRepository(
-                provider = get(named("default")),
-            )
-        }
-        single<TimelineEntryRepository> {
-            DefaultTimelineEntryRepository(
-                provider = get(named("default")),
-            )
-        }
-        single<UserRepository> {
-            DefaultUserRepository(
-                provider = get(named("default")),
-            )
-        }
-        single<NotificationRepository> {
-            DefaultNotificationRepository(
-                provider = get(named("default")),
-            )
-        }
-        single<TrendingRepository> {
-            DefaultTrendingRepository(
-                provider = get(named("default")),
-            )
-        }
-        single<TagRepository> {
-            DefaultTagRepository(
-                provider = get(named("default")),
-            )
-        }
-        single<PhotoRepository> {
-            DefaultPhotoRepository(
-                provider = get(named("default")),
-            )
-        }
-        single<SearchRepository> {
-            DefaultSearchRepository(
-                provider = get(named("default")),
-            )
-        }
-        single<CirclesRepository> {
-            DefaultCirclesRepository(
-                provider = get(named("default")),
-            )
-        }
-        single<InboxManager> {
-            DefaultInboxManager(
-                notificationRepository = get(),
-                markerRepository = get(),
-            )
-        }
-        single<NodeInfoRepository> {
-            DefaultNodeInfoRepository(
-                provider = get(named("default")),
-            )
-        }
-        single<DirectMessageRepository> {
-            DefaultDirectMessageRepository(
-                provider = get(named("default")),
-            )
-        }
-        single<PhotoAlbumRepository> {
-            DefaultPhotoAlbumRepository(
-                provider = get(named("default")),
-            )
-        }
-        single<LocalItemCache<UserModel>> {
-            DefaultLocalItemCache()
-        }
-        single<LocalItemCache<TimelineEntryModel>> {
-            DefaultLocalItemCache()
-        }
-        single<LocalItemCache<EventModel>> {
-            DefaultLocalItemCache()
-        }
-        single<LocalItemCache<CircleModel>> {
-            DefaultLocalItemCache()
-        }
-        single<ScheduledEntryRepository> {
-            DefaultScheduledEntryRepository(
-                provider = get(named("default")),
-            )
-        }
-        single<DraftRepository> {
-            DefaultDraftRepository(
-                draftDao = get(),
-                provider = get(named("default")),
-            )
-        }
-        single<MediaRepository> {
-            DefaultMediaRepository(
-                provider = get(named("default")),
-            )
-        }
-        single<ReportRepository> {
-            DefaultReportRepository(
-                provider = get(named("default")),
-            )
-        }
-        single<SupportedFeatureRepository> {
-            DefaultSupportedFeatureRepository(
-                nodeInfoRepository = get(),
-            )
-        }
-        single<EmojiRepository> {
-            DefaultEmojiRepository(
-                provider = get(named("default")),
-                otherProvider = get(named("other")),
-            )
-        }
-        single<EmojiHelper> {
-            DefaultEmojiHelper(
-                repository = get(),
-            )
-        }
-        single<MarkerRepository> {
-            DefaultMarkerRepository(
-                provider = get(named("default")),
-            )
-        }
-        single<ReplyHelper> {
-            DefaultReplyHelper(
-                entryRepository = get(),
-            )
-        }
-        single<EventRepository> {
-            DefaultEventRepository(
-                provider = get(named("default")),
-            )
-        }
-        single<PushNotificationRepository> {
-            DefaultPushNotificationRepository(
-                provider = get(named("default")),
-            )
-        }
-        single<AnnouncementRepository> {
-            DefaultAnnouncementRepository(
-                provider = get(named("default")),
-            )
-        }
-        single<AnnouncementsManager> {
-            DefaultAnnouncementsManager(
-                announcementRepository = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.domain.content.repository")
+internal class ContentRepositoryModule {
+    @Single
+    fun provideLocalItemCacheUserModel(): LocalItemCache<UserModel> = DefaultLocalItemCache()
+
+    @Single
+    fun provideLocalItemCacheTimelineEntryModel(): LocalItemCache<TimelineEntryModel> = DefaultLocalItemCache()
+
+    @Single
+    fun provideLocalItemCacheEventModel(): LocalItemCache<EventModel> = DefaultLocalItemCache()
+
+    @Single
+    fun provideLocalItemCacheCircleModel(): LocalItemCache<CircleModel> = DefaultLocalItemCache()
+
+    @Single
+    fun provideLocalItemCacheScheduledEntryRepository(): LocalItemCache<ScheduledEntryRepository> = DefaultLocalItemCache()
+}
+
+val domainContentRepositoryModule = ContentRepositoryModule().module

--- a/domain/content/usecase/build.gradle.kts
+++ b/domain/content/usecase/build.gradle.kts
@@ -1,14 +1,14 @@
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
-    alias(libs.plugins.mokkery)
     alias(libs.plugins.kotlinx.kover)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.mokkery)
 }
 
-@OptIn(ExperimentalKotlinGradlePluginApi::class)
 kotlin {
     applyDefaultHierarchyTemplate()
     androidTarget {
@@ -31,6 +31,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.kotlinx.coroutines)
 
                 implementation(projects.domain.content.data)
@@ -46,6 +47,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.domain.content.usecase"
     compileSdk =
@@ -57,5 +66,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/DefaultExportUserListUseCase.kt
+++ b/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/DefaultExportUserListUseCase.kt
@@ -2,7 +2,9 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.usecase
 
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultExportUserListUseCase(
     private val userRepository: UserRepository,
 ) : ExportUserListUseCase {

--- a/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/di/ContentUseCaseModule.kt
+++ b/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/di/ContentUseCaseModule.kt
@@ -1,14 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.di
 
-import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.DefaultExportUserListUseCase
-import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.ExportUserListUseCase
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val domainContentUseCaseModule =
-    module {
-        single<ExportUserListUseCase> {
-            DefaultExportUserListUseCase(
-                userRepository = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.domain.content.usecase")
+internal class ContentUseCaseModule
+
+val domainContentUseCaseModule = ContentUseCaseModule().module


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR migrates the `:domain:content` subprojects to Koin annotations.

## Additional notes
<!-- Anything to declare for code review? -->
Something was still not working after the migration of `:core:persistence`, probably due to KSP running on the `commonMetadata` source set due to the dependency of `:domain:content:repository` on `:core:persistence` (and by extension of the task `kspCommonMainKotlinMetadata` in :domain:content:repository `on` the task `kspCommonMainKotlinMetadata` in `:core:persistence`.

The solution was basically to update the way the DB was instantiated on iOS (in an undocumented way). Room for KMP is still in alpha so such thinks are more than expected.