### PR TITLE
refactor(di): migrate to Koin annotations • 3

### DIFF
--- a/domain/identity/repository/build.gradle.kts
+++ b/domain/identity/repository/build.gradle.kts
@@ -1,16 +1,16 @@
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
-    alias(libs.plugins.mokkery)
     alias(libs.plugins.kotlinx.kover)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.mokkery)
 }
 
-@OptIn(ExperimentalKotlinGradlePluginApi::class)
 kotlin {
     applyDefaultHierarchyTemplate()
     androidTarget {
@@ -36,6 +36,7 @@ kotlin {
                 implementation(compose.runtime)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.ktor.client.core)
 
                 implementation(projects.core.api)
@@ -58,6 +59,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.domain.identity.repository"
     compileSdk =
@@ -69,5 +78,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultAccountCredentialsCache.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultAccountCredentialsCache.kt
@@ -1,7 +1,9 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository
 
 import com.livefast.eattrash.raccoonforfriendica.core.preferences.TemporaryKeyStore
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultAccountCredentialsCache(
     private val keyStore: TemporaryKeyStore,
 ) : AccountCredentialsCache {

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultAccountRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultAccountRepository.kt
@@ -5,7 +5,9 @@ import com.livefast.eattrash.raccoonforfriendica.core.persistence.entities.Accou
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultAccountRepository(
     private val accountDao: AccountDao,
 ) : AccountRepository {

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultApiConfigurationRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultApiConfigurationRepository.kt
@@ -5,9 +5,12 @@ import com.livefast.eattrash.raccoonforfriendica.core.preferences.TemporaryKeySt
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withTimeoutOrNull
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultApiConfigurationRepository(
-    private val serviceProvider: ServiceProvider,
+    @Named("default") private val serviceProvider: ServiceProvider,
     private val keyStore: TemporaryKeyStore,
     private val credentialsRepository: CredentialsRepository,
 ) : ApiConfigurationRepository {

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultCredentialsRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultCredentialsRepository.kt
@@ -23,9 +23,12 @@ import io.ktor.http.path
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultCredentialsRepository(
-    private val provider: ServiceProvider,
+    @Named("other") private val provider: ServiceProvider,
     engine: HttpClientEngine = provideHttpClientEngine(),
 ) : CredentialsRepository {
     private val httpClient =

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultIdentityRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultIdentityRepository.kt
@@ -5,9 +5,12 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.FieldModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
+import org.koin.core.annotation.Named
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultIdentityRepository(
-    private val provider: ServiceProvider,
+    @Named("default") private val provider: ServiceProvider,
 ) : IdentityRepository {
     override val currentUser = MutableStateFlow<UserModel?>(null)
 

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultImageAutoloadObserver.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultImageAutoloadObserver.kt
@@ -11,7 +11,9 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultImageAutoloadObserver(
     networkStateObserver: NetworkStateObserver,
     settingsRepository: SettingsRepository,

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultSettingsRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultSettingsRepository.kt
@@ -17,8 +17,10 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.toSerialMa
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.toUrlOpeningMode
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
+import org.koin.core.annotation.Single
 import kotlin.time.Duration.Companion.seconds
 
+@Single
 internal class DefaultSettingsRepository(
     private val settingsDao: SettingsDao,
 ) : SettingsRepository {

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/di/IdentityRepositoryModule.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/di/IdentityRepositoryModule.kt
@@ -1,64 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di
 
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountCredentialsCache
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.CredentialsRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultAccountCredentialsCache
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultAccountRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultApiConfigurationRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultCredentialsRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultIdentityRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultImageAutoloadObserver
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultSettingsRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ImageAutoloadObserver
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
-import org.koin.core.qualifier.named
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val domainIdentityRepositoryModule =
-    module {
-        single<ApiConfigurationRepository> {
-            DefaultApiConfigurationRepository(
-                serviceProvider = get(named("default")),
-                keyStore = get(),
-                credentialsRepository = get(),
-            )
-        }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.domain.identity.repository")
+internal class IdentityRepositoryModule
 
-        single<IdentityRepository> {
-            DefaultIdentityRepository(
-                provider = get(named("default")),
-            )
-        }
-
-        single<CredentialsRepository> {
-            DefaultCredentialsRepository(
-                provider = get(named("other")),
-            )
-        }
-
-        single<AccountRepository> {
-            DefaultAccountRepository(
-                accountDao = get(),
-            )
-        }
-
-        single<SettingsRepository> {
-            DefaultSettingsRepository(
-                settingsDao = get(),
-            )
-        }
-        single<AccountCredentialsCache> {
-            DefaultAccountCredentialsCache(
-                keyStore = get(),
-            )
-        }
-        single<ImageAutoloadObserver> {
-            DefaultImageAutoloadObserver(
-                networkStateObserver = get(),
-                settingsRepository = get(),
-            )
-        }
-    }
+val domainIdentityRepositoryModule = IdentityRepositoryModule().module

--- a/domain/identity/usecase/build.gradle.kts
+++ b/domain/identity/usecase/build.gradle.kts
@@ -1,5 +1,5 @@
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
@@ -7,11 +7,11 @@ plugins {
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.kotlinx.serialization)
-    alias(libs.plugins.mokkery)
     alias(libs.plugins.kotlinx.kover)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.mokkery)
 }
 
-@OptIn(ExperimentalKotlinGradlePluginApi::class)
 kotlin {
     applyDefaultHierarchyTemplate()
     androidTarget {
@@ -41,6 +41,7 @@ kotlin {
                 implementation(compose.runtime)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.kotlinx.coroutines)
                 implementation(libs.kotlinx.serialization.json)
 
@@ -69,6 +70,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase"
     compileSdk =
@@ -80,5 +89,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitor.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitor.kt
@@ -23,7 +23,9 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultActiveAccountMonitor(
     private val accountRepository: AccountRepository,
     private val apiConfigurationRepository: ApiConfigurationRepository,

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultContentPreloadManager.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultContentPreloadManager.kt
@@ -6,7 +6,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Trend
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultContentPreloadManager(
     private val timelineEntryRepository: TimelineEntryRepository,
     private val trendingRepository: TrendingRepository,

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultDeleteAccountUseCase.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultDeleteAccountUseCase.kt
@@ -4,7 +4,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountMod
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountCredentialsCache
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultDeleteAccountUseCase(
     private val accountRepository: AccountRepository,
     private val settingsRepository: SettingsRepository,

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultEntryActionRepository.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultEntryActionRepository.kt
@@ -3,7 +3,9 @@ package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SupportedFeatureRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultEntryActionRepository(
     private val identityRepository: IdentityRepository,
     private val supportedFeatureRepository: SupportedFeatureRepository,

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultExportSettingsUseCase.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultExportSettingsUseCase.kt
@@ -5,7 +5,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultExportSettingsUseCase(
     private val settingsRepository: SettingsRepository,
 ) : ExportSettingsUseCase {

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultImportSettingsUseCase.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultImportSettingsUseCase.kt
@@ -4,7 +4,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Sett
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultImportSettingsUseCase(
     private val settingsRepository: SettingsRepository,
 ) : ImportSettingsUseCase {

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultLoginUseCase.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultLoginUseCase.kt
@@ -10,7 +10,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiC
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiCredentials
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.CredentialsRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultLoginUseCase(
     private val apiConfigurationRepository: ApiConfigurationRepository,
     private val credentialsRepository: CredentialsRepository,

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultLogoutUseCase.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultLogoutUseCase.kt
@@ -2,7 +2,9 @@ package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
 
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultLogoutUseCase(
     private val apiConfigurationRepository: ApiConfigurationRepository,
     private val accountRepository: AccountRepository,

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultSetupAccountUseCase.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultSetupAccountUseCase.kt
@@ -7,7 +7,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Sett
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultSetupAccountUseCase(
     private val accountRepository: AccountRepository,
     private val settingsRepository: SettingsRepository,

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultSwitchAccountUseCase.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultSwitchAccountUseCase.kt
@@ -2,7 +2,9 @@ package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
 
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultSwitchAccountUseCase(
     private val accountRepository: AccountRepository,
 ) : SwitchAccountUseCase {

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
@@ -1,100 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di
 
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.ActiveAccountMonitor
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.ContentPreloadManager
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultActiveAccountMonitor
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultContentPreloadManager
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultDeleteAccountUseCase
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultEntryActionRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultExportSettingsUseCase
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultImportSettingsUseCase
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultLoginUseCase
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultLogoutUseCase
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultSetupAccountUseCase
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DefaultSwitchAccountUseCase
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.DeleteAccountUseCase
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.EntryActionRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.ExportSettingsUseCase
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.ImportSettingsUseCase
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.LoginUseCase
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.LogoutUseCase
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.SetupAccountUseCase
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.SwitchAccountUseCase
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val domainIdentityUseCaseModule =
-    module {
-        single<SetupAccountUseCase> {
-            DefaultSetupAccountUseCase(
-                accountRepository = get(),
-                settingsRepository = get(),
-            )
-        }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase")
+internal class IdentityUseCaseModule
 
-        single<LoginUseCase> {
-            DefaultLoginUseCase(
-                credentialsRepository = get(),
-                apiConfigurationRepository = get(),
-                accountRepository = get(),
-                settingsRepository = get(),
-                accountCredentialsCache = get(),
-                supportedFeatureRepository = get(),
-            )
-        }
-
-        single<LogoutUseCase> {
-            DefaultLogoutUseCase(
-                apiConfigurationRepository = get(),
-                accountRepository = get(),
-            )
-        }
-        single<SwitchAccountUseCase> {
-            DefaultSwitchAccountUseCase(
-                accountRepository = get(),
-            )
-        }
-        single<DeleteAccountUseCase> {
-            DefaultDeleteAccountUseCase(
-                accountRepository = get(),
-                settingsRepository = get(),
-                accountCredentialsCache = get(),
-            )
-        }
-        single<ActiveAccountMonitor> {
-            DefaultActiveAccountMonitor(
-                accountRepository = get(),
-                apiConfigurationRepository = get(),
-                identityRepository = get(),
-                settingsRepository = get(),
-                accountCredentialsCache = get(),
-                supportedFeatureRepository = get(),
-                contentPreloadManager = get(),
-                markerRepository = get(),
-                notificationCoordinator = get(),
-                announcementsManager = get(),
-            )
-        }
-        single<EntryActionRepository> {
-            DefaultEntryActionRepository(
-                identityRepository = get(),
-                supportedFeatureRepository = get(),
-            )
-        }
-        single<ContentPreloadManager> {
-            DefaultContentPreloadManager(
-                timelineEntryRepository = get(),
-                trendingRepository = get(),
-                notificationRepository = get(),
-            )
-        }
-        single<ImportSettingsUseCase> {
-            DefaultImportSettingsUseCase(
-                settingsRepository = get(),
-            )
-        }
-        single<ExportSettingsUseCase> {
-            DefaultExportSettingsUseCase(
-                settingsRepository = get(),
-            )
-        }
-    }
+val domainIdentityUseCaseModule = IdentityUseCaseModule().module

--- a/domain/pullnotifications/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pullnotifications/DefaultPullNotificationManager.kt
+++ b/domain/pullnotifications/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pullnotifications/DefaultPullNotificationManager.kt
@@ -19,4 +19,8 @@ class DefaultPullNotificationManager : PullNotificationManager {
     override fun cancelAll() {
         // NO-OP
     }
+
+    override fun oneshotCheck() {
+        // NO-OP
+    }
 }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR migrates subprojects inside :domain:identity to Koin Annotations.

