### PR TITLE
refactor(di): migrate to Koin annotations • 4

### DIFF
--- a/core/api/build.gradle.kts
+++ b/core/api/build.gradle.kts
@@ -51,7 +51,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.core.api"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/core/appearance/build.gradle.kts
+++ b/core/appearance/build.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.core.appearance"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/core/architecture/build.gradle.kts
+++ b/core/architecture/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.core.architecture"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/core/commonui/components/build.gradle.kts
+++ b/core/commonui/components/build.gradle.kts
@@ -55,7 +55,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.core.commonui.components"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/core/commonui/content/build.gradle.kts
+++ b/core/commonui/content/build.gradle.kts
@@ -56,7 +56,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.core.commonui.content"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/core/htmlparse/build.gradle.kts
+++ b/core/htmlparse/build.gradle.kts
@@ -44,7 +44,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.core.htmlparse"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/core/l10n/build.gradle.kts
+++ b/core/l10n/build.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.core.commonui.l10n"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/core/navigation/build.gradle.kts
+++ b/core/navigation/build.gradle.kts
@@ -68,7 +68,7 @@ dependencies {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.core.navigation"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/core/notifications/build.gradle.kts
+++ b/core/notifications/build.gradle.kts
@@ -63,7 +63,7 @@ dependencies {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.core.notifications"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/core/persistence/build.gradle.kts
+++ b/core/persistence/build.gradle.kts
@@ -52,7 +52,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.core.persistence"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/core/preferences/build.gradle.kts
+++ b/core/preferences/build.gradle.kts
@@ -65,7 +65,7 @@ dependencies {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.core.preferences"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/core/resources/build.gradle.kts
+++ b/core/resources/build.gradle.kts
@@ -44,7 +44,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.core.resources"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/core/testutils/build.gradle.kts
+++ b/core/testutils/build.gradle.kts
@@ -38,7 +38,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.core.testutils"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/core/utils/build.gradle.kts
+++ b/core/utils/build.gradle.kts
@@ -84,7 +84,7 @@ dependencies {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.core.utils"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/domain/content/data/build.gradle.kts
+++ b/domain/content/data/build.gradle.kts
@@ -45,7 +45,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.domain.content.data"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/domain/content/pagination/build.gradle.kts
+++ b/domain/content/pagination/build.gradle.kts
@@ -64,7 +64,7 @@ dependencies {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.domain.content.pagination"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/domain/content/repository/build.gradle.kts
+++ b/domain/content/repository/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.domain.content.repository"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/domain/content/usecase/build.gradle.kts
+++ b/domain/content/usecase/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.domain.content.usecase"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/domain/identity/data/build.gradle.kts
+++ b/domain/identity/data/build.gradle.kts
@@ -42,7 +42,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.domain.identity.data"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/domain/identity/repository/build.gradle.kts
+++ b/domain/identity/repository/build.gradle.kts
@@ -70,7 +70,7 @@ dependencies {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.domain.identity.repository"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/domain/identity/usecase/build.gradle.kts
+++ b/domain/identity/usecase/build.gradle.kts
@@ -81,7 +81,7 @@ dependencies {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitor.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitor.kt
@@ -13,7 +13,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Acco
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.NotificationCoordinator
+import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.coordinator.NotificationCoordinator
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers

--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitorTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitorTest.kt
@@ -12,7 +12,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiC
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiCredentials
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.NotificationCoordinator
+import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.coordinator.NotificationCoordinator
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.every

--- a/domain/pullnotifications/build.gradle.kts
+++ b/domain/pullnotifications/build.gradle.kts
@@ -1,14 +1,14 @@
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
-@OptIn(ExperimentalKotlinGradlePluginApi::class)
 kotlin {
     applyDefaultHierarchyTemplate()
     androidTarget {
@@ -39,6 +39,7 @@ kotlin {
                 implementation(compose.runtime)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
 
                 implementation(projects.core.appearance)
                 implementation(projects.core.l10n)
@@ -56,10 +57,18 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {
@@ -67,5 +76,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/domain/pullnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pullnotifications/DefaultPullNotificationManager.kt
+++ b/domain/pullnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pullnotifications/DefaultPullNotificationManager.kt
@@ -11,8 +11,10 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.OutOfQuotaPolicy
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
+import org.koin.core.annotation.Single
 import java.util.concurrent.TimeUnit
 
+@Single
 class DefaultPullNotificationManager(
     private val context: Context,
 ) : PullNotificationManager {

--- a/domain/pullnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pullnotifications/di/Utils.kt
+++ b/domain/pullnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pullnotifications/di/Utils.kt
@@ -1,14 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications.di
 
-import com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications.DefaultPullNotificationManager
-import com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications.PullNotificationManager
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-actual val pullNotificationsNativeModule =
-    module {
-        single<PullNotificationManager> {
-            DefaultPullNotificationManager(
-                context = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications")
+internal class PullNotificationsModule
+
+internal actual val nativePullNotificationsModule = PullNotificationsModule().module

--- a/domain/pullnotifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pullnotifications/di/PullNotificationModule.kt
+++ b/domain/pullnotifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pullnotifications/di/PullNotificationModule.kt
@@ -4,5 +4,5 @@ import org.koin.dsl.module
 
 val domainPullNotificationModule =
     module {
-        includes(pullNotificationsNativeModule)
+        includes(nativePullNotificationsModule)
     }

--- a/domain/pullnotifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pullnotifications/di/Utils.kt
+++ b/domain/pullnotifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pullnotifications/di/Utils.kt
@@ -2,4 +2,4 @@ package com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications.di
 
 import org.koin.core.module.Module
 
-internal expect val pullNotificationsNativeModule: Module
+internal expect val nativePullNotificationsModule: Module

--- a/domain/pullnotifications/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pullnotifications/DefaultPullNotificationManager.kt
+++ b/domain/pullnotifications/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pullnotifications/DefaultPullNotificationManager.kt
@@ -1,5 +1,8 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications
 
+import org.koin.core.annotation.Single
+
+@Single
 class DefaultPullNotificationManager : PullNotificationManager {
     override val isSupported = false
     override val isBackgroundRestricted = false

--- a/domain/pullnotifications/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pullnotifications/di/Utils.kt
+++ b/domain/pullnotifications/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pullnotifications/di/Utils.kt
@@ -2,9 +2,15 @@ package com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications.di
 
 import com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications.DefaultPullNotificationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications.PullNotificationManager
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
 import org.koin.dsl.module
 
-actual val pullNotificationsNativeModule =
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications")
+internal class NativePullNotificationsModule
+
+internal actual val nativePullNotificationsModule =
     module {
         single<PullNotificationManager> {
             DefaultPullNotificationManager()

--- a/domain/pushnotifications/build.gradle.kts
+++ b/domain/pushnotifications/build.gradle.kts
@@ -1,16 +1,16 @@
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
-    alias(libs.plugins.mokkery)
     alias(libs.plugins.kotlinx.kover)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.mokkery)
 }
 
-@OptIn(ExperimentalKotlinGradlePluginApi::class)
 kotlin {
     applyDefaultHierarchyTemplate()
     androidTarget {
@@ -41,6 +41,7 @@ kotlin {
                 implementation(compose.runtime)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.ktor.client.core)
 
                 implementation(projects.core.api)
@@ -66,10 +67,18 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {
@@ -77,5 +86,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/domain/pushnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/di/Utils.kt
+++ b/domain/pushnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/di/Utils.kt
@@ -1,16 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.di
 
-import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.DefaultPushNotificationManager
-import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.PushNotificationManager
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-actual val nativePushNotificationsModule =
-    module {
-        single<PushNotificationManager> {
-            DefaultPushNotificationManager(
-                context = get(),
-                pushNotificationRepository = get(),
-                accountRepository = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.impl")
+internal class NativePushNotificationsModule
+
+internal actual val nativePushNotificationsModule = NativePushNotificationsModule().module

--- a/domain/pushnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/impl/DefaultPushNotificationManager.kt
+++ b/domain/pushnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/impl/DefaultPushNotificationManager.kt
@@ -1,4 +1,4 @@
-package com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications
+package com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.impl
 
 import android.app.NotificationManager
 import android.content.Context
@@ -7,14 +7,18 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.Notificatio
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.PushNotificationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.PushNotificationManager
+import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.PushNotificationManagerState
 import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.utils.CryptoUtil
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Single
 import org.unifiedpush.android.connector.UnifiedPush
 
+@Single
 internal class DefaultPushNotificationManager(
     private val context: Context,
     private val pushNotificationRepository: PushNotificationRepository,

--- a/domain/pushnotifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/coordinator/DefaultNotificationCoordinator.kt
+++ b/domain/pushnotifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/coordinator/DefaultNotificationCoordinator.kt
@@ -1,9 +1,10 @@
-package com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications
+package com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.coordinator
 
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.InboxManager
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.NotificationMode
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications.PullNotificationManager
+import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.PushNotificationManager
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -14,7 +15,9 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultNotificationCoordinator(
     private val settingsRepository: SettingsRepository,
     private val inboxManager: InboxManager,

--- a/domain/pushnotifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/coordinator/NotificationCoordinator.kt
+++ b/domain/pushnotifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/coordinator/NotificationCoordinator.kt
@@ -1,4 +1,4 @@
-package com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications
+package com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.coordinator
 
 interface NotificationCoordinator {
     suspend fun setupAnonymousUser()

--- a/domain/pushnotifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/di/PushNotificationsModule.kt
+++ b/domain/pushnotifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/di/PushNotificationsModule.kt
@@ -1,19 +1,18 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.di
 
-import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.DefaultNotificationCoordinator
-import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.NotificationCoordinator
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
 import org.koin.dsl.module
+import org.koin.ksp.generated.module
+
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.coordinator")
+internal class PushNotificationsModule
 
 val domainPushNotificationsModule =
     module {
-        includes(nativePushNotificationsModule)
-
-        single<NotificationCoordinator> {
-            DefaultNotificationCoordinator(
-                settingsRepository = get(),
-                inboxManager = get(),
-                pullNotificationManager = get(),
-                pushNotificationManager = get(),
-            )
-        }
+        includes(
+            nativePushNotificationsModule,
+            PushNotificationsModule().module,
+        )
     }

--- a/domain/pushnotifications/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/DefaultNotificationCoordinatorTest.kt
+++ b/domain/pushnotifications/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/DefaultNotificationCoordinatorTest.kt
@@ -5,6 +5,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.Notificati
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications.PullNotificationManager
+import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.coordinator.DefaultNotificationCoordinator
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.every

--- a/domain/pushnotifications/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/di/Utils.kt
+++ b/domain/pushnotifications/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/di/Utils.kt
@@ -1,8 +1,14 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.di
 
-import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.DefaultPushNotificationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.PushNotificationManager
+import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.impl.DefaultPushNotificationManager
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
 import org.koin.dsl.module
+
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.impl")
+internal class NativePushNotificationsModule
 
 actual val nativePushNotificationsModule =
     module {

--- a/domain/pushnotifications/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/impl/DefaultPushNotificationManager.kt
+++ b/domain/pushnotifications/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/impl/DefaultPushNotificationManager.kt
@@ -1,8 +1,12 @@
-package com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications
+package com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.impl
 
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
+import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.PushNotificationManager
+import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.PushNotificationManagerState
 import kotlinx.coroutines.flow.MutableStateFlow
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultPushNotificationManager : PushNotificationManager {
     override val state =
         MutableStateFlow<PushNotificationManagerState>(PushNotificationManagerState.Unsupported)

--- a/domain/urlhandler/build.gradle.kts
+++ b/domain/urlhandler/build.gradle.kts
@@ -1,13 +1,15 @@
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
-    alias(libs.plugins.mokkery)
     alias(libs.plugins.kotlinx.kover)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.mokkery)
 }
 
 @OptIn(ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.runtime)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
 
                 implementation(projects.core.appearance)
                 implementation(projects.core.l10n)
@@ -60,10 +63,18 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.domain.urlhandler"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {
@@ -71,5 +82,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/DefaultCustomUriHandler.kt
+++ b/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/DefaultCustomUriHandler.kt
@@ -14,9 +14,12 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.InjectedParam
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultCustomUriHandler(
-    private val defaultHandler: UriHandler,
+    @InjectedParam private val defaultHandler: UriHandler,
     private val customTabsHelper: CustomTabsHelper,
     private val settingsRepository: SettingsRepository,
     private val detailOpener: DetailOpener,

--- a/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/di/UrlHandlerModule.kt
+++ b/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/di/UrlHandlerModule.kt
@@ -1,57 +1,16 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.di
 
-import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.CustomUriHandler
-import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.DefaultCustomUriHandler
-import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor.DefaultEntryProcessor
-import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor.DefaultFetchEntryUseCase
-import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor.DefaultFetchUserUseCase
-import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor.DefaultHashtagProcessor
-import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor.DefaultUserProcessor
-import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor.EntryProcessor
-import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor.FetchEntryUseCase
-import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor.FetchUserUseCase
-import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor.HashtagProcessor
-import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor.UserProcessor
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
 import org.koin.dsl.module
+import org.koin.ksp.generated.module
 
-val domainUrlHandlerModule =
-    module {
-        single<FetchUserUseCase> {
-            DefaultFetchUserUseCase(
-                searchRepository = get(),
-            )
-        }
-        single<FetchEntryUseCase> {
-            DefaultFetchEntryUseCase(
-                searchRepository = get(),
-            )
-        }
-        single<HashtagProcessor> {
-            DefaultHashtagProcessor(
-                detailOpener = get(),
-            )
-        }
-        single<UserProcessor> {
-            DefaultUserProcessor(
-                detailOpener = get(),
-                fetchUser = get(),
-            )
-        }
-        single<EntryProcessor> {
-            DefaultEntryProcessor(
-                detailOpener = get(),
-                fetchEntry = get(),
-            )
-        }
-        single<CustomUriHandler> { params ->
-            DefaultCustomUriHandler(
-                defaultHandler = params[0],
-                customTabsHelper = get(),
-                settingsRepository = get(),
-                detailOpener = get(),
-                hashtagProcessor = get(),
-                userProcessor = get(),
-                entryProcessor = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor")
+internal class UrlHandlerProcessorModule
+
+@Module(includes = [UrlHandlerProcessorModule::class])
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.domain.urlhandler")
+internal class UrlHandlerModule
+
+val domainUrlHandlerModule = UrlHandlerModule().module

--- a/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/DefaultFetchEntryUseCase.kt
+++ b/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/DefaultFetchEntryUseCase.kt
@@ -5,7 +5,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.SearchResul
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SearchRepository
 import kotlinx.coroutines.withTimeoutOrNull
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultFetchEntryUseCase(
     private val searchRepository: SearchRepository,
 ) : FetchEntryUseCase {

--- a/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/DefaultFetchUserUseCase.kt
+++ b/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/DefaultFetchUserUseCase.kt
@@ -5,7 +5,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.SearchResul
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SearchRepository
 import kotlinx.coroutines.withTimeoutOrNull
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultFetchUserUseCase(
     private val searchRepository: SearchRepository,
 ) : FetchUserUseCase {

--- a/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/EntryProcessor.kt
+++ b/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/EntryProcessor.kt
@@ -1,9 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor
 
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
+import org.koin.core.annotation.Single
 
 internal interface EntryProcessor : UrlProcessor
 
+@Single
 internal class DefaultEntryProcessor(
     private val detailOpener: DetailOpener,
     private val fetchEntry: FetchEntryUseCase,

--- a/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/HashtagProcessor.kt
+++ b/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/HashtagProcessor.kt
@@ -3,9 +3,11 @@ package com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
 import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor.UriHandlerConstants.DETAIL_FRAGMENT
 import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor.UriHandlerConstants.INSTANCE_FRAGMENT
+import org.koin.core.annotation.Single
 
 internal interface HashtagProcessor : UrlProcessor
 
+@Single
 internal class DefaultHashtagProcessor(
     private val detailOpener: DetailOpener,
 ) : HashtagProcessor {

--- a/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/UserProcessor.kt
+++ b/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/UserProcessor.kt
@@ -1,9 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor
 
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
+import org.koin.core.annotation.Single
 
 internal interface UserProcessor : UrlProcessor
 
+@Single
 internal class DefaultUserProcessor(
     private val detailOpener: DetailOpener,
     private val fetchUser: FetchUserUseCase,

--- a/feature/announcements/build.gradle.kts
+++ b/feature/announcements/build.gradle.kts
@@ -60,7 +60,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.announcements"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/feature/calendar/build.gradle.kts
+++ b/feature/calendar/build.gradle.kts
@@ -61,7 +61,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.calendar"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/feature/circles/build.gradle.kts
+++ b/feature/circles/build.gradle.kts
@@ -63,7 +63,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.circles"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/feature/composer/build.gradle.kts
+++ b/feature/composer/build.gradle.kts
@@ -64,7 +64,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.composer"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/feature/directmessages/build.gradle.kts
+++ b/feature/directmessages/build.gradle.kts
@@ -62,7 +62,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.directmessages"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/feature/drawer/build.gradle.kts
+++ b/feature/drawer/build.gradle.kts
@@ -61,7 +61,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.drawer"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/feature/entrydetail/build.gradle.kts
+++ b/feature/entrydetail/build.gradle.kts
@@ -61,7 +61,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.entrydetail"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/feature/explore/build.gradle.kts
+++ b/feature/explore/build.gradle.kts
@@ -63,7 +63,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.explore"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/feature/favorites/build.gradle.kts
+++ b/feature/favorites/build.gradle.kts
@@ -63,7 +63,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.favorites"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/feature/followrequests/build.gradle.kts
+++ b/feature/followrequests/build.gradle.kts
@@ -62,7 +62,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.followrequests"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/feature/gallery/build.gradle.kts
+++ b/feature/gallery/build.gradle.kts
@@ -62,7 +62,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.gallery"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/feature/hashtag/build.gradle.kts
+++ b/feature/hashtag/build.gradle.kts
@@ -63,7 +63,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.hashtag"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/feature/imagedetail/build.gradle.kts
+++ b/feature/imagedetail/build.gradle.kts
@@ -53,7 +53,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.imagedetail"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/feature/inbox/build.gradle.kts
+++ b/feature/inbox/build.gradle.kts
@@ -63,7 +63,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.inbox"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/feature/licences/build.gradle.kts
+++ b/feature/licences/build.gradle.kts
@@ -57,7 +57,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.licences"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/feature/login/build.gradle.kts
+++ b/feature/login/build.gradle.kts
@@ -58,7 +58,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.login"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/feature/manageblocks/build.gradle.kts
+++ b/feature/manageblocks/build.gradle.kts
@@ -61,7 +61,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.manageblocks"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/feature/nodeinfo/build.gradle.kts
+++ b/feature/nodeinfo/build.gradle.kts
@@ -92,7 +92,7 @@ dependencies {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.nodeinfo"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/feature/profile/build.gradle.kts
+++ b/feature/profile/build.gradle.kts
@@ -64,7 +64,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.profile"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/feature/report/build.gradle.kts
+++ b/feature/report/build.gradle.kts
@@ -59,7 +59,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.report"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/feature/search/build.gradle.kts
+++ b/feature/search/build.gradle.kts
@@ -63,7 +63,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.search"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -64,7 +64,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.settings"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/feature/thread/build.gradle.kts
+++ b/feature/thread/build.gradle.kts
@@ -61,7 +61,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.thread"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/feature/timeline/build.gradle.kts
+++ b/feature/timeline/build.gradle.kts
@@ -63,7 +63,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.timeline"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/feature/unpublished/build.gradle.kts
+++ b/feature/unpublished/build.gradle.kts
@@ -62,7 +62,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.unpublished"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/feature/userdetail/build.gradle.kts
+++ b/feature/userdetail/build.gradle.kts
@@ -62,7 +62,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.userdetail"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {

--- a/feature/userlist/build.gradle.kts
+++ b/feature/userlist/build.gradle.kts
@@ -62,7 +62,7 @@ kotlin {
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.userlist"
     compileSdk =
-        libs.versions.android.targetSdk
+        libs.versions.android.compileSdk
             .get()
             .toInt()
     defaultConfig {


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR migrates `:domain:pullnotifications`, `:domain:pushnotifications` and `:domain:urlhandler` to Koin annotations.

## Additional notes
<!-- Anything to declare for code review? -->
The `compileSdk` value in many subprojects was assigned the value of `targetSdk` read from TOML. This is fixed so that, even if the two values diverge in the future, modules are configured correctly.