### PR TITLE
refactor(di): migrate to Koin annotations • 5

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,12 +1,14 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
-    alias(libs.plugins.mokkery)
     alias(libs.plugins.kotlinx.kover)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.mokkery)
 }
 
 kotlin {
@@ -196,6 +198,12 @@ android {
 }
 
 dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+
     kover(projects.core.appearance)
     kover(projects.core.navigation)
     kover(projects.core.notifications)
@@ -209,6 +217,16 @@ dependencies {
     kover(projects.domain.pushnotifications)
     kover(projects.domain.urlhandler)
     kover(projects.feature.nodeinfo)
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
+    }
 }
 
 kover {

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/auth/DefaultAuthManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/auth/DefaultAuthManager.kt
@@ -15,7 +15,9 @@ import io.ktor.http.URLProtocol
 import io.ktor.http.Url
 import io.ktor.http.path
 import kotlinx.coroutines.flow.MutableSharedFlow
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultAuthManager(
     private val navigationCoordinator: NavigationCoordinator,
     private val credentialsRepository: CredentialsRepository,

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/CoreResourcesModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/CoreResourcesModule.kt
@@ -1,12 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.di
 
-import com.livefast.eattrash.raccoonforfriendica.core.resources.CoreResources
-import com.livefast.eattrash.raccoonforfriendica.resources.SharedResources
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-internal val coreResourceModule =
-    module {
-        single<CoreResources> {
-            SharedResources()
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.resources")
+internal class ResourceModule
+
+internal val coreResourceModule = ResourceModule().module

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/SharedModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/SharedModule.kt
@@ -1,36 +1,25 @@
 package com.livefast.eattrash.raccoonforfriendica.di
 
-import com.livefast.eattrash.raccoonforfriendica.auth.DefaultAuthManager
-import com.livefast.eattrash.raccoonforfriendica.core.navigation.DetailOpener
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AuthManager
-import com.livefast.eattrash.raccoonforfriendica.main.MainMviModel
-import com.livefast.eattrash.raccoonforfriendica.main.MainViewModel
-import com.livefast.eattrash.raccoonforfriendica.navigation.DefaultDetailOpener
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
 import org.koin.dsl.module
+import org.koin.ksp.generated.module
+
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.main")
+internal class MainModule
+
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.navigation")
+internal class NavigationModule
+
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.auth")
+internal class AuthModule
 
 internal val sharedModule =
     module {
-        factory<MainMviModel> {
-            MainViewModel(
-                inboxManager = get(),
-            )
-        }
-        single<DetailOpener> {
-            DefaultDetailOpener(
-                navigationCoordinator = get(),
-                identityRepository = get(),
-                userCache = get(),
-                settingsRepository = get(),
-                entryCache = get(),
-                eventCache = get(),
-                circleCache = get(),
-            )
-        }
-        single<AuthManager> {
-            DefaultAuthManager(
-                navigationCoordinator = get(),
-                credentialsRepository = get(),
-                keyStore = get(),
-            )
-        }
+        includes(MainModule().module)
+        includes(NavigationModule().module)
+        includes(AuthModule().module)
     }

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/main/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/main/MainViewModel.kt
@@ -7,7 +7,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Inbox
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
 
+@Factory(binds = [MainMviModel::class])
 class MainViewModel(
     private val inboxManager: InboxManager,
 ) : DefaultMviModel<MainMviModel.Intent, MainMviModel.UiState, MainMviModel.Effect>(

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
@@ -50,7 +50,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Single
 
+@Single
 class DefaultDetailOpener(
     private val navigationCoordinator: NavigationCoordinator,
     private val identityRepository: IdentityRepository,

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/resources/SharedResources.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/resources/SharedResources.kt
@@ -11,6 +11,7 @@ import chaintech.videoplayer.model.ScreenResize
 import com.livefast.eattrash.raccoonforfriendica.core.resources.CoreResources
 import org.jetbrains.compose.resources.Font
 import org.jetbrains.compose.resources.painterResource
+import org.koin.core.annotation.Single
 import raccoonforfriendica.composeapp.generated.resources.Res
 import raccoonforfriendica.composeapp.generated.resources.atkinsonhyperlegible_bold
 import raccoonforfriendica.composeapp.generated.resources.atkinsonhyperlegible_italic
@@ -28,6 +29,7 @@ import raccoonforfriendica.composeapp.generated.resources.notosans_italic
 import raccoonforfriendica.composeapp.generated.resources.notosans_medium
 import raccoonforfriendica.composeapp.generated.resources.notosans_regular
 
+@Single
 internal class SharedResources : CoreResources {
     override val atkinsonHyperlegible: FontFamily
         @Composable

--- a/core/notifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/notifications/di/NotificationsModule.kt
+++ b/core/notifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/notifications/di/NotificationsModule.kt
@@ -6,6 +6,6 @@ import org.koin.ksp.generated.module
 
 @Module
 @ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.notifications")
-class NotificationsModule
+internal class NotificationsModule
 
 val coreNotificationsModule = NotificationsModule().module

--- a/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/di/PreferencesModule.kt
+++ b/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/di/PreferencesModule.kt
@@ -7,7 +7,7 @@ import org.koin.ksp.generated.module
 
 @Module
 @ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.preferences")
-class PreferencesModule
+internal class PreferencesModule
 
 val corePreferencesModule =
     module {

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/UtilsModule.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/UtilsModule.kt
@@ -7,11 +7,11 @@ import org.koin.ksp.generated.module
 
 @Module
 @ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.utils.imageload")
-class ImageLoadModule
+internal class ImageLoadModule
 
 @Module
 @ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.utils.network")
-class NetworkStateModule
+internal class NetworkStateModule
 
 val coreUtilsModule =
     module {

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
@@ -2,7 +2,6 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.di
 
 import org.koin.core.annotation.ComponentScan
 import org.koin.core.annotation.Module
-import org.koin.dsl.module
 import org.koin.ksp.generated.module
 
 @Module

--- a/feature/announcements/build.gradle.kts
+++ b/feature/announcements/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.navigator)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.koin)
@@ -57,6 +60,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.announcements"
     compileSdk =
@@ -68,5 +79,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/announcements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/announcements/AnnouncementsViewModel.kt
+++ b/feature/announcements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/announcements/AnnouncementsViewModel.kt
@@ -12,7 +12,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Sett
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
 
+@Factory(binds = [AnnouncementsMviModel::class])
 class AnnouncementsViewModel(
     private val identityRepository: IdentityRepository,
     private val settingsRepository: SettingsRepository,

--- a/feature/announcements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/announcements/di/AnnouncementsModule.kt
+++ b/feature/announcements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/announcements/di/AnnouncementsModule.kt
@@ -1,19 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.announcements.di
 
-import com.livefast.eattrash.raccoonforfriendica.feature.announcements.AnnouncementsMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.announcements.AnnouncementsViewModel
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureAnnouncementsModule =
-    module {
-        factory<AnnouncementsMviModel> {
-            AnnouncementsViewModel(
-                identityRepository = get(),
-                settingsRepository = get(),
-                announcementRepository = get(),
-                emojiRepository = get(),
-                announcementsManager = get(),
-                imageAutoloadObserver = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.feature.announcements")
+internal class AnnouncementsModule
+
+val featureAnnouncementsModule = AnnouncementsModule().module

--- a/feature/calendar/build.gradle.kts
+++ b/feature/calendar/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.navigator)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.koin)
@@ -58,6 +61,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.calendar"
     compileSdk =
@@ -69,5 +80,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/detail/EventDetailViewModel.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/detail/EventDetailViewModel.kt
@@ -8,9 +8,12 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Sett
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
+import org.koin.core.annotation.InjectedParam
 
+@Factory(binds = [EventDetailMviModel::class])
 class EventDetailViewModel(
-    eventId: String,
+    @InjectedParam eventId: String,
     eventCache: LocalItemCache<EventModel>,
     private val settingsRepository: SettingsRepository,
 ) : DefaultMviModel<EventDetailMviModel.Intent, EventDetailMviModel.State, EventDetailMviModel.Effect>(

--- a/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/di/CalendarModule.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/di/CalendarModule.kt
@@ -1,25 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.calendar.di
 
-import com.livefast.eattrash.raccoonforfriendica.feature.calendar.detail.EventDetailMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.calendar.detail.EventDetailViewModel
-import com.livefast.eattrash.raccoonforfriendica.feature.calendar.list.CalendarMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.calendar.list.CalendarViewModel
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureCalendarModule =
-    module {
-        factory<CalendarMviModel> {
-            CalendarViewModel(
-                identityRepository = get(),
-                settingsRepository = get(),
-                paginationManager = get(),
-            )
-        }
-        factory<EventDetailMviModel> {
-            EventDetailViewModel(
-                eventId = it[0],
-                eventCache = get(),
-                settingsRepository = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.feature.calendar")
+internal class CalendarModule
+
+val featureCalendarModule = CalendarModule().module

--- a/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/list/CalendarViewModel.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/list/CalendarViewModel.kt
@@ -11,7 +11,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Sett
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
 
+@Factory(binds = [CalendarMviModel::class])
 class CalendarViewModel(
     private val identityRepository: IdentityRepository,
     private val settingsRepository: SettingsRepository,

--- a/feature/circles/build.gradle.kts
+++ b/feature/circles/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.navigator)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.koin)
@@ -60,6 +63,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.circles"
     compileSdk =
@@ -71,5 +82,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/di/CirclesModule.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/di/CirclesModule.kt
@@ -1,47 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.circles.di
 
-import com.livefast.eattrash.raccoonforfriendica.feature.circles.editmembers.CircleMembersMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.circles.editmembers.CircleMembersViewModel
-import com.livefast.eattrash.raccoonforfriendica.feature.circles.list.CirclesMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.circles.list.CirclesViewModel
-import com.livefast.eattrash.raccoonforfriendica.feature.circles.timeline.CircleTimelineMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.circles.timeline.CircleTimelineViewModel
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureCirclesModule =
-    module {
-        factory<CirclesMviModel> {
-            CirclesViewModel(
-                circlesRepository = get(),
-                settingsRepository = get(),
-                userRepository = get(),
-            )
-        }
-        factory<CircleMembersMviModel> { params ->
-            CircleMembersViewModel(
-                id = params[0],
-                paginationManager = get(),
-                circlesRepository = get(),
-                settingsRepository = get(),
-                searchPaginationManager = get(),
-                imagePreloadManager = get(),
-                imageAutoloadObserver = get(),
-            )
-        }
-        factory<CircleTimelineMviModel> { param ->
-            CircleTimelineViewModel(
-                id = param[0],
-                paginationManager = get(),
-                identityRepository = get(),
-                timelineEntryRepository = get(),
-                settingsRepository = get(),
-                circleCache = get(),
-                userRepository = get(),
-                hapticFeedback = get(),
-                notificationCenter = get(),
-                imagePreloadManager = get(),
-                blurHashRepository = get(),
-                imageAutoloadObserver = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.feature.circles")
+internal class CirclesModule
+
+val featureCirclesModule = CirclesModule().module

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/editmembers/CircleMembersViewModel.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/editmembers/CircleMembersViewModel.kt
@@ -18,10 +18,13 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.yield
+import org.koin.core.annotation.Factory
+import org.koin.core.annotation.InjectedParam
 
+@Factory(binds = [CircleMembersMviModel::class])
 @OptIn(FlowPreview::class)
 class CircleMembersViewModel(
-    private val id: String,
+    @InjectedParam private val id: String,
     private val paginationManager: UserPaginationManager,
     private val circlesRepository: CirclesRepository,
     private val settingsRepository: SettingsRepository,

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/list/CirclesViewModel.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/list/CirclesViewModel.kt
@@ -12,7 +12,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Sett
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
 
+@Factory(binds = [CirclesMviModel::class])
 class CirclesViewModel(
     private val circlesRepository: CirclesRepository,
     private val settingsRepository: SettingsRepository,

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineViewModel.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineViewModel.kt
@@ -26,10 +26,13 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Sett
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
+import org.koin.core.annotation.InjectedParam
 import kotlin.time.Duration
 
+@Factory(binds = [CircleTimelineMviModel::class])
 class CircleTimelineViewModel(
-    id: String,
+    @InjectedParam id: String,
     private val paginationManager: TimelinePaginationManager,
     private val identityRepository: IdentityRepository,
     private val timelineEntryRepository: TimelineEntryRepository,

--- a/feature/composer/build.gradle.kts
+++ b/feature/composer/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.navigator)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.koin)
@@ -61,6 +64,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.composer"
     compileSdk =
@@ -72,5 +83,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
@@ -56,13 +56,16 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
+import org.koin.core.annotation.InjectedParam
 import kotlin.time.Duration
 
 private const val PLACEHOLDER_ID = "placeholder"
 
+@Factory(binds = [ComposerMviModel::class])
 @OptIn(FlowPreview::class)
 class ComposerViewModel(
-    private val inReplyToId: String? = null,
+    @InjectedParam private val inReplyToId: String? = null,
     private val identityRepository: IdentityRepository,
     private val timelineEntryRepository: TimelineEntryRepository,
     private val photoRepository: PhotoRepository,

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/converters/DefaultBBCodeConverter.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/converters/DefaultBBCodeConverter.kt
@@ -4,7 +4,9 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.substituteAllOccurre
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.utils.ComposerRegexes
 import com.mohamedrejeb.ksoup.html.parser.KsoupHtmlHandler
 import com.mohamedrejeb.ksoup.html.parser.KsoupHtmlParser
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultBBCodeConverter : BBCodeConverter {
     override fun toHtml(value: String) =
         value

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/converters/DefaultMarkdownConverter.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/converters/DefaultMarkdownConverter.kt
@@ -2,7 +2,9 @@ package com.livefast.eattrash.raccoonforfriendica.feature.composer.converters
 
 import com.livefast.eattrash.raccoonforfriendica.core.utils.substituteAllOccurrences
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.utils.ComposerRegexes
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultMarkdownConverter : MarkdownConverter {
     override fun toHtml(value: String) =
         value

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/di/ComposerModule.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/di/ComposerModule.kt
@@ -1,60 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.composer.di
 
-import com.livefast.eattrash.raccoonforfriendica.feature.composer.ComposerMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.composer.ComposerViewModel
-import com.livefast.eattrash.raccoonforfriendica.feature.composer.converters.BBCodeConverter
-import com.livefast.eattrash.raccoonforfriendica.feature.composer.converters.DefaultBBCodeConverter
-import com.livefast.eattrash.raccoonforfriendica.feature.composer.converters.DefaultMarkdownConverter
-import com.livefast.eattrash.raccoonforfriendica.feature.composer.converters.MarkdownConverter
-import com.livefast.eattrash.raccoonforfriendica.feature.composer.usecase.DefaultPrepareForPreviewUseCase
-import com.livefast.eattrash.raccoonforfriendica.feature.composer.usecase.DefaultStripMarkupUseCase
-import com.livefast.eattrash.raccoonforfriendica.feature.composer.usecase.PrepareForPreviewUseCase
-import com.livefast.eattrash.raccoonforfriendica.feature.composer.usecase.StripMarkupUseCase
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureComposerModule =
-    module {
-        single<BBCodeConverter> {
-            DefaultBBCodeConverter()
-        }
-        single<MarkdownConverter> {
-            DefaultMarkdownConverter()
-        }
-        single<PrepareForPreviewUseCase> {
-            DefaultPrepareForPreviewUseCase(
-                apiConfigurationRepository = get(),
-                bbCodeConverter = get(),
-                markdownConverter = get(),
-            )
-        }
-        single<StripMarkupUseCase> {
-            DefaultStripMarkupUseCase(
-                prepareForPreview = get(),
-            )
-        }
-        factory<ComposerMviModel> { params ->
-            ComposerViewModel(
-                inReplyToId = params[0],
-                timelineEntryRepository = get(),
-                photoRepository = get(),
-                identityRepository = get(),
-                userPaginationManager = get(),
-                circlesRepository = get(),
-                nodeInfoRepository = get(),
-                supportedFeatureRepository = get(),
-                mediaRepository = get(),
-                albumRepository = get(),
-                albumPhotoPaginationManager = get(),
-                entryCache = get(),
-                scheduledEntryRepository = get(),
-                draftRepository = get(),
-                settingsRepository = get(),
-                emojiRepository = get(),
-                userRepository = get(),
-                prepareForPreview = get(),
-                stripMarkup = get(),
-                notificationCenter = get(),
-                bbCodeConverter = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.feature.composer")
+internal class ComposerModule
+
+val featureComposerModule = ComposerModule().module

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/usecase/DefaultPrepareForPreviewUseCase.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/usecase/DefaultPrepareForPreviewUseCase.kt
@@ -8,7 +8,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiC
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.converters.BBCodeConverter
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.converters.MarkdownConverter
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.utils.ComposerRegexes
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultPrepareForPreviewUseCase(
     private val apiConfigurationRepository: ApiConfigurationRepository,
     private val bbCodeConverter: BBCodeConverter,

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/usecase/DefaultStripMarkupUseCase.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/usecase/DefaultStripMarkupUseCase.kt
@@ -3,7 +3,9 @@ package com.livefast.eattrash.raccoonforfriendica.feature.composer.usecase
 import androidx.compose.ui.graphics.Color
 import com.livefast.eattrash.raccoonforfriendica.core.htmlparse.parseHtml
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.MarkupMode
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultStripMarkupUseCase(
     private val prepareForPreview: PrepareForPreviewUseCase,
 ) : StripMarkupUseCase {

--- a/feature/directmessages/build.gradle.kts
+++ b/feature/directmessages/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.navigator)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.koin)
@@ -59,6 +62,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.directmessages"
     compileSdk =
@@ -70,5 +81,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationViewModel.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationViewModel.kt
@@ -21,12 +21,15 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
+import org.koin.core.annotation.InjectedParam
 
 private const val POLLING_INTERVAL = 1200L
 
+@Factory(binds = [ConversationMviModel::class])
 class ConversationViewModel(
-    private val otherUserId: String,
-    parentUri: String,
+    @InjectedParam private val otherUserId: String,
+    @InjectedParam parentUri: String,
     private val paginationManager: DirectMessagesPaginationManager,
     private val identityRepository: IdentityRepository,
     private val userRepository: UserRepository,

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/di/DirectMessagesModule.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/di/DirectMessagesModule.kt
@@ -1,32 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.directmessages.di
 
-import com.livefast.eattrash.raccoonforfriendica.feature.directmessages.detail.ConversationMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.directmessages.detail.ConversationViewModel
-import com.livefast.eattrash.raccoonforfriendica.feature.directmessages.list.DirectMessageListMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.directmessages.list.DirectMessageListViewModel
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureDirectMessagesModule =
-    module {
-        factory<DirectMessageListMviModel> {
-            DirectMessageListViewModel(
-                paginationManager = get(),
-                identityRepository = get(),
-                settingsRepository = get(),
-                userPaginationManager = get(),
-                imageAutoloadObserver = get(),
-            )
-        }
-        factory<ConversationMviModel> { params ->
-            ConversationViewModel(
-                otherUserId = params[0],
-                parentUri = params[1],
-                paginationManager = get(),
-                userRepository = get(),
-                identityRepository = get(),
-                messageRepository = get(),
-                userCache = get(),
-                imageAutoloadObserver = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.feature.directmessages")
+internal class DirectMessagesModule
+
+val featureDirectMessagesModule = DirectMessagesModule().module

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/list/DirectMessageListViewModel.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/list/DirectMessageListViewModel.kt
@@ -18,7 +18,9 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
 
+@Factory(binds = [DirectMessageListMviModel::class])
 @OptIn(FlowPreview::class)
 class DirectMessageListViewModel(
     private val paginationManager: DirectMessagesPaginationManager,

--- a/feature/drawer/build.gradle.kts
+++ b/feature/drawer/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.navigator)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.koin)
@@ -58,6 +61,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.drawer"
     compileSdk =
@@ -69,5 +80,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerViewModel.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerViewModel.kt
@@ -15,7 +15,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.SwitchA
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
 
+@Factory(binds = [DrawerMviModel::class])
 class DrawerViewModel(
     private val apiConfigurationRepository: ApiConfigurationRepository,
     private val identityRepository: IdentityRepository,

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/di/DrawerModule.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/di/DrawerModule.kt
@@ -1,21 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.drawer.di
 
-import com.livefast.eattrash.raccoonforfriendica.feature.drawer.DrawerMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.drawer.DrawerViewModel
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureDrawerModule =
-    module {
-        single<DrawerMviModel> {
-            DrawerViewModel(
-                apiConfigurationRepository = get(),
-                identityRepository = get(),
-                supportedFeatureRepository = get(),
-                credentialsRepository = get(),
-                accountRepository = get(),
-                switchAccountUseCase = get(),
-                emojiHelper = get(),
-                imageAutoloadObserver = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.feature.drawer")
+internal class DrawerModule
+
+val featureDrawerModule = DrawerModule().module

--- a/feature/entrydetail/build.gradle.kts
+++ b/feature/entrydetail/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.koin)
 
@@ -58,6 +61,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.entrydetail"
     compileSdk =
@@ -69,5 +80,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailViewModel.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailViewModel.kt
@@ -25,10 +25,13 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Sett
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
+import org.koin.core.annotation.InjectedParam
 import kotlin.time.Duration
 
+@Factory(binds = [EntryDetailMviModel::class])
 class EntryDetailViewModel(
-    private val id: String,
+    @InjectedParam private val id: String,
     private val timelineEntryRepository: TimelineEntryRepository,
     private val identityRepository: IdentityRepository,
     private val settingsRepository: SettingsRepository,

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/di/EntryDetailModule.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/di/EntryDetailModule.kt
@@ -1,26 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.entrydetail.di
 
-import com.livefast.eattrash.raccoonforfriendica.feature.entrydetail.EntryDetailMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.entrydetail.EntryDetailViewModel
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureEntryDetailModule =
-    module {
-        factory<EntryDetailMviModel> { params ->
-            EntryDetailViewModel(
-                id = params[0],
-                timelineEntryRepository = get(),
-                identityRepository = get(),
-                settingsRepository = get(),
-                userRepository = get(),
-                hapticFeedback = get(),
-                entryCache = get(),
-                notificationCenter = get(),
-                imagePreloadManager = get(),
-                blurHashRepository = get(),
-                emojiHelper = get(),
-                replyHelper = get(),
-                imageAutoloadObserver = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.feature.entrydetail")
+internal class EntryDetailModule
+
+val featureEntryDetailModule = EntryDetailModule().module

--- a/feature/explore/build.gradle.kts
+++ b/feature/explore/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.navigator)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.koin)
@@ -60,6 +63,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.explore"
     compileSdk =
@@ -71,5 +82,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreViewModel.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreViewModel.kt
@@ -28,8 +28,10 @@ import com.livefast.eattrash.raccoonforfriendica.feature.explore.data.ExploreSec
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
 import kotlin.time.Duration
 
+@Factory(binds = [ExploreMviModel::class])
 class ExploreViewModel(
     private val paginationManager: ExplorePaginationManager,
     private val userRepository: UserRepository,

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/di/ExploreModule.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/di/ExploreModule.kt
@@ -1,23 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.explore.di
 
-import com.livefast.eattrash.raccoonforfriendica.feature.explore.ExploreMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.explore.ExploreViewModel
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureExploreModule =
-    module {
-        factory<ExploreMviModel> {
-            ExploreViewModel(
-                paginationManager = get(),
-                userRepository = get(),
-                timelineEntryRepository = get(),
-                identityRepository = get(),
-                settingsRepository = get(),
-                hapticFeedback = get(),
-                notificationCenter = get(),
-                imagePreloadManager = get(),
-                blurHashRepository = get(),
-                imageAutoloadObserver = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.feature.explore")
+internal class ExploreModule
+
+val featureExploreModule = ExploreModule().module

--- a/feature/favorites/build.gradle.kts
+++ b/feature/favorites/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.navigator)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.koin)
@@ -60,6 +63,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.favorites"
     compileSdk =
@@ -71,5 +82,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesViewModel.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesViewModel.kt
@@ -23,10 +23,13 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Sett
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
+import org.koin.core.annotation.InjectedParam
 import kotlin.time.Duration
 
+@Factory(binds = [FavoritesMviModel::class])
 class FavoritesViewModel(
-    private val type: FavoritesType,
+    @InjectedParam private val type: FavoritesType,
     private val paginationManager: FavoritesPaginationManager,
     private val timelineEntryRepository: TimelineEntryRepository,
     private val settingsRepository: SettingsRepository,

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/di/FavoritesModule.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/di/FavoritesModule.kt
@@ -1,24 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.favorites.di
 
-import com.livefast.eattrash.raccoonforfriendica.feature.favorites.FavoritesMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.favorites.FavoritesViewModel
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureFavoritesModule =
-    module {
-        factory<FavoritesMviModel> { params ->
-            FavoritesViewModel(
-                type = params[0],
-                paginationManager = get(),
-                timelineEntryRepository = get(),
-                settingsRepository = get(),
-                identityRepository = get(),
-                userRepository = get(),
-                hapticFeedback = get(),
-                notificationCenter = get(),
-                imagePreloadManager = get(),
-                blurHashRepository = get(),
-                imageAutoloadObserver = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.feature.favorites")
+internal class FavoritesModule
+
+val featureFavoritesModule = FavoritesModule().module

--- a/feature/followrequests/build.gradle.kts
+++ b/feature/followrequests/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.navigator)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.koin)
@@ -59,6 +62,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.followrequests"
     compileSdk =
@@ -70,5 +81,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/followrequests/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/followrequests/FollowRequestsViewModel.kt
+++ b/feature/followrequests/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/followrequests/FollowRequestsViewModel.kt
@@ -10,7 +10,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Sett
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
 
+@Factory(binds = [FollowRequestsMviModel::class])
 class FollowRequestsViewModel(
     private val paginationManager: FollowRequestPaginationManager,
     private val userRepository: UserRepository,

--- a/feature/followrequests/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/followrequests/di/FollowRequestsModule.kt
+++ b/feature/followrequests/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/followrequests/di/FollowRequestsModule.kt
@@ -1,17 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.followrequests.di
 
-import com.livefast.eattrash.raccoonforfriendica.feature.followrequests.FollowRequestsMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.followrequests.FollowRequestsViewModel
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureFollowRequestsModule =
-    module {
-        factory<FollowRequestsMviModel> {
-            FollowRequestsViewModel(
-                paginationManager = get(),
-                userRepository = get(),
-                settingsRepository = get(),
-                imageAutoloadObserver = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.feature.followrequests")
+internal class FollowRequestsModule
+
+val featureFollowRequestsModule = FollowRequestsModule().module

--- a/feature/gallery/build.gradle.kts
+++ b/feature/gallery/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.navigator)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.koin)
@@ -59,6 +62,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.gallery"
     compileSdk =
@@ -70,5 +81,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/gallery/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/gallery/detail/AlbumDetailViewModel.kt
+++ b/feature/gallery/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/gallery/detail/AlbumDetailViewModel.kt
@@ -15,9 +15,12 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Sett
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
+import org.koin.core.annotation.InjectedParam
 
+@Factory(binds = [AlbumDetailMviModel::class])
 class AlbumDetailViewModel(
-    private val albumName: String,
+    @InjectedParam private val albumName: String,
     private val paginationManager: AlbumPhotoPaginationManager,
     private val photoRepository: PhotoRepository,
     private val albumRepository: PhotoAlbumRepository,

--- a/feature/gallery/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/gallery/di/GalleryModule.kt
+++ b/feature/gallery/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/gallery/di/GalleryModule.kt
@@ -1,29 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.gallery.di
 
-import com.livefast.eattrash.raccoonforfriendica.feature.gallery.detail.AlbumDetailMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.gallery.detail.AlbumDetailViewModel
-import com.livefast.eattrash.raccoonforfriendica.feature.gallery.list.GalleryMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.gallery.list.GalleryViewModel
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureGalleryModule =
-    module {
-        factory<GalleryMviModel> {
-            GalleryViewModel(
-                albumRepository = get(),
-                settingsRepository = get(),
-                notificationCenter = get(),
-            )
-        }
-        factory<AlbumDetailMviModel> { params ->
-            AlbumDetailViewModel(
-                albumName = params[0],
-                paginationManager = get(),
-                albumRepository = get(),
-                photoRepository = get(),
-                settingsRepository = get(),
-                notificationCenter = get(),
-                imageAutoloadObserver = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.feature.gallery")
+internal class GalleryModule
+
+val featureGalleryModule = GalleryModule().module

--- a/feature/gallery/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/gallery/list/GalleryViewModel.kt
+++ b/feature/gallery/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/gallery/list/GalleryViewModel.kt
@@ -10,7 +10,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Sett
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
 
+@Factory(binds = [GalleryMviModel::class])
 class GalleryViewModel(
     private val albumRepository: PhotoAlbumRepository,
     private val settingsRepository: SettingsRepository,

--- a/feature/hashtag/build.gradle.kts
+++ b/feature/hashtag/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.navigator)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.koin)
@@ -60,6 +63,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.hashtag"
     compileSdk =
@@ -71,5 +82,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/di/HashtagModule.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/di/HashtagModule.kt
@@ -1,36 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.hashtag.di
 
-import com.livefast.eattrash.raccoonforfriendica.feature.hashtag.followed.FollowedHashtagsMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.hashtag.followed.FollowedHashtagsViewModel
-import com.livefast.eattrash.raccoonforfriendica.feature.hashtag.timeline.HashtagMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.hashtag.timeline.HashtagViewModel
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureHashtagModule =
-    module {
-        factory<HashtagMviModel> { params ->
-            HashtagViewModel(
-                tag = params[0],
-                paginationManager = get(),
-                timelineEntryRepository = get(),
-                tagRepository = get(),
-                settingsRepository = get(),
-                identityRepository = get(),
-                userRepository = get(),
-                hapticFeedback = get(),
-                notificationCenter = get(),
-                imagePreloadManager = get(),
-                blurHashRepository = get(),
-                imageAutoloadObserver = get(),
-            )
-        }
-        factory<FollowedHashtagsMviModel> {
-            FollowedHashtagsViewModel(
-                paginationManager = get(),
-                tagRepository = get(),
-                settingsRepository = get(),
-                hapticFeedback = get(),
-                notificationCenter = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.feature.hashtag")
+internal class HashtagModule
+
+val featureHashtagModule = HashtagModule().module

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/followed/FollowedHashtagsViewModel.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/followed/FollowedHashtagsViewModel.kt
@@ -12,7 +12,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Sett
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
 
+@Factory(binds = [FollowedHashtagsMviModel::class])
 class FollowedHashtagsViewModel(
     private val paginationManager: FollowedHashtagsPaginationManager,
     private val tagRepository: TagRepository,

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagViewModel.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagViewModel.kt
@@ -24,10 +24,13 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Sett
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
+import org.koin.core.annotation.InjectedParam
 import kotlin.time.Duration
 
+@Factory(binds = [HashtagMviModel::class])
 class HashtagViewModel(
-    private val tag: String,
+    @InjectedParam private val tag: String,
     private val paginationManager: TimelinePaginationManager,
     private val timelineEntryRepository: TimelineEntryRepository,
     private val tagRepository: TagRepository,

--- a/feature/imagedetail/build.gradle.kts
+++ b/feature/imagedetail/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.koin)
 
@@ -50,6 +53,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.imagedetail"
     compileSdk =
@@ -61,5 +72,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/imagedetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/imagedetail/ImageDetailViewModel.kt
+++ b/feature/imagedetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/imagedetail/ImageDetailViewModel.kt
@@ -12,9 +12,12 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.koin.core.annotation.Factory
+import org.koin.core.annotation.InjectedParam
 
+@Factory(binds = [ImageDetailMviModel::class])
 class ImageDetailViewModel(
-    private val urls: List<String>,
+    @InjectedParam private val urls: List<String>,
     private val initialIndex: Int = 0,
     private val shareHelper: ShareHelper,
     private val galleryHelper: GalleryHelper,

--- a/feature/imagedetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/imagedetail/di/ImageDetailModule.kt
+++ b/feature/imagedetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/imagedetail/di/ImageDetailModule.kt
@@ -1,18 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.imagedetail.di
 
-import com.livefast.eattrash.raccoonforfriendica.feature.imagedetail.ImageDetailMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.imagedetail.ImageDetailViewModel
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureImageDetailModule =
-    module {
-        factory<ImageDetailMviModel> { params ->
-            ImageDetailViewModel(
-                urls = params[0],
-                initialIndex = params[1],
-                shareHelper = get(),
-                galleryHelper = get(),
-                imagePreloadManager = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.feature.imagedetail")
+class ImageDetailModule
+
+val featureImageDetailModule = ImageDetailModule().module

--- a/feature/inbox/build.gradle.kts
+++ b/feature/inbox/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.navigator)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.koin)
@@ -60,6 +63,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.inbox"
     compileSdk =
@@ -71,5 +82,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
@@ -26,7 +26,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications.PullNo
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
 
+@Factory(binds = [InboxMviModel::class])
 class InboxViewModel(
     private val paginationManager: NotificationsPaginationManager,
     private val userRepository: UserRepository,

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/di/InboxModule.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/di/InboxModule.kt
@@ -1,25 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.inbox.di
 
-import com.livefast.eattrash.raccoonforfriendica.feature.inbox.InboxMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.inbox.InboxViewModel
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureInboxModule =
-    module {
-        factory<InboxMviModel> {
-            InboxViewModel(
-                paginationManager = get(),
-                userRepository = get(),
-                identityRepository = get(),
-                settingsRepository = get(),
-                notificationRepository = get(),
-                inboxManager = get(),
-                hapticFeedback = get(),
-                imagePreloadManager = get(),
-                blurHashRepository = get(),
-                markerRepository = get(),
-                pullNotificationManager = get(),
-                imageAutoloadObserver = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.feature.inbox")
+internal class InboxModule
+
+val featureInboxModule = InboxModule().module

--- a/feature/licences/build.gradle.kts
+++ b/feature/licences/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -35,6 +37,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.navigator)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.koin)
@@ -54,6 +57,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.licences"
     compileSdk =
@@ -65,5 +76,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/licences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/unit/licences/LicencesViewModel.kt
+++ b/feature/licences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/unit/licences/LicencesViewModel.kt
@@ -8,7 +8,9 @@ import com.livefast.eattrash.raccoonforfriendica.unit.licences.models.LicenceIte
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
 
+@Factory(binds = [LicencesMviModel::class])
 class LicencesViewModel(
     private val settingsRepository: SettingsRepository,
 ) : DefaultMviModel<LicencesMviModel.Intent, LicencesMviModel.State, LicencesMviModel.Effect>(

--- a/feature/licences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/unit/licences/di/LicenceModule.kt
+++ b/feature/licences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/unit/licences/di/LicenceModule.kt
@@ -1,14 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.unit.licences.di
 
-import com.livefast.eattrash.raccoonforfriendica.unit.licences.LicencesMviModel
-import com.livefast.eattrash.raccoonforfriendica.unit.licences.LicencesViewModel
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureLicenceModule =
-    module {
-        factory<LicencesMviModel> {
-            LicencesViewModel(
-                settingsRepository = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.unit.licences")
+internal class LicenceModule
+
+val featureLicenceModule = LicenceModule().module

--- a/feature/login/build.gradle.kts
+++ b/feature/login/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.koin)
 
@@ -55,6 +58,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.login"
     compileSdk =
@@ -66,5 +77,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/di/LoginModule.kt
+++ b/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/di/LoginModule.kt
@@ -1,27 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.login.di
 
-import com.livefast.eattrash.raccoonforfriendica.feature.login.legacy.LegacyLoginMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.login.legacy.LegacyLoginViewModel
-import com.livefast.eattrash.raccoonforfriendica.feature.login.oauth.LoginMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.login.oauth.LoginViewModel
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureLoginModule =
-    module {
-        factory<LegacyLoginMviModel> {
-            LegacyLoginViewModel(
-                credentialsRepository = get(),
-                apiConfigurationRepository = get(),
-                loginUseCase = get(),
-            )
-        }
-        factory<LoginMviModel> { params ->
-            LoginViewModel(
-                type = params[0],
-                credentialsRepository = get(),
-                apiConfigurationRepository = get(),
-                authManager = get(),
-                loginUseCase = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.feature.login")
+internal class LoginModule
+
+val featureLoginModule = LoginModule().module

--- a/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/legacy/LegacyLoginViewModel.kt
+++ b/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/legacy/LegacyLoginViewModel.kt
@@ -8,7 +8,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiC
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.CredentialsRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.LoginUseCase
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
 
+@Factory(binds = [LegacyLoginMviModel::class])
 class LegacyLoginViewModel(
     private val credentialsRepository: CredentialsRepository,
     private val apiConfigurationRepository: ApiConfigurationRepository,

--- a/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/oauth/LoginViewModel.kt
+++ b/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/oauth/LoginViewModel.kt
@@ -14,10 +14,13 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
+import org.koin.core.annotation.InjectedParam
 
+@Factory(binds = [LoginMviModel::class])
 @OptIn(FlowPreview::class)
 class LoginViewModel(
-    private val type: LoginType,
+    @InjectedParam private val type: LoginType,
     private val apiConfigurationRepository: ApiConfigurationRepository,
     private val credentialsRepository: CredentialsRepository,
     private val authManager: AuthManager,

--- a/feature/manageblocks/build.gradle.kts
+++ b/feature/manageblocks/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.navigator)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.koin)
@@ -58,6 +61,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.manageblocks"
     compileSdk =
@@ -69,5 +80,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/ManageBlocksViewModel.kt
+++ b/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/ManageBlocksViewModel.kt
@@ -13,7 +13,9 @@ import com.livefast.eattrash.raccoonforfriendica.feature.manageblocks.data.Manag
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
 
+@Factory(binds = [ManageBlocksMviModel::class])
 class ManageBlocksViewModel(
     private val paginationManager: UserPaginationManager,
     private val userRepository: UserRepository,

--- a/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/di/ManageBlocksModule.kt
+++ b/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/di/ManageBlocksModule.kt
@@ -1,18 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.manageblocks.di
 
-import com.livefast.eattrash.raccoonforfriendica.feature.manageblocks.ManageBlocksMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.manageblocks.ManageBlocksViewModel
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureManageBlocksModule =
-    module {
-        factory<ManageBlocksMviModel> {
-            ManageBlocksViewModel(
-                paginationManager = get(),
-                userRepository = get(),
-                settingsRepository = get(),
-                imagePreloadManager = get(),
-                imageAutoloadObserver = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.feature.manageblocks")
+internal class ManageBlocksModule
+
+val featureManageBlocksModule = ManageBlocksModule().module

--- a/feature/nodeinfo/build.gradle.kts
+++ b/feature/nodeinfo/build.gradle.kts
@@ -1,14 +1,16 @@
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
-    alias(libs.plugins.mokkery)
     alias(libs.plugins.kotlinx.kover)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.mokkery)
 }
 
 @OptIn(ExperimentalKotlinGradlePluginApi::class)
@@ -40,6 +42,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.koin)
                 implementation(libs.lyricist)
@@ -87,6 +90,12 @@ kotlin {
 
 dependencies {
     debugImplementation(libs.compose.ui.test.manifest)
+
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
 }
 
 android {
@@ -102,5 +111,15 @@ android {
                 .toInt()
         testOptions.unitTests.isIncludeAndroidResources = true
         testInstrumentationRunner = "org.robolectric.RobolectricTestRunner"
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/nodeinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/NodeInfoViewModel.kt
+++ b/feature/nodeinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/NodeInfoViewModel.kt
@@ -9,7 +9,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Sett
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
 
+@Factory(binds = [NodeInfoMviModel::class])
 class NodeInfoViewModel(
     private val nodeInfoRepository: NodeInfoRepository,
     private val settingsRepository: SettingsRepository,

--- a/feature/nodeinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/di/NodeInfoModule.kt
+++ b/feature/nodeinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/di/NodeInfoModule.kt
@@ -1,17 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.nodeinfo.di
 
-import com.livefast.eattrash.raccoonforfriendica.feature.nodeinfo.NodeInfoMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.nodeinfo.NodeInfoViewModel
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureNodeInfoModule =
-    module {
-        factory<NodeInfoMviModel> {
-            NodeInfoViewModel(
-                nodeInfoRepository = get(),
-                settingsRepository = get(),
-                emojiHelper = get(),
-                imageAutoloadObserver = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.feature.nodeinfo")
+internal class NodeInfoModule
+
+val featureNodeInfoModule = NodeInfoModule().module

--- a/feature/profile/build.gradle.kts
+++ b/feature/profile/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.tab)
                 implementation(libs.voyager.koin)
@@ -61,6 +64,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.profile"
     compileSdk =
@@ -72,5 +83,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileViewModel.kt
@@ -14,7 +14,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.SwitchA
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
 
+@Factory(binds = [ProfileMviModel::class])
 class ProfileViewModel(
     private val identityRepository: IdentityRepository,
     private val accountRepository: AccountRepository,

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/di/ProfileModule.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/di/ProfileModule.kt
@@ -1,58 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.profile.di
 
-import com.livefast.eattrash.raccoonforfriendica.feature.profile.ProfileMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.profile.ProfileViewModel
-import com.livefast.eattrash.raccoonforfriendica.feature.profile.edit.EditProfileMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.profile.edit.EditProfileViewModel
-import com.livefast.eattrash.raccoonforfriendica.feature.profile.loginintro.LoginIntroMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.profile.loginintro.LoginIntroViewModel
-import com.livefast.eattrash.raccoonforfriendica.feature.profile.myaccount.MyAccountMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.profile.myaccount.MyAccountViewModel
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureProfileModule =
-    module {
-        factory<ProfileMviModel> {
-            ProfileViewModel(
-                identityRepository = get(),
-                accountRepository = get(),
-                settingsRepository = get(),
-                logoutUseCase = get(),
-                switchAccountUseCase = get(),
-                deleteAccountUseCase = get(),
-                authManager = get(),
-                imageAutoloadObserver = get(),
-            )
-        }
-        factory<MyAccountMviModel> {
-            MyAccountViewModel(
-                userRepository = get(),
-                identityRepository = get(),
-                paginationManager = get(),
-                timelineEntryRepository = get(),
-                settingsRepository = get(),
-                apiConfigurationRepository = get(),
-                logout = get(),
-                hapticFeedback = get(),
-                notificationCenter = get(),
-                imagePreloadManager = get(),
-                blurHashRepository = get(),
-                emojiHelper = get(),
-                replyHelper = get(),
-                imageAutoloadObserver = get(),
-            )
-        }
-        factory<LoginIntroMviModel> {
-            LoginIntroViewModel(
-                authManager = get(),
-            )
-        }
-        factory<EditProfileMviModel> {
-            EditProfileViewModel(
-                userRepository = get(),
-                emojiRepository = get(),
-                settingsRepository = get(),
-                imageAutoloadObserver = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.feature.profile")
+internal class ProfileModule
+
+val featureProfileModule = ProfileModule().module

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
 
 sealed interface EditProfilerFieldType {
     data object DisplayName : EditProfilerFieldType
@@ -22,6 +23,7 @@ sealed interface EditProfilerFieldType {
     data object Bio : EditProfilerFieldType
 }
 
+@Factory(binds = [EditProfileMviModel::class])
 class EditProfileViewModel(
     private val userRepository: UserRepository,
     private val emojiRepository: EmojiRepository,

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/loginintro/LoginIntroViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/loginintro/LoginIntroViewModel.kt
@@ -2,7 +2,9 @@ package com.livefast.eattrash.raccoonforfriendica.feature.profile.loginintro
 
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AuthManager
+import org.koin.core.annotation.Factory
 
+@Factory(binds = [LoginIntroMviModel::class])
 class LoginIntroViewModel(
     private val authManager: AuthManager,
 ) : DefaultMviModel<LoginIntroMviModel.Intent, LoginIntroMviModel.State, LoginIntroMviModel.Effect>(

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
@@ -31,7 +31,9 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
 
+@Factory(binds = [MyAccountMviModel::class])
 @OptIn(FlowPreview::class)
 class MyAccountViewModel(
     private val userRepository: UserRepository,

--- a/feature/report/build.gradle.kts
+++ b/feature/report/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.navigator)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.koin)
@@ -56,6 +59,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.report"
     compileSdk =
@@ -67,5 +78,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/report/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/report/CreateReportViewModel.kt
+++ b/feature/report/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/report/CreateReportViewModel.kt
@@ -12,10 +12,13 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Suppo
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
+import org.koin.core.annotation.InjectedParam
 
+@Factory(binds = [CreateReportMviModel::class])
 class CreateReportViewModel(
-    private val userId: String,
-    private val entryId: String?,
+    @InjectedParam private val userId: String,
+    @InjectedParam private val entryId: String?,
     private val nodeInfoRepository: NodeInfoRepository,
     private val supportedFeatureRepository: SupportedFeatureRepository,
     private val reportRepository: ReportRepository,

--- a/feature/report/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/report/di/ReportModule.kt
+++ b/feature/report/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/report/di/ReportModule.kt
@@ -1,20 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.report.di
 
-import com.livefast.eattrash.raccoonforfriendica.feature.report.CreateReportMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.report.CreateReportViewModel
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureReportModule =
-    module {
-        factory<CreateReportMviModel> { params ->
-            CreateReportViewModel(
-                userId = params[0],
-                entryId = params[1],
-                nodeInfoRepository = get(),
-                supportedFeatureRepository = get(),
-                reportRepository = get(),
-                userCache = get(),
-                entryCache = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.feature.report")
+internal class ReportModule
+
+val featureReportModule = ReportModule().module

--- a/feature/search/build.gradle.kts
+++ b/feature/search/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.navigator)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.koin)
@@ -60,6 +63,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.search"
     compileSdk =
@@ -71,5 +82,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchViewModel.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchViewModel.kt
@@ -33,8 +33,10 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
 import kotlin.time.Duration
 
+@Factory(binds = [SearchMviModel::class])
 @OptIn(FlowPreview::class)
 class SearchViewModel(
     private val paginationManager: SearchPaginationManager,

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/di/SearchModule.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/di/SearchModule.kt
@@ -1,23 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.feaure.search.di
 
-import com.livefast.eattrash.raccoonforfriendica.feaure.search.SearchMviModel
-import com.livefast.eattrash.raccoonforfriendica.feaure.search.SearchViewModel
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureSearchModule =
-    module {
-        factory<SearchMviModel> {
-            SearchViewModel(
-                paginationManager = get(),
-                userRepository = get(),
-                timelineEntryRepository = get(),
-                settingsRepository = get(),
-                identityRepository = get(),
-                hapticFeedback = get(),
-                notificationCenter = get(),
-                imagePreloadManager = get(),
-                blurHashRepository = get(),
-                imageAutoloadObserver = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.feaure.search")
+internal class SearchModule
+
+val featureSearchModule = SearchModule().module

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.koin)
                 implementation(libs.lyricist)
@@ -61,6 +64,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.settings"
     compileSdk =
@@ -72,5 +83,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsViewModel.kt
@@ -38,8 +38,10 @@ import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.PushNo
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
 import kotlin.time.Duration
 
+@Factory(binds = [SettingsMviModel::class])
 class SettingsViewModel(
     private val settingsRepository: SettingsRepository,
     private val l10nManager: L10nManager,

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/di/SettingsModule.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/di/SettingsModule.kt
@@ -1,35 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.settings.di
 
-import com.livefast.eattrash.raccoonforfriendica.feature.settings.SettingsMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.settings.SettingsViewModel
-import com.livefast.eattrash.raccoonforfriendica.feature.settings.feedback.UserFeedbackMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.settings.feedback.UserFeedbackViewModel
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureSettingsModule =
-    module {
-        factory<SettingsMviModel> {
-            SettingsViewModel(
-                l10nManager = get(),
-                themeRepository = get(),
-                settingsRepository = get(),
-                colorSchemeProvider = get(),
-                themeColorRepository = get(),
-                identityRepository = get(),
-                supportedFeatureRepository = get(),
-                circlesRepository = get(),
-                pullNotificationManager = get(),
-                pushNotificationManager = get(),
-                crashReportManager = get(),
-                appIconManager = get(),
-                fileSystemManager = get(),
-                importSettings = get(),
-                exportSettings = get(),
-            )
-        }
-        factory<UserFeedbackMviModel> {
-            UserFeedbackViewModel(
-                crashReportManager = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.feature.settings")
+internal class SettingsModule
+
+val featureSettingsModule = SettingsModule().module

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/feedback/UserFeedbackViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/feedback/UserFeedbackViewModel.kt
@@ -7,7 +7,9 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.debug.CrashReportTag
 import com.livefast.eattrash.raccoonforfriendica.core.utils.validation.ValidationError
 import com.livefast.eattrash.raccoonforfriendica.core.utils.validation.isValidEmail
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
 
+@Factory(binds = [UserFeedbackMviModel::class])
 class UserFeedbackViewModel(
     private val crashReportManager: CrashReportManager,
 ) : DefaultMviModel<UserFeedbackMviModel.Intent, UserFeedbackMviModel.State, UserFeedbackMviModel.Effect>(

--- a/feature/thread/build.gradle.kts
+++ b/feature/thread/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.koin)
 
@@ -58,6 +61,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.thread"
     compileSdk =
@@ -69,5 +80,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadViewModel.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadViewModel.kt
@@ -22,10 +22,13 @@ import com.livefast.eattrash.raccoonforfriendica.feature.thread.usecase.Populate
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
+import org.koin.core.annotation.InjectedParam
 import kotlin.time.Duration
 
+@Factory(binds = [ThreadMviModel::class])
 class ThreadViewModel(
-    private val entryId: String,
+    @InjectedParam private val entryId: String,
     private val populateThreadUseCase: PopulateThreadUseCase,
     private val timelineEntryRepository: TimelineEntryRepository,
     private val identityRepository: IdentityRepository,

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/di/ThreadModule.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/di/ThreadModule.kt
@@ -1,33 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.thread.di
 
-import com.livefast.eattrash.raccoonforfriendica.feature.thread.ThreadMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.thread.ThreadViewModel
-import com.livefast.eattrash.raccoonforfriendica.feature.thread.usecase.DefaultPopulateThreadUseCase
-import com.livefast.eattrash.raccoonforfriendica.feature.thread.usecase.PopulateThreadUseCase
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureThreadModule =
-    module {
-        single<PopulateThreadUseCase> {
-            DefaultPopulateThreadUseCase(
-                timelineEntryRepository = get(),
-                emojiHelper = get(),
-            )
-        }
-        factory<ThreadMviModel> { params ->
-            ThreadViewModel(
-                entryId = params[0],
-                populateThreadUseCase = get(),
-                timelineEntryRepository = get(),
-                identityRepository = get(),
-                settingsRepository = get(),
-                userRepository = get(),
-                hapticFeedback = get(),
-                entryCache = get(),
-                notificationCenter = get(),
-                imagePreloadManager = get(),
-                blurHashRepository = get(),
-                imageAutoloadObserver = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.feature.thread")
+internal class ThreadModule
+
+val featureThreadModule = ThreadModule().module

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/usecase/DefaultPopulateThreadUseCase.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/usecase/DefaultPopulateThreadUseCase.kt
@@ -7,7 +7,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Emoji
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.feature.thread.data.ConversationNode
 import kotlinx.coroutines.coroutineScope
+import org.koin.core.annotation.Single
 
+@Single
 internal class DefaultPopulateThreadUseCase(
     private val timelineEntryRepository: TimelineEntryRepository,
     private val emojiHelper: EmojiHelper,

--- a/feature/timeline/build.gradle.kts
+++ b/feature/timeline/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.navigator)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.koin)
@@ -60,6 +63,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.timeline"
     compileSdk =
@@ -71,5 +82,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
@@ -33,8 +33,10 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
 import kotlin.time.Duration
 
+@Factory(binds = [TimelineMviModel::class])
 @OptIn(FlowPreview::class)
 class TimelineViewModel(
     private val paginationManager: TimelinePaginationManager,

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/di/TimelineModule.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/di/TimelineModule.kt
@@ -1,27 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.timeline.di
 
-import com.livefast.eattrash.raccoonforfriendica.feature.timeline.TimelineMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.timeline.TimelineViewModel
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureTimelineModule =
-    module {
-        factory<TimelineMviModel> {
-            TimelineViewModel(
-                paginationManager = get(),
-                identityRepository = get(),
-                apiConfigurationRepository = get(),
-                activeAccountMonitor = get(),
-                timelineEntryRepository = get(),
-                settingsRepository = get(),
-                userRepository = get(),
-                circlesRepository = get(),
-                hapticFeedback = get(),
-                notificationCenter = get(),
-                imagePreloadManager = get(),
-                blurHashRepository = get(),
-                imageAutoloadObserver = get(),
-                announcementsManager = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.feature.timeline")
+internal class TimelineModule
+
+val featureTimelineModule = TimelineModule().module

--- a/feature/unpublished/build.gradle.kts
+++ b/feature/unpublished/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.navigator)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.koin)
@@ -59,6 +62,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.unpublished"
     compileSdk =
@@ -70,5 +81,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/unpublished/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/unpublished/UnpublishedViewModel.kt
+++ b/feature/unpublished/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/unpublished/UnpublishedViewModel.kt
@@ -24,7 +24,9 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Sett
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
 
+@Factory(binds = [UnpublishedMviModel::class])
 class UnpublishedViewModel(
     private val paginationManager: UnpublishedPaginationManager,
     private val identityRepository: IdentityRepository,

--- a/feature/unpublished/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/unpublished/di/UnpublishedModule.kt
+++ b/feature/unpublished/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/unpublished/di/UnpublishedModule.kt
@@ -1,22 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.unpublished.di
 
-import com.livefast.eattrash.raccoonforfriendica.feature.unpublished.UnpublishedMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.unpublished.UnpublishedViewModel
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureUnpublishedModule =
-    module {
-        factory<UnpublishedMviModel> {
-            UnpublishedViewModel(
-                paginationManager = get(),
-                identityRepository = get(),
-                settingsRepository = get(),
-                scheduledEntryRepository = get(),
-                draftRepository = get(),
-                notificationCenter = get(),
-                imagePreloadManager = get(),
-                blurHashRepository = get(),
-                imageAutoloadObserver = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.feature.unpublished")
+internal class UnpublishedModule
+
+val featureUnpublishedModule = UnpublishedModule().module

--- a/feature/userdetail/build.gradle.kts
+++ b/feature/userdetail/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.koin)
 
@@ -59,6 +62,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.userdetail"
     compileSdk =
@@ -70,5 +81,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailViewModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailViewModel.kt
@@ -28,10 +28,13 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Sett
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
+import org.koin.core.annotation.InjectedParam
 import kotlin.time.Duration
 
+@Factory(binds = [UserDetailMviModel::class])
 class UserDetailViewModel(
-    private val id: String,
+    @InjectedParam private val id: String,
     private val userRepository: UserRepository,
     private val paginationManager: TimelinePaginationManager,
     private val timelineEntryRepository: TimelineEntryRepository,

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/di/UserDetailModule.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/di/UserDetailModule.kt
@@ -1,44 +1,11 @@
 package com.livefast.eattrash.feature.userdetail.di
 
-import com.livefast.eattrash.feature.userdetail.classic.UserDetailMviModel
-import com.livefast.eattrash.feature.userdetail.classic.UserDetailViewModel
-import com.livefast.eattrash.feature.userdetail.forum.ForumListMviModel
-import com.livefast.eattrash.feature.userdetail.forum.ForumListViewModel
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureUserDetailModule =
-    module {
-        factory<UserDetailMviModel> { params ->
-            UserDetailViewModel(
-                id = params[0],
-                userRepository = get(),
-                paginationManager = get(),
-                timelineEntryRepository = get(),
-                identityRepository = get(),
-                settingsRepository = get(),
-                hapticFeedback = get(),
-                userCache = get(),
-                notificationCenter = get(),
-                imagePreloadManager = get(),
-                blurHashRepository = get(),
-                emojiHelper = get(),
-                imageAutoloadObserver = get(),
-            )
-        }
-        factory<ForumListMviModel> { params ->
-            ForumListViewModel(
-                id = params[0],
-                userRepository = get(),
-                paginationManager = get(),
-                timelineEntryRepository = get(),
-                identityRepository = get(),
-                settingsRepository = get(),
-                hapticFeedback = get(),
-                userCache = get(),
-                notificationCenter = get(),
-                imagePreloadManager = get(),
-                blurHashRepository = get(),
-                imageAutoloadObserver = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.feature.userdetail")
+internal class UserDetailModule
+
+val featureUserDetailModule = UserDetailModule().module

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListViewModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListViewModel.kt
@@ -24,10 +24,13 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Sett
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
+import org.koin.core.annotation.InjectedParam
 import kotlin.time.Duration
 
+@Factory(binds = [ForumListMviModel::class])
 class ForumListViewModel(
-    private val id: String,
+    @InjectedParam private val id: String,
     private val userRepository: UserRepository,
     private val paginationManager: TimelinePaginationManager,
     private val timelineEntryRepository: TimelineEntryRepository,

--- a/feature/userlist/build.gradle.kts
+++ b/feature/userlist/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.ksp)
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
@@ -36,6 +38,7 @@ kotlin {
                 implementation(compose.materialIconsExtended)
 
                 implementation(libs.koin.core)
+                api(libs.koin.annotations)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.koin)
 
@@ -59,6 +62,14 @@ kotlin {
     }
 }
 
+dependencies {
+    add("kspCommonMainMetadata", libs.koin.ksp)
+    add("kspAndroid", libs.koin.ksp)
+    add("kspIosX64", libs.koin.ksp)
+    add("kspIosArm64", libs.koin.ksp)
+    add("kspIosSimulatorArm64", libs.koin.ksp)
+}
+
 android {
     namespace = "com.livefast.eattrash.raccoonforfriendica.feature.userlist"
     compileSdk =
@@ -70,5 +81,15 @@ android {
             libs.versions.android.minSdk
                 .get()
                 .toInt()
+    }
+}
+
+kotlin.sourceSets.commonMain.configure {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+
+tasks.withType(KotlinCompilationTask::class.java).configureEach {
+    if (name != "kspCommonMainKotlinMetadata") {
+        dependsOn("kspCommonMainKotlinMetadata")
     }
 }

--- a/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListViewModel.kt
+++ b/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListViewModel.kt
@@ -22,11 +22,14 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Sett
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import org.koin.core.annotation.Factory
+import org.koin.core.annotation.InjectedParam
 
+@Factory(binds = [UserListMviModel::class])
 internal class UserListViewModel(
-    private val type: UserListType,
-    private val userId: String? = null,
-    private val entryId: String? = null,
+    @InjectedParam private val type: UserListType,
+    @InjectedParam private val userId: String? = null,
+    @InjectedParam private val entryId: String? = null,
     private val paginationManager: UserPaginationManager,
     private val userRepository: UserRepository,
     private val identityRepository: IdentityRepository,

--- a/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/di/UserListModule.kt
+++ b/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/di/UserListModule.kt
@@ -1,26 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.userlist.di
 
-import com.livefast.eattrash.raccoonforfriendica.feature.userlist.UserListMviModel
-import com.livefast.eattrash.raccoonforfriendica.feature.userlist.UserListViewModel
-import org.koin.dsl.module
+import org.koin.core.annotation.ComponentScan
+import org.koin.core.annotation.Module
+import org.koin.ksp.generated.module
 
-val featureUserListModule =
-    module {
-        factory<UserListMviModel> { params ->
-            UserListViewModel(
-                type = params[0],
-                userId = params[1],
-                entryId = params[2],
-                paginationManager = get(),
-                userRepository = get(),
-                identityRepository = get(),
-                settingsRepository = get(),
-                hapticFeedback = get(),
-                imagePreloadManager = get(),
-                notificationCenter = get(),
-                userCache = get(),
-                imageAutoloadObserver = get(),
-                exportUserList = get(),
-            )
-        }
-    }
+@Module
+@ComponentScan("com.livefast.eattrash.raccoonforfriendica.feature.userlist")
+internal class UserListModule
+
+val featureUserListModule = UserListModule().module


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR migrates all feature modules and the main module (`:composeApp`) to Koin annotations.

## Additional notes
<!-- Anything to declare for code review? -->
Moreover, this reviews the work of all previous steps to make sure the new `@Module` classes are internal.
