### PR TITLE
fix(di): injected params, settings provider inclusion, better module separation

### DIFF
--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/di/PersistenceModule.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/di/PersistenceModule.kt
@@ -11,7 +11,10 @@ import org.koin.ksp.generated.module
 
 @Module
 @ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.persistence.provider")
-internal class ProviderModule {
+internal class ProviderModule
+
+@Module
+internal class DaoModule {
     @Single
     fun provideAccountDao(dbProvider: DatabaseProvider): AccountDao = dbProvider.provideDatabase().getAccountDao()
 
@@ -22,7 +25,7 @@ internal class ProviderModule {
     fun provideDraftDao(dbProvider: DatabaseProvider): DraftDao = dbProvider.provideDatabase().getDraftDao()
 }
 
-@Module(includes = [BuilderModule::class, ProviderModule::class])
+@Module(includes = [BuilderModule::class, ProviderModule::class, DaoModule::class])
 internal class PersistenceModule
 
 val corePersistenceModule = PersistenceModule().module

--- a/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/di/PreferencesModule.kt
+++ b/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/di/PreferencesModule.kt
@@ -9,16 +9,26 @@ import org.koin.ksp.generated.module
 
 @Module
 @ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.preferences.settings")
-internal class SettingsModule {
-    @Single
-    fun provideSettings(provider: SettingsProvider): Settings = provider.provide()
-}
+internal class SettingsWrapperModule
 
 @Module
 @ComponentScan("com.livefast.eattrash.raccoonforfriendica.core.preferences.store")
 internal class StoreModule
 
-@Module(includes = [SettingsModule::class, StoreModule::class])
+@Module
+internal class SettingsModule {
+    @Single
+    fun provideSettings(provider: SettingsProvider): Settings = provider.provide()
+}
+
+@Module(
+    includes = [
+        ProviderModule::class,
+        SettingsModule::class,
+        SettingsWrapperModule::class,
+        StoreModule::class,
+    ],
+)
 internal class PreferencesModule
 
 val corePreferencesModule = PreferencesModule().module

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
@@ -12,9 +12,12 @@ import org.koin.core.annotation.Module
 import org.koin.core.annotation.Single
 import org.koin.ksp.generated.module
 
-@Module
+@Module(includes = [CacheModule::class])
 @ComponentScan("com.livefast.eattrash.raccoonforfriendica.domain.content.repository")
-internal class ContentRepositoryModule {
+internal class ContentRepositoryModule
+
+@Module
+internal class CacheModule {
     @Single
     fun provideLocalItemCacheUserModel(): LocalItemCache<UserModel> = DefaultLocalItemCache()
 

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
@@ -65,7 +65,7 @@ private const val PLACEHOLDER_ID = "placeholder"
 @Factory(binds = [ComposerMviModel::class])
 @OptIn(FlowPreview::class)
 class ComposerViewModel(
-    @InjectedParam private val inReplyToId: String? = null,
+    @InjectedParam private val inReplyToId: String?,
     private val identityRepository: IdentityRepository,
     private val timelineEntryRepository: TimelineEntryRepository,
     private val photoRepository: PhotoRepository,

--- a/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListViewModel.kt
+++ b/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListViewModel.kt
@@ -28,8 +28,8 @@ import org.koin.core.annotation.InjectedParam
 @Factory(binds = [UserListMviModel::class])
 internal class UserListViewModel(
     @InjectedParam private val type: UserListType,
-    @InjectedParam private val userId: String? = null,
-    @InjectedParam private val entryId: String? = null,
+    @InjectedParam private val userId: String?,
+    @InjectedParam private val entryId: String?,
     private val paginationManager: UserPaginationManager,
     private val userRepository: UserRepository,
     private val identityRepository: IdentityRepository,


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR avoids mixing modules generated by scanning and modules defined with functions. Moreover it fixes a bug due to `ProviderModule` not being properly included in `PreferencesModule`.

Moreover if fixes another issue: if an `@InjectedParam` parameter has a default value, generated code does not properly pass it, even if it is present in `parametersOf()`. Since all parameters should always be passed, default values are useless and can safely be removed.

## Additional notes
<!-- Anything to declare for code review? -->
Runtime crashes can still happen if you accidentally forget to include a module! Wooooops! 💥 
