### PR TITLE
fix: cap image height in posts and links

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentImage.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentImage.kt
@@ -56,7 +56,7 @@ fun ContentImage(
     originalWidth: Int = 0,
     originalHeight: Int = 0,
     minHeight: Dp = 50.dp,
-    maxHeight: Dp = Dp.Unspecified,
+    maxHeight: Dp = 200.dp,
     contentScale: ContentScale = ContentScale.FillWidth,
     onClick: (() -> Unit)? = null,
     centerComposable: (@Composable () -> Unit) = {},

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentPreview.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentPreview.kt
@@ -4,8 +4,11 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -68,21 +71,30 @@ fun ContentPreview(
             verticalArrangement = Arrangement.spacedBy(Spacing.xs),
         ) {
             if (image.isNotBlank() && autoloadImages) {
-                CustomImage(
+                Box(
                     modifier =
-                        Modifier
-                            .clip(
-                                RoundedCornerShape(
-                                    topStart = cornerSize,
-                                    topEnd = cornerSize,
-                                ),
-                            ).clickable {
-                                onOpenImage?.invoke(image)
-                            },
-                    url = image,
-                    quality = FilterQuality.Low,
-                    contentScale = ContentScale.FillWidth,
-                )
+                        Modifier.heightIn(
+                            min = 50.dp,
+                            max = 200.dp,
+                        ),
+                ) {
+                    CustomImage(
+                        modifier =
+                            Modifier
+                                .fillMaxSize()
+                                .clip(
+                                    RoundedCornerShape(
+                                        topStart = cornerSize,
+                                        topEnd = cornerSize,
+                                    ),
+                                ).clickable {
+                                    onOpenImage?.invoke(image)
+                                },
+                        url = image,
+                        quality = FilterQuality.Low,
+                        contentScale = ContentScale.FillWidth,
+                    )
+                }
             } else if (type == PreviewType.Video && url.isNotBlank()) {
                 VideoPlayer(
                     modifier = Modifier.fillMaxWidth(),
@@ -104,7 +116,10 @@ fun ContentPreview(
                     val annotatedTitle =
                         title.parseHtml(
                             linkColor = MaterialTheme.colorScheme.primary,
-                            quoteColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha),
+                            quoteColor =
+                                MaterialTheme.colorScheme.onBackground.copy(
+                                    ancillaryTextAlpha,
+                                ),
                         )
                     Text(
                         text = annotatedTitle,
@@ -116,7 +131,10 @@ fun ContentPreview(
                     val annotatedDescription =
                         description.parseHtml(
                             linkColor = MaterialTheme.colorScheme.primary,
-                            quoteColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha),
+                            quoteColor =
+                                MaterialTheme.colorScheme.onBackground.copy(
+                                    ancillaryTextAlpha,
+                                ),
                         )
                     Text(
                         text = annotatedDescription,

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/LinkItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/LinkItem.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -79,7 +80,13 @@ fun LinkItem(
         verticalArrangement = Arrangement.spacedBy(Spacing.xs),
     ) {
         if (!image.isNullOrBlank()) {
-            Box {
+            Box(
+                modifier =
+                    Modifier.heightIn(
+                        min = 50.dp,
+                        max = 200.dp,
+                    ),
+            ) {
                 CustomImage(
                     modifier =
                         Modifier


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR set a maximum height for images in post cards and links, in order to prevent bounding issues or using too much space in the timeline.

## Additional notes
<!-- Anything to declare for code review? -->
This potentially fixes #607 (which I can not reproduce) but I'll wait for user feedback before closing it.