### PR TITLE
fix: avoid using nullable types for injected params

### DIFF
--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
@@ -118,7 +118,7 @@ class ComposerScreen(
     @Composable
     override fun Content() {
         val model =
-            getScreenModel<ComposerMviModel>(parameters = { parametersOf(inReplyToId) })
+            getScreenModel<ComposerMviModel>(parameters = { parametersOf(inReplyToId.orEmpty()) })
         val uiState by model.uiState.collectAsState()
         val topAppBarState = rememberTopAppBarState()
         val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
@@ -65,7 +65,7 @@ private const val PLACEHOLDER_ID = "placeholder"
 @Factory(binds = [ComposerMviModel::class])
 @OptIn(FlowPreview::class)
 class ComposerViewModel(
-    @InjectedParam private val inReplyToId: String?,
+    @InjectedParam private val inReplyToId: String,
     private val identityRepository: IdentityRepository,
     private val timelineEntryRepository: TimelineEntryRepository,
     private val photoRepository: PhotoRepository,
@@ -150,9 +150,10 @@ class ComposerViewModel(
                         )
                     }
                 }.launchIn(this)
-            val parent = inReplyToId?.let { e -> entryCache.get(e) }
+            val parentId = inReplyToId.takeIf { it.isNotEmpty() }
+            val parent = parentId?.let { e -> entryCache.get(e) }
             val initialVisibility =
-                if (inReplyToId != null) {
+                if (parentId != null) {
                     currentSettings
                         ?.defaultReplyVisibility
                         ?.toVisibility()
@@ -301,6 +302,7 @@ class ComposerViewModel(
                             }
                             val mentions =
                                 inReplyToId
+                                    .takeIf { it.isNotEmpty() }
                                     ?.let { entryCache.get(it) }
                                     ?.mentions
                                     .orEmpty()
@@ -1360,7 +1362,7 @@ class ComposerViewModel(
 
     private suspend fun createPreview() {
         val currentState = uiState.value
-        val inReplyTo = inReplyToId?.let { entryCache.get(it) }
+        val inReplyTo = inReplyToId.takeIf { it.isNotEmpty() }?.let { entryCache.get(it) }
         val localId = getUuid()
         val entry =
             TimelineEntryModel(
@@ -1532,7 +1534,7 @@ class ComposerViewModel(
                                     localId = key,
                                     title = title,
                                     text = text,
-                                    inReplyTo = inReplyToId,
+                                    inReplyTo = inReplyToId.takeIf { it.isNotEmpty() },
                                     spoilerText = spoiler,
                                     sensitive = currentState.sensitive,
                                     visibility = visibility,
@@ -1552,7 +1554,7 @@ class ComposerViewModel(
                                     id = editId,
                                     title = title,
                                     text = text,
-                                    inReplyTo = inReplyToId,
+                                    inReplyTo = inReplyToId.takeIf { it.isNotEmpty() },
                                     spoilerText = spoiler,
                                     sensitive = currentState.sensitive,
                                     visibility = visibility,
@@ -1567,7 +1569,7 @@ class ComposerViewModel(
                                     localId = key,
                                     title = title,
                                     text = text,
-                                    inReplyTo = inReplyToId,
+                                    inReplyTo = inReplyToId.takeIf { it.isNotEmpty() },
                                     spoilerText = spoiler,
                                     sensitive = currentState.sensitive,
                                     visibility = visibility,
@@ -1591,7 +1593,7 @@ class ComposerViewModel(
                                     spoiler = spoiler,
                                     sensitive = currentState.sensitive,
                                     visibility = visibility,
-                                    parentId = inReplyToId,
+                                    parentId = inReplyToId.takeIf { it.isNotEmpty() },
                                     lang = currentState.lang,
                                     attachments =
                                         attachmentIds.map {

--- a/feature/report/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/report/CreateReportScreen.kt
+++ b/feature/report/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/report/CreateReportScreen.kt
@@ -68,7 +68,7 @@ class CreateReportScreen(
         val model =
             getScreenModel<CreateReportMviModel>(
                 parameters = {
-                    parametersOf(userId, entryId)
+                    parametersOf(userId, entryId.orEmpty())
                 },
             )
         val uiState by model.uiState.collectAsState()

--- a/feature/report/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/report/CreateReportViewModel.kt
+++ b/feature/report/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/report/CreateReportViewModel.kt
@@ -18,7 +18,7 @@ import org.koin.core.annotation.InjectedParam
 @Factory(binds = [CreateReportMviModel::class])
 class CreateReportViewModel(
     @InjectedParam private val userId: String,
-    @InjectedParam private val entryId: String?,
+    @InjectedParam private val entryId: String,
     private val nodeInfoRepository: NodeInfoRepository,
     private val supportedFeatureRepository: SupportedFeatureRepository,
     private val reportRepository: ReportRepository,
@@ -47,7 +47,7 @@ class CreateReportViewModel(
                     }
                 }.launchIn(this)
             val user = userCache.get(userId)
-            val entry = entryId?.let { entryCache.get(it) }
+            val entry = entryId.takeIf { it.isNotEmpty() }?.let { entryCache.get(it) }
             val rules = nodeInfoRepository.getRules().orEmpty()
             updateState {
                 it.copy(
@@ -101,7 +101,7 @@ class CreateReportViewModel(
             val successful =
                 reportRepository.create(
                     userId = userId,
-                    entryIds = entryId?.let { listOf(it) },
+                    entryIds = entryId.takeIf { it.isNotEmpty() }?.let { listOf(it) },
                     category = category,
                     comment = currentState.commentValue.text,
                     forward = currentState.forward,

--- a/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListScreen.kt
+++ b/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListScreen.kt
@@ -112,8 +112,8 @@ class UserListScreen(
             getScreenModel<UserListMviModel>(parameters = {
                 parametersOf(
                     type.toUserListType(),
-                    userId,
-                    entryId,
+                    userId.orEmpty(),
+                    entryId.orEmpty(),
                 )
             })
         val uiState by model.uiState.collectAsState()

--- a/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListViewModel.kt
+++ b/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListViewModel.kt
@@ -28,8 +28,8 @@ import org.koin.core.annotation.InjectedParam
 @Factory(binds = [UserListMviModel::class])
 internal class UserListViewModel(
     @InjectedParam private val type: UserListType,
-    @InjectedParam private val userId: String?,
-    @InjectedParam private val entryId: String?,
+    @InjectedParam private val userId: String,
+    @InjectedParam private val entryId: String,
     private val paginationManager: UserPaginationManager,
     private val userRepository: UserRepository,
     private val identityRepository: IdentityRepository,
@@ -87,8 +87,8 @@ internal class UserListViewModel(
     private suspend fun loadUser() {
         val userId =
             when (type) {
-                is UserListType.Follower -> userId
-                is UserListType.Following -> userId
+                is UserListType.Follower -> userId.takeIf { it.isNotEmpty() }
+                is UserListType.Following -> userId.takeIf { it.isNotEmpty() }
                 else -> null
             }
         if (userId != null) {
@@ -122,11 +122,12 @@ internal class UserListViewModel(
         }
         paginationManager.reset(
             when (type) {
-                is UserListType.Follower -> UserPaginationSpecification.Follower(userId.orEmpty())
-                is UserListType.Following -> UserPaginationSpecification.Following(userId.orEmpty())
+                is UserListType.Follower -> UserPaginationSpecification.Follower(userId)
+                is UserListType.Following -> UserPaginationSpecification.Following(userId)
                 is UserListType.UsersFavorite ->
-                    UserPaginationSpecification.EntryUsersFavorite(entryId.orEmpty())
-                is UserListType.UsersReblog -> UserPaginationSpecification.EntryUsersReblog(entryId.orEmpty())
+                    UserPaginationSpecification.EntryUsersFavorite(entryId)
+
+                is UserListType.UsersReblog -> UserPaginationSpecification.EntryUsersReblog(entryId)
             },
         )
         loadNextPage()
@@ -240,8 +241,8 @@ internal class UserListViewModel(
     private fun handleExport() {
         val specification =
             when (type) {
-                UserListType.Follower -> ExportUserSpecification.Follower(userId.orEmpty())
-                UserListType.Following -> ExportUserSpecification.Following(userId.orEmpty())
+                UserListType.Follower -> ExportUserSpecification.Follower(userId)
+                UserListType.Following -> ExportUserSpecification.Following(userId)
                 UserListType.UsersFavorite -> null
                 UserListType.UsersReblog -> null
             } ?: return


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR replaces nullable types in `@InjectedParams` with non-null types with a sentinel for missing values. 

## Additional notes
<!-- Anything to declare for code review? -->
This is due to a (probably) bug in Koin Annotations 2.0.0-Beta2. See RfL counterpart [here](https://github.com/LiveFastEatTrashRaccoon/RaccoonForLemmy/pull/147).
