### PR TITLE
fix: detect Friendica RC versions

### DIFF
--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepository.kt
@@ -33,7 +33,7 @@ internal class DefaultSupportedFeatureRepository(
 }
 
 private val FRIENDICA_REGEX =
-    Regex("\\(compatible; Friendica (?<version>[a-zA-Z0-9.-_]*)\\)")
+    Regex("\\(compatible; Friendica (?<version>[a-zA-Z0-9.\\-_]*)\\)")
 
 private val NodeInfoModel?.isFriendica: Boolean
     get() = this?.version?.contains(FRIENDICA_REGEX) ?: false

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepositoryTest.kt
@@ -1,0 +1,100 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NodeFeatures
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NodeInfoModel
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DefaultSupportedFeatureRepositoryTest {
+    private val nodeInfoRepository = mock<NodeInfoRepository>()
+    private val sut = DefaultSupportedFeatureRepository(nodeInfoRepository)
+
+    @Test
+    fun `when initial then result is as expected`() =
+        runTest {
+            val expected = NodeFeatures()
+            val res = sut.features.value
+
+            assertEquals(expected, res)
+            verifySuspend(VerifyMode.not) {
+                nodeInfoRepository.getInfo()
+            }
+        }
+
+    @Test
+    fun `given Mastodon when refresh then result is as expected`() =
+        runTest {
+            everySuspend { nodeInfoRepository.getInfo() } returns NodeInfoModel(version = "2.8")
+            sut.refresh()
+            val res = sut.features.value
+
+            assertFalse(res.supportsPhotoGallery)
+            assertFalse(res.supportsDirectMessages)
+            assertFalse(res.supportsEntryTitles)
+            assertFalse(res.supportsCustomCircles)
+            assertTrue(res.supportReportCategoryRuleViolation)
+            assertTrue(res.supportsPolls)
+            assertFalse(res.supportsBBCode)
+            assertTrue(res.supportsMarkdown)
+            assertFalse(res.supportsEntryShare)
+            assertFalse(res.supportsCalendar)
+            assertTrue(res.supportsAnnouncements)
+            verifySuspend {
+                nodeInfoRepository.getInfo()
+            }
+        }
+
+    @Test
+    fun `given Friendica when refresh then result is as expected`() =
+        runTest {
+            everySuspend { nodeInfoRepository.getInfo() } returns NodeInfoModel(version = "2.8.0 (compatible; Friendica 2024.09)")
+            sut.refresh()
+            val res = sut.features.value
+
+            assertTrue(res.supportsPhotoGallery)
+            assertTrue(res.supportsDirectMessages)
+            assertTrue(res.supportsEntryTitles)
+            assertTrue(res.supportsCustomCircles)
+            assertFalse(res.supportReportCategoryRuleViolation)
+            assertFalse(res.supportsPolls)
+            assertTrue(res.supportsBBCode)
+            assertTrue(res.supportsMarkdown)
+            assertTrue(res.supportsEntryShare)
+            assertTrue(res.supportsCalendar)
+            assertFalse(res.supportsAnnouncements)
+            verifySuspend {
+                nodeInfoRepository.getInfo()
+            }
+        }
+
+    @Test
+    fun `given Friendica RC when refresh then result is as expected`() =
+        runTest {
+            everySuspend { nodeInfoRepository.getInfo() } returns NodeInfoModel(version = "2.8.0 (compatible; Friendica 2024.09-rc)")
+            sut.refresh()
+            val res = sut.features.value
+
+            assertTrue(res.supportsPhotoGallery)
+            assertTrue(res.supportsDirectMessages)
+            assertTrue(res.supportsEntryTitles)
+            assertTrue(res.supportsCustomCircles)
+            assertFalse(res.supportReportCategoryRuleViolation)
+            assertFalse(res.supportsPolls)
+            assertTrue(res.supportsBBCode)
+            assertTrue(res.supportsMarkdown)
+            assertTrue(res.supportsEntryShare)
+            assertTrue(res.supportsCalendar)
+            assertFalse(res.supportsAnnouncements)
+            verifySuspend {
+                nodeInfoRepository.getInfo()
+            }
+        }
+}


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes a bug due to which Friendica RC versions were not properly detected and, as a result, all Friendica specific features of Raccoon were not available on those instances (Gallery, Direct messages, Calendar, Circles, quoting posts, titles, etc.).

## Additional notes
<!-- Anything to declare for code review? -->
<div align="center">
<img src="https://www.globalnerdy.com/wp-content/uploads/2022/01/regex-fright.jpg" width="310" />
</div>