### PR TITLE
fix: udpate image description when editing posts

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/MediaService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/MediaService.kt
@@ -8,6 +8,7 @@ import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.POST
 import de.jensklingenberg.ktorfit.http.PUT
 import de.jensklingenberg.ktorfit.http.Path
+import io.ktor.client.request.forms.FormDataContent
 import io.ktor.client.request.forms.MultiPartFormDataContent
 
 interface MediaService {
@@ -24,7 +25,7 @@ interface MediaService {
     @PUT("v1/media/{id}")
     suspend fun update(
         @Path("id") id: String,
-        @Body content: MultiPartFormDataContent,
+        @Body content: FormDataContent,
     ): MediaAttachment
 
     @DELETE("v1/media/{id}")

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TextWithCustomEmojis.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TextWithCustomEmojis.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
@@ -23,6 +22,7 @@ import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.em
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomImage
 import com.livefast.eattrash.raccoonforfriendica.core.utils.substituteAllOccurrences
 import com.livefast.eattrash.raccoonforfriendica.core.utils.uuid.getUuid
@@ -100,7 +100,7 @@ fun TextWithCustomEmojis(
                         ),
                 ) {
                     CustomImage(
-                        modifier = Modifier.size(with(LocalDensity.current) { EMOJI_SIZE.toDp() }),
+                        modifier = Modifier.size(IconSize.m),
                         url = emoji.url,
                         contentDescription = null,
                         contentScale = ContentScale.FillWidth,

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMediaRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMediaRepository.kt
@@ -3,10 +3,12 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.AttachmentModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
+import io.ktor.client.request.forms.FormDataContent
 import io.ktor.client.request.forms.MultiPartFormDataContent
 import io.ktor.client.request.forms.formData
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
+import io.ktor.http.parameters
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.delay
@@ -73,8 +75,9 @@ internal class DefaultMediaRepository(
         withContext(Dispatchers.IO) {
             runCatching {
                 val content =
-                    MultiPartFormDataContent(
-                        formData {
+                    FormDataContent(
+                        parameters {
+                            append("description", alt)
                         },
                     )
                 provider.media.update(id = id, content = content)

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMediaRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMediaRepositoryTest.kt
@@ -9,6 +9,7 @@ import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
+import dev.mokkery.matcher.matching
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
@@ -81,7 +82,13 @@ class DefaultMediaRepositoryTest {
 
             assertTrue(res)
             verifySuspend {
-                mediaService.update(id = any(), content = any())
+                mediaService.update(
+                    id = any(),
+                    content =
+                        matching {
+                            it.formData["description"] == "fake-description"
+                        },
+                )
             }
         }
 }

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
@@ -1183,18 +1183,10 @@ class ComposerViewModel(
     ) {
         screenModelScope.launch {
             val successful =
-                if (shouldUserPhotoRepository) {
-                    photoRepository.update(
-                        id = attachment.id,
-                        album = attachment.album.orEmpty(),
-                        alt = description,
-                    )
-                } else {
-                    mediaRepository.update(
-                        id = attachment.id,
-                        alt = description,
-                    )
-                }
+                mediaRepository.update(
+                    id = attachment.id,
+                    alt = description,
+                )
 
             if (successful) {
                 updateAttachmentInState(attachment.id) {


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes a bug which prevented image descriptions from being updated when editing posts.

## Additional notes
<!-- Anything to declare for code review? -->
It is not necessary to use Friendica's photo APIs to update media attachments, the Mastodon API works well in this respect.
