### PR TITLE
fix(di): prevent Koin metadata files from being compiled

### DIFF
--- a/build-logic/convention/src/main/kotlin/extensions/ConfigureKoinAnnotations.kt
+++ b/build-logic/convention/src/main/kotlin/extensions/ConfigureKoinAnnotations.kt
@@ -19,6 +19,7 @@ internal fun Project.configureKoinAnnotations(extension: KotlinMultiplatformExte
                 }
 
                 kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+                kotlin.exclude("**/KoinMeta-*.kt")
             }
         }
     }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR  excludes Koin metadata files from the compilation task, because their name contains a hash code (not deterministic).

--- 
Related (but not necessary closing): #657 
