### PR TITLE
fix: retrieve post source for editing even for plain text

### DIFF
--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
@@ -1329,8 +1329,9 @@ class ComposerViewModel(
                     entry.copy(content = bbCode)
                 }
                 // make the server strip off all the HTML
-                MarkupMode.HTML -> timelineEntryRepository.getSource(entry.id) ?: entry
-                // Markdown or PlainText are good to go
+                MarkupMode.HTML, MarkupMode.PlainText ->
+                    timelineEntryRepository.getSource(entry.id) ?: entry
+                // Markdown is good to go
                 else -> entry
             }
 


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR retrieves the post source from the backend even if plain text is selected.

## Additional notes
<!-- Anything to declare for code review? -->
Requested via private message.
