### PR TITLE
feat: add "compact" post layout

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -379,6 +379,7 @@
     <string name="timeline_entry_in_reply_to">in reply to</string>
     <string name="timeline_entry_reblogged_by">re-shared by</string>
     <string name="timeline_local">Local</string>
+    <string name="timeline_layout_compact">Compact</string>
     <string name="timeline_layout_distraction_free">Distraction free</string>
     <string name="timeline_layout_full">Full</string>
     <string name="timeline_subscriptions">Subscriptions</string>

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/resources/SharedStrings.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/resources/SharedStrings.kt
@@ -403,6 +403,7 @@ import raccoonforfriendica.composeapp.generated.resources.time_second_short
 import raccoonforfriendica.composeapp.generated.resources.timeline_all
 import raccoonforfriendica.composeapp.generated.resources.timeline_entry_in_reply_to
 import raccoonforfriendica.composeapp.generated.resources.timeline_entry_reblogged_by
+import raccoonforfriendica.composeapp.generated.resources.timeline_layout_compact
 import raccoonforfriendica.composeapp.generated.resources.timeline_layout_distraction_free
 import raccoonforfriendica.composeapp.generated.resources.timeline_layout_full
 import raccoonforfriendica.composeapp.generated.resources.timeline_local
@@ -1205,6 +1206,8 @@ class SharedStrings : Strings {
         @Composable get() = stringResource(Res.string.timeline_entry_in_reply_to)
     override val timelineEntryRebloggedBy: String
         @Composable get() = stringResource(Res.string.timeline_entry_reblogged_by)
+    override val timelineLayoutCompact: String
+        @Composable get() = stringResource(Res.string.timeline_layout_compact)
     override val timelineLayoutDistractionFree: String
         @Composable get() = stringResource(Res.string.timeline_layout_distraction_free)
     override val timelineLayoutFull: String

--- a/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/data/TimelineLayout.kt
+++ b/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/data/TimelineLayout.kt
@@ -6,23 +6,27 @@ import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 enum class TimelineLayout {
     Full,
     DistractionFree,
+    Compact,
 }
 
 fun TimelineLayout.toInt(): Int =
     when (this) {
         TimelineLayout.DistractionFree -> 1
+        TimelineLayout.Compact -> 2
         else -> 0
     }
 
 fun Int.toTimelineLayout(): TimelineLayout =
     when (this) {
         1 -> TimelineLayout.DistractionFree
+        2 -> TimelineLayout.Compact
         else -> TimelineLayout.Full
-}
+    }
 
 @Composable
 fun TimelineLayout.toReadableName(): String =
     when (this) {
         TimelineLayout.Full -> LocalStrings.current.timelineLayoutFull
         TimelineLayout.DistractionFree -> LocalStrings.current.timelineLayoutDistractionFree
-}
+        TimelineLayout.Compact -> LocalStrings.current.timelineLayoutCompact
+    }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CompactTimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CompactTimelineItem.kt
@@ -1,0 +1,322 @@
+package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.DpOffset
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomDropDown
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.embeddedImageUrls
+
+@Composable
+internal fun CompactTimelineItem(
+    entryToDisplay: TimelineEntryModel,
+    modifier: Modifier = Modifier,
+    actionsEnabled: Boolean = true,
+    autoloadImages: Boolean = true,
+    blurNsfw: Boolean = true,
+    extendedSocialInfoEnabled: Boolean = false,
+    maxBodyLines: Int = Int.MAX_VALUE,
+    maxTitleLines: Int = Int.MAX_VALUE,
+    options: List<Option> = emptyList(),
+    optionsMenuOpen: Boolean = false,
+    originalCreator: UserModel? = null,
+    originalInReplyTo: TimelineEntryModel? = null,
+    pollEnabled: Boolean = true,
+    reshareAndReplyVisible: Boolean = true,
+    onBookmark: ((TimelineEntryModel) -> Unit)? = null,
+    onClick: ((TimelineEntryModel) -> Unit)? = null,
+    onFavorite: ((TimelineEntryModel) -> Unit)? = null,
+    onOpenImage: ((List<String>, Int, List<Int>) -> Unit)? = null,
+    onOpenUrl: ((String) -> Unit)? = null,
+    onOpenUser: ((UserModel) -> Unit)? = null,
+    onOpenUsersFavorite: ((TimelineEntryModel) -> Unit)? = null,
+    onOpenUsersReblog: ((TimelineEntryModel) -> Unit)? = null,
+    onOptionSelected: ((OptionId) -> Unit)? = null,
+    onOptionsMenuToggled: ((Boolean) -> Unit)? = null,
+    onPollVote: ((TimelineEntryModel, List<Int>) -> Unit)? = null,
+    onReblog: ((TimelineEntryModel) -> Unit)? = null,
+    onReply: ((TimelineEntryModel) -> Unit)? = null,
+) {
+    val contentHorizontalPadding = Spacing.s
+    var optionsOffset by remember { mutableStateOf(Offset.Zero) }
+    val spoiler = entryToDisplay.spoiler.orEmpty()
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+    ) {
+        // reshare and reply info
+        if (reshareAndReplyVisible) {
+            Column(
+                modifier = Modifier.padding(horizontal = contentHorizontalPadding),
+            ) {
+                originalCreator?.let {
+                    ReblogInfo(
+                        user = it,
+                        autoloadImages = autoloadImages,
+                        onOpenUser = onOpenUser,
+                    )
+                }
+                originalInReplyTo?.creator?.let {
+                    InReplyToInfo(
+                        user = it,
+                        autoloadImages = autoloadImages,
+                        onOpenUser = onOpenUser,
+                    )
+                }
+            }
+        }
+
+        // header and options
+        Row(
+            modifier = Modifier.padding(horizontal = contentHorizontalPadding),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            ContentHeader(
+                modifier = Modifier.weight(1f),
+                user = entryToDisplay.creator,
+                autoloadImages = autoloadImages,
+                date = entryToDisplay.updated ?: entryToDisplay.created,
+                scheduleDate = entryToDisplay.scheduled,
+                isEdited = entryToDisplay.updated != null,
+                onOpenUser = onOpenUser,
+            )
+            if (options.isNotEmpty()) {
+                Box {
+                    IconButton(
+                        modifier =
+                            Modifier
+                                .onGloballyPositioned {
+                                    optionsOffset = it.positionInParent()
+                                }.clearAndSetSemantics { },
+                        onClick = {
+                            onOptionsMenuToggled?.invoke(true)
+                        },
+                    ) {
+                        Icon(
+                            modifier = Modifier.size(IconSize.s),
+                            imageVector = Icons.Default.MoreVert,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onBackground,
+                        )
+                    }
+
+                    CustomDropDown(
+                        expanded = optionsMenuOpen,
+                        onDismiss = {
+                            onOptionsMenuToggled?.invoke(false)
+                        },
+                        offset =
+                            with(LocalDensity.current) {
+                                DpOffset(
+                                    x = optionsOffset.x.toDp(),
+                                    y = optionsOffset.y.toDp(),
+                                )
+                            },
+                    ) {
+                        options.forEach { option ->
+                            DropdownMenuItem(
+                                text = {
+                                    Text(option.label)
+                                },
+                                onClick = {
+                                    onOptionsMenuToggled?.invoke(false)
+                                    onOptionSelected?.invoke(option.id)
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        // post spoiler
+        var spoilerActive by remember { mutableStateOf(false) }
+        if (spoiler.isNotEmpty()) {
+            SpoilerCard(
+                modifier =
+                    Modifier.fillMaxWidth().padding(
+                        vertical = Spacing.s,
+                        horizontal = contentHorizontalPadding,
+                    ),
+                content = spoiler,
+                autoloadImages = autoloadImages,
+                active = spoilerActive,
+                onClick = {
+                    spoilerActive = !spoilerActive
+                },
+            )
+        }
+
+        AnimatedVisibility(
+            modifier = Modifier.padding(horizontal = contentHorizontalPadding),
+            visible = spoilerActive || spoiler.isEmpty(),
+        ) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+            ) {
+                Row(
+                    modifier = Modifier.padding(vertical = Spacing.xxxs),
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+                    verticalAlignment = Alignment.Top,
+                ) {
+                    Column(
+                        modifier = Modifier.weight(COMPACT_POST_TITLE_WEIGHT),
+                        verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+                    ) {
+                        // post title
+                        val title = entryToDisplay.title
+                        if (!title.isNullOrBlank()) {
+                            ContentTitle(
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .semantics { heading() },
+                                content = title,
+                                maxLines = maxTitleLines,
+                                autoloadImages = autoloadImages,
+                                emojis = entryToDisplay.emojis,
+                                onClick = { onClick?.invoke(entryToDisplay) },
+                                onOpenUrl = onOpenUrl,
+                            )
+                        }
+
+                        // post body
+                        val body = entryToDisplay.content
+                        if (body.isNotBlank()) {
+                            ContentBody(
+                                modifier =
+                                    Modifier.fillMaxWidth().then(
+                                        if (title == null) {
+                                            Modifier
+                                        } else {
+                                            Modifier.padding(top = Spacing.xxxs)
+                                        },
+                                    ),
+                                content = body,
+                                autoloadImages = autoloadImages,
+                                maxLines = maxBodyLines,
+                                emojis = entryToDisplay.emojis,
+                                onClick = { onClick?.invoke(entryToDisplay) },
+                                onOpenUrl = onOpenUrl,
+                            )
+                        }
+                    }
+
+                    // attachments
+                    ContentAttachments(
+                        modifier = Modifier.weight(1 - COMPACT_POST_TITLE_WEIGHT),
+                        attachments =
+                            entryToDisplay.attachments.filter {
+                                it.url !in entryToDisplay.embeddedImageUrls
+                            },
+                        blurNsfw = blurNsfw,
+                        autoloadImages = autoloadImages,
+                        sensitive = entryToDisplay.sensitive,
+                        cornerSize = CornerSize.s,
+                        onOpenImage = onOpenImage,
+                    )
+                }
+
+                // poll
+                entryToDisplay.poll?.also { poll ->
+                    PollCard(
+                        modifier = Modifier.fillMaxWidth(),
+                        poll = poll,
+                        emojis = entryToDisplay.emojis,
+                        enabled = pollEnabled,
+                        onVote = { choices ->
+                            onPollVote?.invoke(entryToDisplay, choices)
+                        },
+                    )
+                }
+            }
+        }
+
+        // reblog and favorite info
+        if (extendedSocialInfoEnabled) {
+            ContentExtendedSocialInfo(
+                modifier =
+                    Modifier.padding(
+                        vertical = Spacing.xs,
+                        horizontal = contentHorizontalPadding,
+                    ),
+                reblogCount = entryToDisplay.reblogCount,
+                favoriteCount = entryToDisplay.favoriteCount,
+                onOpenUsersReblog = {
+                    onOpenUsersReblog?.invoke(entryToDisplay)
+                },
+                onOpenUsersFavorite = {
+                    onOpenUsersFavorite?.invoke(entryToDisplay)
+                },
+            )
+        }
+
+        if (actionsEnabled) {
+            ContentFooter(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            top = Spacing.xxs,
+                            start = contentHorizontalPadding,
+                            end = contentHorizontalPadding,
+                        ),
+                favoriteCount = entryToDisplay.favoriteCount,
+                favorite = entryToDisplay.favorite,
+                favoriteLoading = entryToDisplay.favoriteLoading,
+                reblogCount = entryToDisplay.reblogCount,
+                reblogged = entryToDisplay.reblogged,
+                reblogLoading = entryToDisplay.reblogLoading,
+                bookmarked = entryToDisplay.bookmarked,
+                bookmarkLoading = entryToDisplay.bookmarkLoading,
+                replyCount = entryToDisplay.replyCount,
+                onReply = {
+                    onReply?.invoke(entryToDisplay)
+                },
+                onReblog = {
+                    onReblog?.invoke(entryToDisplay)
+                },
+                onFavorite = {
+                    onFavorite?.invoke(entryToDisplay)
+                },
+                onBookmark = {
+                    onBookmark?.invoke(entryToDisplay)
+                },
+            )
+        }
+    }
+}
+
+private const val COMPACT_POST_TITLE_WEIGHT = 0.8f

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentAttachments.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentAttachments.kt
@@ -20,7 +20,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.AttachmentModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
@@ -33,6 +35,7 @@ fun ContentAttachments(
     blurNsfw: Boolean = true,
     autoloadImages: Boolean = true,
     sensitive: Boolean = false,
+    cornerSize: Dp = CornerSize.xl,
     onOpenImage: ((List<String>, Int, List<Int>) -> Unit)? = null,
 ) {
     val filteredAttachments =
@@ -84,6 +87,7 @@ fun ContentAttachments(
                     sensitive = blurNsfw && sensitive,
                     autoload = autoloadImages,
                     contentScale = ContentScale.FillWidth,
+                    cornerSize = cornerSize,
                     onClick = {
                         handleClick(0)
                     },
@@ -140,6 +144,7 @@ private fun AttachmentElement(
     blurNsfw: Boolean = true,
     autoload: Boolean = true,
     sensitive: Boolean = false,
+    cornerSize: Dp = CornerSize.xl,
     onClick: (() -> Unit)? = null,
 ) {
     val attachmentWidth = attachment.originalWidth ?: 0
@@ -154,6 +159,7 @@ private fun AttachmentElement(
                 blurHash = attachment.blurHash,
                 originalWidth = attachmentWidth,
                 originalHeight = attachmentHeight,
+                cornerSize = cornerSize,
                 sensitive = blurNsfw && sensitive,
                 autoload = autoload,
                 contentScale = contentScale,

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentImage.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentImage.kt
@@ -57,6 +57,7 @@ fun ContentImage(
     originalHeight: Int = 0,
     minHeight: Dp = 50.dp,
     maxHeight: Dp = 200.dp,
+    cornerSize: Dp = CornerSize.xl,
     contentScale: ContentScale = ContentScale.FillWidth,
     onClick: (() -> Unit)? = null,
     centerComposable: (@Composable () -> Unit) = {},
@@ -76,7 +77,7 @@ fun ContentImage(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .clip(RoundedCornerShape(CornerSize.xl))
+                        .clip(RoundedCornerShape(cornerSize))
                         .clickable {
                             onClick?.invoke()
                         },
@@ -91,7 +92,7 @@ fun ContentImage(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .clip(RoundedCornerShape(CornerSize.xl))
+                    .clip(RoundedCornerShape(cornerSize))
                     .clickable {
                         onClick?.invoke()
                     },

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
@@ -265,6 +265,38 @@ fun TimelineItem(
                     onReblog = onReblog,
                     onReply = onReply,
                 )
+
+            TimelineLayout.Compact ->
+                CompactTimelineItem(
+                    actionsEnabled = actionsEnabled,
+                    autoloadImages = autoloadImages,
+                    blurNsfw = blurNsfw,
+                    entryToDisplay = entryToDisplay,
+                    extendedSocialInfoEnabled = extendedSocialInfoEnabled,
+                    originalCreator = entry.creator?.takeIf { isReblog },
+                    originalInReplyTo = entry.inReplyTo?.takeIf { isReply },
+                    maxBodyLines = maxBodyLines,
+                    maxTitleLines = maxTitleLines,
+                    options = options,
+                    optionsMenuOpen = optionsMenuOpen,
+                    pollEnabled = pollEnabled,
+                    reshareAndReplyVisible = reshareAndReplyVisible,
+                    onBookmark = onBookmark,
+                    onClick = onClick,
+                    onFavorite = onFavorite,
+                    onOpenImage = onOpenImage,
+                    onOpenUrl = onOpenUrl,
+                    onOpenUser = onOpenUser,
+                    onOpenUsersFavorite = onOpenUsersFavorite,
+                    onOpenUsersReblog = onOpenUsersReblog,
+                    onOptionSelected = onOptionSelected,
+                    onOptionsMenuToggled = {
+                        optionsMenuOpen = it
+                    },
+                    onPollVote = onPollVote,
+                    onReblog = onReblog,
+                    onReply = onReply,
+                )
         }
     }
 }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineReplyItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineReplyItem.kt
@@ -247,6 +247,29 @@ fun TimelineReplyItem(
                         onReblog = onReblog,
                         onReply = onReply,
                     )
+
+                TimelineLayout.Compact ->
+                    CompactTimelineItem(
+                        modifier = contentModifier,
+                        actionsEnabled = actionsEnabled,
+                        autoloadImages = autoloadImages,
+                        blurNsfw = blurNsfw,
+                        entryToDisplay = entryToDisplay,
+                        options = options,
+                        optionsMenuOpen = optionsMenuOpen,
+                        onBookmark = onBookmark,
+                        onClick = onClick,
+                        onFavorite = onFavorite,
+                        onOpenImage = onOpenImage,
+                        onOpenUrl = onOpenUrl,
+                        onOpenUser = onOpenUser,
+                        onOptionSelected = onOptionSelected,
+                        onOptionsMenuToggled = {
+                            optionsMenuOpen = it
+                        },
+                        onReblog = onReblog,
+                        onReply = onReply,
+                    )
             }
         }
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/Strings.kt
@@ -390,6 +390,7 @@ interface Strings {
     val timelineAll: String @Composable get
     val timelineEntryInReplyTo: String @Composable get
     val timelineEntryRebloggedBy: String @Composable get
+    val timelineLayoutCompact: String @Composable get
     val timelineLayoutDistractionFree: String @Composable get
     val timelineLayoutFull: String @Composable get
     val timelineLocal: String @Composable get

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/testutils/MockStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/testutils/MockStrings.kt
@@ -787,6 +787,8 @@ class MockStrings : Strings {
         @Composable get() = retrieve("timelineEntryInReplyTo")
     override val timelineEntryRebloggedBy: String
         @Composable get() = retrieve("timelineEntryRebloggedBy")
+    override val timelineLayoutCompact: String
+        @Composable get() = retrieve("timelineLayoutCompact")
     override val timelineLayoutDistractionFree: String
         @Composable get() = retrieve("timelineLayoutDistractionFree")
     override val timelineLayoutFull: String

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
@@ -990,6 +990,7 @@ class SettingsScreen : Screen {
             val values =
                 listOf(
                     TimelineLayout.Full,
+                    TimelineLayout.Compact,
                     TimelineLayout.DistractionFree,
                 )
             CustomModalBottomSheet(


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds a new "compact" post layout, which allows to display title/body on one side and the image on the other side horizontally, without any preview.

## Additional notes
<!-- Anything to declare for code review? -->
I am planning to add another "card" layout in the future, don't know exactly whether in 0.4.0 or in another intermediate release, it also will depend on user feedback.
