### PR TITLE
fix: add dislike action outside home screen

### DIFF
--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineMviModel.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineMviModel.kt
@@ -24,6 +24,10 @@ interface CircleTimelineMviModel :
             val entry: TimelineEntryModel,
         ) : Intent
 
+        data class ToggleDislike(
+            val entry: TimelineEntryModel,
+        ) : Intent
+
         data class ToggleBookmark(
             val entry: TimelineEntryModel,
         ) : Intent

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineScreen.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineScreen.kt
@@ -271,6 +271,10 @@ class CircleTimelineScreen(
                                 { e: TimelineEntryModel ->
                                     model.reduce(CircleTimelineMviModel.Intent.ToggleFavorite(e))
                                 }.takeIf { actionRepository.canFavorite(entry.original) },
+                            onDislike =
+                                { e: TimelineEntryModel ->
+                                    model.reduce(CircleTimelineMviModel.Intent.ToggleDislike(e))
+                                }.takeIf { actionRepository.canDislike(entry.original) },
                             onReply =
                                 { e: TimelineEntryModel ->
                                     detailOpener.openComposer(

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineViewModel.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineViewModel.kt
@@ -112,6 +112,7 @@ class CircleTimelineViewModel(
 
             is CircleTimelineMviModel.Intent.ToggleReblog -> toggleReblog(intent.entry)
             is CircleTimelineMviModel.Intent.ToggleFavorite -> toggleFavorite(intent.entry)
+            is CircleTimelineMviModel.Intent.ToggleDislike -> toggleDislike(intent.entry)
             is CircleTimelineMviModel.Intent.ToggleBookmark -> toggleBookmark(intent.entry)
             is CircleTimelineMviModel.Intent.DeleteEntry -> deleteEntry(intent.entryId)
             is CircleTimelineMviModel.Intent.MuteUser ->

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailMviModel.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailMviModel.kt
@@ -23,6 +23,10 @@ interface EntryDetailMviModel :
             val entry: TimelineEntryModel,
         ) : Intent
 
+        data class ToggleDislike(
+            val entry: TimelineEntryModel,
+        ) : Intent
+
         data class ToggleBookmark(
             val entry: TimelineEntryModel,
         ) : Intent

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -297,6 +297,10 @@ class EntryDetailScreen(
                                 { e: TimelineEntryModel ->
                                     model.reduce(EntryDetailMviModel.Intent.ToggleFavorite(e))
                                 }.takeIf { actionRepository.canFavorite(entry.original) },
+                            onDislike =
+                                { e: TimelineEntryModel ->
+                                    model.reduce(EntryDetailMviModel.Intent.ToggleDislike(e))
+                                }.takeIf { actionRepository.canDislike(entry.original) },
                             onOpenUsersFavorite = { e ->
                                 detailOpener.openEntryUsersFavorite(
                                     entryId = e.id,

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailViewModel.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailViewModel.kt
@@ -120,6 +120,7 @@ class EntryDetailViewModel(
 
             is EntryDetailMviModel.Intent.ToggleReblog -> toggleReblog(intent.entry)
             is EntryDetailMviModel.Intent.ToggleFavorite -> toggleFavorite(intent.entry)
+            is EntryDetailMviModel.Intent.ToggleDislike -> toggleDislike(intent.entry)
             is EntryDetailMviModel.Intent.ToggleBookmark -> toggleBookmark(intent.entry)
             is EntryDetailMviModel.Intent.DeleteEntry -> deleteEntry(intent.entryId)
             is EntryDetailMviModel.Intent.MuteUser ->

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreMviModel.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreMviModel.kt
@@ -38,6 +38,10 @@ interface ExploreMviModel :
             val entry: TimelineEntryModel,
         ) : Intent
 
+        data class ToggleDislike(
+            val entry: TimelineEntryModel,
+        ) : Intent
+
         data class ToggleBookmark(
             val entry: TimelineEntryModel,
         ) : Intent

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
@@ -346,6 +346,10 @@ class ExploreScreen : Screen {
                                         { e: TimelineEntryModel ->
                                             model.reduce(ExploreMviModel.Intent.ToggleFavorite(e))
                                         }.takeIf { actionRepository.canFavorite(item.entry.original) },
+                                    onDislike =
+                                        { e: TimelineEntryModel ->
+                                            model.reduce(ExploreMviModel.Intent.ToggleDislike(e))
+                                        }.takeIf { actionRepository.canDislike(item.entry.original) },
                                     onReply =
                                         { e: TimelineEntryModel ->
                                             detailOpener.openComposer(

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreViewModel.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreViewModel.kt
@@ -136,6 +136,7 @@ class ExploreViewModel(
             is ExploreMviModel.Intent.Unfollow -> unfollow(intent.userId)
             is ExploreMviModel.Intent.ToggleBookmark -> toggleBookmark(intent.entry)
             is ExploreMviModel.Intent.ToggleFavorite -> toggleFavorite(intent.entry)
+            is ExploreMviModel.Intent.ToggleDislike -> toggleDislike(intent.entry)
             is ExploreMviModel.Intent.ToggleReblog -> toggleReblog(intent.entry)
             is ExploreMviModel.Intent.DeleteEntry -> deleteEntry(intent.entryId)
             is ExploreMviModel.Intent.MuteUser ->

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesMviModel.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesMviModel.kt
@@ -24,6 +24,10 @@ interface FavoritesMviModel :
             val entry: TimelineEntryModel,
         ) : Intent
 
+        data class ToggleDislike(
+            val entry: TimelineEntryModel,
+        ) : Intent
+
         data class ToggleBookmark(
             val entry: TimelineEntryModel,
         ) : Intent

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
@@ -257,6 +257,10 @@ class FavoritesScreen(
                                 { e: TimelineEntryModel ->
                                     model.reduce(FavoritesMviModel.Intent.ToggleFavorite(e))
                                 }.takeIf { actionRepository.canFavorite(entry.original) },
+                            onDislike =
+                                { e: TimelineEntryModel ->
+                                    model.reduce(FavoritesMviModel.Intent.ToggleDislike(e))
+                                }.takeIf { actionRepository.canDislike(entry.original) },
                             onReply =
                                 { e: TimelineEntryModel ->
                                     detailOpener.openComposer(

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesViewModel.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesViewModel.kt
@@ -102,6 +102,7 @@ class FavoritesViewModel(
 
             is FavoritesMviModel.Intent.ToggleReblog -> toggleReblog(intent.entry)
             is FavoritesMviModel.Intent.ToggleFavorite -> toggleFavorite(intent.entry)
+            is FavoritesMviModel.Intent.ToggleDislike -> toggleDislike(intent.entry)
             is FavoritesMviModel.Intent.ToggleBookmark -> toggleBookmark(intent.entry)
             is FavoritesMviModel.Intent.DeleteEntry -> deleteEntry(intent.entryId)
             is FavoritesMviModel.Intent.MuteUser ->

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagMviModel.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagMviModel.kt
@@ -28,6 +28,10 @@ interface HashtagMviModel :
             val entry: TimelineEntryModel,
         ) : Intent
 
+        data class ToggleDislike(
+            val entry: TimelineEntryModel,
+        ) : Intent
+
         data class ToggleBookmark(
             val entry: TimelineEntryModel,
         ) : Intent

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
@@ -278,6 +278,10 @@ class HashtagScreen(
                                 { e: TimelineEntryModel ->
                                     model.reduce(HashtagMviModel.Intent.ToggleFavorite(e))
                                 }.takeIf { actionRepository.canFavorite(entry.original) },
+                            onDislike =
+                                { e: TimelineEntryModel ->
+                                    model.reduce(HashtagMviModel.Intent.ToggleDislike(e))
+                                }.takeIf { actionRepository.canDislike(entry.original) },
                             onReply =
                                 { e: TimelineEntryModel ->
                                     detailOpener.openComposer(

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagViewModel.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagViewModel.kt
@@ -118,6 +118,7 @@ class HashtagViewModel(
 
             is HashtagMviModel.Intent.ToggleReblog -> toggleReblog(intent.entry)
             is HashtagMviModel.Intent.ToggleFavorite -> toggleFavorite(intent.entry)
+            is HashtagMviModel.Intent.ToggleDislike -> toggleDislike(intent.entry)
             is HashtagMviModel.Intent.ToggleBookmark -> toggleBookmark(intent.entry)
             is HashtagMviModel.Intent.ToggleTagFollow -> toggleTagFollow(intent.newValue)
             is HashtagMviModel.Intent.DeleteEntry -> deleteEntry(intent.entryId)

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountMviModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountMviModel.kt
@@ -29,6 +29,10 @@ interface MyAccountMviModel :
             val entry: TimelineEntryModel,
         ) : Intent
 
+        data class ToggleDislike(
+            val entry: TimelineEntryModel,
+        ) : Intent
+
         data class ToggleBookmark(
             val entry: TimelineEntryModel,
         ) : Intent

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
@@ -398,6 +398,10 @@ object MyAccountScreen : Tab {
                             { e: TimelineEntryModel ->
                                 model.reduce(MyAccountMviModel.Intent.ToggleFavorite(e))
                             }.takeIf { actionRepository.canFavorite(entry.original) },
+                        onDislike =
+                            { e: TimelineEntryModel ->
+                                model.reduce(MyAccountMviModel.Intent.ToggleDislike(e))
+                            }.takeIf { actionRepository.canDislike(entry.original) },
                         onReply =
                             { e: TimelineEntryModel ->
                                 detailOpener.openComposer(

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountViewModel.kt
@@ -189,6 +189,7 @@ class MyAccountViewModel(
 
             is MyAccountMviModel.Intent.ToggleReblog -> toggleReblog(intent.entry)
             is MyAccountMviModel.Intent.ToggleFavorite -> toggleFavorite(intent.entry)
+            is MyAccountMviModel.Intent.ToggleDislike -> toggleDislike(intent.entry)
             is MyAccountMviModel.Intent.ToggleBookmark -> toggleBookmark(intent.entry)
             is MyAccountMviModel.Intent.DeleteEntry -> deleteEntry(intent.entryId)
             is MyAccountMviModel.Intent.TogglePin -> togglePin(intent.entry)

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchMviModel.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchMviModel.kt
@@ -42,6 +42,10 @@ interface SearchMviModel :
             val entry: TimelineEntryModel,
         ) : Intent
 
+        data class ToggleDislike(
+            val entry: TimelineEntryModel,
+        ) : Intent
+
         data class ToggleBookmark(
             val entry: TimelineEntryModel,
         ) : Intent

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
@@ -348,6 +348,10 @@ class SearchScreen : Screen {
                                         { e: TimelineEntryModel ->
                                             model.reduce(SearchMviModel.Intent.ToggleFavorite(e))
                                         }.takeIf { actionRepository.canFavorite(item.entry.original) },
+                                    onDislike =
+                                        { e: TimelineEntryModel ->
+                                            model.reduce(SearchMviModel.Intent.ToggleDislike(e))
+                                        }.takeIf { actionRepository.canDislike(item.entry.original) },
                                     onReply =
                                         { e: TimelineEntryModel ->
                                             detailOpener.openComposer(

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchViewModel.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchViewModel.kt
@@ -149,6 +149,7 @@ class SearchViewModel(
             is SearchMviModel.Intent.Unfollow -> unfollow(intent.userId)
             is SearchMviModel.Intent.ToggleBookmark -> toggleBookmark(intent.entry)
             is SearchMviModel.Intent.ToggleFavorite -> toggleFavorite(intent.entry)
+            is SearchMviModel.Intent.ToggleDislike -> toggleDislike(intent.entry)
             is SearchMviModel.Intent.ToggleReblog -> toggleReblog(intent.entry)
             is SearchMviModel.Intent.DeleteEntry -> deleteEntry(intent.entryId)
             is SearchMviModel.Intent.MuteUser ->

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadMviModel.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadMviModel.kt
@@ -22,6 +22,10 @@ interface ThreadMviModel :
             val entry: TimelineEntryModel,
         ) : Intent
 
+        data class ToggleDislike(
+            val entry: TimelineEntryModel,
+        ) : Intent
+
         data class ToggleBookmark(
             val entry: TimelineEntryModel,
         ) : Intent

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadViewModel.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadViewModel.kt
@@ -101,6 +101,7 @@ class ThreadViewModel(
 
             is ThreadMviModel.Intent.ToggleBookmark -> toggleBookmark(intent.entry)
             is ThreadMviModel.Intent.ToggleFavorite -> toggleFavorite(intent.entry)
+            is ThreadMviModel.Intent.ToggleDislike -> toggleDislike(intent.entry)
             is ThreadMviModel.Intent.ToggleReblog -> toggleReblog(intent.entry)
             is ThreadMviModel.Intent.DeleteEntry -> deleteEntry(intent.entryId)
             is ThreadMviModel.Intent.MuteUser ->

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailMviModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailMviModel.kt
@@ -34,6 +34,10 @@ interface UserDetailMviModel :
             val entry: TimelineEntryModel,
         ) : Intent
 
+        data class ToggleDislike(
+            val entry: TimelineEntryModel,
+        ) : Intent
+
         data class ToggleBookmark(
             val entry: TimelineEntryModel,
         ) : Intent

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -601,6 +601,10 @@ class UserDetailScreen(
                                 { e: TimelineEntryModel ->
                                     model.reduce(UserDetailMviModel.Intent.ToggleFavorite(e))
                                 }.takeIf { actionRepository.canFavorite(entry.original) },
+                            onDislike =
+                                { e: TimelineEntryModel ->
+                                    model.reduce(UserDetailMviModel.Intent.ToggleDislike(e))
+                                }.takeIf { actionRepository.canDislike(entry.original) },
                             onReply =
                                 { e: TimelineEntryModel ->
                                     detailOpener.openComposer(

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailViewModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailViewModel.kt
@@ -122,6 +122,7 @@ class UserDetailViewModel(
             UserDetailMviModel.Intent.Unfollow -> unfollow()
             is UserDetailMviModel.Intent.ToggleReblog -> toggleReblog(intent.entry)
             is UserDetailMviModel.Intent.ToggleFavorite -> toggleFavorite(intent.entry)
+            is UserDetailMviModel.Intent.ToggleDislike -> toggleDislike(intent.entry)
             is UserDetailMviModel.Intent.ToggleBookmark -> toggleBookmark(intent.entry)
             UserDetailMviModel.Intent.DisableNotifications -> toggleNotifications(enabled = false)
             UserDetailMviModel.Intent.EnableNotifications -> toggleNotifications(enabled = true)

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListMviModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListMviModel.kt
@@ -26,6 +26,10 @@ interface ForumListMviModel :
             val entry: TimelineEntryModel,
         ) : Intent
 
+        data class ToggleDislike(
+            val entry: TimelineEntryModel,
+        ) : Intent
+
         data class ToggleBookmark(
             val entry: TimelineEntryModel,
         ) : Intent

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
@@ -368,6 +368,10 @@ class ForumListScreen(
                                 { e: TimelineEntryModel ->
                                     model.reduce(ForumListMviModel.Intent.ToggleFavorite(e))
                                 }.takeIf { actionRepository.canFavorite(entry.original) },
+                            onDislike =
+                                { e: TimelineEntryModel ->
+                                    model.reduce(ForumListMviModel.Intent.ToggleDislike(e))
+                                }.takeIf { actionRepository.canDislike(entry.original) },
                             onReply =
                                 { e: TimelineEntryModel ->
                                     detailOpener.openComposer(

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListViewModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListViewModel.kt
@@ -105,6 +105,7 @@ class ForumListViewModel(
 
             is ForumListMviModel.Intent.ToggleReblog -> toggleReblog(intent.entry)
             is ForumListMviModel.Intent.ToggleFavorite -> toggleFavorite(intent.entry)
+            is ForumListMviModel.Intent.ToggleDislike -> toggleDislike(intent.entry)
             is ForumListMviModel.Intent.ToggleBookmark -> toggleBookmark(intent.entry)
             is ForumListMviModel.Intent.DeleteEntry -> deleteEntry(intent.entryId)
             is ForumListMviModel.Intent.MuteUser ->


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR makes the dislike action available in other screens apart from the home (main timeline).

## Additional notes
<!-- Anything to declare for code review? -->
This should have been included in #675 but my 🧠 was on 🏖️.
