### PR TITLE
feat: add "card" post layout

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -381,6 +381,7 @@
     <string name="timeline_entry_in_reply_to">in reply to</string>
     <string name="timeline_entry_reblogged_by">re-shared by</string>
     <string name="timeline_local">Local</string>
+    <string name="timeline_layout_card">Card</string>
     <string name="timeline_layout_compact">Compact</string>
     <string name="timeline_layout_distraction_free">Distraction free</string>
     <string name="timeline_layout_full">Full</string>

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/resources/SharedStrings.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/resources/SharedStrings.kt
@@ -405,6 +405,7 @@ import raccoonforfriendica.composeapp.generated.resources.time_second_short
 import raccoonforfriendica.composeapp.generated.resources.timeline_all
 import raccoonforfriendica.composeapp.generated.resources.timeline_entry_in_reply_to
 import raccoonforfriendica.composeapp.generated.resources.timeline_entry_reblogged_by
+import raccoonforfriendica.composeapp.generated.resources.timeline_layout_card
 import raccoonforfriendica.composeapp.generated.resources.timeline_layout_compact
 import raccoonforfriendica.composeapp.generated.resources.timeline_layout_distraction_free
 import raccoonforfriendica.composeapp.generated.resources.timeline_layout_full
@@ -1212,6 +1213,8 @@ class SharedStrings : Strings {
         @Composable get() = stringResource(Res.string.timeline_entry_in_reply_to)
     override val timelineEntryRebloggedBy: String
         @Composable get() = stringResource(Res.string.timeline_entry_reblogged_by)
+    override val timelineLayoutCard: String
+        @Composable get() = stringResource(Res.string.timeline_layout_card)
     override val timelineLayoutCompact: String
         @Composable get() = stringResource(Res.string.timeline_layout_compact)
     override val timelineLayoutDistractionFree: String

--- a/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/data/TimelineLayout.kt
+++ b/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/data/TimelineLayout.kt
@@ -7,12 +7,14 @@ enum class TimelineLayout {
     Full,
     DistractionFree,
     Compact,
+    Card,
 }
 
 fun TimelineLayout.toInt(): Int =
     when (this) {
         TimelineLayout.DistractionFree -> 1
         TimelineLayout.Compact -> 2
+        TimelineLayout.Card -> 3
         else -> 0
     }
 
@@ -20,6 +22,7 @@ fun Int.toTimelineLayout(): TimelineLayout =
     when (this) {
         1 -> TimelineLayout.DistractionFree
         2 -> TimelineLayout.Compact
+        3 -> TimelineLayout.Card
         else -> TimelineLayout.Full
     }
 
@@ -29,4 +32,5 @@ fun TimelineLayout.toReadableName(): String =
         TimelineLayout.Full -> LocalStrings.current.timelineLayoutFull
         TimelineLayout.DistractionFree -> LocalStrings.current.timelineLayoutDistractionFree
         TimelineLayout.Compact -> LocalStrings.current.timelineLayoutCompact
+        TimelineLayout.Card -> LocalStrings.current.timelineLayoutCard
     }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CardTimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CardTimelineItem.kt
@@ -1,0 +1,351 @@
+package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.surfaceColorAtElevation
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomDropDown
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.embeddedImageUrls
+
+@Composable
+internal fun CardTimelineItem(
+    entryToDisplay: TimelineEntryModel,
+    modifier: Modifier = Modifier,
+    actionsEnabled: Boolean = true,
+    autoloadImages: Boolean = true,
+    blurNsfw: Boolean = true,
+    extendedSocialInfoEnabled: Boolean = false,
+    maxBodyLines: Int = Int.MAX_VALUE,
+    maxTitleLines: Int = Int.MAX_VALUE,
+    options: List<Option> = emptyList(),
+    optionsMenuOpen: Boolean = false,
+    originalCreator: UserModel? = null,
+    originalInReplyTo: TimelineEntryModel? = null,
+    pollEnabled: Boolean = true,
+    reshareAndReplyVisible: Boolean = true,
+    onBookmark: ((TimelineEntryModel) -> Unit)? = null,
+    onClick: ((TimelineEntryModel) -> Unit)? = null,
+    onFavorite: ((TimelineEntryModel) -> Unit)? = null,
+    onDislike: ((TimelineEntryModel) -> Unit)? = null,
+    onOpenImage: ((List<String>, Int, List<Int>) -> Unit)? = null,
+    onOpenUrl: ((String) -> Unit)? = null,
+    onOpenUser: ((UserModel) -> Unit)? = null,
+    onOpenUsersFavorite: ((TimelineEntryModel) -> Unit)? = null,
+    onOpenUsersReblog: ((TimelineEntryModel) -> Unit)? = null,
+    onOptionSelected: ((OptionId) -> Unit)? = null,
+    onOptionsMenuToggled: ((Boolean) -> Unit)? = null,
+    onPollVote: ((TimelineEntryModel, List<Int>) -> Unit)? = null,
+    onReblog: ((TimelineEntryModel) -> Unit)? = null,
+    onReply: ((TimelineEntryModel) -> Unit)? = null,
+) {
+    val contentHorizontalPadding = Spacing.s
+    var optionsOffset by remember { mutableStateOf(Offset.Zero) }
+    val spoiler = entryToDisplay.spoiler.orEmpty()
+
+    Column(
+        modifier =
+            modifier
+                .padding(horizontal = Spacing.xs)
+                .shadow(
+                    elevation = 5.dp,
+                    shape = RoundedCornerShape(CornerSize.l),
+                ).background(
+                    color = MaterialTheme.colorScheme.surfaceColorAtElevation(5.dp),
+                    shape = RoundedCornerShape(CornerSize.l),
+                ).padding(
+                    vertical = Spacing.s,
+                    horizontal = Spacing.xxxs,
+                ),
+        verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+    ) {
+        // reshare and reply info
+        if (reshareAndReplyVisible) {
+            Column(
+                modifier = Modifier.padding(horizontal = contentHorizontalPadding),
+            ) {
+                originalCreator?.let {
+                    ReblogInfo(
+                        user = it,
+                        autoloadImages = autoloadImages,
+                        onOpenUser = onOpenUser,
+                    )
+                }
+                originalInReplyTo?.creator?.let {
+                    InReplyToInfo(
+                        user = it,
+                        autoloadImages = autoloadImages,
+                        onOpenUser = onOpenUser,
+                    )
+                }
+            }
+        }
+
+        // header and options
+        Row(
+            modifier = Modifier.padding(horizontal = contentHorizontalPadding),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            ContentHeader(
+                modifier = Modifier.weight(1f),
+                user = entryToDisplay.creator,
+                autoloadImages = autoloadImages,
+                date = entryToDisplay.updated ?: entryToDisplay.created,
+                scheduleDate = entryToDisplay.scheduled,
+                isEdited = entryToDisplay.updated != null,
+                onOpenUser = onOpenUser,
+            )
+            if (options.isNotEmpty()) {
+                Box {
+                    IconButton(
+                        modifier =
+                            Modifier
+                                .onGloballyPositioned {
+                                    optionsOffset = it.positionInParent()
+                                }.clearAndSetSemantics { },
+                        onClick = {
+                            onOptionsMenuToggled?.invoke(true)
+                        },
+                    ) {
+                        Icon(
+                            modifier = Modifier.size(IconSize.s),
+                            imageVector = Icons.Default.MoreVert,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onBackground,
+                        )
+                    }
+
+                    CustomDropDown(
+                        expanded = optionsMenuOpen,
+                        onDismiss = {
+                            onOptionsMenuToggled?.invoke(false)
+                        },
+                        offset =
+                            with(LocalDensity.current) {
+                                DpOffset(
+                                    x = optionsOffset.x.toDp(),
+                                    y = optionsOffset.y.toDp(),
+                                )
+                            },
+                    ) {
+                        options.forEach { option ->
+                            DropdownMenuItem(
+                                text = {
+                                    Text(option.label)
+                                },
+                                onClick = {
+                                    onOptionsMenuToggled?.invoke(false)
+                                    onOptionSelected?.invoke(option.id)
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        // post spoiler
+        var spoilerActive by remember { mutableStateOf(false) }
+        if (spoiler.isNotEmpty()) {
+            SpoilerCard(
+                modifier =
+                    Modifier.fillMaxWidth().padding(
+                        vertical = Spacing.s,
+                        horizontal = contentHorizontalPadding,
+                    ),
+                content = spoiler,
+                autoloadImages = autoloadImages,
+                active = spoilerActive,
+                onClick = {
+                    spoilerActive = !spoilerActive
+                },
+            )
+        }
+
+        AnimatedVisibility(
+            modifier = Modifier.padding(horizontal = contentHorizontalPadding),
+            visible = spoilerActive || spoiler.isEmpty(),
+        ) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+            ) {
+                // post title
+                val title = entryToDisplay.title
+                if (!title.isNullOrBlank()) {
+                    ContentTitle(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .semantics { heading() },
+                        content = title,
+                        maxLines = maxTitleLines,
+                        autoloadImages = autoloadImages,
+                        emojis = entryToDisplay.emojis,
+                        onClick = { onClick?.invoke(entryToDisplay) },
+                        onOpenUrl = onOpenUrl,
+                    )
+                }
+
+                // post body
+                val body = entryToDisplay.content
+                if (body.isNotBlank()) {
+                    ContentBody(
+                        modifier =
+                            Modifier.fillMaxWidth().then(
+                                if (title == null) {
+                                    Modifier
+                                } else {
+                                    Modifier.padding(top = Spacing.xxxs)
+                                },
+                            ),
+                        content = body,
+                        autoloadImages = autoloadImages,
+                        maxLines = maxBodyLines,
+                        emojis = entryToDisplay.emojis,
+                        onClick = { onClick?.invoke(entryToDisplay) },
+                        onOpenUrl = onOpenUrl,
+                    )
+                }
+
+                // attachments
+                ContentAttachments(
+                    modifier =
+                        Modifier.fillMaxWidth().padding(
+                            top = Spacing.s,
+                            bottom = Spacing.xxxs,
+                        ),
+                    attachments =
+                        entryToDisplay.attachments.filter {
+                            it.url !in entryToDisplay.embeddedImageUrls
+                        },
+                    blurNsfw = blurNsfw,
+                    autoloadImages = autoloadImages,
+                    sensitive = entryToDisplay.sensitive,
+                    onOpenImage = onOpenImage,
+                )
+
+                // poll
+                entryToDisplay.poll?.also { poll ->
+                    PollCard(
+                        modifier = Modifier.fillMaxWidth(),
+                        poll = poll,
+                        emojis = entryToDisplay.emojis,
+                        enabled = pollEnabled,
+                        onVote = { choices ->
+                            onPollVote?.invoke(entryToDisplay, choices)
+                        },
+                    )
+                }
+            }
+        }
+
+        // reblog and favorite info
+        if (extendedSocialInfoEnabled) {
+            ContentExtendedSocialInfo(
+                modifier =
+                    Modifier.padding(
+                        vertical = Spacing.xs,
+                        horizontal = contentHorizontalPadding,
+                    ),
+                reblogCount = entryToDisplay.reblogCount,
+                favoriteCount = entryToDisplay.favoriteCount,
+                onOpenUsersReblog = {
+                    onOpenUsersReblog?.invoke(entryToDisplay)
+                },
+                onOpenUsersFavorite = {
+                    onOpenUsersFavorite?.invoke(entryToDisplay)
+                },
+            )
+        }
+
+        if (actionsEnabled) {
+            ContentFooter(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            top = Spacing.xxs,
+                            start = contentHorizontalPadding,
+                            end = contentHorizontalPadding,
+                        ),
+                favoriteCount = entryToDisplay.favoriteCount,
+                favorite = entryToDisplay.favorite,
+                favoriteLoading = entryToDisplay.favoriteLoading,
+                reblogCount = entryToDisplay.reblogCount,
+                reblogged = entryToDisplay.reblogged,
+                reblogLoading = entryToDisplay.reblogLoading,
+                bookmarked = entryToDisplay.bookmarked,
+                bookmarkLoading = entryToDisplay.bookmarkLoading,
+                replyCount = entryToDisplay.replyCount,
+                disliked = entryToDisplay.disliked,
+                dislikeCount = entryToDisplay.dislikesCount,
+                dislikeLoading = entryToDisplay.dislikeLoading,
+                onReply =
+                    if (onReply != null) {
+                        { onReply(entryToDisplay) }
+                    } else {
+                        null
+                    },
+                onReblog =
+                    if (onReblog != null) {
+                        { onReblog(entryToDisplay) }
+                    } else {
+                        null
+                    },
+                onFavorite =
+                    if (onFavorite != null) {
+                        { onFavorite(entryToDisplay) }
+                    } else {
+                        null
+                    },
+                onBookmark =
+                    if (onBookmark != null) {
+                        { onBookmark(entryToDisplay) }
+                    } else {
+                        null
+                    },
+                onDislike =
+                    if (onDislike != null) {
+                        { onDislike(entryToDisplay) }
+                    } else {
+                        null
+                    },
+            )
+        }
+    }
+}

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineDivider.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineDivider.kt
@@ -1,0 +1,28 @@
+package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.TimelineLayout
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+
+@Composable
+fun TimelineDivider(
+    modifier: Modifier = Modifier,
+    layout: TimelineLayout = TimelineLayout.Full,
+) {
+    when (layout) {
+        TimelineLayout.Card ->
+            Spacer(
+                modifier = modifier.height(Spacing.s),
+            )
+
+        else ->
+            HorizontalDivider(
+                modifier = modifier.padding(vertical = Spacing.s),
+            )
+    }
+}

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
@@ -339,6 +339,39 @@ fun TimelineItem(
                     onReblog = onReblog,
                     onReply = onReply,
                 )
+
+            TimelineLayout.Card ->
+                CardTimelineItem(
+                    actionsEnabled = actionsEnabled,
+                    autoloadImages = autoloadImages,
+                    blurNsfw = blurNsfw,
+                    entryToDisplay = entryToDisplay,
+                    extendedSocialInfoEnabled = extendedSocialInfoEnabled,
+                    originalCreator = entry.creator?.takeIf { isReblog },
+                    originalInReplyTo = entry.inReplyTo?.takeIf { isReply },
+                    maxBodyLines = maxBodyLines,
+                    maxTitleLines = maxTitleLines,
+                    options = options,
+                    optionsMenuOpen = optionsMenuOpen,
+                    pollEnabled = pollEnabled,
+                    reshareAndReplyVisible = reshareAndReplyVisible,
+                    onBookmark = onBookmark,
+                    onClick = onClick,
+                    onFavorite = onFavorite,
+                    onDislike = onDislike,
+                    onOpenImage = onOpenImage,
+                    onOpenUrl = onOpenUrl,
+                    onOpenUser = onOpenUser,
+                    onOpenUsersFavorite = onOpenUsersFavorite,
+                    onOpenUsersReblog = onOpenUsersReblog,
+                    onOptionSelected = onOptionSelected,
+                    onOptionsMenuToggled = {
+                        optionsMenuOpen = it
+                    },
+                    onPollVote = onPollVote,
+                    onReblog = onReblog,
+                    onReply = onReply,
+                )
         }
     }
 }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineReplyItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineReplyItem.kt
@@ -241,7 +241,7 @@ fun TimelineReplyItem(
                         }
                 }
             when (layout) {
-                TimelineLayout.Full ->
+                TimelineLayout.Full, TimelineLayout.Card ->
                     FullTimelineItem(
                         modifier = contentModifier,
                         actionsEnabled = actionsEnabled,

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/Strings.kt
@@ -392,6 +392,7 @@ interface Strings {
     val timelineAll: String @Composable get
     val timelineEntryInReplyTo: String @Composable get
     val timelineEntryRebloggedBy: String @Composable get
+    val timelineLayoutCard: String @Composable get
     val timelineLayoutCompact: String @Composable get
     val timelineLayoutDistractionFree: String @Composable get
     val timelineLayoutFull: String @Composable get

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/testutils/MockStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/testutils/MockStrings.kt
@@ -791,6 +791,8 @@ class MockStrings : Strings {
         @Composable get() = retrieve("timelineEntryInReplyTo")
     override val timelineEntryRebloggedBy: String
         @Composable get() = retrieve("timelineEntryRebloggedBy")
+    override val timelineLayoutCard: String
+        @Composable get() = retrieve("timelineLayoutCard")
     override val timelineLayoutCompact: String
         @Composable get() = retrieve("timelineLayoutCompact")
     override val timelineLayoutDistractionFree: String

--- a/feature/announcements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/announcements/AnnouncementsScreen.kt
+++ b/feature/announcements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/announcements/AnnouncementsScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -44,6 +43,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.GenericPlaceholder
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.InsertEmojiBottomSheet
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineDivider
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.feature.announcements.components.AnnouncementCard
@@ -159,9 +159,7 @@ class AnnouncementsScreen : Screen {
                                 height = 200.dp,
                             )
                             if (idx < placeholderCount - 1) {
-                                HorizontalDivider(
-                                    modifier = Modifier.padding(vertical = Spacing.s),
-                                )
+                                TimelineDivider()
                             }
                         }
                     }
@@ -208,9 +206,7 @@ class AnnouncementsScreen : Screen {
                             },
                         )
                         if (idx < uiState.items.lastIndex) {
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = Spacing.s),
-                            )
+                            TimelineDivider()
                         }
                     }
 

--- a/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/detail/EventDetailScreen.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/detail/EventDetailScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -40,6 +39,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ContentBody
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ContentTitle
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineDivider
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.feature.calendar.composables.CalendarEventFooter
@@ -154,9 +154,7 @@ class EventDetailScreen(
 
                     uiState.event?.description?.also { title ->
                         item {
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = Spacing.s),
-                            )
+                            TimelineDivider()
 
                             ContentBody(
                                 modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.s),

--- a/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/list/CalendarScreen.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/list/CalendarScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -43,6 +42,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineDivider
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toOption
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDetailOpener
@@ -147,9 +147,7 @@ class CalendarScreen : Screen {
                         items(placeholderCount) { idx ->
                             CalendarRowPlaceholder(modifier = Modifier.fillMaxWidth())
                             if (idx < placeholderCount - 1) {
-                                HorizontalDivider(
-                                    modifier = Modifier.padding(vertical = Spacing.s),
-                                )
+                                TimelineDivider()
                             }
                         }
                     }
@@ -206,9 +204,7 @@ class CalendarScreen : Screen {
                                     },
                                 )
                                 if (idx < uiState.items.lastIndex && uiState.items[idx + 1] !is CalendarItem.Header) {
-                                    HorizontalDivider(
-                                        modifier = Modifier.padding(vertical = Spacing.s),
-                                    )
+                                    TimelineDivider()
                                 }
                             }
                         }

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineScreen.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -52,6 +51,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomCon
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.EntryDetailDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.PollVoteErrorDialog
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineDivider
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItemPlaceholder
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toOption
@@ -203,9 +203,7 @@ class CircleTimelineScreen(
                         items(placeholderCount) { idx ->
                             TimelineItemPlaceholder(modifier = Modifier.fillMaxWidth())
                             if (idx < placeholderCount - 1) {
-                                HorizontalDivider(
-                                    modifier = Modifier.padding(vertical = Spacing.s),
-                                )
+                                TimelineDivider(layout = uiState.layout)
                             }
                         }
                     }
@@ -395,9 +393,7 @@ class CircleTimelineScreen(
                             },
                         )
                         if (idx < uiState.entries.lastIndex) {
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = Spacing.s),
-                            )
+                            TimelineDivider(layout = uiState.layout)
                         }
 
                         val canFetchMore =

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/list/DirectMessageListScreen.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/list/DirectMessageListScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -49,6 +48,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLo
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.getFabNestedScrollConnection
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.GenericPlaceholder
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.SelectUserDialog
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineDivider
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDetailOpener
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
@@ -172,9 +172,7 @@ class DirectMessageListScreen : Screen {
                         items(placeholderCount) { idx ->
                             GenericPlaceholder(height = 120.dp)
                             if (idx < placeholderCount - 1) {
-                                HorizontalDivider(
-                                    modifier = Modifier.padding(vertical = Spacing.s),
-                                )
+                                TimelineDivider()
                             }
                         }
                     }
@@ -211,9 +209,7 @@ class DirectMessageListScreen : Screen {
                             },
                         )
                         if (idx < uiState.items.lastIndex) {
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = Spacing.s),
-                            )
+                            TimelineDivider()
                         }
 
                         val canFetchMore =

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -3,6 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica.feature.entrydetail
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -12,12 +13,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Reply
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -30,6 +31,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -39,15 +41,18 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.core.screen.ScreenKey
 import cafe.adriel.voyager.kodein.rememberScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.TimelineLayout
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.getFabNestedScrollConnection
@@ -56,6 +61,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomCon
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.EntryDetailDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.PollVoteErrorDialog
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineDivider
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItemPlaceholder
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toOption
@@ -242,6 +248,25 @@ class EntryDetailScreen(
                     ) { idx, entry ->
                         val isMainEntry = entry.id == id
                         TimelineItem(
+                            modifier =
+                                Modifier.then(
+                                    if (isMainEntry && uiState.layout == TimelineLayout.Card) {
+                                        Modifier
+                                            .padding(horizontal = Spacing.xs)
+                                            .shadow(
+                                                elevation = 5.dp,
+                                                shape = RoundedCornerShape(CornerSize.l),
+                                            ).background(
+                                                color = MaterialTheme.colorScheme.surfaceColorAtElevation(5.dp),
+                                                shape = RoundedCornerShape(CornerSize.l),
+                                            ).padding(
+                                                vertical = Spacing.s,
+                                                horizontal = Spacing.xxxs,
+                                            )
+                                    } else {
+                                        Modifier
+                                    },
+                                ),
                             entry = entry,
                             extendedSocialInfoEnabled = isMainEntry,
                             layout =
@@ -425,9 +450,7 @@ class EntryDetailScreen(
                             },
                         )
                         if (idx < uiState.entries.lastIndex) {
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = Spacing.s),
-                            )
+                            TimelineDivider(layout = uiState.layout)
                         }
                     }
 
@@ -437,9 +460,7 @@ class EntryDetailScreen(
                         items(placeholderCount) { idx ->
                             TimelineItemPlaceholder(modifier = Modifier.fillMaxWidth())
                             if (idx < placeholderCount - 1) {
-                                HorizontalDivider(
-                                    modifier = Modifier.padding(vertical = Spacing.s),
-                                )
+                                TimelineDivider(layout = uiState.layout)
                             }
                         }
                     }

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -58,6 +57,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.HashtagIt
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.LinkItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.PollVoteErrorDialog
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineDivider
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItemPlaceholder
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.UserItem
@@ -264,9 +264,7 @@ class ExploreScreen : Screen {
                                 ExploreSection.Posts -> {
                                     TimelineItemPlaceholder(modifier = modifier)
                                     if (idx < placeholderCount - 1) {
-                                        HorizontalDivider(
-                                            modifier = Modifier.padding(vertical = Spacing.s),
-                                        )
+                                        TimelineDivider(layout = uiState.layout)
                                     }
                                 }
 
@@ -470,9 +468,7 @@ class ExploreScreen : Screen {
                                     },
                                 )
                                 if (idx < uiState.items.lastIndex) {
-                                    HorizontalDivider(
-                                        modifier = Modifier.padding(vertical = Spacing.s),
-                                    )
+                                    TimelineDivider(layout = uiState.layout)
                                 }
                             }
 

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -51,6 +50,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomCon
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.EntryDetailDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.PollVoteErrorDialog
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineDivider
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItemPlaceholder
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toOption
@@ -189,9 +189,7 @@ class FavoritesScreen(
                         items(placeholderCount) { idx ->
                             TimelineItemPlaceholder(modifier = Modifier.fillMaxWidth())
                             if (idx < placeholderCount - 1) {
-                                HorizontalDivider(
-                                    modifier = Modifier.padding(vertical = Spacing.s),
-                                )
+                                TimelineDivider(layout = uiState.layout)
                             }
                         }
                     }
@@ -375,9 +373,7 @@ class FavoritesScreen(
                             },
                         )
                         if (idx < uiState.entries.lastIndex) {
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = Spacing.s),
-                            )
+                            TimelineDivider(layout = uiState.layout)
                         }
 
                         val canFetchMore =

--- a/feature/followrequests/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/followrequests/FollowRequestsScreen.kt
+++ b/feature/followrequests/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/followrequests/FollowRequestsScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -38,6 +37,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.GenericPlaceholder
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineDivider
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDetailOpener
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
@@ -123,9 +123,7 @@ class FollowRequestsScreen : Screen {
                         items(placeholderCount) { idx ->
                             GenericPlaceholder(modifier = Modifier.fillMaxWidth())
                             if (idx < placeholderCount - 1) {
-                                HorizontalDivider(
-                                    modifier = Modifier.padding(vertical = Spacing.s),
-                                )
+                                TimelineDivider()
                             }
                         }
                     }

--- a/feature/gallery/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/gallery/list/GalleryScreen.kt
+++ b/feature/gallery/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/gallery/list/GalleryScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -54,6 +53,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.get
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.GenericPlaceholder
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineDivider
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toOption
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDetailOpener
@@ -195,9 +195,7 @@ class GalleryScreen : Screen {
                         items(placeholderCount) { idx ->
                             GenericPlaceholder()
                             if (idx < placeholderCount - 1) {
-                                HorizontalDivider(
-                                    modifier = Modifier.padding(vertical = Spacing.s),
-                                )
+                                TimelineDivider()
                             }
                         }
                     }
@@ -236,9 +234,7 @@ class GalleryScreen : Screen {
                             },
                         )
                         if (idx < uiState.items.lastIndex) {
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = Spacing.s),
-                            )
+                            TimelineDivider()
                         }
 
                         val canFetchMore =

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/followed/FollowedHashtagsScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/followed/FollowedHashtagsScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -41,6 +40,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLo
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.FollowHashtagItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.GenericPlaceholder
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineDivider
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDetailOpener
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
@@ -126,9 +126,7 @@ class FollowedHashtagsScreen : Screen {
                         items(placeholderCount) { idx ->
                             GenericPlaceholder(modifier = Modifier.fillMaxWidth())
                             if (idx < placeholderCount - 1) {
-                                HorizontalDivider(
-                                    modifier = Modifier.padding(vertical = Spacing.s),
-                                )
+                                TimelineDivider()
                             }
                         }
                     }

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -52,6 +51,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomCon
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.EntryDetailDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.PollVoteErrorDialog
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineDivider
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItemPlaceholder
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TwoStateButton
@@ -210,9 +210,7 @@ class HashtagScreen(
                         items(placeholderCount) { idx ->
                             TimelineItemPlaceholder(modifier = Modifier.fillMaxWidth())
                             if (idx < placeholderCount - 1) {
-                                HorizontalDivider(
-                                    modifier = Modifier.padding(vertical = Spacing.s),
-                                )
+                                TimelineDivider(layout = uiState.layout)
                             }
                         }
                     }
@@ -394,9 +392,7 @@ class HashtagScreen(
                             },
                         )
                         if (idx < uiState.entries.lastIndex) {
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = Spacing.s),
-                            )
+                            TimelineDivider(layout = uiState.layout)
                         }
 
                         val canFetchMore =

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxMviModel.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxMviModel.kt
@@ -1,7 +1,6 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.inbox
 
 import cafe.adriel.voyager.core.model.ScreenModel
-import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.TimelineLayout
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationType
@@ -50,7 +49,6 @@ interface InboxMviModel :
         val maxBodyLines: Int = Int.MAX_VALUE,
         val autoloadImages: Boolean = true,
         val hideNavigationBarWhileScrolling: Boolean = true,
-        val layout: TimelineLayout = TimelineLayout.Full,
     )
 
     sealed interface Effect {

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
@@ -1,5 +1,6 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.inbox
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -16,7 +17,6 @@ import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -191,16 +191,12 @@ class InboxScreen : Screen {
             ) {
                 LazyColumn(
                     state = lazyListState,
+                    verticalArrangement = Arrangement.spacedBy(Spacing.s),
                 ) {
                     if (uiState.initial) {
                         val placeholderCount = 5
                         items(placeholderCount) { idx ->
                             NotificationItemPlaceholder(modifier = Modifier.fillMaxWidth())
-                            if (idx < placeholderCount - 1) {
-                                HorizontalDivider(
-                                    modifier = Modifier.padding(vertical = Spacing.interItem),
-                                )
-                            }
                         }
                     }
 
@@ -210,7 +206,6 @@ class InboxScreen : Screen {
                     ) { idx, notification ->
                         NotificationItem(
                             notification = notification,
-                            layout = uiState.layout,
                             blurNsfw = uiState.blurNsfw,
                             autoloadImages = uiState.autoloadImages,
                             maxBodyLines = uiState.maxBodyLines,
@@ -250,11 +245,6 @@ class InboxScreen : Screen {
                                 }
                             },
                         )
-                        if (idx < uiState.notifications.lastIndex) {
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = Spacing.interItem),
-                            )
-                        }
 
                         val canFetchMore =
                             !uiState.initial && !uiState.loading && uiState.canFetchMore

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
@@ -1,7 +1,6 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.inbox
 
 import cafe.adriel.voyager.core.model.screenModelScope
-import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.TimelineLayout
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
 import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.BlurHashRepository
 import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.ImagePreloadManager
@@ -63,7 +62,6 @@ class InboxViewModel(
                             maxBodyLines = settings?.maxPostBodyLines ?: Int.MAX_VALUE,
                             hideNavigationBarWhileScrolling =
                                 settings?.hideNavigationBarWhileScrolling ?: true,
-                            layout = settings?.timelineLayout ?: TimelineLayout.Full,
                         )
                     }
                 }.launchIn(this)

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationItem.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationItem.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
@@ -50,13 +51,11 @@ internal fun NotificationItem(
     blurNsfw: Boolean = false,
     maxBodyLines: Int = Int.MAX_VALUE,
     autoloadImages: Boolean = true,
-    layout: TimelineLayout = TimelineLayout.Full,
     onOpenUrl: ((String) -> Unit)? = null,
     onOpenUser: ((UserModel) -> Unit)? = null,
     onOpenEntry: ((TimelineEntryModel) -> Unit)? = null,
     onUserRelationshipClicked: ((String, RelationshipStatusNextAction) -> Unit)? = null,
 ) {
-    val boxColor = MaterialTheme.colorScheme.surfaceColorAtElevation(5.dp)
     val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha)
     val entry = notification.entry
     val user = notification.user
@@ -115,8 +114,11 @@ internal fun NotificationItem(
             modifier =
                 Modifier
                     .padding(horizontal = contentHorizontalPadding)
-                    .background(
-                        color = boxColor,
+                    .shadow(
+                        elevation = 5.dp,
+                        shape = RoundedCornerShape(CornerSize.l),
+                    ).background(
+                        color = MaterialTheme.colorScheme.surfaceColorAtElevation(5.dp),
                         shape = RoundedCornerShape(CornerSize.l),
                     ).clip(RoundedCornerShape(CornerSize.l))
                     .padding(
@@ -133,7 +135,7 @@ internal fun NotificationItem(
                             bottom = Spacing.s,
                         ),
                     entry = entry,
-                    layout = layout,
+                    layout = TimelineLayout.DistractionFree,
                     blurNsfw = blurNsfw,
                     maxBodyLines = maxBodyLines,
                     autoloadImages = autoloadImages,

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
@@ -54,6 +54,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.Sectio
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.EntryDetailDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineDivider
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItemPlaceholder
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.UserFields
@@ -356,9 +357,7 @@ object MyAccountScreen : Tab {
                     items(placeholderCount) { idx ->
                         TimelineItemPlaceholder(modifier = Modifier.fillMaxWidth())
                         if (idx < placeholderCount - 1) {
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = Spacing.s),
-                            )
+                            TimelineDivider(layout = uiState.layout)
                         }
                     }
                 }
@@ -485,9 +484,7 @@ object MyAccountScreen : Tab {
                         },
                     )
                     if (idx < uiState.entries.lastIndex) {
-                        HorizontalDivider(
-                            modifier = Modifier.padding(vertical = Spacing.s),
-                        )
+                        TimelineDivider(layout = uiState.layout)
                     }
 
                     val canFetchMore =

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -60,6 +59,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.GenericPl
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.HashtagItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.PollVoteErrorDialog
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineDivider
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItemPlaceholder
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.UserItem
@@ -245,9 +245,7 @@ class SearchScreen : Screen {
                                 SearchSection.Posts -> {
                                     TimelineItemPlaceholder(modifier = modifier)
                                     if (idx < placeholderCount - 1) {
-                                        HorizontalDivider(
-                                            modifier = Modifier.padding(vertical = Spacing.s),
-                                        )
+                                        TimelineDivider(layout = uiState.layout)
                                     }
                                 }
 
@@ -471,9 +469,7 @@ class SearchScreen : Screen {
                                     },
                                 )
                                 if (idx < uiState.items.lastIndex) {
-                                    HorizontalDivider(
-                                        modifier = Modifier.padding(vertical = Spacing.s),
-                                    )
+                                    TimelineDivider(layout = uiState.layout)
                                 }
                             }
 

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
@@ -992,6 +992,7 @@ class SettingsScreen : Screen {
                     TimelineLayout.Full,
                     TimelineLayout.Compact,
                     TimelineLayout.DistractionFree,
+                    TimelineLayout.Card,
                 )
             CustomModalBottomSheet(
                 title = LocalStrings.current.settingsItemTimelineLayout,

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
@@ -3,7 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica.feature.thread
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
-import androidx.compose.foundation.border
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -22,7 +22,6 @@ import androidx.compose.material.icons.automirrored.filled.Reply
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -35,6 +34,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -44,17 +44,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.kodein.rememberScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.TimelineLayout
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
-import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.getFabNestedScrollConnection
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.ConfirmMuteUserBottomSheet
@@ -62,6 +62,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomCon
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.EntryDetailDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.PollVoteErrorDialog
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineDivider
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItemPlaceholder
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineReplyItem
@@ -232,12 +233,12 @@ class ThreadScreen(
                             TimelineItem(
                                 modifier =
                                     Modifier
-                                        .border(
-                                            width = Dp.Hairline,
-                                            color =
-                                                MaterialTheme.colorScheme.onBackground.copy(
-                                                    ancillaryTextAlpha,
-                                                ),
+                                        .padding(horizontal = Spacing.xs)
+                                        .shadow(
+                                            elevation = 5.dp,
+                                            shape = RoundedCornerShape(CornerSize.l),
+                                        ).background(
+                                            color = MaterialTheme.colorScheme.surfaceColorAtElevation(5.dp),
                                             shape = RoundedCornerShape(CornerSize.l),
                                         ).padding(
                                             vertical = Spacing.s,
@@ -300,7 +301,7 @@ class ThreadScreen(
                                         model.reduce(ThreadMviModel.Intent.ToggleDislike(e))
                                     }.takeIf {
                                         val e = uiState.entry ?: return@takeIf false
-                                    actionRepository.canDislike(e)
+                                        actionRepository.canDislike(e)
                                     },
                                 onOpenUsersFavorite = { e ->
                                     detailOpener.openEntryUsersFavorite(
@@ -387,9 +388,7 @@ class ThreadScreen(
                         items(placeholderCount) { idx ->
                             TimelineItemPlaceholder(modifier = Modifier.fillMaxWidth())
                             if (idx < placeholderCount - 1) {
-                                HorizontalDivider(
-                                    modifier = Modifier.padding(vertical = Spacing.s),
-                                )
+                                TimelineDivider(layout = uiState.layout)
                             }
                         }
                     }
@@ -443,7 +442,7 @@ class ThreadScreen(
                             onDislike =
                                 { e: TimelineEntryModel ->
                                     model.reduce(ThreadMviModel.Intent.ToggleDislike(e))
-                            }.takeIf { actionRepository.canDislike(entry.original) },
+                                }.takeIf { actionRepository.canDislike(entry.original) },
                             onReply =
                                 { e: TimelineEntryModel ->
                                     detailOpener.openComposer(
@@ -565,9 +564,7 @@ class ThreadScreen(
                             }
                         }
                         if (idx < uiState.replies.lastIndex) {
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = Spacing.s),
-                            )
+                            TimelineDivider(layout = uiState.layout)
                         }
                     }
                     item {

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -68,6 +67,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomCon
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.EntryDetailDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.PollVoteErrorDialog
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineDivider
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItemPlaceholder
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toOption
@@ -297,9 +297,7 @@ class TimelineScreen : Screen {
                         items(placeholderCount) { idx ->
                             TimelineItemPlaceholder(modifier = Modifier.fillMaxWidth())
                             if (idx < placeholderCount - 1) {
-                                HorizontalDivider(
-                                    modifier = Modifier.padding(vertical = Spacing.s),
-                                )
+                                TimelineDivider(layout = uiState.layout)
                             }
                         }
                     }
@@ -483,9 +481,7 @@ class TimelineScreen : Screen {
                             },
                         )
                         if (idx < uiState.entries.lastIndex) {
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = Spacing.s),
-                            )
+                            TimelineDivider(layout = uiState.layout)
                         }
 
                         val canFetchMore =

--- a/feature/unpublished/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/unpublished/UnpublishedScreen.kt
+++ b/feature/unpublished/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/unpublished/UnpublishedScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -44,6 +43,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowI
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.SectionSelector
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineDivider
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItemPlaceholder
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toOption
@@ -180,9 +180,7 @@ class UnpublishedScreen : Screen {
                             val modifier = Modifier.fillMaxWidth()
                             TimelineItemPlaceholder(modifier = modifier)
                             if (idx < placeholderCount - 1) {
-                                HorizontalDivider(
-                                    modifier = Modifier.padding(vertical = Spacing.s),
-                                )
+                                TimelineDivider(layout = uiState.layout)
                             }
                         }
                     }
@@ -228,9 +226,7 @@ class UnpublishedScreen : Screen {
                             },
                         )
                         if (idx < uiState.entries.lastIndex) {
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = Spacing.s),
-                            )
+                            TimelineDivider(layout = uiState.layout)
                         }
                     }
                 }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -78,6 +78,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.EntryDeta
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.Option
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.PollVoteErrorDialog
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineDivider
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItemPlaceholder
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.UserFields
@@ -542,9 +543,7 @@ class UserDetailScreen(
                         items(placeholderCount) { idx ->
                             TimelineItemPlaceholder(modifier = Modifier.fillMaxWidth())
                             if (idx < placeholderCount - 1) {
-                                HorizontalDivider(
-                                    modifier = Modifier.padding(vertical = Spacing.s),
-                                )
+                                TimelineDivider(layout = uiState.layout)
                             }
                         }
                     }
@@ -678,9 +677,7 @@ class UserDetailScreen(
                             },
                         )
                         if (idx < uiState.entries.lastIndex) {
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = Spacing.s),
-                            )
+                            TimelineDivider(layout = uiState.layout)
                         }
 
                         val canFetchMore =

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -67,6 +66,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomCon
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.EntryDetailDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.PollVoteErrorDialog
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineDivider
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItemPlaceholder
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toOption
@@ -310,9 +310,7 @@ class ForumListScreen(
                         items(placeholderCount) { idx ->
                             TimelineItemPlaceholder(modifier = Modifier.fillMaxWidth())
                             if (idx < placeholderCount - 1) {
-                                HorizontalDivider(
-                                    modifier = Modifier.padding(vertical = Spacing.s),
-                                )
+                                TimelineDivider(layout = uiState.layout)
                             }
                         }
                     }
@@ -473,9 +471,7 @@ class ForumListScreen(
                             },
                         )
                         if (idx < uiState.entries.lastIndex) {
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = Spacing.s),
-                            )
+                            TimelineDivider(layout = uiState.layout)
                         }
 
                         val canFetchMore =


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds a new "Card" option for post layout to customize timeline appearance.

## Additional notes
<!-- Anything to declare for code review? -->
Some adjustments have been needed in EntryDetailScreen, ThreadScreen and InboxScreen to make sure paddings, shadows, background and rounded corners have a consistent appearance.
