### PR TITLE
feat: add audio player component to support audio playback

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/resources/SharedResources.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/resources/SharedResources.kt
@@ -6,8 +6,10 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import chaintech.videoplayer.model.AudioPlayerConfig
 import chaintech.videoplayer.model.PlayerConfig
 import chaintech.videoplayer.model.ScreenResize
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.resources.CoreResources
 import org.jetbrains.compose.resources.Font
 import org.jetbrains.compose.resources.painterResource
@@ -87,5 +89,10 @@ internal class SharedResources : CoreResources {
                 } else {
                     ScreenResize.FILL
                 },
+        )
+
+    override fun getAudioPlayerConfig(): AudioPlayerConfig =
+        AudioPlayerConfig(
+            controlsBottomPadding = Spacing.s,
         )
 }

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/AudioPlayer.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/AudioPlayer.kt
@@ -1,0 +1,29 @@
+package com.livefast.eattrash.raccoonforfriendica.core.commonui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import chaintech.videoplayer.model.AudioFile
+import chaintech.videoplayer.ui.audio.AudioPlayerComposable
+import com.livefast.eattrash.raccoonforfriendica.core.resources.di.getCoreResources
+
+@Composable
+fun AudioPlayer(
+    urls: List<String>,
+    titles: List<String>,
+    modifier: Modifier = Modifier,
+) {
+    val resources = remember { getCoreResources() }
+    val config = resources.getAudioPlayerConfig()
+    AudioPlayerComposable(
+        modifier = modifier,
+        audios =
+            urls.mapIndexed { i, u ->
+                AudioFile(
+                    audioUrl = u,
+                    audioTitle = titles.getOrNull(i).orEmpty(),
+                )
+            },
+        audioPlayerConfig = config,
+    )
+}

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CardTimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CardTimelineItem.kt
@@ -39,6 +39,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSiz
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomDropDown
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.embeddedImageUrls
@@ -243,21 +244,35 @@ internal fun CardTimelineItem(
                 }
 
                 // attachments
-                ContentAttachments(
-                    modifier =
-                        Modifier.fillMaxWidth().padding(
-                            top = Spacing.s,
-                            bottom = Spacing.xxxs,
-                        ),
-                    attachments =
-                        entryToDisplay.attachments.filter {
-                            it.url !in entryToDisplay.embeddedImageUrls
-                        },
-                    blurNsfw = blurNsfw,
-                    autoloadImages = autoloadImages,
-                    sensitive = entryToDisplay.sensitive,
-                    onOpenImage = onOpenImage,
-                )
+                val attachments =
+                    entryToDisplay.attachments.filter { it.url !in entryToDisplay.embeddedImageUrls }
+                val visualAttachments =
+                    attachments.filter { it.type == MediaType.Image || it.type == MediaType.Video }
+                val audioAttachments = attachments.filter { it.type == MediaType.Audio }
+                if (visualAttachments.isNotEmpty()) {
+                    ContentVisualAttachments(
+                        modifier =
+                            Modifier.fillMaxWidth().padding(
+                                top = Spacing.s,
+                                bottom = Spacing.xxxs,
+                            ),
+                        attachments =
+                            entryToDisplay.attachments.filter {
+                                it.url !in entryToDisplay.embeddedImageUrls
+                            },
+                        blurNsfw = blurNsfw,
+                        autoloadImages = autoloadImages,
+                        sensitive = entryToDisplay.sensitive,
+                        onOpenImage = onOpenImage,
+                    )
+                }
+                if (audioAttachments.isNotEmpty()) {
+                    ContentAudioAttachments(
+                        modifier =
+                            Modifier.fillMaxWidth().padding(vertical = Spacing.xxxs),
+                        attachments = audioAttachments,
+                    )
+                }
 
                 // poll
                 entryToDisplay.poll?.also { poll ->

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CompactTimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CompactTimelineItem.kt
@@ -34,6 +34,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSiz
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomDropDown
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.embeddedImageUrls
@@ -184,6 +185,8 @@ internal fun CompactTimelineItem(
             modifier = Modifier.padding(horizontal = contentHorizontalPadding),
             visible = spoilerActive || spoiler.isEmpty(),
         ) {
+            val attachments =
+                entryToDisplay.attachments.filter { it.url !in entryToDisplay.embeddedImageUrls }
             Column(
                 verticalArrangement = Arrangement.spacedBy(Spacing.xs),
             ) {
@@ -235,18 +238,31 @@ internal fun CompactTimelineItem(
                         }
                     }
 
-                    // attachments
-                    ContentAttachments(
-                        modifier = Modifier.weight(1 - COMPACT_POST_TITLE_WEIGHT),
-                        attachments =
-                            entryToDisplay.attachments.filter {
-                                it.url !in entryToDisplay.embeddedImageUrls
-                            },
-                        blurNsfw = blurNsfw,
-                        autoloadImages = autoloadImages,
-                        sensitive = entryToDisplay.sensitive,
-                        cornerSize = CornerSize.s,
-                        onOpenImage = onOpenImage,
+                    // visual attachments
+                    val visualAttachments =
+                        attachments.filter { it.type == MediaType.Image || it.type == MediaType.Video }
+                    if (visualAttachments.isNotEmpty()) {
+                        ContentVisualAttachments(
+                            modifier = Modifier.weight(1 - COMPACT_POST_TITLE_WEIGHT),
+                            attachments =
+                                entryToDisplay.attachments.filter {
+                                    it.url !in entryToDisplay.embeddedImageUrls
+                                },
+                            blurNsfw = blurNsfw,
+                            autoloadImages = autoloadImages,
+                            sensitive = entryToDisplay.sensitive,
+                            cornerSize = CornerSize.s,
+                            onOpenImage = onOpenImage,
+                        )
+                    }
+                }
+                // audio attachments
+                val audioAttachments = attachments.filter { it.type == MediaType.Audio }
+                if (audioAttachments.isNotEmpty()) {
+                    ContentAudioAttachments(
+                        modifier =
+                            Modifier.fillMaxWidth().padding(vertical = Spacing.xxxs),
+                        attachments = audioAttachments,
                     )
                 }
 
@@ -334,8 +350,8 @@ internal fun CompactTimelineItem(
                     if (onDislike != null) {
                         { onDislike(entryToDisplay) }
                     } else {
-                    null
-                },
+                        null
+                    },
             )
         }
     }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentAudioAttachments.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentAudioAttachments.kt
@@ -1,0 +1,23 @@
+package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.Dp
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.AudioPlayer
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.AttachmentModel
+
+@Composable
+fun ContentAudioAttachments(
+    attachments: List<AttachmentModel>,
+    modifier: Modifier = Modifier,
+    cornerSize: Dp = CornerSize.xl,
+) {
+    AudioPlayer(
+        modifier = modifier.clip(RoundedCornerShape(cornerSize)),
+        urls = attachments.map { it.url },
+        titles = attachments.map { it.description.orEmpty() },
+    )
+}

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentVisualAttachments.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentVisualAttachments.kt
@@ -29,7 +29,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.aspectRatio
 
 @Composable
-fun ContentAttachments(
+fun ContentVisualAttachments(
     attachments: List<AttachmentModel>,
     modifier: Modifier = Modifier,
     blurNsfw: Boolean = true,
@@ -38,15 +38,10 @@ fun ContentAttachments(
     cornerSize: Dp = CornerSize.xl,
     onOpenImage: ((List<String>, Int, List<Int>) -> Unit)? = null,
 ) {
-    val filteredAttachments =
-        attachments
-            .filter { it.type == MediaType.Image || it.type == MediaType.Video }
-            .takeIf { it.isNotEmpty() } ?: return
-
     fun handleClick(index: Int) {
-        val urls = filteredAttachments.map { it.url }
+        val urls = attachments.map { it.url }
         val videoIndices =
-            filteredAttachments.mapIndexedNotNull { idx, attachmentModel ->
+            attachments.mapIndexedNotNull { idx, attachmentModel ->
                 if (attachmentModel.type == MediaType.Video) {
                     idx
                 } else {
@@ -59,14 +54,14 @@ fun ContentAttachments(
     val pagerState =
         rememberPagerState(
             initialPage = 0,
-            pageCount = { filteredAttachments.size },
+            pageCount = { attachments.size },
         )
     val referenceAspectRatio =
-        filteredAttachments
+        attachments
             .minBy { it.originalHeight ?: 0 }
             .aspectRatio
             .takeIf { it > 0 } ?: (16 / 9f)
-    val hasMultipleElements = filteredAttachments.size > 1
+    val hasMultipleElements = attachments.size > 1
     Column(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(Spacing.xs),
@@ -83,7 +78,7 @@ fun ContentAttachments(
             Box {
                 AttachmentElement(
                     modifier = Modifier.fillMaxSize(),
-                    attachment = filteredAttachments[index],
+                    attachment = attachments[index],
                     sensitive = blurNsfw && sensitive,
                     autoload = autoloadImages,
                     contentScale = ContentScale.FillWidth,

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/FullTimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/FullTimelineItem.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.unit.DpOffset
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomDropDown
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.embeddedImageUrls
@@ -225,21 +226,35 @@ internal fun FullTimelineItem(
                 }
 
                 // attachments
-                ContentAttachments(
-                    modifier =
-                        Modifier.fillMaxWidth().padding(
-                            top = Spacing.s,
-                            bottom = Spacing.xxxs,
-                        ),
-                    attachments =
-                        entryToDisplay.attachments.filter {
-                            it.url !in entryToDisplay.embeddedImageUrls
-                        },
-                    blurNsfw = blurNsfw,
-                    autoloadImages = autoloadImages,
-                    sensitive = entryToDisplay.sensitive,
-                    onOpenImage = onOpenImage,
-                )
+                val attachments =
+                    entryToDisplay.attachments.filter { it.url !in entryToDisplay.embeddedImageUrls }
+                val visualAttachments =
+                    attachments.filter { it.type == MediaType.Image || it.type == MediaType.Video }
+                val audioAttachments = attachments.filter { it.type == MediaType.Audio }
+                if (visualAttachments.isNotEmpty()) {
+                    ContentVisualAttachments(
+                        modifier =
+                            Modifier.fillMaxWidth().padding(
+                                top = Spacing.s,
+                                bottom = Spacing.xxxs,
+                            ),
+                        attachments =
+                            entryToDisplay.attachments.filter {
+                                it.url !in entryToDisplay.embeddedImageUrls
+                            },
+                        blurNsfw = blurNsfw,
+                        autoloadImages = autoloadImages,
+                        sensitive = entryToDisplay.sensitive,
+                        onOpenImage = onOpenImage,
+                    )
+                }
+                if (audioAttachments.isNotEmpty()) {
+                    ContentAudioAttachments(
+                        modifier =
+                            Modifier.fillMaxWidth().padding(vertical = Spacing.xxxs),
+                        attachments = audioAttachments,
+                    )
+                }
 
                 // poll
                 entryToDisplay.poll?.also { poll ->
@@ -256,7 +271,6 @@ internal fun FullTimelineItem(
 
                 // preview
                 entryToDisplay.card?.also { preview ->
-                    val attachments = entryToDisplay.attachments
                     ContentPreview(
                         modifier =
                             Modifier

--- a/core/resources/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/resources/CoreResources.kt
+++ b/core/resources/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/resources/CoreResources.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontFamily
+import chaintech.videoplayer.model.AudioPlayerConfig
 import chaintech.videoplayer.model.PlayerConfig
 
 interface CoreResources {
@@ -19,4 +20,6 @@ interface CoreResources {
         contentScale: ContentScale,
         muted: Boolean,
     ): PlayerConfig
+
+    fun getAudioPlayerConfig(): AudioPlayerConfig
 }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds the possibility to listen to audio attachments in posts.

## Additional notes
The idea is to create a component (`AudioPlayer`) similar to `VideoPlayer` to handle multiple files and a wrapper  around it (`ContentAudioAttachments`) to be used in post layouts similar to the existing `ContentAttachments` (renamed to `ContentVisualAttachments`) for images and videos.
