### PR TITLE
enhancement: disable autoplay from AudioPlayer and hides all controls except "Play" at startup

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -51,6 +51,7 @@
     <string name="action_open_preview">Open preview</string>
     <string name="action_open_side_menu">Open side menu</string>
     <string name="action_pin">Pin to profile</string>
+    <string name="action_play">Play</string>
     <string name="action_publish_default">Publish now</string>
     <string name="action_quote">Quote</string>
     <string name="action_reblog">Reshare</string>

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/resources/SharedStrings.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/resources/SharedStrings.kt
@@ -60,6 +60,7 @@ import raccoonforfriendica.composeapp.generated.resources.action_open_options
 import raccoonforfriendica.composeapp.generated.resources.action_open_preview
 import raccoonforfriendica.composeapp.generated.resources.action_open_side_menu
 import raccoonforfriendica.composeapp.generated.resources.action_pin
+import raccoonforfriendica.composeapp.generated.resources.action_play
 import raccoonforfriendica.composeapp.generated.resources.action_publish_default
 import raccoonforfriendica.composeapp.generated.resources.action_quote
 import raccoonforfriendica.composeapp.generated.resources.action_reblog
@@ -537,6 +538,8 @@ class SharedStrings : Strings {
         @Composable get() = stringResource(Res.string.action_open_side_menu)
     override val actionPin: String
         @Composable get() = stringResource(Res.string.action_pin)
+    override val actionPlay: String
+        @Composable get() = stringResource(Res.string.action_play)
     override val actionPublishDefault: String
         @Composable get() = stringResource(Res.string.action_publish_default)
     override val actionQuote: String

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/AudioPlayer.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/AudioPlayer.kt
@@ -1,10 +1,36 @@
 package com.livefast.eattrash.raccoonforfriendica.core.commonui.components
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.max
 import chaintech.videoplayer.model.AudioFile
+import chaintech.videoplayer.model.AudioPlayerConfig
+import chaintech.videoplayer.ui.audio.AlbumArt
 import chaintech.videoplayer.ui.audio.AudioPlayerComposable
+import chaintech.videoplayer.ui.audio.TimeDetails
+import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.resources.di.getCoreResources
 
 @Composable
@@ -12,18 +38,133 @@ fun AudioPlayer(
     urls: List<String>,
     titles: List<String>,
     modifier: Modifier = Modifier,
+    autoplay: Boolean = false,
 ) {
     val resources = remember { getCoreResources() }
     val config = resources.getAudioPlayerConfig()
-    AudioPlayerComposable(
-        modifier = modifier,
-        audios =
-            urls.mapIndexed { i, u ->
-                AudioFile(
-                    audioUrl = u,
-                    audioTitle = titles.getOrNull(i).orEmpty(),
-                )
+    var isInitial by remember { mutableStateOf(true) }
+
+    if (!autoplay && isInitial) {
+        FakeAudioPlayerComposable(
+            modifier = modifier,
+            audioPlayerConfig = config,
+            onPlay = {
+                isInitial = false
             },
-        audioPlayerConfig = config,
-    )
+        )
+    } else {
+        AudioPlayerComposable(
+            modifier = modifier,
+            audioPlayerConfig = config,
+            audios =
+                urls.mapIndexed { idx, url ->
+                    AudioFile(
+                        audioUrl = url,
+                        audioTitle = titles.getOrNull(idx).orEmpty(),
+                    )
+                },
+        )
+    }
+}
+
+/**
+ * Create a "fake" player with the same aspect as the original one, when tapping on the play
+ * button it calls the onPlay callback which can be used to display the real player.
+ *
+ * It also hides all the controls except "play" in order to make it easier to skip with talkback.
+ */
+@Composable
+private fun FakeAudioPlayerComposable(
+    modifier: Modifier = Modifier,
+    audioPlayerConfig: AudioPlayerConfig,
+    onPlay: () -> Unit,
+) {
+    Box(
+        modifier = modifier.background(audioPlayerConfig.backgroundColor),
+    ) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            Column(
+                modifier =
+                    Modifier
+                        .align(Alignment.BottomStart)
+                        .padding(bottom = audioPlayerConfig.controlsBottomPadding),
+                verticalArrangement = Arrangement.spacedBy(30.dp),
+            ) {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .weight(0.5f)
+                            .padding(horizontal = 25.dp),
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    Spacer(modifier = Modifier.weight(0.25f))
+                    AlbumArt(
+                        audioPlayerConfig = audioPlayerConfig,
+                        thumbnailUrl = "",
+                    )
+                    Spacer(modifier = Modifier.weight(0.05f))
+                }
+
+                if (audioPlayerConfig.isControlsVisible) {
+                    Row(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp),
+                        verticalAlignment = Alignment.Top,
+                    ) {
+                        Column(
+                            modifier = Modifier.weight(1f),
+                        ) {
+                            Slider(
+                                enabled = false,
+                                modifier = Modifier.fillMaxWidth().height(25.dp),
+                                value = 0f,
+                                onValueChange = {},
+                                colors =
+                                    SliderDefaults.colors(
+                                        thumbColor = audioPlayerConfig.seekBarThumbColor,
+                                        inactiveTrackColor = audioPlayerConfig.seekBarInactiveTrackColor,
+                                        activeTrackColor = audioPlayerConfig.seekBarActiveTrackColor,
+                                    ),
+                            )
+
+                            TimeDetails(
+                                audioPlayerConfig = audioPlayerConfig,
+                                currentTime = 0,
+                                totalTime = 0,
+                            )
+                        }
+                    }
+
+                    val controlPanelHeight =
+                        max(
+                            audioPlayerConfig.pauseResumeIconSize,
+                            audioPlayerConfig.previousNextIconSize,
+                        )
+
+                    Row(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .height(controlPanelHeight),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceAround,
+                    ) {
+                        IconButton(
+                            onClick = onPlay,
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.PlayArrow,
+                                contentDescription = LocalStrings.current.actionPlay,
+                                tint = audioPlayerConfig.iconsTintColor,
+                                modifier = Modifier.fillMaxSize(),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/Strings.kt
@@ -54,6 +54,7 @@ interface Strings {
     val actionOpenPreview: String @Composable get
     val actionOpenSideMenu: String @Composable get
     val actionPin: String @Composable get
+    val actionPlay: String @Composable get
     val actionPublishDefault: String @Composable get
     val actionQuote: String @Composable get
     val actionReblog: String @Composable get

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/testutils/MockStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/testutils/MockStrings.kt
@@ -115,6 +115,8 @@ class MockStrings : Strings {
         @Composable get() = retrieve("actionOpenSideMenu")
     override val actionPin: String
         @Composable get() = retrieve("actionPin")
+    override val actionPlay: String
+        @Composable get() = retrieve("actionPlay")
     override val actionPublishDefault: String
         @Composable get() = retrieve("actionPublishDefault")
     override val actionQuote: String


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR prevents audio files from automatically start playing and hides all controls except "Play" at startup, as requested in #688.

## Additional notes
<!-- Anything to declare for code review? -->
Unfortunately, there is no simple way to accomplish this using Compose Multiplatform Media Player, so I had to create a "fake" interface of a paused player which shows the real player when the play button is pressed.
