### PR TITLE
fix: add clearAndSetSemantics on disabled slider in fake audio player

### DIFF
--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/AudioPlayer.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/AudioPlayer.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.max
 import chaintech.videoplayer.model.AudioFile
@@ -118,8 +119,12 @@ private fun FakeAudioPlayerComposable(
                             modifier = Modifier.weight(1f),
                         ) {
                             Slider(
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .height(25.dp)
+                                        .clearAndSetSemantics { },
                                 enabled = false,
-                                modifier = Modifier.fillMaxWidth().height(25.dp),
                                 value = 0f,
                                 onValueChange = {},
                                 colors =


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR reset semantics on the disabled slider in the fake audio plater, as per [this comment](https://github.com/LiveFastEatTrashRaccoon/RaccoonForFriendica/issues/688#issuecomment-2563471024).
