### PR TITLE
fix: process embedded images separately from text flow in post body

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentBody.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentBody.kt
@@ -1,14 +1,23 @@
 package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomImage
 import com.livefast.eattrash.raccoonforfriendica.core.htmlparse.parseHtml
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EmojiModel
+
+internal val IMAGE_REGEX = Regex("<img.*?/>")
 
 @Composable
 fun ContentBody(
@@ -19,33 +28,78 @@ fun ContentBody(
     autoloadImages: Boolean = true,
     emojis: List<EmojiModel> = emptyList(),
     onClick: (() -> Unit)? = null,
+    onOpenImage: ((String) -> Unit)? = null,
     onOpenUrl: ((String) -> Unit)? = null,
 ) {
     Box(modifier = modifier) {
-        val annotatedContent =
-            content.parseHtml(
-                linkColor = MaterialTheme.colorScheme.primary,
-                quoteColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha),
-            )
-        TextWithCustomEmojis(
-            style = MaterialTheme.typography.bodyMedium.copy(color = color),
-            text = annotatedContent,
-            maxLines = maxLines,
-            overflow = TextOverflow.Ellipsis,
-            emojis = emojis,
-            autoloadImages = autoloadImages,
-            onClick = { offset ->
-                val url =
-                    annotatedContent
-                        .getStringAnnotations(start = offset, end = offset)
-                        .firstOrNull()
-                        ?.item
-                if (!url.isNullOrBlank()) {
-                    onOpenUrl?.invoke(url)
+        val chunks = content.splitTextAndImages()
+        Column {
+            for (chunk in chunks) {
+                if (IMAGE_REGEX.matches(chunk)) {
+                    extractImageData(chunk)?.also { data ->
+                        CustomImage(
+                            modifier =
+                                Modifier
+                                    .fillMaxSize()
+                                    .clip(RoundedCornerShape(CornerSize.xl))
+                                    .clickable {
+                                        onOpenImage?.invoke(data.url)
+                                    },
+                            url = data.url,
+                            contentDescription = data.description,
+                        )
+                    }
                 } else {
-                    onClick?.invoke()
+                    val annotatedContent =
+                        chunk.parseHtml(
+                            linkColor = MaterialTheme.colorScheme.primary,
+                            quoteColor =
+                                MaterialTheme.colorScheme.onBackground.copy(
+                                    ancillaryTextAlpha,
+                                ),
+                        )
+                    TextWithCustomEmojis(
+                        style = MaterialTheme.typography.bodyMedium.copy(color = color),
+                        text = annotatedContent,
+                        maxLines = maxLines,
+                        overflow = TextOverflow.Ellipsis,
+                        emojis = emojis,
+                        autoloadImages = autoloadImages,
+                        onClick = { offset ->
+                            val url =
+                                annotatedContent
+                                    .getStringAnnotations(start = offset, end = offset)
+                                    .firstOrNull()
+                                    ?.item
+                            if (!url.isNullOrBlank()) {
+                                onOpenUrl?.invoke(url)
+                            } else {
+                                onClick?.invoke()
+                            }
+                        },
+                    )
                 }
-            },
-        )
+            }
+        }
     }
 }
+
+private fun String.splitTextAndImages(): List<String> =
+    buildList {
+        val original = this@splitTextAndImages
+        val matches = IMAGE_REGEX.findAll(original).toList()
+        var index = 0
+        for (match in matches) {
+            val range = match.range
+            add(original.substring(index, range.first).trim())
+            val htmlImage = original.substring(range)
+            val data = extractImageData(htmlImage)
+            if (data != null && data.description?.looksLikeAnEmoji != true) {
+                add(htmlImage.trim())
+            }
+            index = range.last + 1
+        }
+        if (index < original.length) {
+            add(original.substring(index, original.length).trim())
+        }
+    }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ImageData.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ImageData.kt
@@ -1,0 +1,33 @@
+package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
+
+import com.mohamedrejeb.ksoup.html.parser.KsoupHtmlHandler
+import com.mohamedrejeb.ksoup.html.parser.KsoupHtmlParser
+
+internal data class ImageData(
+    val url: String,
+    val description: String? = null,
+)
+
+internal fun extractImageData(html: String): ImageData? {
+    var url: String? = null
+    var description: String? = null
+    KsoupHtmlParser(
+        KsoupHtmlHandler
+            .Builder()
+            .onOpenTag { name, attributes, _ ->
+                when (name) {
+                    "img" -> {
+                        url = attributes["src"]
+                        description = attributes["alt"]
+                    }
+
+                    else -> Unit
+                }
+            }.build(),
+    ).apply {
+        write(html)
+        end()
+    }
+
+    return url?.let { ImageData(url = it, description = description) }
+}


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR iterates on the issue reported in #607 which affected both custom emojis and embedded images. The issue was solved for emojis in #654 but the issue with "floating" images overlapping text could still happen for images which were not emojis.

This PR applies a different solution to that problem, separating images and text (ie. images are treated as "block elements" rather than "inline" elements), in order not to break text flow on Compose.

## Additional notes
<!-- Anything to declare for code review? -->
This changes `TextWithCustomEmojis` too (simplifying it) so pay attention when dealing with #689.
