### PR TITLE
fix: preserve transient post fields after toggling favorite

### DIFF
--- a/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/DefaultToggleEntryFavoriteUseCase.kt
+++ b/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/DefaultToggleEntryFavoriteUseCase.kt
@@ -23,14 +23,17 @@ internal class DefaultToggleEntryFavoriteUseCase(
             } else {
                 entryRepository.unfavorite(entryId)
             }?.let { referenceEntry ->
-                if (dislikeRemoved) {
-                    referenceEntry.copy(
-                        disliked = false,
-                        dislikesCount = (entry.dislikesCount - 1).coerceAtLeast(0),
-                    )
-                } else {
-                    referenceEntry
-                }
+                entry.copy(
+                    disliked = false,
+                    dislikesCount =
+                        if (dislikeRemoved) {
+                            (entry.dislikesCount - 1).coerceAtLeast(0)
+                        } else {
+                            entry.dislikesCount
+                        },
+                    favorite = referenceEntry.favorite,
+                    favoriteCount = referenceEntry.favoriteCount,
+                )
             }
         } else {
             null


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes a bug introduced in #675 due to which all transient fields (including custom emojis) are lost when an entry is added/removed from favorites.

## Additional notes
<!-- Anything to declare for code review? -->
There was a reason why entry fields were copied and not just updated with the new remote entirely.
