### PR TITLE
fix: top padding between post and first reply placeholder in post detail

### DIFF
--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -458,7 +458,16 @@ class EntryDetailScreen(
                     if (uiState.initial) {
                         val placeholderCount = 5
                         items(placeholderCount) { idx ->
-                            TimelineItemPlaceholder(modifier = Modifier.fillMaxWidth())
+                            TimelineItemPlaceholder(
+                                modifier =
+                                    Modifier.fillMaxWidth().then(
+                                        if (idx == 0) {
+                                            Modifier.padding(top = Spacing.s)
+                                        } else {
+                                            Modifier
+                                        },
+                                    ),
+                            )
                             if (idx < placeholderCount - 1) {
                                 TimelineDivider(layout = uiState.layout)
                             }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes a layout bug due to which there was no padding in the post detail screen between the main post and the first reply placeholder during reply loading.

## Additional notes
<!-- Anything to declare for code review? -->
This became apparent just with the card layout which has a solid background for each entry.