### PR TITLE
refactor: convert `LruCache<K, V>` to interface and add test for reply helper

### DIFF
--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/cache/DefaultLruCache.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/cache/DefaultLruCache.kt
@@ -1,0 +1,52 @@
+package com.livefast.eattrash.raccoonforfriendica.core.utils.cache
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+class DefaultLruCache<K, V>(
+    private val capacity: Int,
+) : LruCache<K, V> {
+    private val mutex = Mutex()
+    private val keysSortedByLastAccess = mutableListOf<K>()
+    private val map = mutableMapOf<K, V>()
+
+    override suspend fun containsKey(key: K) =
+        mutex.withLock {
+            keysSortedByLastAccess.contains(key)
+        }
+
+    override suspend fun put(
+        key: K,
+        value: V,
+    ) = mutex.withLock {
+        if (keysSortedByLastAccess.contains(key)) {
+            keysSortedByLastAccess.remove(key)
+        } else if (keysSortedByLastAccess.size >= capacity) {
+            keysSortedByLastAccess.lastOrNull()?.also { lastKey ->
+                keysSortedByLastAccess.remove(lastKey)
+                map.remove(lastKey)
+            }
+        }
+        map[key] = value
+        keysSortedByLastAccess.add(0, key)
+    }
+
+    override suspend fun get(key: K): V? =
+        mutex.withLock {
+            if (keysSortedByLastAccess.contains(key)) {
+                keysSortedByLastAccess.remove(key)
+                keysSortedByLastAccess.add(0, key)
+            }
+            return map[key]
+        }
+
+    override suspend fun remove(key: K): Unit =
+        mutex.withLock {
+            map.remove(key)
+        }
+
+    override suspend fun clear() =
+        mutex.withLock {
+            map.clear()
+        }
+}

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/cache/LruCache.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/cache/LruCache.kt
@@ -1,52 +1,20 @@
 package com.livefast.eattrash.raccoonforfriendica.core.utils.cache
 
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
-
-class LruCache<K, V>(
-    private val capacity: Int,
-) {
-    private val mutex = Mutex()
-    private val keysSortedByLastAccess = mutableListOf<K>()
-    private val map = mutableMapOf<K, V>()
-
-    suspend fun containsKey(key: K) =
-        mutex.withLock {
-            keysSortedByLastAccess.contains(key)
-        }
+interface LruCache<K, V> {
+    suspend fun containsKey(key: K): Boolean
 
     suspend fun put(
         key: K,
         value: V,
-    ) = mutex.withLock {
-        if (keysSortedByLastAccess.contains(key)) {
-            keysSortedByLastAccess.remove(key)
-        } else if (keysSortedByLastAccess.size >= capacity) {
-            keysSortedByLastAccess.lastOrNull()?.also { lastKey ->
-                keysSortedByLastAccess.remove(lastKey)
-                map.remove(lastKey)
-            }
-        }
-        map[key] = value
-        keysSortedByLastAccess.add(0, key)
-    }
+    )
 
-    suspend fun get(key: K): V? =
-        mutex.withLock {
-            if (keysSortedByLastAccess.contains(key)) {
-            keysSortedByLastAccess.remove(key)
-            keysSortedByLastAccess.add(0, key)
-        }
-        return map[key]
-        }
+    suspend fun get(key: K): V?
 
-    suspend fun remove(key: K) =
-        mutex.withLock {
-        map.remove(key)
-        }
+    suspend fun remove(key: K)
 
-    suspend fun clear() =
-        mutex.withLock {
-        map.clear()
+    suspend fun clear()
+
+    companion object {
+        fun <K, V> factory(capacity: Int): LruCache<K, V> = DefaultLruCache(capacity)
     }
 }

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/DefaultBlurHashDecoder.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/DefaultBlurHashDecoder.kt
@@ -18,10 +18,10 @@ private const val MAX_CACHE_SIZE = 10
  * The original code has been modified here to work with Compose (multiplatform) ImageBitmap
  * and Color in order to be used in common source set and shared across platforms.
  */
-internal class DefaultBlurHashDecoder : BlurHashDecoder {
-    private val cacheCosinesX = LruCache<Int, DoubleArray>(MAX_CACHE_SIZE)
-    private val cacheCosinesY = LruCache<Int, DoubleArray>(MAX_CACHE_SIZE)
-
+internal class DefaultBlurHashDecoder(
+    private val cacheCosinesX: LruCache<Int, DoubleArray> = LruCache.factory(MAX_CACHE_SIZE),
+    private val cacheCosinesY: LruCache<Int, DoubleArray> = LruCache.factory(MAX_CACHE_SIZE),
+) : BlurHashDecoder {
     override suspend fun clearCache() {
         cacheCosinesX.clear()
         cacheCosinesY.clear()

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/DefaultBlurHashRepository.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/DefaultBlurHashRepository.kt
@@ -9,10 +9,9 @@ import kotlinx.coroutines.withContext
 
 internal class DefaultBlurHashRepository(
     private val decoder: BlurHashDecoder,
+    private val cache: LruCache<String, ImageBitmap> = LruCache.factory(CACHE_SIZE),
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : BlurHashRepository {
-    private val cache = LruCache<String, ImageBitmap>(CACHE_SIZE)
-
     override suspend fun preload(params: BlurHashParams) {
         val key = params.hash
         if (!cache.containsKey(key)) {

--- a/core/utils/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/cache/DefaultLruCacheTest.kt
+++ b/core/utils/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/cache/DefaultLruCacheTest.kt
@@ -8,8 +8,8 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-class LruCacheTest {
-    private val sut = LruCache<String, Any>(CAPACITY)
+class DefaultLruCacheTest {
+    private val sut = DefaultLruCache<String, Any>(CAPACITY)
 
     @Test
     fun `given ley not in cache when get then result is as expected`() =

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEmojiRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEmojiRepository.kt
@@ -11,15 +11,16 @@ import kotlinx.coroutines.withContext
 internal class DefaultEmojiRepository(
     private val provider: ServiceProvider,
     private val otherProvider: ServiceProvider,
-    private val cache: LruCache<String, List<EmojiModel>> = LruCache(20),
+    private val cache: LruCache<String, List<EmojiModel>> = LruCache.factory(20),
 ) : EmojiRepository {
     override suspend fun getAll(
         node: String?,
         refresh: Boolean,
-    ): List<EmojiModel>? {
+    ): List<EmojiModel> {
         val key = node.orEmpty()
-        return if (cache.containsKey(key) && !refresh) {
-            cache.get(key)
+        val cachedValue = cache.get(key)
+        return if (cachedValue != null && !refresh) {
+            cachedValue
         } else {
             retrieve(node).orEmpty().also {
                 cache.put(key, it)

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultLocalItemCache.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultLocalItemCache.kt
@@ -2,9 +2,9 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 
 import com.livefast.eattrash.raccoonforfriendica.core.utils.cache.LruCache
 
-internal class DefaultLocalItemCache<T> : LocalItemCache<T> {
-    private val cache = LruCache<String, T>(MAX_SIZE)
-
+internal class DefaultLocalItemCache<T>(
+    private val cache: LruCache<String, T> = LruCache.factory(MAX_SIZE),
+) : LocalItemCache<T> {
     override suspend fun put(
         key: String,
         value: T,

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultReplyHelper.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultReplyHelper.kt
@@ -5,7 +5,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEnt
 
 internal class DefaultReplyHelper(
     private val entryRepository: TimelineEntryRepository,
-    private val entryCache: LruCache<String, TimelineEntryModel> = LruCache(100),
+    private val entryCache: LruCache<String, TimelineEntryModel> = LruCache.factory(100),
 ) : ReplyHelper {
     override suspend fun TimelineEntryModel.withInReplyToIfMissing(): TimelineEntryModel {
         val parent = inReplyTo ?: return this
@@ -16,7 +16,7 @@ internal class DefaultReplyHelper(
         val parentId = parent.id
         val cachedValue = entryCache.get(parentId)
         if (cachedValue != null) {
-            return cachedValue
+            return copy(inReplyTo = cachedValue)
         }
 
         val remoteParent =

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEmojiRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEmojiRepositoryTest.kt
@@ -4,12 +4,15 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.dto.CustomEmoji
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.InstanceService
 import com.livefast.eattrash.raccoonforfriendica.core.utils.cache.LruCache
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EmojiModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
+import dev.mokkery.answering.sequentiallyReturns
 import dev.mokkery.answering.throws
 import dev.mokkery.every
 import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode
@@ -26,25 +29,27 @@ class DefaultEmojiRepositoryTest {
         mock<ServiceProvider> { every { instance } returns instanceService }
     private val otherServiceProvider =
         mock<ServiceProvider>(MockMode.autoUnit) { every { instance } returns instanceService }
+    private val cache = mock<LruCache<String, List<EmojiModel>>>(MockMode.autoUnit)
     private val sut =
         DefaultEmojiRepository(
             provider = serviceProvider,
             otherProvider = otherServiceProvider,
-            cache = LruCache(capacity = 20),
+            cache = cache,
         )
 
     @Test
     fun `given error when getAll then result is as expected`() =
         runTest {
+            everySuspend { cache.get(any()) } returns null
             everySuspend { instanceService.getCustomEmojis() } throws IOException("No network")
 
             val res = sut.getAll(node = null, refresh = false)
 
-            assertTrue(res.orEmpty().isEmpty())
+            assertTrue(res.isEmpty())
         }
 
     @Test
-    fun `given results when getAll on local instance then result is as expected`() =
+    fun `given results and cache miss when getAll on local instance then result is as expected`() =
         runTest {
             val list =
                 listOf(
@@ -55,15 +60,43 @@ class DefaultEmojiRepositoryTest {
                     ),
                 )
             everySuspend { instanceService.getCustomEmojis() } returns list
+            everySuspend { cache.get(any()) } returns null
 
             val res = sut.getAll(node = null, refresh = false)
 
             assertEquals(list.map { it.toModel() }, res)
             verifySuspend {
+                cache.get("")
                 serviceProvider.instance
                 instanceService.getCustomEmojis()
             }
             verify(VerifyMode.not) {
+                otherServiceProvider.instance
+            }
+        }
+
+    @Test
+    fun `given results and cache hit when getAll on local instance then result is as expected`() =
+        runTest {
+            val list =
+                listOf(
+                    CustomEmoji(
+                        shortCode = "",
+                        url = "",
+                        staticUrl = "",
+                    ),
+                )
+            everySuspend { cache.get(any()) } returns list.map { it.toModel() }
+
+            val res = sut.getAll(node = null, refresh = false)
+
+            assertEquals(list.map { it.toModel() }, res)
+            verifySuspend {
+                cache.get("")
+            }
+            verifySuspend(VerifyMode.not) {
+                serviceProvider.instance
+                instanceService.getCustomEmojis()
                 otherServiceProvider.instance
             }
         }
@@ -80,6 +113,8 @@ class DefaultEmojiRepositoryTest {
                     ),
                 )
             everySuspend { instanceService.getCustomEmojis() } returns list
+            everySuspend { cache.get(any()) } sequentiallyReturns
+                listOf(null, list.map { it.toModel() })
 
             sut.getAll()
             val res = sut.getAll()
@@ -87,6 +122,9 @@ class DefaultEmojiRepositoryTest {
             assertEquals(list.map { it.toModel() }, res)
             verify {
                 serviceProvider.instance
+            }
+            verifySuspend(VerifyMode.exactly(2)) {
+                cache.get("")
             }
             verifySuspend(VerifyMode.exactly(1)) {
                 instanceService.getCustomEmojis()
@@ -108,6 +146,8 @@ class DefaultEmojiRepositoryTest {
                     ),
                 )
             everySuspend { instanceService.getCustomEmojis() } returns list
+            everySuspend { cache.get(any()) } sequentiallyReturns
+                listOf(null, list.map { it.toModel() })
 
             sut.getAll()
             val res = sut.getAll(refresh = true)
@@ -117,6 +157,7 @@ class DefaultEmojiRepositoryTest {
                 serviceProvider.instance
             }
             verifySuspend(VerifyMode.exactly(2)) {
+                cache.get("")
                 instanceService.getCustomEmojis()
             }
             verify(VerifyMode.not) {
@@ -125,7 +166,7 @@ class DefaultEmojiRepositoryTest {
         }
 
     @Test
-    fun `given results when getAll on other instance then result is as expected`() =
+    fun `given results and cache miss when getAll on other instance then result is as expected`() =
         runTest {
             val list =
                 listOf(
@@ -136,16 +177,46 @@ class DefaultEmojiRepositoryTest {
                     ),
                 )
             everySuspend { instanceService.getCustomEmojis() } returns list
+            everySuspend { cache.get(any()) } returns null
 
             val res = sut.getAll(node = "node")
 
             assertEquals(list.map { it.toModel() }, res)
             verifySuspend {
+                cache.get("node")
                 otherServiceProvider.instance
                 instanceService.getCustomEmojis()
             }
             verify(VerifyMode.not) {
                 serviceProvider.instance
+            }
+        }
+
+    @Test
+    fun `given results and cache hit when getAll on other instance then result is as expected`() =
+        runTest {
+            val list =
+                listOf(
+                    CustomEmoji(
+                        shortCode = "",
+                        url = "",
+                        staticUrl = "",
+                    ),
+                )
+            everySuspend { cache.get(any()) } returns list.map { it.toModel() }
+
+            val res = sut.getAll(node = "node")
+
+            assertEquals(list.map { it.toModel() }, res)
+            verifySuspend {
+                cache.get("node")
+            }
+            verify(VerifyMode.not) {
+                otherServiceProvider.instance
+                serviceProvider.instance
+            }
+            verifySuspend(VerifyMode.not) {
+                instanceService.getCustomEmojis()
             }
         }
 
@@ -161,6 +232,8 @@ class DefaultEmojiRepositoryTest {
                     ),
                 )
             everySuspend { instanceService.getCustomEmojis() } returns list
+            everySuspend { cache.get(any()) } sequentiallyReturns
+                listOf(null, list.map { it.toModel() })
 
             sut.getAll(node = "node")
             val res = sut.getAll(node = "node")
@@ -168,6 +241,9 @@ class DefaultEmojiRepositoryTest {
             assertEquals(list.map { it.toModel() }, res)
             verify {
                 otherServiceProvider.instance
+            }
+            verifySuspend(VerifyMode.exactly(2)) {
+                cache.get("node")
             }
             verifySuspend(VerifyMode.exactly(1)) {
                 instanceService.getCustomEmojis()
@@ -189,6 +265,7 @@ class DefaultEmojiRepositoryTest {
                     ),
                 )
             everySuspend { instanceService.getCustomEmojis() } returns list
+            everySuspend { cache.get(any()) } returns null
 
             sut.getAll(node = "node")
             val res = sut.getAll(node = "node", refresh = true)
@@ -198,6 +275,7 @@ class DefaultEmojiRepositoryTest {
                 otherServiceProvider.instance
             }
             verifySuspend(VerifyMode.exactly(2)) {
+                cache.get("node")
                 instanceService.getCustomEmojis()
             }
             verify(VerifyMode.not) {

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultLocalItemCacheTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultLocalItemCacheTest.kt
@@ -1,57 +1,67 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 
+import com.livefast.eattrash.raccoonforfriendica.core.utils.cache.LruCache
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 class DefaultLocalItemCacheTest {
-    private val sut = DefaultLocalItemCache<TimelineEntryModel>()
+    private val cache = mock<LruCache<String, TimelineEntryModel>>(MockMode.autoUnit)
+    private val sut = DefaultLocalItemCache(cache = cache)
 
     @Test
     fun `given item not present when get then result is as expected`() =
         runTest {
+            everySuspend { cache.get(any()) } returns null
+
             val res = sut.get("1")
+
             assertNull(res)
+            verifySuspend {
+                cache.get("1")
+            }
         }
 
     @Test
     fun `given item present when get then result is as expected`() =
         runTest {
             val item = TimelineEntryModel(id = "1", content = "")
+            everySuspend { cache.get(any()) } returns item
 
             sut.put(item.id, item)
             val res = sut.get("1")
 
             assertEquals(item, res)
+            verifySuspend {
+                cache.get("1")
+            }
         }
 
     @Test
-    fun `when remove then result is as expected`() =
+    fun `when remove then interactions are as expected`() =
         runTest {
-            val item = TimelineEntryModel(id = "1", content = "")
-
-            sut.put(item.id, item)
-            val res1 = sut.get("1")
             sut.remove("1")
-            val res2 = sut.get("1")
 
-            assertEquals(item, res1)
-            assertNull(res2)
+            verifySuspend {
+                cache.remove("1")
+            }
         }
 
     @Test
-    fun `when clear then result is as expected`() =
+    fun `when clear then interactions are as expected`() =
         runTest {
-            val item = TimelineEntryModel(id = "1", content = "")
-
-            sut.put(item.id, item)
-            val res1 = sut.get("1")
             sut.clear()
-            val res2 = sut.get("1")
 
-            assertEquals(item, res1)
-            assertNull(res2)
+            verifySuspend {
+                cache.clear()
+            }
         }
 }

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultReplyHelperTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultReplyHelperTest.kt
@@ -1,0 +1,147 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+import com.livefast.eattrash.raccoonforfriendica.core.utils.cache.LruCache
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DefaultReplyHelperTest {
+    private val entryRepository = mock<TimelineEntryRepository>()
+    private val entryCache = mock<LruCache<String, TimelineEntryModel>>(MockMode.autoUnit)
+    private val sut =
+        DefaultReplyHelper(
+            entryRepository = entryRepository,
+            entryCache = entryCache,
+        )
+
+    @Test
+    fun `given no parent when withInReplyToIfMissing then result is as expected`() =
+        runTest {
+            val entry = TimelineEntryModel(id = "1", content = "content")
+
+            val res =
+                with(sut) {
+                    entry.withInReplyToIfMissing()
+                }
+
+            assertEquals(entry, res)
+            verifySuspend(VerifyMode.not) {
+                entryRepository.getById(any())
+                entryCache.get(any())
+                entryCache.put(any(), any())
+            }
+        }
+
+    @Test
+    fun `given parent with content when withInReplyToIfMissing then result is as expected`() =
+        runTest {
+            val parent =
+                TimelineEntryModel(
+                    id = "0",
+                    content = "parent content",
+                )
+            val entry =
+                TimelineEntryModel(
+                    id = "1",
+                    content = "content",
+                    inReplyTo = parent,
+                )
+
+            val res =
+                with(sut) {
+                    entry.withInReplyToIfMissing()
+                }
+
+            assertEquals(entry, res)
+            verifySuspend(VerifyMode.not) {
+                entryRepository.getById(any())
+                entryCache.get(any())
+                entryCache.put(any(), any())
+            }
+        }
+
+    @Test
+    fun `given parent with empty content and cache hit when withInReplyToIfMissing then result is as expected`() =
+        runTest {
+            val emptyParent =
+                TimelineEntryModel(
+                    id = "0",
+                    content = "",
+                )
+            val fullParent =
+                TimelineEntryModel(
+                    id = "0",
+                    content = "parent content",
+                )
+            val entry =
+                TimelineEntryModel(
+                    id = "1",
+                    content = "content",
+                    inReplyTo = emptyParent,
+                )
+            everySuspend {
+                entryCache.get("0")
+            } returns fullParent
+
+            val res =
+                with(sut) {
+                    entry.withInReplyToIfMissing()
+                }
+
+            assertEquals(entry.copy(inReplyTo = fullParent), res)
+            verifySuspend {
+                entryCache.get("0")
+            }
+            verifySuspend(VerifyMode.not) {
+                entryRepository.getById(any())
+                entryCache.put(any(), any())
+            }
+        }
+
+    @Test
+    fun `given parent with empty content and cache miss when withInReplyToIfMissing then result is as expected`() =
+        runTest {
+            val emptyParent =
+                TimelineEntryModel(
+                    id = "0",
+                    content = "",
+                )
+            val fullParent =
+                TimelineEntryModel(
+                    id = "0",
+                    content = "parent content",
+                )
+            val entry =
+                TimelineEntryModel(
+                    id = "1",
+                    content = "content",
+                    inReplyTo = emptyParent,
+                )
+            everySuspend {
+                entryCache.get("0")
+            } returns null
+            everySuspend {
+                entryRepository.getById("0")
+            } returns fullParent
+
+            val res =
+                with(sut) {
+                    entry.withInReplyToIfMissing()
+                }
+
+            assertEquals(entry.copy(inReplyTo = fullParent), res)
+            verifySuspend {
+                entryCache.get("0")
+                entryRepository.getById("0")
+                entryCache.put("0", fullParent)
+            }
+        }
+}


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds the test for `DefaultReplyHelper`. Moreover, since `LruCache` was not mockable with mokkery because it was a class instead of an interface, this also abstracts an interface from it and provides a utility factory method to instantiate default implementations where needed.

## Additional notes
<!-- Anything to declare for code review? -->
Tests where `LruCache` could be mocked have been updated.

`DefaultReplyHelper` had a bug in case of cache hit, in that the parent post was returned instead of the child with `inReplyTo` populated with the parent; which was fixed. Luckily, that bug was only apparent under some circumstances.[^1]

[^1]: e.g. if the server does not return a full parent for posts, which only happens on some Mastodon instances.
