### PR TITLE
fix(l10n): quantity placeholder in hashtag_people_using and items plurals

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-de/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-de/strings.xml
@@ -423,12 +423,12 @@
         <item quantity="other">%1$d geteilt</item>
     </plurals>
     <plurals name="hashtag_people_using">
-        <item quantity="one">$1%d Person spricht darüber</item>
-        <item quantity="other">$1%d Personen sprechen darüber</item>
+        <item quantity="one">%1$d Person spricht darüber</item>
+        <item quantity="other">%1$d Personen sprechen darüber</item>
     </plurals>
     <plurals name="items">
-        <item quantity="one">$1%d Element</item>
-        <item quantity="other">$1%d Elemente</item>
+        <item quantity="one">%1$d Element</item>
+        <item quantity="other">%1$d Elemente</item>
     </plurals>
     <plurals name="messages">
         <item quantity="one">%1$d Nachricht</item>

--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -423,12 +423,12 @@
         <item quantity="other">%1$d redistribuciones</item>
     </plurals>
     <plurals name="hashtag_people_using">
-        <item quantity="one">$1%d persona está hablando de ello</item>
-        <item quantity="other">$1%d personas están hablando de ello</item>
+        <item quantity="one">%1$d persona está hablando de ello</item>
+        <item quantity="other">%1$d personas están hablando de ello</item>
     </plurals>
     <plurals name="items">
-        <item quantity="one">$1%d elemento</item>
-        <item quantity="other">$1%d elementos</item>
+        <item quantity="one">%1$d elemento</item>
+        <item quantity="other">%1$d elementos</item>
     </plurals>
     <plurals name="messages">
         <item quantity="one">%1$d mensaje</item>

--- a/composeApp/src/commonMain/composeResources/values-fi/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-fi/strings.xml
@@ -424,12 +424,12 @@
         <item quantity="other">%1$d uusintaosaketta</item>
     </plurals>
     <plurals name="hashtag_people_using">
-        <item quantity="one">$1%d henkilö puhuu siitä</item>
-        <item quantity="other">$1%d ihmistä puhuu siitä</item>
+        <item quantity="one">%1$d henkilö puhuu siitä</item>
+        <item quantity="other">%1$d ihmistä puhuu siitä</item>
     </plurals>
     <plurals name="items">
-        <item quantity="one">$1%d kohde</item>
-        <item quantity="other">$1%d kohteet</item>
+        <item quantity="one">%1$d kohde</item>
+        <item quantity="other">%1$d kohteet</item>
     </plurals>
     <plurals name="messages">
         <item quantity="one">%1$d viesti</item>

--- a/composeApp/src/commonMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-fr/strings.xml
@@ -423,12 +423,12 @@
         <item quantity="other">%1$d repartages</item>
     </plurals>
     <plurals name="hashtag_people_using">
-        <item quantity="one">$1%d personne en parle</item>
-        <item quantity="other">$1%d personnes en parlent</item>
+        <item quantity="one">%1$d personne en parle</item>
+        <item quantity="other">%1$d personnes en parlent</item>
     </plurals>
     <plurals name="items">
-        <item quantity="one">$1%d objet</item>
-        <item quantity="other">$1%d objets</item>
+        <item quantity="one">%1$d objet</item>
+        <item quantity="other">%1$d objets</item>
     </plurals>
     <plurals name="messages">
         <item quantity="one">%1$d message</item>

--- a/composeApp/src/commonMain/composeResources/values-it/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-it/strings.xml
@@ -429,14 +429,14 @@
         <item quantity="other">%1$d ricondivisioni</item>
     </plurals>
     <plurals name="hashtag_people_using">
-        <item quantity="one">$1%d persona ne sta parlando</item>
-        <item quantity="many">$1%d di persone ne stanno parlando</item>
-        <item quantity="other">$1%d persone ne stanno parlando</item>
+        <item quantity="one">%1$d persona ne sta parlando</item>
+        <item quantity="many">%1$d di persone ne stanno parlando</item>
+        <item quantity="other">%1$d persone ne stanno parlando</item>
     </plurals>
     <plurals name="items">
-        <item quantity="one">$1%d elemento</item>
-        <item quantity="many">$1%d di elementi</item>
-        <item quantity="other">$1%d elementi</item>
+        <item quantity="one">%1$d elemento</item>
+        <item quantity="many">%1$d di elementi</item>
+        <item quantity="other">%1$d elementi</item>
     </plurals>
     <plurals name="messages">
         <item quantity="one">%1$d messaggio</item>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -422,12 +422,12 @@
         <item quantity="other">%1$d udostępnienia</item>
     </plurals>
     <plurals name="hashtag_people_using">
-        <item quantity="one">$1%d osoba o tym mówi</item>
-        <item quantity="other">$1%d osoby o tym mówią</item>
+        <item quantity="one">%1$d osoba o tym mówi</item>
+        <item quantity="other">%1$d osoby o tym mówią</item>
     </plurals>
     <plurals name="items">
-        <item quantity="one">$1%d sztuka</item>
-        <item quantity="other">$1%d sztuki</item>
+        <item quantity="one">%1$d sztuka</item>
+        <item quantity="other">%1$d sztuki</item>
     </plurals>
     <plurals name="messages">
         <item quantity="one">%1$d wiadomość</item>

--- a/composeApp/src/commonMain/composeResources/values-pt/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pt/strings.xml
@@ -424,12 +424,12 @@
         <item quantity="other">%1$d partilhas</item>
     </plurals>
     <plurals name="hashtag_people_using">
-        <item quantity="one">$1%d pessoa está a falar sobre isso</item>
-        <item quantity="other">$1%d pessoas estão a falar sobre isso</item>
+        <item quantity="one">%1$d pessoa está a falar sobre isso</item>
+        <item quantity="other">%1$d pessoas estão a falar sobre isso</item>
     </plurals>
     <plurals name="items">
-        <item quantity="one">$1%d elemento</item>
-        <item quantity="other">$1%d elementos</item>
+        <item quantity="one">%1$d elemento</item>
+        <item quantity="other">%1$d elementos</item>
     </plurals>
     <plurals name="messages">
         <item quantity="one">%1$d mensagem</item>

--- a/composeApp/src/commonMain/composeResources/values-ua/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ua/strings.xml
@@ -424,12 +424,12 @@
         <item quantity="other">%1$d репости</item>
     </plurals>
     <plurals name="hashtag_people_using">
-        <item quantity="one">$1%d pлюдина говорить про це</item>
-        <item quantity="other">$1%d люди говорять про це</item>
+        <item quantity="one">%1$d pлюдина говорить про це</item>
+        <item quantity="other">%1$d люди говорять про це</item>
     </plurals>
     <plurals name="items">
-        <item quantity="one">$1%d пункт</item>
-        <item quantity="other">$1%d предмети</item>
+        <item quantity="one">%1$d пункт</item>
+        <item quantity="other">%1$d предмети</item>
     </plurals>
     <plurals name="messages">
         <item quantity="one">%1$d повідомлення</item>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -433,12 +433,12 @@
         <item quantity="other">%1$d re-shares</item>
     </plurals>
     <plurals name="hashtag_people_using">
-        <item quantity="one">$1%d person is talking about it</item>
-        <item quantity="other">$1%d people are talking about it</item>
+        <item quantity="one">%1$d person is talking about it</item>
+        <item quantity="other">%1$d people are talking about it</item>
     </plurals>
     <plurals name="items">
-        <item quantity="one">$1%d item</item>
-        <item quantity="other">$1%d items</item>
+        <item quantity="one">%1$d item</item>
+        <item quantity="other">%1$d items</item>
     </plurals>
     <plurals name="messages">
         <item quantity="one">%1$d message</item>


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes a bug in the decimal number placeholder used in `hashtag_people_using` and `items` plural strings.

## Additional notes
<!-- Anything to declare for code review? -->
The error appeared in the English source in #645 , then it was propagated to all languages during the continuous localization process.

Hope this will not generated a merge conflict with Weblate working copy (surely it will do).
