### PR TITLE
fix: status bar color and top bar insets

### DIFF
--- a/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/DefaultBarColorProvider.kt
+++ b/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/DefaultBarColorProvider.kt
@@ -39,15 +39,17 @@ internal class DefaultBarColorProvider : BarColorProvider {
                         UiBarTheme.Transparent -> baseColor.copy(alpha = 0.01f)
                         else -> baseColor
                     }.toArgb()
-                statusBarColor = barColor
-                navigationBarColor = barColor
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+                    statusBarColor = barColor
+                    navigationBarColor = barColor
+                }
 
                 if (barTheme != UiBarTheme.Solid) {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                        setDecorFitsSystemWindows(false)
-                    }
+                    WindowCompat.setDecorFitsSystemWindows(this, false)
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                        isStatusBarContrastEnforced = true
+                        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+                            isStatusBarContrastEnforced = true
+                        }
                         isNavigationBarContrastEnforced = true
                     }
                 }

--- a/feature/acknowledgements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feat/acknowledgements/main/AcknowledgementsScreen.kt
+++ b/feature/acknowledgements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feat/acknowledgements/main/AcknowledgementsScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.text.style.TextAlign
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.kodein.rememberScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.feat.acknowledgements.components.AcknowledgementItem
@@ -52,6 +53,7 @@ class AcknowledgementsScreen : Screen {
             contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
+                    windowInsets = topAppBarState.toWindowInsets(),
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(
@@ -94,7 +96,7 @@ class AcknowledgementsScreen : Screen {
                         Modifier
                             .fillMaxSize()
                             .padding(horizontal = Spacing.xs),
-                        verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+                    verticalArrangement = Arrangement.spacedBy(Spacing.xs),
                 ) {
                     if (uiState.initial) {
                         items(5) {

--- a/feature/licences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feat/licences/LicencesScreen.kt
+++ b/feature/licences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feat/licences/LicencesScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.platform.LocalUriHandler
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.kodein.rememberScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.feat.licences.components.LicenceItem
@@ -49,6 +50,7 @@ class LicencesScreen : Screen {
             contentWindowInsets = WindowInsets(0, 0, 0, 0),
             topBar = {
                 TopAppBar(
+                    windowInsets = topAppBarState.toWindowInsets(),
                     scrollBehavior = scrollBehavior,
                     title = {
                         Text(


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR contains some fixes for Android 15 and its edge-to-edge behaviour (counterpart of [RfL#214](https://github.com/LiveFastEatTrashRaccoon/RaccoonForLemmy/issues/214)). Moreover, since in a couple of cases the top bar did not have a variable inset linked to the scroll amount, this fixes it.
