### PR TITLE
fix: handle notifications runtime permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ For the main app:
 - [Multiplatform Settings](https://github.com/russhwolf/multiplatform-settings) for encrypted shared
   preferences;
 - [MaterialKolor](https://github.com/jordond/MaterialKolor) for custom theme generation;
+- [Moko-Permissions](https://github.com/icerockdev/moko-permissions) for runtime permission management;
 - [Room](https://developer.android.com/kotlin/multiplatform/room) for local persistence;
 - [Sentry](https://sentry.io) for crash reporting and user feedback collection;
 - [UnifiedPush](https://unifiedpush.org) for push notifications;

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.VIBRATE"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <queries>
         <intent>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -36,6 +36,7 @@
     <string name="action_filter">Filter</string>
     <string name="action_follow">Follow</string>
     <string name="action_go_back">Go back</string>
+    <string name="action_grant_permission">Grant</string>
     <string name="action_hide_content">Hide content</string>
     <string name="action_hide_results">Show results</string>
     <string name="action_insert_link">Insert link</string>
@@ -49,6 +50,7 @@
     <string name="action_open_link">Open link</string>
     <string name="action_open_options">Options</string>
     <string name="action_open_preview">Open preview</string>
+    <string name="action_open_settings">Open settings</string>
     <string name="action_open_side_menu">Open side menu</string>
     <string name="action_pin">Pin to profile</string>
     <string name="action_play">Play</string>
@@ -345,6 +347,8 @@
     <string name="settings_notification_mode_push_explanation">UnifiedPush</string>
     <string name="settings_option_background_notification_check">Check for notifications in background</string>
     <string name="settings_option_unlimited">Unlimited</string>
+    <string name="settings_push_notification_permission_denied_permanently">Push notification permission permanently denied</string>
+    <string name="settings_push_notification_permission_not_granted">Push notification permission not granted</string>
     <string name="settings_push_notification_state_enabled">Active</string>
     <string name="settings_push_notification_state_idle">Idle</string>
     <string name="settings_push_notification_state_initializing">Initializing…</string>

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/resources/SharedStrings.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/resources/SharedStrings.kt
@@ -45,6 +45,7 @@ import raccoonforfriendica.composeapp.generated.resources.action_export
 import raccoonforfriendica.composeapp.generated.resources.action_filter
 import raccoonforfriendica.composeapp.generated.resources.action_follow
 import raccoonforfriendica.composeapp.generated.resources.action_go_back
+import raccoonforfriendica.composeapp.generated.resources.action_grant_permission
 import raccoonforfriendica.composeapp.generated.resources.action_hide_content
 import raccoonforfriendica.composeapp.generated.resources.action_hide_results
 import raccoonforfriendica.composeapp.generated.resources.action_insert_link
@@ -58,6 +59,7 @@ import raccoonforfriendica.composeapp.generated.resources.action_open_full_scree
 import raccoonforfriendica.composeapp.generated.resources.action_open_link
 import raccoonforfriendica.composeapp.generated.resources.action_open_options
 import raccoonforfriendica.composeapp.generated.resources.action_open_preview
+import raccoonforfriendica.composeapp.generated.resources.action_open_settings
 import raccoonforfriendica.composeapp.generated.resources.action_open_side_menu
 import raccoonforfriendica.composeapp.generated.resources.action_pin
 import raccoonforfriendica.composeapp.generated.resources.action_play
@@ -371,6 +373,8 @@ import raccoonforfriendica.composeapp.generated.resources.settings_notification_
 import raccoonforfriendica.composeapp.generated.resources.settings_notification_mode_push_explanation
 import raccoonforfriendica.composeapp.generated.resources.settings_option_background_notification_check
 import raccoonforfriendica.composeapp.generated.resources.settings_option_unlimited
+import raccoonforfriendica.composeapp.generated.resources.settings_push_notification_permission_denied_permanently
+import raccoonforfriendica.composeapp.generated.resources.settings_push_notification_permission_not_granted
 import raccoonforfriendica.composeapp.generated.resources.settings_push_notification_state_enabled
 import raccoonforfriendica.composeapp.generated.resources.settings_push_notification_state_idle
 import raccoonforfriendica.composeapp.generated.resources.settings_push_notification_state_initializing
@@ -509,6 +513,8 @@ class SharedStrings : Strings {
         @Composable get() = stringResource(Res.string.action_follow)
     override val actionGoBack: String
         @Composable get() = stringResource(Res.string.action_go_back)
+    override val actionGrantPermission: String
+        @Composable get() = stringResource(Res.string.action_grant_permission)
     override val actionHideContent: String
         @Composable get() = stringResource(Res.string.action_hide_content)
     override val actionHideResults: String
@@ -535,6 +541,8 @@ class SharedStrings : Strings {
         @Composable get() = stringResource(Res.string.action_open_options)
     override val actionOpenPreview: String
         @Composable get() = stringResource(Res.string.action_open_preview)
+    override val actionOpenSettings: String
+        @Composable get() = stringResource(Res.string.action_open_settings)
     override val actionOpenSideMenu: String
         @Composable get() = stringResource(Res.string.action_open_side_menu)
     override val actionPin: String
@@ -1147,6 +1155,10 @@ class SharedStrings : Strings {
         @Composable get() = stringResource(Res.string.settings_option_background_notification_check)
     override val settingsOptionUnlimited: String
         @Composable get() = stringResource(Res.string.settings_option_unlimited)
+    override val settingsPushNotificationPermissionDeniedPermanently: String
+        @Composable get() = stringResource(Res.string.settings_push_notification_permission_denied_permanently)
+    override val settingsPushNotificationPermissionNotGranted: String
+        @Composable get() = stringResource(Res.string.settings_push_notification_permission_not_granted)
     override val settingsPushNotificationStateEnabled: String
         @Composable get() = stringResource(Res.string.settings_push_notification_state_enabled)
     override val settingsPushNotificationStateIdle: String

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/Strings.kt
@@ -39,6 +39,7 @@ interface Strings {
     val actionFilter: String @Composable get
     val actionFollow: String @Composable get
     val actionGoBack: String @Composable get
+    val actionGrantPermission: String @Composable get
     val actionHideContent: String @Composable get
     val actionHideResults: String @Composable get
     val actionInsertLink: String @Composable get
@@ -52,6 +53,7 @@ interface Strings {
     val actionOpenLink: String @Composable get
     val actionOpenOptions: String @Composable get
     val actionOpenPreview: String @Composable get
+    val actionOpenSettings: String @Composable get
     val actionOpenSideMenu: String @Composable get
     val actionPin: String @Composable get
     val actionPlay: String @Composable get
@@ -358,6 +360,8 @@ interface Strings {
     val settingsNotificationModePushExplanation: String @Composable get
     val settingsOptionBackgroundNotificationCheck: String @Composable get
     val settingsOptionUnlimited: String @Composable get
+    val settingsPushNotificationPermissionDeniedPermanently: String @Composable get
+    val settingsPushNotificationPermissionNotGranted: String @Composable get
     val settingsPushNotificationStateEnabled: String @Composable get
     val settingsPushNotificationStateIdle: String @Composable get
     val settingsPushNotificationStateInitializing: String @Composable get

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/testutils/MockStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/testutils/MockStrings.kt
@@ -85,6 +85,8 @@ class MockStrings : Strings {
         @Composable get() = retrieve("actionFollow")
     override val actionGoBack: String
         @Composable get() = retrieve("actionGoBack")
+    override val actionGrantPermission: String
+        @Composable get() = retrieve("actionGrantPermission")
     override val actionHideContent: String
         @Composable get() = retrieve("actionHideContent")
     override val actionHideResults: String
@@ -113,6 +115,8 @@ class MockStrings : Strings {
         @Composable get() = retrieve("actionOpenPreview")
     override val actionOpenSideMenu: String
         @Composable get() = retrieve("actionOpenSideMenu")
+    override val actionOpenSettings: String
+        @Composable get() = retrieve("actionOpenSettings")
     override val actionPin: String
         @Composable get() = retrieve("actionPin")
     override val actionPlay: String
@@ -723,6 +727,10 @@ class MockStrings : Strings {
         @Composable get() = retrieve("settingsOptionBackgroundNotificationCheck")
     override val settingsOptionUnlimited: String
         @Composable get() = retrieve("settingsOptionUnlimited")
+    override val settingsPushNotificationPermissionDeniedPermanently: String
+        @Composable get() = retrieve("settingsPushNotificationPermissionDeniedPermanently")
+    override val settingsPushNotificationPermissionNotGranted: String
+        @Composable get() = retrieve("settingsPushNotificationPermissionNotGranted")
     override val settingsPushNotificationStateEnabled: String
         @Composable get() = retrieve("settingsPushNotificationStateEnabled")
     override val settingsPushNotificationStateIdle: String

--- a/feature/licences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feat/licences/LicenceUrls.kt
+++ b/feature/licences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feat/licences/LicenceUrls.kt
@@ -17,6 +17,7 @@ internal object LicenceUrls {
     const val MASTODON = "https://github.com/mastodon/mastodon/blob/main/LICENSE"
     const val MATERIAL_ICONS = "https://github.com/google/material-design-icons/blob/master/LICENSE"
     const val MATERIAL_KOLOR = "https://github.com/jordond/MaterialKolor/blob/main/LICENSE"
+    const val MOKO_PERMISSIONS = "https://github.com/icerockdev/moko-permissions/blob/master/LICENSE.md"
     const val OFL = "https://openfontlicense.org/"
     const val SETTINGS = "https://github.com/russhwolf/multiplatform-settings/blob/main/LICENSE.txt"
     const val SENTRY = "https://github.com/getsentry/sentry-kotlin-multiplatform/blob/main/LICENSE"

--- a/feature/licences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feat/licences/LicencesViewModel.kt
+++ b/feature/licences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feat/licences/LicencesViewModel.kt
@@ -147,6 +147,13 @@ class LicencesViewModel(
                         this +=
                             LicenceItem(
                                 type = LicenceItemType.Library,
+                                title = "Moko-Permissions",
+                                subtitle = "Kotlin MultiPlatform library for providing runtime permissions on iOS & Android",
+                                url = LicenceUrls.MOKO_PERMISSIONS,
+                            )
+                        this +=
+                            LicenceItem(
+                                type = LicenceItemType.Library,
                                 title = "Multiplatform Settings",
                                 subtitle = "A Kotlin library for Multiplatform apps, so that common code can persist key-value data",
                                 url = LicenceUrls.SETTINGS,

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -8,6 +8,8 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(libs.kodein)
+                implementation(libs.moko.permissions)
+                implementation(libs.moko.permissions.compose)
                 implementation(libs.voyager.screenmodel)
                 implementation(libs.voyager.kodein)
 

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsMviModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsMviModel.kt
@@ -18,6 +18,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.MarkupMode
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.NotificationMode
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.UrlOpeningMode
 import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.manager.PushNotificationManagerState
+import dev.icerock.moko.permissions.PermissionState
 import kotlin.time.Duration
 
 @Stable
@@ -105,6 +106,8 @@ interface SettingsMviModel :
             val value: String,
         ) : Intent
 
+        data object GrantPushNotificationsPermission : Intent
+
         data class ChangeCrashReportEnabled(
             val value: Boolean,
         ) : Intent
@@ -173,6 +176,7 @@ interface SettingsMviModel :
         val supportSettingsImportExport: Boolean = true,
         val barTheme: UiBarTheme = UiBarTheme.Transparent,
         val timelineLayout: TimelineLayout = TimelineLayout.Full,
+        val pushNotificationPermissionState: PermissionState = PermissionState.NotDetermined,
     )
 
     sealed interface Effect {

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/di/SettingsModule.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/di/SettingsModule.kt
@@ -4,16 +4,19 @@ import com.livefast.eattrash.raccoonforfriendica.feature.settings.SettingsMviMod
 import com.livefast.eattrash.raccoonforfriendica.feature.settings.SettingsViewModel
 import com.livefast.eattrash.raccoonforfriendica.feature.settings.feedback.UserFeedbackMviModel
 import com.livefast.eattrash.raccoonforfriendica.feature.settings.feedback.UserFeedbackViewModel
+import dev.icerock.moko.permissions.PermissionsController
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.factory
 import org.kodein.di.instance
 import org.kodein.di.provider
 
 val settingsModule =
     DI.Module("SettingsModule") {
         bind<SettingsMviModel> {
-            provider {
+            factory { controller: PermissionsController ->
                 SettingsViewModel(
+                    permissionController = controller,
                     settingsRepository = instance(),
                     l10nManager = instance(),
                     themeRepository = instance(),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ ktorfit = "2.2.0"
 ktorfit-ksp = "2.2.0-1.0.29"
 materialKolor = "2.0.0"
 mokkery = "2.6.1"
+moko = "0.18.1"
 multiplatform-settings = "1.3.0"
 robolectric = "4.14.1"
 room = "2.7.0-alpha12"
@@ -94,7 +95,8 @@ ktorfit-converters-response = { module = "de.jensklingenberg.ktorfit:ktorfit-con
 ksp-gradlePlugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 
 materialKolor = { module = "com.materialkolor:material-kolor", version.ref = "materialKolor" }
-
+moko-permissions = { module = "dev.icerock.moko:permissions", version.ref = "moko" }
+moko-permissions-compose = { module = "dev.icerock.moko:permissions-compose", version.ref = "moko" }
 multiplatform-settings = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatform-settings" }
 
 sentry = { module = "io.sentry:sentry-kotlin-multiplatform", version.ref = "sentry" }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR implements the management of runtime permissions for push notifications, required on API level >= 33 (Android 13). This was an oversight in #433 where the complexity of integrating UnifiedPush distracted me away from this very trivial detail. 

## Additional notes
<!-- Anything to declare for code review? -->
This is related to #695 but until I don't test it thoroughly I will not close it.
