### PR TITLE
fix(a11y): move custom actions assignment outside options conditional

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
@@ -240,9 +240,10 @@ fun TimelineItem(
                                     true
                                 },
                             )
-                        if (helperActions.isNotEmpty()) {
-                            customActions = helperActions
-                        }
+                    }
+
+                    if (helperActions.isNotEmpty()) {
+                        customActions = helperActions
                     }
                 },
         contentAlignment = Alignment.Center,

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineReplyItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineReplyItem.kt
@@ -207,9 +207,10 @@ fun TimelineReplyItem(
                                     true
                                 },
                             )
-                        if (helperActions.isNotEmpty()) {
-                            customActions = helperActions
-                        }
+                    }
+
+                    if (helperActions.isNotEmpty()) {
+                        customActions = helperActions
                     }
                 },
         contentAlignment = Alignment.Center,


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR makes sure custom accessibility actions for posts and replies are considered in the node's semantic no matter whether drop-down options are passed or not.

## Additional notes
Basically it was just the `if` accidentally being nested in another `if `instead of being at the same level.
