### PR TITLE
enhancement: allow insert color hex

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -115,6 +115,7 @@
     <string name="circle_type_group">Groups</string>
     <string name="circle_type_predefined">Channels</string>
     <string name="circle_type_user_defined">Your lists</string>
+    <string name="color_picker_dialog_insert_hex">Insert hex color code</string>
     <string name="color_picker_dialog_title">Select a color</string>
     <string name="confirm_change_markup_mode">If you change the markup type, all the formatting will be lost. Proceed anyway?</string>
     <string name="content_scale_fill_height">Fill height</string>

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/resources/SharedStrings.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/resources/SharedStrings.kt
@@ -124,6 +124,7 @@ import raccoonforfriendica.composeapp.generated.resources.circle_edit_field_name
 import raccoonforfriendica.composeapp.generated.resources.circle_type_group
 import raccoonforfriendica.composeapp.generated.resources.circle_type_predefined
 import raccoonforfriendica.composeapp.generated.resources.circle_type_user_defined
+import raccoonforfriendica.composeapp.generated.resources.color_picker_dialog_insert_hex
 import raccoonforfriendica.composeapp.generated.resources.color_picker_dialog_title
 import raccoonforfriendica.composeapp.generated.resources.confirm_change_markup_mode
 import raccoonforfriendica.composeapp.generated.resources.content_scale_fill_height
@@ -674,6 +675,8 @@ class SharedStrings : Strings {
         @Composable get() = stringResource(Res.string.circle_type_predefined)
     override val circleTypeUserDefined: String
         @Composable get() = stringResource(Res.string.circle_type_user_defined)
+    override val colorPickerDialogInsertHex: String
+        @Composable get() = stringResource(Res.string.color_picker_dialog_insert_hex)
     override val colorPickerDialogTitle: String
         @Composable get() = stringResource(Res.string.color_picker_dialog_title)
     override val confirmChangeMarkupMode: String

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/CustomColorPickerDialog.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/CustomColorPickerDialog.kt
@@ -11,9 +11,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.surfaceColorAtElevation
@@ -40,6 +45,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 @Composable
 fun CustomColorPickerDialog(
     initialValue: Color,
+    allowManualSelection: Boolean = false,
     onClose: ((Color?) -> Unit)? = null,
 ) {
     val controller =
@@ -47,6 +53,7 @@ fun CustomColorPickerDialog(
         }
     var selectedColor by remember { mutableStateOf(initialValue) }
     var selectedColorHex by remember { mutableStateOf("") }
+    var manualInputDialogOpen by remember { mutableStateOf(false) }
 
     BasicAlertDialog(
         modifier = Modifier.clip(RoundedCornerShape(CornerSize.xxl)),
@@ -84,24 +91,42 @@ fun CustomColorPickerDialog(
                 },
             )
 
-            Box(
-                modifier =
-                    Modifier
-                        .border(
-                            color = selectedColor,
-                            width = Dp.Hairline,
-                            shape = RoundedCornerShape(CornerSize.xxl),
-                        ).padding(
-                            horizontal = Spacing.m,
-                            vertical = Spacing.s,
-                        ),
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(
-                    text = "#$selectedColorHex",
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    color = selectedColor,
-                )
+                Box(
+                    modifier =
+                        Modifier
+                            .border(
+                                color = selectedColor,
+                                width = Dp.Hairline,
+                                shape = RoundedCornerShape(CornerSize.xxl),
+                            ).padding(
+                                horizontal = Spacing.m,
+                                vertical = Spacing.s,
+                            ),
+                ) {
+                    SelectionContainer {
+                        Text(
+                            text = "#$selectedColorHex",
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            color = selectedColor,
+                        )
+                    }
+                }
+                if (allowManualSelection) {
+                    FilledIconButton(
+                        onClick = {
+                            manualInputDialogOpen = true
+                        },
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Edit,
+                            contentDescription = LocalStrings.current.actionEdit,
+                        )
+                    }
+                }
             }
 
             Spacer(modifier = Modifier.height(Spacing.s))
@@ -126,5 +151,53 @@ fun CustomColorPickerDialog(
                 }
             }
         }
+    }
+
+    if (manualInputDialogOpen) {
+        var isError by remember { mutableStateOf(false) }
+        var label by remember { mutableStateOf("") }
+        val invalidFieldMessage = LocalStrings.current.messageInvalidField
+
+        EditTextualInfoDialog(
+            title = LocalStrings.current.colorPickerDialogInsertHex,
+            value = selectedColorHex,
+            label = label,
+            isError = isError,
+            singleLine = true,
+            onClose = { value ->
+                val newColor = value?.toColor()
+                when {
+                    value != null && newColor == null -> {
+                        isError = true
+                        label = invalidFieldMessage
+                    }
+
+                    newColor != null -> {
+                        isError = false
+                        label = ""
+                        selectedColorHex = value
+                        selectedColor = newColor
+                        manualInputDialogOpen = false
+                    }
+
+                    else -> manualInputDialogOpen = false
+                }
+            },
+        )
+    }
+}
+
+private fun String.toColor(): Color? {
+    val sanitized =
+        if (startsWith("#")) {
+            substring(1)
+        } else {
+            this
+        }
+    return when {
+        sanitized.length == 6 || sanitized.length == 8 ->
+            sanitized.toLongOrNull(16)?.let { Color(it) }
+
+        else -> null
     }
 }

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/EditTextualInfoDialog.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/EditTextualInfoDialog.kt
@@ -41,6 +41,8 @@ fun EditTextualInfoDialog(
     value: String = "",
     minLines: Int = 1,
     maxLines: Int = 20,
+    isError: Boolean = false,
+    singleLine: Boolean = false,
     onClose: ((String?) -> Unit)? = null,
 ) {
     var textFieldValue by remember {
@@ -72,6 +74,8 @@ fun EditTextualInfoDialog(
                 modifier = Modifier.fillMaxWidth(),
                 minLines = minLines,
                 maxLines = maxLines,
+                singleLine = singleLine,
+                isError = isError,
                 colors =
                     TextFieldDefaults.colors(
                         focusedContainerColor = Color.Transparent,

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/Strings.kt
@@ -118,6 +118,7 @@ interface Strings {
     val circleTypeGroup: String @Composable get
     val circleTypePredefined: String @Composable get
     val circleTypeUserDefined: String @Composable get
+    val colorPickerDialogInsertHex: String @Composable get
     val colorPickerDialogTitle: String @Composable get
     val confirmChangeMarkupMode: String @Composable get
     val contentScaleFillHeight: String @Composable get

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/testutils/MockStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/testutils/MockStrings.kt
@@ -243,6 +243,8 @@ class MockStrings : Strings {
         @Composable get() = retrieve("circleTypePredefined")
     override val circleTypeUserDefined: String
         @Composable get() = retrieve("circleTypeUserDefined")
+    override val colorPickerDialogInsertHex: String
+        @Composable get() = retrieve("colorPickerDialogInsertHex")
     override val colorPickerDialogTitle: String
         @Composable get() = retrieve("colorPickerDialogTitle")
     override val confirmChangeMarkupMode: String


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR allows to select colors by manually inserting the hex code, if the `CustomColorPickerDialog` is configured to do so.

## Additional notes
This is the counterpart of [rfl#233](https://github.com/LiveFastEatTrashRaccoon/RaccoonForLemmy/pull/233).
