### PR TITLE
enhancement: avoid waiting for completion in content preload

### DIFF
--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultContentPreloadManager.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultContentPreloadManager.kt
@@ -3,17 +3,27 @@ package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.NotificationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TrendingRepository
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 
 internal class DefaultContentPreloadManager(
     private val timelineEntryRepository: TimelineEntryRepository,
     private val trendingRepository: TrendingRepository,
     private val notificationRepository: NotificationRepository,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ContentPreloadManager {
-    override suspend fun preload(userRemoteId: String?) =
-        coroutineScope {
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+
+    override suspend fun preload(userRemoteId: String?) {
+        // actually, it is not so important to wait for completion
+        // timelineEntryRepository.getByUser may take a long time
+        scope.launch {
             val tasks =
                 buildList {
                     this +=
@@ -44,4 +54,5 @@ internal class DefaultContentPreloadManager(
 
             tasks.awaitAll().let {}
         }
+    }
 }

--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultContentPreloadManagerTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultContentPreloadManagerTest.kt
@@ -8,29 +8,53 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class DefaultContentPreloadManagerTest {
     private val timelineEntryRepository =
         mock<TimelineEntryRepository> {
             everySuspend {
-                getByUser(any(), any(), any(), any(), any(), any(), any(), any())
+                getByUser(
+                    userId = any(),
+                    pageCursor = any(),
+                    excludeReplies = any(),
+                    excludeReblogs = any(),
+                    pinned = any(),
+                    onlyMedia = any(),
+                    enableCache = any(),
+                    refresh = any(),
+                )
             } returns listOf()
         }
     private val trendingRepository =
         mock<TrendingRepository> {
-            everySuspend { getHashtags(any(), any()) } returns listOf()
+            everySuspend {
+                getHashtags(
+                    offset = any(),
+                    refresh = any(),
+                )
+            } returns listOf()
         }
     private val notificationRepository =
         mock<NotificationRepository> {
-            everySuspend { getAll(any(), any(), any()) } returns listOf()
+            everySuspend {
+                getAll(
+                    types = any(),
+                    pageCursor = any(),
+                    refresh = any(),
+                )
+            } returns listOf()
         }
     private val sut =
         DefaultContentPreloadManager(
             timelineEntryRepository = timelineEntryRepository,
             trendingRepository = trendingRepository,
             notificationRepository = notificationRepository,
+            dispatcher = UnconfinedTestDispatcher(),
         )
 
     @Test

--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultDeleteAccountUseCaseTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultDeleteAccountUseCaseTest.kt
@@ -49,6 +49,7 @@ class DefaultDeleteAccountUseCaseTest {
         }
 
     @Test
+    @Throws(IllegalStateException::class)
     fun `given account is active when executed then interactions are as expected`() =
         runTest {
             val accountId = 1L


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR avoids waiting for full completion of content preload, because loading current user's posts may have a negative impact on app startup time.

## Additional notes
<!-- Anything to declare for code review? -->
The downside is that, if opening the profile immediately after app startup, you still have to wait for server response which may be slow (and its performance appears to have degraded a lot on most recent server versions, I don't know why). 
