### PR TITLE
enhancement: allow to skip internal resolution for external URLs

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/App.kt
@@ -36,6 +36,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getA
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getSetupAccountUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.ProvideCustomUriHandler
 import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.di.getCustomUriHandler
+import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.openInternally
 import com.livefast.eattrash.raccoonforfriendica.feature.drawer.DrawerContent
 import com.livefast.eattrash.raccoonforfriendica.main.MainScreen
 import kotlinx.coroutines.FlowPreview
@@ -130,10 +131,7 @@ fun App(onLoadingFinished: (() -> Unit)? = null) {
         navigationCoordinator.deepLinkUrl
             .debounce(750)
             .onEach { url ->
-                customUriHandler.openUri(
-                    uri = url,
-                    allowOpenExternal = false,
-                )
+                customUriHandler.openInternally(url)
             }.launchIn(this)
     }
 

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CardTimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CardTimelineItem.kt
@@ -65,7 +65,7 @@ internal fun CardTimelineItem(
     onFavorite: ((TimelineEntryModel) -> Unit)? = null,
     onDislike: ((TimelineEntryModel) -> Unit)? = null,
     onOpenImage: ((List<String>, Int, List<Int>) -> Unit)? = null,
-    onOpenUrl: ((String) -> Unit)? = null,
+    onOpenUrl: ((String, Boolean) -> Unit)? = null,
     onOpenUser: ((UserModel) -> Unit)? = null,
     onOpenUsersFavorite: ((TimelineEntryModel) -> Unit)? = null,
     onOpenUsersReblog: ((TimelineEntryModel) -> Unit)? = null,
@@ -218,7 +218,7 @@ internal fun CardTimelineItem(
                         autoloadImages = autoloadImages,
                         emojis = entryToDisplay.emojis,
                         onClick = { onClick?.invoke(entryToDisplay) },
-                        onOpenUrl = onOpenUrl,
+                        onOpenUrl = onOpenUrl?.let { block -> { url -> block(url, true) } },
                     )
                 }
 
@@ -239,7 +239,7 @@ internal fun CardTimelineItem(
                         maxLines = maxBodyLines,
                         emojis = entryToDisplay.emojis,
                         onClick = { onClick?.invoke(entryToDisplay) },
-                        onOpenUrl = onOpenUrl,
+                        onOpenUrl = onOpenUrl?.let { block -> { url -> block(url, true) } },
                     )
                 }
 

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CompactTimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CompactTimelineItem.kt
@@ -60,7 +60,7 @@ internal fun CompactTimelineItem(
     onFavorite: ((TimelineEntryModel) -> Unit)? = null,
     onDislike: ((TimelineEntryModel) -> Unit)? = null,
     onOpenImage: ((List<String>, Int, List<Int>) -> Unit)? = null,
-    onOpenUrl: ((String) -> Unit)? = null,
+    onOpenUrl: ((String, Boolean) -> Unit)? = null,
     onOpenUser: ((UserModel) -> Unit)? = null,
     onOpenUsersFavorite: ((TimelineEntryModel) -> Unit)? = null,
     onOpenUsersReblog: ((TimelineEntryModel) -> Unit)? = null,
@@ -212,7 +212,7 @@ internal fun CompactTimelineItem(
                                 autoloadImages = autoloadImages,
                                 emojis = entryToDisplay.emojis,
                                 onClick = { onClick?.invoke(entryToDisplay) },
-                                onOpenUrl = onOpenUrl,
+                                onOpenUrl = onOpenUrl?.let { block -> { url -> block(url, true) } },
                             )
                         }
 
@@ -233,7 +233,7 @@ internal fun CompactTimelineItem(
                                 maxLines = maxBodyLines,
                                 emojis = entryToDisplay.emojis,
                                 onClick = { onClick?.invoke(entryToDisplay) },
-                                onOpenUrl = onOpenUrl,
+                                onOpenUrl = onOpenUrl?.let { block -> { url -> block(url, true) } },
                             )
                         }
                     }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/DistractionFreeTimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/DistractionFreeTimelineItem.kt
@@ -53,7 +53,7 @@ internal fun DistractionFreeTimelineItem(
     onClick: ((TimelineEntryModel) -> Unit)? = null,
     onFavorite: ((TimelineEntryModel) -> Unit)? = null,
     onDislike: ((TimelineEntryModel) -> Unit)? = null,
-    onOpenUrl: ((String) -> Unit)? = null,
+    onOpenUrl: ((String, Boolean) -> Unit)? = null,
     onOpenUser: ((UserModel) -> Unit)? = null,
     onOptionSelected: ((OptionId) -> Unit)? = null,
     onOptionsMenuToggled: ((Boolean) -> Unit)? = null,
@@ -191,7 +191,7 @@ internal fun DistractionFreeTimelineItem(
                         autoloadImages = autoloadImages,
                         emojis = entryToDisplay.emojis,
                         onClick = { onClick?.invoke(entryToDisplay) },
-                        onOpenUrl = onOpenUrl,
+                        onOpenUrl = onOpenUrl?.let { block -> { url -> block(url, true) } },
                     )
                 }
 
@@ -212,7 +212,7 @@ internal fun DistractionFreeTimelineItem(
                         maxLines = maxBodyLines,
                         emojis = entryToDisplay.emojis,
                         onClick = { onClick?.invoke(entryToDisplay) },
-                        onOpenUrl = onOpenUrl,
+                        onOpenUrl = onOpenUrl?.let { block -> { url -> block(url, true) } },
                     )
                 }
             }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/FullTimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/FullTimelineItem.kt
@@ -59,7 +59,7 @@ internal fun FullTimelineItem(
     onFavorite: ((TimelineEntryModel) -> Unit)? = null,
     onDislike: ((TimelineEntryModel) -> Unit)? = null,
     onOpenImage: ((List<String>, Int, List<Int>) -> Unit)? = null,
-    onOpenUrl: ((String) -> Unit)? = null,
+    onOpenUrl: ((String, Boolean) -> Unit)? = null,
     onOpenUser: ((UserModel) -> Unit)? = null,
     onOpenUsersFavorite: ((TimelineEntryModel) -> Unit)? = null,
     onOpenUsersReblog: ((TimelineEntryModel) -> Unit)? = null,
@@ -200,7 +200,7 @@ internal fun FullTimelineItem(
                         autoloadImages = autoloadImages,
                         emojis = entryToDisplay.emojis,
                         onClick = { onClick?.invoke(entryToDisplay) },
-                        onOpenUrl = onOpenUrl,
+                        onOpenUrl = onOpenUrl?.let { block -> { url -> block(url, true) } },
                     )
                 }
 
@@ -221,7 +221,7 @@ internal fun FullTimelineItem(
                         maxLines = maxBodyLines,
                         emojis = entryToDisplay.emojis,
                         onClick = { onClick?.invoke(entryToDisplay) },
-                        onOpenUrl = onOpenUrl,
+                        onOpenUrl = onOpenUrl?.let { block -> { url -> block(url, true) } },
                     )
                 }
 
@@ -285,7 +285,7 @@ internal fun FullTimelineItem(
                                 image = preview.image.takeIf { attachments.isEmpty() },
                             ),
                         autoloadImages = autoloadImages,
-                        onOpen = onOpenUrl,
+                        onOpen = onOpenUrl?.let { block -> { url -> block(url, false) } },
                         onOpenImage = { url ->
                             onOpenImage?.invoke(listOf(url), 0, emptyList())
                         },

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
@@ -33,7 +33,7 @@ fun TimelineItem(
     maxBodyLines: Int = Int.MAX_VALUE,
     layout: TimelineLayout = TimelineLayout.Full,
     options: List<Option> = emptyList(),
-    onOpenUrl: ((String) -> Unit)? = null,
+    onOpenUrl: ((String, Boolean) -> Unit)? = null,
     onClick: ((TimelineEntryModel) -> Unit)? = null,
     onOpenUser: ((UserModel) -> Unit)? = null,
     onReply: ((TimelineEntryModel) -> Unit)? = null,

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineReplyItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineReplyItem.kt
@@ -40,7 +40,7 @@ fun TimelineReplyItem(
     autoloadImages: Boolean = true,
     layout: TimelineLayout = TimelineLayout.Full,
     options: List<Option> = emptyList(),
-    onOpenUrl: ((String) -> Unit)? = null,
+    onOpenUrl: ((String, Boolean) -> Unit)? = null,
     onClick: ((TimelineEntryModel) -> Unit)? = null,
     onOpenUser: ((UserModel) -> Unit)? = null,
     onReply: ((TimelineEntryModel) -> Unit)? = null,

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserFields.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserFields.kt
@@ -31,7 +31,7 @@ fun UserFields(
     fields: List<FieldModel> = emptyList(),
     autoloadImages: Boolean = true,
     modifier: Modifier = Modifier,
-    onOpenUrl: ((String) -> Unit)? = null,
+    onOpenUrl: ((String, Boolean) -> Unit)? = null,
 ) {
     val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha)
 
@@ -76,7 +76,7 @@ fun UserFields(
                                     .firstOrNull()
                                     ?.item
                             if (!url.isNullOrBlank()) {
-                                onOpenUrl?.invoke(url)
+                                onOpenUrl?.invoke(url, true)
                             }
                         },
                     )

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserHeader.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserHeader.kt
@@ -40,7 +40,7 @@ fun UserHeader(
     onOpenImage: ((String) -> Unit)? = null,
     onOpenFollowers: (() -> Unit)? = null,
     onOpenFollowing: (() -> Unit)? = null,
-    onOpenUrl: ((String) -> Unit)? = null,
+    onOpenUrl: ((String, Boolean) -> Unit)? = null,
     onRelationshipClicked: ((RelationshipStatusNextAction) -> Unit)? = null,
     onNotificationsClicked: ((NotificationStatusNextAction) -> Unit)? = null,
     onEditClicked: (() -> Unit)? = null,
@@ -209,7 +209,7 @@ fun UserHeader(
                 ContentBody(
                     content = bio,
                     emojis = user.emojis,
-                    onOpenUrl = onOpenUrl,
+                    onOpenUrl = onOpenUrl?.let { block -> { url -> block(url, true) } },
                 )
             }
         }

--- a/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/CustomUriHandler.kt
+++ b/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/CustomUriHandler.kt
@@ -7,6 +7,23 @@ import androidx.compose.ui.platform.UriHandler
 interface CustomUriHandler : UriHandler {
     fun openUri(
         uri: String,
-        allowOpenExternal: Boolean,
+        allowOpenExternal: Boolean = true,
+        allowOpenInternal: Boolean = true,
     )
+}
+
+fun UriHandler.openExternally(uri: String) {
+    if (this is CustomUriHandler) {
+        openUri(uri = uri, allowOpenInternal = false)
+    } else {
+        openUri(uri)
+    }
+}
+
+fun UriHandler.openInternally(uri: String) {
+    if (this is CustomUriHandler) {
+        openUri(uri = uri, allowOpenExternal = false)
+    } else {
+        openUri(uri)
+    }
 }

--- a/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/DefaultCustomUriHandler.kt
+++ b/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/DefaultCustomUriHandler.kt
@@ -30,6 +30,7 @@ internal class DefaultCustomUriHandler(
     override fun openUri(uri: String) {
         openUri(
             uri = uri,
+            allowOpenInternal = true,
             allowOpenExternal = true,
         )
     }
@@ -37,17 +38,20 @@ internal class DefaultCustomUriHandler(
     override fun openUri(
         uri: String,
         allowOpenExternal: Boolean,
+        allowOpenInternal: Boolean,
     ) {
         val urlOpeningMode =
             settingsRepository.current.value?.urlOpeningMode ?: UrlOpeningMode.External
 
         val processors =
-            // careful: topmost items have higher priority
-            listOf(
-                hashtagProcessor,
-                userProcessor,
-                entryProcessor,
-            )
+            buildList {
+                // careful: topmost items have higher priority
+                if (allowOpenInternal) {
+                    this += hashtagProcessor
+                    this += userProcessor
+                    this += entryProcessor
+                }
+            }
         scope.launch {
             if (processors.none { it.process(uri) }) {
                 if (allowOpenExternal) {

--- a/domain/urlhandler/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/DefaultCustomUriHandlerTest.kt
+++ b/domain/urlhandler/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/DefaultCustomUriHandlerTest.kt
@@ -116,9 +116,6 @@ class DefaultCustomUriHandlerTest {
 
     @Test
     fun `given hashtag URL when openUri then interactions are as expected`() {
-        every {
-            settingsRepository.current
-        } returns MutableStateFlow(SettingsModel())
         everySuspend { hashtagProcessor.process(any()) } returns true
         val tag = "fake-hashtag"
         val url = "https://$CURRENT_INSTANCE/search?tag=$tag"
@@ -135,9 +132,6 @@ class DefaultCustomUriHandlerTest {
 
     @Test
     fun `given user profile URL when openUri then interactions are as expected`() {
-        every {
-            settingsRepository.current
-        } returns MutableStateFlow(SettingsModel())
         everySuspend { userProcessor.process(any()) } returns true
         val url = "https://$CURRENT_INSTANCE/profile/username"
 
@@ -153,9 +147,6 @@ class DefaultCustomUriHandlerTest {
 
     @Test
     fun `given post display URL when openUri then interactions are as expected`() {
-        every {
-            settingsRepository.current
-        } returns MutableStateFlow(SettingsModel())
         everySuspend { entryProcessor.process(any()) } returns true
         val url = "https://$CURRENT_INSTANCE/display/objectId"
 
@@ -169,8 +160,39 @@ class DefaultCustomUriHandlerTest {
         }
     }
 
+    @Test
+    fun `given URL when openUri with allowOpenInternal false then interactions are as expected`() {
+        val url = "https://$CURRENT_INSTANCE/display/objectId"
+
+        sut.openUri(uri = url, allowOpenInternal = false)
+
+        verifySuspend(mode = VerifyMode.not) {
+            hashtagProcessor.process(any())
+            userProcessor.process(any())
+            entryProcessor.process(any())
+        }
+        verify {
+            defaultHandler.openUri(url)
+        }
+    }
+
+    @Test
+    fun `given URL when openUri with allowOpenExternal false then interactions are as expected`() {
+        val url = "https://$CURRENT_INSTANCE/display/objectId"
+
+        sut.openUri(uri = url, allowOpenExternal = false)
+
+        verifySuspend {
+            hashtagProcessor.process(any())
+            userProcessor.process(any())
+            entryProcessor.process(any())
+        }
+        verify(mode = VerifyMode.not) {
+            defaultHandler.openUri(url)
+        }
+    }
+
     companion object {
         private const val CURRENT_INSTANCE = "fake-instance.com"
-        private const val OTHER_INSTANCE = "other-instance.com"
     }
 }

--- a/feature/announcements/build.gradle.kts
+++ b/feature/announcements/build.gradle.kts
@@ -24,6 +24,7 @@ kotlin {
                 implementation(projects.domain.content.repository)
                 implementation(projects.domain.identity.data)
                 implementation(projects.domain.identity.repository)
+                implementation(projects.domain.urlhandler)
             }
         }
     }

--- a/feature/announcements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/announcements/AnnouncementsScreen.kt
+++ b/feature/announcements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/announcements/AnnouncementsScreen.kt
@@ -46,6 +46,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.InsertEmo
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineDivider
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
+import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.openExternally
 import com.livefast.eattrash.raccoonforfriendica.feature.announcements.components.AnnouncementCard
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -182,8 +183,12 @@ class AnnouncementsScreen : Screen {
                         AnnouncementCard(
                             announcement = announcement,
                             autoloadImages = uiState.autoloadImages,
-                            onOpenUrl = { url ->
-                                uriHandler.openUri(url)
+                            onOpenUrl = { url, allowOpenInternal ->
+                                if (allowOpenInternal) {
+                                    uriHandler.openUri(url)
+                                } else {
+                                    uriHandler.openExternally(url)
+                                }
                             },
                             onAddNewReaction = {
                                 chooseReactionAnnouncementIdBottomSheetOpened = announcement.id

--- a/feature/announcements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/announcements/components/AnnouncementCard.kt
+++ b/feature/announcements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/announcements/components/AnnouncementCard.kt
@@ -27,7 +27,7 @@ internal fun AnnouncementCard(
     announcement: AnnouncementModel,
     modifier: Modifier = Modifier,
     autoloadImages: Boolean = true,
-    onOpenUrl: ((String) -> Unit)? = null,
+    onOpenUrl: ((String, Boolean) -> Unit)? = null,
     onAddNewReaction: (() -> Unit)? = null,
     onAddReaction: ((String) -> Unit)? = null,
     onRemoveReaction: ((String) -> Unit)? = null,
@@ -67,7 +67,7 @@ internal fun AnnouncementCard(
                 content = body,
                 autoloadImages = autoloadImages,
                 emojis = announcement.emojis,
-                onOpenUrl = onOpenUrl,
+                onOpenUrl = onOpenUrl?.let { block -> { url -> block(url, true) } },
             )
         }
 

--- a/feature/calendar/build.gradle.kts
+++ b/feature/calendar/build.gradle.kts
@@ -25,6 +25,7 @@ kotlin {
                 implementation(projects.domain.content.repository)
                 implementation(projects.domain.identity.data)
                 implementation(projects.domain.identity.repository)
+                implementation(projects.domain.urlhandler)
             }
         }
     }

--- a/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/composables/CalendarRow.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/composables/CalendarRow.kt
@@ -42,7 +42,7 @@ fun CalendarRow(
     event: EventModel,
     modifier: Modifier = Modifier,
     options: List<Option> = emptyList(),
-    onOpenUrl: ((String) -> Unit)? = null,
+    onOpenUrl: ((String, Boolean) -> Unit)? = null,
     onClick: (() -> Unit)? = null,
     onOptionSelected: ((OptionId) -> Unit)? = null,
 ) {
@@ -67,7 +67,7 @@ fun CalendarRow(
             ContentTitle(
                 modifier = Modifier.weight(1f).padding(horizontal = Spacing.s),
                 content = event.title,
-                onOpenUrl = onOpenUrl,
+                onOpenUrl = onOpenUrl?.let { block -> { url -> block(url, true) } },
                 maxLines = 5,
                 onClick = {
                     onClick?.invoke()

--- a/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/list/CalendarScreen.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/list/CalendarScreen.kt
@@ -50,6 +50,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigatio
 import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.toEpochMillis
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getCalendarHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.isNearTheEnd
+import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.openExternally
 import com.livefast.eattrash.raccoonforfriendica.feature.calendar.composables.CalendarHeader
 import com.livefast.eattrash.raccoonforfriendica.feature.calendar.composables.CalendarRow
 import com.livefast.eattrash.raccoonforfriendica.feature.calendar.composables.CalendarRowPlaceholder
@@ -175,8 +176,12 @@ class CalendarScreen : Screen {
                                 CalendarRow(
                                     modifier = Modifier.fillMaxWidth(),
                                     event = item.event,
-                                    onOpenUrl = { url ->
-                                        uriHandler.openUri(url)
+                                    onOpenUrl = { url, allowOpenInternal ->
+                                        if (allowOpenInternal) {
+                                            uriHandler.openUri(url)
+                                        } else {
+                                            uriHandler.openExternally(url)
+                                        }
                                     },
                                     onClick = {
                                         detailOpener.openEvent(event = item.event)

--- a/feature/circles/build.gradle.kts
+++ b/feature/circles/build.gradle.kts
@@ -28,6 +28,7 @@ kotlin {
                 implementation(projects.domain.identity.data)
                 implementation(projects.domain.identity.repository)
                 implementation(projects.domain.identity.usecase)
+                implementation(projects.domain.urlhandler)
             }
         }
     }

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineScreen.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineScreen.kt
@@ -66,6 +66,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isOldEntry
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getEntryActionRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.openExternally
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -232,8 +233,12 @@ class CircleTimelineScreen(
                             onClick = { e ->
                                 detailOpener.openEntryDetail(e)
                             },
-                            onOpenUrl = { url ->
-                                uriHandler.openUri(url)
+                            onOpenUrl = { url, allowOpenInternal ->
+                                if (allowOpenInternal) {
+                                    uriHandler.openUri(url)
+                                } else {
+                                    uriHandler.openExternally(url)
+                                }
                             },
                             onOpenUser = {
                                 detailOpener.openUserDetail(it)

--- a/feature/entrydetail/build.gradle.kts
+++ b/feature/entrydetail/build.gradle.kts
@@ -26,6 +26,7 @@ kotlin {
                 implementation(projects.domain.identity.data)
                 implementation(projects.domain.identity.repository)
                 implementation(projects.domain.identity.usecase)
+                implementation(projects.domain.urlhandler)
             }
         }
     }

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -75,6 +75,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isOldEntry
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getEntryActionRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.openExternally
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -277,8 +278,12 @@ class EntryDetailScreen(
                                 },
                             blurNsfw = uiState.blurNsfw,
                             autoloadImages = uiState.autoloadImages,
-                            onOpenUrl = { url ->
-                                uriHandler.openUri(url)
+                            onOpenUrl = { url, allowOpenInternal ->
+                                if (allowOpenInternal) {
+                                    uriHandler.openUri(url)
+                                } else {
+                                    uriHandler.openExternally(url)
+                                }
                             },
                             onClick = { e ->
                                 if (e.id != id) {

--- a/feature/explore/build.gradle.kts
+++ b/feature/explore/build.gradle.kts
@@ -28,6 +28,7 @@ kotlin {
                 implementation(projects.domain.identity.data)
                 implementation(projects.domain.identity.repository)
                 implementation(projects.domain.identity.usecase)
+                implementation(projects.domain.urlhandler)
             }
         }
     }

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
@@ -78,6 +78,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isOldEntry
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getEntryActionRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.openExternally
 import com.livefast.eattrash.raccoonforfriendica.feature.explore.data.ExploreSection
 import com.livefast.eattrash.raccoonforfriendica.feature.explore.data.toReadableName
 import kotlinx.coroutines.flow.launchIn
@@ -307,8 +308,12 @@ class ExploreScreen : Screen {
                                     onClick = { e ->
                                         detailOpener.openEntryDetail(e)
                                     },
-                                    onOpenUrl = { url ->
-                                        uriHandler.openUri(url)
+                                    onOpenUrl = { url, allowOpenInternal ->
+                                        if (allowOpenInternal) {
+                                            uriHandler.openUri(url)
+                                        } else {
+                                            uriHandler.openExternally(url)
+                                        }
                                     },
                                     onOpenUser = {
                                         detailOpener.openUserDetail(it)
@@ -487,7 +492,7 @@ class ExploreScreen : Screen {
                                     link = item.link,
                                     autoloadImages = uiState.autoloadImages,
                                     onOpen = { url ->
-                                        uriHandler.openUri(url)
+                                        uriHandler.openExternally(url)
                                     },
                                 )
                                 Spacer(modifier = Modifier.height(Spacing.interItem))

--- a/feature/favorites/build.gradle.kts
+++ b/feature/favorites/build.gradle.kts
@@ -28,6 +28,7 @@ kotlin {
                 implementation(projects.domain.identity.data)
                 implementation(projects.domain.identity.repository)
                 implementation(projects.domain.identity.usecase)
+                implementation(projects.domain.urlhandler)
             }
         }
     }

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
@@ -67,6 +67,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toFavoritesType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toReadableName
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getEntryActionRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.openExternally
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -218,8 +219,12 @@ class FavoritesScreen(
                             onClick = { e ->
                                 detailOpener.openEntryDetail(e)
                             },
-                            onOpenUrl = { url ->
-                                uriHandler.openUri(url)
+                            onOpenUrl = { url, allowOpenInternal ->
+                                if (allowOpenInternal) {
+                                    uriHandler.openUri(url)
+                                } else {
+                                    uriHandler.openExternally(url)
+                                }
                             },
                             onOpenUser = {
                                 detailOpener.openUserDetail(it)

--- a/feature/hashtag/build.gradle.kts
+++ b/feature/hashtag/build.gradle.kts
@@ -28,6 +28,7 @@ kotlin {
                 implementation(projects.domain.identity.data)
                 implementation(projects.domain.identity.repository)
                 implementation(projects.domain.identity.usecase)
+                implementation(projects.domain.urlhandler)
             }
         }
     }

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
@@ -67,6 +67,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isOldEntry
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getEntryActionRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.openExternally
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -239,8 +240,12 @@ class HashtagScreen(
                             onClick = { e ->
                                 detailOpener.openEntryDetail(e)
                             },
-                            onOpenUrl = { url ->
-                                uriHandler.openUri(url)
+                            onOpenUrl = { url, allowOpenInternal ->
+                                if (allowOpenInternal) {
+                                    uriHandler.openUri(url)
+                                } else {
+                                    uriHandler.openExternally(url)
+                                }
                             },
                             onOpenUser = {
                                 detailOpener.openUserDetail(it)

--- a/feature/inbox/build.gradle.kts
+++ b/feature/inbox/build.gradle.kts
@@ -27,6 +27,7 @@ kotlin {
                 implementation(projects.domain.identity.repository)
                 implementation(projects.domain.identity.usecase)
                 implementation(projects.domain.pullnotifications)
+                implementation(projects.domain.urlhandler)
             }
         }
     }

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
@@ -54,6 +54,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigatio
 import com.livefast.eattrash.raccoonforfriendica.core.utils.isNearTheEnd
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.RelationshipStatusNextAction
+import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.openExternally
 import com.livefast.eattrash.raccoonforfriendica.feature.inbox.composable.ConfigureNotificationTypeDialog
 import com.livefast.eattrash.raccoonforfriendica.feature.inbox.composable.NotificationItem
 import com.livefast.eattrash.raccoonforfriendica.feature.inbox.composable.NotificationItemPlaceholder
@@ -213,8 +214,12 @@ class InboxScreen : Screen {
                                 detailOpener.openEntryDetail(entry)
                                 model.reduce(InboxMviModel.Intent.MarkAsRead(notification))
                             },
-                            onOpenUrl = { url ->
-                                uriHandler.openUri(url)
+                            onOpenUrl = { url, allowOpenInternal ->
+                                if (allowOpenInternal) {
+                                    uriHandler.openUri(url)
+                                } else {
+                                    uriHandler.openExternally(url)
+                                }
                             },
                             onOpenUser = {
                                 detailOpener.openUserDetail(it)

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationItem.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationItem.kt
@@ -51,7 +51,7 @@ internal fun NotificationItem(
     blurNsfw: Boolean = false,
     maxBodyLines: Int = Int.MAX_VALUE,
     autoloadImages: Boolean = true,
-    onOpenUrl: ((String) -> Unit)? = null,
+    onOpenUrl: ((String, Boolean) -> Unit)? = null,
     onOpenUser: ((UserModel) -> Unit)? = null,
     onOpenEntry: ((TimelineEntryModel) -> Unit)? = null,
     onUserRelationshipClicked: ((String, RelationshipStatusNextAction) -> Unit)? = null,
@@ -155,7 +155,7 @@ internal fun NotificationItem(
                         ),
                     user = user,
                     autoloadImages = autoloadImages,
-                    onOpenUrl = onOpenUrl,
+                    onOpenUrl = onOpenUrl?.let { block -> { url -> block(url, true) } },
                     onOpenUser = {
                         onOpenUser?.invoke(user)
                     },

--- a/feature/licences/build.gradle.kts
+++ b/feature/licences/build.gradle.kts
@@ -22,6 +22,7 @@ kotlin {
 
                 implementation(projects.domain.identity.data)
                 implementation(projects.domain.identity.repository)
+                implementation(projects.domain.urlhandler)
             }
         }
     }

--- a/feature/licences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feat/licences/LicencesScreen.kt
+++ b/feature/licences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feat/licences/LicencesScreen.kt
@@ -33,6 +33,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
+import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.openExternally
 import com.livefast.eattrash.raccoonforfriendica.feat.licences.components.LicenceItem
 
 class LicencesScreen : Screen {
@@ -97,7 +98,7 @@ class LicencesScreen : Screen {
                         modifier = Modifier.fillMaxWidth(),
                         onClick = {
                             if (item.url.isNotBlank()) {
-                                uriHandler.openUri(item.url)
+                                uriHandler.openExternally(item.url)
                             }
                         },
                     )

--- a/feature/profile/build.gradle.kts
+++ b/feature/profile/build.gradle.kts
@@ -29,6 +29,7 @@ kotlin {
                 implementation(projects.domain.identity.data)
                 implementation(projects.domain.identity.repository)
                 implementation(projects.domain.identity.usecase)
+                implementation(projects.domain.urlhandler)
             }
         }
     }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/loginintro/LoginIntroScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/loginintro/LoginIntroScreen.kt
@@ -63,6 +63,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toOption
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.resources.di.getCoreResources
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.LoginType
+import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.openExternally
 
 internal class LoginIntroScreen : Screen {
     @OptIn(ExperimentalMaterial3Api::class)
@@ -114,7 +115,7 @@ internal class LoginIntroScreen : Screen {
                 title = LocalStrings.current.loginFriendicaHeader,
                 painter = resources.friendicaLogo,
                 onInfoClicked = {
-                    uriHandler.openUri(LoginIntroLinks.ABOUT_FRIENDICA)
+                    uriHandler.openExternally(LoginIntroLinks.ABOUT_FRIENDICA)
                 },
             )
             Button(
@@ -129,7 +130,7 @@ internal class LoginIntroScreen : Screen {
             PlatformLink(
                 title = LocalStrings.current.helpMeChooseAnInstance,
                 onClick = {
-                    uriHandler.openUri(LoginIntroLinks.FRIENDICA_INSTANCE_HELP)
+                    uriHandler.openExternally(LoginIntroLinks.FRIENDICA_INSTANCE_HELP)
                 },
                 options =
                     buildList {
@@ -161,7 +162,7 @@ internal class LoginIntroScreen : Screen {
                 title = LocalStrings.current.loginMastodonHeader,
                 painter = resources.mastodonLogo,
                 onInfoClicked = {
-                    uriHandler.openUri(LoginIntroLinks.ABOUT_MASTODON)
+                    uriHandler.openExternally(LoginIntroLinks.ABOUT_MASTODON)
                 },
             )
             Button(
@@ -177,7 +178,7 @@ internal class LoginIntroScreen : Screen {
             PlatformLink(
                 title = LocalStrings.current.helpMeChooseAnInstance,
                 onClick = {
-                    uriHandler.openUri(LoginIntroLinks.MASTODON_INSTANCE_HELP)
+                    uriHandler.openExternally(LoginIntroLinks.MASTODON_INSTANCE_HELP)
                 },
             )
         }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
@@ -75,6 +75,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEnt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getEntryActionRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.openExternally
 import com.livefast.eattrash.raccoonforfriendica.feature.profile.LocalProfileTopAppBarStateWrapper
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -189,8 +190,12 @@ object MyAccountScreen : Tab {
                             user = uiState.user,
                             autoloadImages = uiState.autoloadImages,
                             editButtonEnabled = true,
-                            onOpenUrl = { url ->
-                                uriHandler.openUri(url)
+                            onOpenUrl = { url, allowOpenInternal ->
+                                if (allowOpenInternal) {
+                                    uriHandler.openUri(url)
+                                } else {
+                                    uriHandler.openExternally(url)
+                                }
                             },
                             onOpenFollowers = {
                                 uiState.user?.also { user ->
@@ -316,8 +321,12 @@ object MyAccountScreen : Tab {
                         UserFields(
                             fields = fields,
                             autoloadImages = uiState.autoloadImages,
-                            onOpenUrl = { url ->
-                                uriHandler.openUri(url)
+                            onOpenUrl = { url, allowOpenInternal ->
+                                if (allowOpenInternal) {
+                                    uriHandler.openUri(url)
+                                } else {
+                                    uriHandler.openExternally(url)
+                                }
                             },
                         )
                     }
@@ -376,8 +385,12 @@ object MyAccountScreen : Tab {
                         onClick = { e ->
                             detailOpener.openEntryDetail(e)
                         },
-                        onOpenUrl = { url ->
-                            uriHandler.openUri(url)
+                        onOpenUrl = { url, allowOpenInternal ->
+                            if (allowOpenInternal) {
+                                uriHandler.openUri(url)
+                            } else {
+                                uriHandler.openExternally(url)
+                            }
                         },
                         onOpenUser = {
                             detailOpener.openUserDetail(it)

--- a/feature/search/build.gradle.kts
+++ b/feature/search/build.gradle.kts
@@ -28,6 +28,7 @@ kotlin {
                 implementation(projects.domain.identity.data)
                 implementation(projects.domain.identity.repository)
                 implementation(projects.domain.identity.usecase)
+                implementation(projects.domain.urlhandler)
             }
         }
     }

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
@@ -79,6 +79,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isOldEntry
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getEntryActionRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.openExternally
 import com.livefast.eattrash.raccoonforfriendica.feaure.search.data.SearchSection
 import com.livefast.eattrash.raccoonforfriendica.feaure.search.data.toReadableName
 import kotlinx.coroutines.flow.launchIn
@@ -309,8 +310,12 @@ class SearchScreen : Screen {
                                     onClick = { e ->
                                         detailOpener.openEntryDetail(e)
                                     },
-                                    onOpenUrl = { url ->
-                                        uriHandler.openUri(url)
+                                    onOpenUrl = { url, allowOpenInternal ->
+                                        if (allowOpenInternal) {
+                                            uriHandler.openUri(url)
+                                        } else {
+                                            uriHandler.openExternally(url)
+                                        }
                                     },
                                     onOpenUser = {
                                         detailOpener.openUserDetail(it)

--- a/feature/thread/build.gradle.kts
+++ b/feature/thread/build.gradle.kts
@@ -26,6 +26,7 @@ kotlin {
                 implementation(projects.domain.identity.data)
                 implementation(projects.domain.identity.repository)
                 implementation(projects.domain.identity.usecase)
+                implementation(projects.domain.urlhandler)
             }
         }
     }

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
@@ -77,6 +77,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isOldEntry
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getEntryActionRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.openExternally
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -250,8 +251,12 @@ class ThreadScreen(
                                 extendedSocialInfoEnabled = true,
                                 blurNsfw = uiState.blurNsfw,
                                 autoloadImages = uiState.autoloadImages,
-                                onOpenUrl = { url ->
-                                    uriHandler.openUri(url)
+                                onOpenUrl = { url, allowOpenInternal ->
+                                    if (allowOpenInternal) {
+                                        uriHandler.openUri(url)
+                                    } else {
+                                        uriHandler.openExternally(url)
+                                    }
                                 },
                                 onOpenUser = {
                                     detailOpener.openUserDetail(it)
@@ -402,8 +407,12 @@ class ThreadScreen(
                             entry = entry,
                             layout = uiState.layout,
                             autoloadImages = uiState.autoloadImages,
-                            onOpenUrl = { url ->
-                                uriHandler.openUri(url)
+                            onOpenUrl = { url, allowOpenInternal ->
+                                if (allowOpenInternal) {
+                                    uriHandler.openUri(url)
+                                } else {
+                                    uriHandler.openExternally(url)
+                                }
                             },
                             onOpenUser = {
                                 detailOpener.openUserDetail(it)

--- a/feature/timeline/build.gradle.kts
+++ b/feature/timeline/build.gradle.kts
@@ -28,6 +28,7 @@ kotlin {
                 implementation(projects.domain.identity.data)
                 implementation(projects.domain.identity.repository)
                 implementation(projects.domain.identity.usecase)
+                implementation(projects.domain.urlhandler)
             }
         }
     }

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
@@ -86,6 +86,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toIcon
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toReadableName
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getEntryActionRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.openExternally
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -326,8 +327,12 @@ class TimelineScreen : Screen {
                             onClick = { e ->
                                 detailOpener.openEntryDetail(e)
                             },
-                            onOpenUrl = { url ->
-                                uriHandler.openUri(url)
+                            onOpenUrl = { url, allowOpenInternal ->
+                                if (allowOpenInternal) {
+                                    uriHandler.openUri(url)
+                                } else {
+                                    uriHandler.openExternally(url)
+                                }
                             },
                             onOpenUser = {
                                 detailOpener.openUserDetail(it)

--- a/feature/userdetail/build.gradle.kts
+++ b/feature/userdetail/build.gradle.kts
@@ -27,6 +27,7 @@ kotlin {
                 implementation(projects.domain.identity.data)
                 implementation(projects.domain.identity.repository)
                 implementation(projects.domain.identity.usecase)
+                implementation(projects.domain.urlhandler)
             }
         }
     }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -106,6 +106,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isOldEntry
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getEntryActionRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.openExternally
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -415,8 +416,12 @@ class UserDetailScreen(
                             UserHeader(
                                 user = uiState.user,
                                 autoloadImages = uiState.autoloadImages,
-                                onOpenUrl = { url ->
-                                    uriHandler.openUri(url)
+                                onOpenUrl = { url, allowOpenInternal ->
+                                    if (allowOpenInternal) {
+                                        uriHandler.openUri(url)
+                                    } else {
+                                        uriHandler.openExternally(url)
+                                    }
                                 },
                                 onOpenImage = { url ->
                                     detailOpener.openImageDetail(url)
@@ -518,8 +523,12 @@ class UserDetailScreen(
                             UserFields(
                                 fields = fields,
                                 autoloadImages = uiState.autoloadImages,
-                                onOpenUrl = { url ->
-                                    uriHandler.openUri(url)
+                                onOpenUrl = { url, allowOpenInternal ->
+                                    if (allowOpenInternal) {
+                                        uriHandler.openUri(url)
+                                    } else {
+                                        uriHandler.openExternally(url)
+                                    }
                                 },
                             )
                         }
@@ -575,8 +584,12 @@ class UserDetailScreen(
                             onClick = { e ->
                                 detailOpener.openEntryDetail(e)
                             },
-                            onOpenUrl = { url ->
-                                uriHandler.openUri(url)
+                            onOpenUrl = { url, allowOpenInternal ->
+                                if (allowOpenInternal) {
+                                    uriHandler.openUri(url)
+                                } else {
+                                    uriHandler.openExternally(url)
+                                }
                             },
                             onOpenUser = { user ->
                                 if (user.id != uiState.user?.id) {

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
@@ -82,6 +82,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isOldEntry
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getEntryActionRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.openExternally
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -329,8 +330,12 @@ class ForumListScreen(
                             onClick = { e ->
                                 detailOpener.openThread(e)
                             },
-                            onOpenUrl = { url ->
-                                uriHandler.openUri(url)
+                            onOpenUrl = { url, allowOpenInternal ->
+                                if (allowOpenInternal) {
+                                    uriHandler.openUri(url)
+                                } else {
+                                    uriHandler.openExternally(url)
+                                }
                             },
                             onOpenUser = {
                                 detailOpener.openUserDetail(it)


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR makes it possible to "skip" internal reference resolution for those URLs which are known to point to some destination outside the Fediverse (e.g. post card previews, licences, help pages).

This will make it faster to open links and could improve the performance issues reported in #736.
