### PR TITLE
fix: remove UI bar theme option from settings if not supported

### DIFF
--- a/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/DefaultBarColorProvider.kt
+++ b/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/DefaultBarColorProvider.kt
@@ -13,6 +13,9 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.UiBarTheme
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.UiTheme
 
 internal class DefaultBarColorProvider : BarColorProvider {
+    override val isBarThemeSupported: Boolean
+        get() = Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM
+
     @Composable
     override fun setBarColorAccordingToTheme(
         theme: UiTheme,
@@ -39,19 +42,17 @@ internal class DefaultBarColorProvider : BarColorProvider {
                         UiBarTheme.Transparent -> baseColor.copy(alpha = 0.01f)
                         else -> baseColor
                     }.toArgb()
-                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+                if (isBarThemeSupported) {
                     statusBarColor = barColor
                     navigationBarColor = barColor
                 }
 
-                if (barTheme != UiBarTheme.Solid) {
-                    WindowCompat.setDecorFitsSystemWindows(this, false)
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-                            isStatusBarContrastEnforced = true
-                        }
-                        isNavigationBarContrastEnforced = true
+                WindowCompat.setDecorFitsSystemWindows(this, false)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+                        isStatusBarContrastEnforced = true
                     }
+                    isNavigationBarContrastEnforced = true
                 }
 
                 val forceLight = baseColor == Color.White

--- a/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/BarColorProvider.kt
+++ b/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/BarColorProvider.kt
@@ -5,6 +5,8 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.UiBarTheme
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.UiTheme
 
 interface BarColorProvider {
+    val isBarThemeSupported: Boolean
+
     @Composable
     fun setBarColorAccordingToTheme(
         theme: UiTheme,

--- a/core/appearance/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/DefaultBarColorProvider.kt
+++ b/core/appearance/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/DefaultBarColorProvider.kt
@@ -11,6 +11,8 @@ import platform.UIKit.UIStatusBarStyleLightContent
 import platform.UIKit.setStatusBarStyle
 
 internal class DefaultBarColorProvider : BarColorProvider {
+    override val isBarThemeSupported = false
+
     @Composable
     override fun setBarColorAccordingToTheme(
         theme: UiTheme,

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsMviModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsMviModel.kt
@@ -177,6 +177,7 @@ interface SettingsMviModel :
         val barTheme: UiBarTheme = UiBarTheme.Transparent,
         val timelineLayout: TimelineLayout = TimelineLayout.Full,
         val pushNotificationPermissionState: PermissionState = PermissionState.NotDetermined,
+        val isBarThemeSupported: Boolean = false,
     )
 
     sealed interface Effect {

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
@@ -433,13 +433,15 @@ class SettingsScreen : Screen {
                                 },
                             )
                         }
-                        SettingsRow(
-                            title = LocalStrings.current.settingsItemBarTheme,
-                            value = uiState.barTheme.toReadableName(),
-                            onTap = {
-                                barThemeBottomSheetOpened = true
-                            },
-                        )
+                        if (uiState.isBarThemeSupported) {
+                            SettingsRow(
+                                title = LocalStrings.current.settingsItemBarTheme,
+                                value = uiState.barTheme.toReadableName(),
+                                onTap = {
+                                    barThemeBottomSheetOpened = true
+                                },
+                            )
+                        }
 
                         // NSFW section
                         SettingsHeader(

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsViewModel.kt
@@ -10,6 +10,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.UiFontScal
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.UiTheme
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.repository.ThemeColorRepository
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.repository.ThemeRepository
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.BarColorProvider
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ColorSchemeProvider
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModel
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.L10nManager
@@ -64,6 +65,7 @@ class SettingsViewModel(
     private val importSettings: ImportSettingsUseCase,
     private val exportSettings: ExportSettingsUseCase,
     private val permissionController: PermissionsController,
+    private val barColorProvider: BarColorProvider,
 ) : DefaultMviModel<SettingsMviModel.Intent, SettingsMviModel.State, SettingsMviModel.Effect>(
         initialState = SettingsMviModel.State(),
     ),
@@ -96,6 +98,7 @@ class SettingsViewModel(
                     appIconChangeSupported = appIconManager.supportsMultipleIcons,
                     supportSettingsImportExport = fileSystemManager.isSupported,
                     pushNotificationPermissionState = pushNotificationPermissionState,
+                    isBarThemeSupported = barColorProvider.isBarThemeSupported,
                 )
             }
 

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/di/SettingsModule.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/di/SettingsModule.kt
@@ -32,6 +32,7 @@ val settingsModule =
                     fileSystemManager = instance(),
                     importSettings = instance(),
                     exportSettings = instance(),
+                    barColorProvider = instance(),
                 )
             }
         }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR removes the possibility to configure the UI bar theme when it is not supported (iOS or Android >= 15).

## Additional notes
<!-- Anything to declare for code review? -->
This is the counterpart of [RfL#279](https://github.com/LiveFastEatTrashRaccoon/RaccoonForLemmy/pull/279)
