### PR TITLE
feat: implement post navigation component

### DIFF
--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelineNavigationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelineNavigationManager.kt
@@ -1,0 +1,58 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+import kotlinx.coroutines.flow.MutableStateFlow
+
+internal class DefaultTimelineNavigationManager(
+    private val paginationManager: TimelinePaginationManager,
+) : TimelineNavigationManager {
+    override val canNavigate = MutableStateFlow(false)
+    private var states: MutableList<TimelinePaginationManagerState> = mutableListOf()
+
+    override fun push(state: TimelinePaginationManagerState) {
+        states += state
+        canNavigate.value = true
+        paginationManager.restoreState(state)
+    }
+
+    override fun pop() {
+        states.removeLastOrNull()
+        val canStillNavigate = states.isNotEmpty()
+        canNavigate.value = canStillNavigate
+        if (canStillNavigate) {
+            states.lastOrNull()?.also { lastState ->
+                paginationManager.restoreState(lastState)
+            }
+        }
+    }
+
+    override suspend fun getPrevious(postId: String): TimelineEntryModel? {
+        val history = paginationManager.history
+        val index =
+            history
+                .indexOfFirst { it.id == postId }
+                .takeIf { it >= 0 } ?: return null
+        return when (index) {
+            0 -> null
+            else -> history.getOrNull(index - 1)
+        }
+    }
+
+    override suspend fun getNext(postId: String): TimelineEntryModel? {
+        val history = paginationManager.history
+        val index =
+            history
+                .indexOfFirst { it.id == postId }
+                .takeIf { it >= 0 } ?: return null
+        return when {
+            index < history.lastIndex -> history[index + 1]
+            !paginationManager.canFetchMore -> null
+            else ->
+                run {
+                    val newPosts = paginationManager.loadNextPage()
+                    val newIndex = newPosts.indexOfFirst { it.id == postId }
+                    newPosts.getOrNull(newIndex + 1)
+                }
+        }
+    }
+}

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
@@ -222,6 +222,24 @@ internal class DefaultTimelinePaginationManager(
         }
     }
 
+    override fun extractState(): TimelinePaginationManagerState =
+        DefaultTimelinePaginationManagerState(
+            specification = specification,
+            pageCursor = pageCursor,
+            history = history,
+            userRateLimits = userRateLimits,
+        )
+
+    override fun restoreState(state: TimelinePaginationManagerState) {
+        (state as? DefaultTimelinePaginationManagerState)?.also {
+            specification = it.specification
+            pageCursor = it.pageCursor
+            history.clear()
+            history.addAll(it.history)
+            userRateLimits.putAll(it.userRateLimits)
+        }
+    }
+
     private fun List<TimelineEntryModel>.toListWithPageCursor(): ListWithPageCursor<TimelineEntryModel> =
         let { list ->
             val cursor = list.lastOrNull()?.id

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManagerState.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManagerState.kt
@@ -1,0 +1,10 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+
+internal data class DefaultTimelinePaginationManagerState(
+    val specification: TimelinePaginationSpecification? = null,
+    val pageCursor: String? = null,
+    val history: List<TimelineEntryModel> = emptyList(),
+    val userRateLimits: Map<String, Double> = emptyMap(),
+) : TimelinePaginationManagerState

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/TimelineNavigationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/TimelineNavigationManager.kt
@@ -1,0 +1,16 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+import kotlinx.coroutines.flow.StateFlow
+
+interface TimelineNavigationManager {
+    val canNavigate: StateFlow<Boolean>
+
+    fun push(state: TimelinePaginationManagerState)
+
+    fun pop()
+
+    suspend fun getPrevious(postId: String): TimelineEntryModel?
+
+    suspend fun getNext(postId: String): TimelineEntryModel?
+}

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/TimelinePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/TimelinePaginationManager.kt
@@ -11,4 +11,8 @@ interface TimelinePaginationManager {
     suspend fun loadNextPage(): List<TimelineEntryModel>
 
     suspend fun restoreHistory(values: List<TimelineEntryModel>)
+
+    fun extractState(): TimelinePaginationManagerState
+
+    fun restoreState(state: TimelinePaginationManagerState)
 }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
@@ -9,6 +9,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.Defau
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultFollowedHashtagsPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultNotificationsPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultSearchPaginationManager
+import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultTimelineNavigationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultTimelinePaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultUnpublishedPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.DefaultUserPaginationManager
@@ -19,6 +20,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.Follo
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.FollowedHashtagsPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.NotificationsPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.SearchPaginationManager
+import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelineNavigationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.UnpublishedPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.UserPaginationManager
@@ -26,6 +28,7 @@ import org.kodein.di.DI
 import org.kodein.di.bind
 import org.kodein.di.instance
 import org.kodein.di.provider
+import org.kodein.di.singleton
 
 val contentPaginationModule =
     DI.Module("ContentPaginationModule") {
@@ -130,6 +133,13 @@ val contentPaginationModule =
                     userRateLimitRepository = instance(),
                     emojiHelper = instance(),
                     notificationCenter = instance(),
+                )
+            }
+        }
+        bind<TimelineNavigationManager> {
+            singleton {
+                DefaultTimelineNavigationManager(
+                    paginationManager = instance(),
                 )
             }
         }

--- a/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelineNavigationManagerTest.kt
+++ b/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelineNavigationManagerTest.kt
@@ -1,0 +1,191 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DefaultTimelineNavigationManagerTest {
+    private val paginationManager = mock<TimelinePaginationManager>(MockMode.autoUnit)
+    private val sut =
+        DefaultTimelineNavigationManager(paginationManager = paginationManager)
+
+    @Test
+    fun whenInitial_thenCanNotNavigate() =
+        runTest {
+            val res = sut.canNavigate.value
+            assertFalse(res)
+        }
+
+    @Test
+    fun whenPush_thenCanNavigate() =
+        runTest {
+            val mockState = mock<TimelinePaginationManagerState>()
+            sut.push(mockState)
+
+            val res = sut.canNavigate.value
+            assertTrue(res)
+
+            verify {
+                paginationManager.restoreState(mockState)
+            }
+        }
+
+    @Test
+    fun givenEmpty_whenPop_thenCanNotNavigate() {
+        sut.pop()
+
+        val res = sut.canNavigate.value
+
+        assertFalse(res)
+    }
+
+    @Test
+    fun whenPopWithMoreThanOneState_thenCanNavigate() =
+        runTest {
+            val mockState1 = mock<TimelinePaginationManagerState>()
+            sut.push(mockState1)
+            val mockState2 = mock<TimelinePaginationManagerState>()
+            sut.push(mockState2)
+
+            sut.pop()
+            val res = sut.canNavigate.value
+            assertTrue(res)
+
+            verify(VerifyMode.order) {
+                paginationManager.restoreState(mockState1)
+                paginationManager.restoreState(mockState2)
+                paginationManager.restoreState(mockState1)
+            }
+        }
+
+    @Test
+    fun whenPopWithOneState_thenCanNotNavigate() =
+        runTest {
+            val mockState = mock<TimelinePaginationManagerState>()
+            sut.push(mockState)
+
+            sut.pop()
+            val res = sut.canNavigate.value
+            assertFalse(res)
+
+            verify(VerifyMode.order) {
+                paginationManager.restoreState(mockState)
+            }
+        }
+
+    @Test
+    fun givenEmptyHistory_whenGetPrevious_thenResultIsAsExpected() =
+        runTest {
+            every { paginationManager.history } returns emptyList()
+
+            val res = sut.getPrevious("1")
+
+            assertNull(res)
+        }
+
+    @Test
+    fun givenHistory_whenGetPreviousWithFirstId_thenResultIsAsExpected() =
+        runTest {
+            val postId = "1"
+            every { paginationManager.history } returns
+                listOf(TimelineEntryModel(id = postId, content = ""))
+
+            val res = sut.getPrevious(postId)
+
+            assertNull(res)
+        }
+
+    @Test
+    fun givenHistory_whenGetPreviousWithNotFirstId_thenResultIsAsExpected() =
+        runTest {
+            val otherPostId = "1"
+            val postId = "2"
+            every { paginationManager.history } returns
+                listOf(
+                    TimelineEntryModel(id = otherPostId, content = ""),
+                    TimelineEntryModel(id = postId, content = ""),
+                )
+
+            val res = sut.getPrevious(postId)
+
+            assertNotNull(res)
+            assertEquals(otherPostId, res.id)
+        }
+
+    @Test
+    fun givenEmptyHistory_whenGetNext_thenResultIsAsExpected() =
+        runTest {
+            every { paginationManager.history } returns emptyList()
+
+            val res = sut.getNext("1")
+
+            assertNull(res)
+        }
+
+    @Test
+    fun givenHistoryAndCanNotFetchMore_whenGetNextWithLastId_thenResultIsAsExpected() =
+        runTest {
+            val postId = "1"
+            every { paginationManager.history } returns
+                listOf(TimelineEntryModel(id = postId, content = ""))
+            every { paginationManager.canFetchMore } returns false
+
+            val res = sut.getNext(postId)
+
+            assertNull(res)
+            verifySuspend(VerifyMode.not) {
+                paginationManager.loadNextPage()
+            }
+        }
+
+    @Test
+    fun givenHistoryAndCanFetchMore_whenGetNextWithLastId_thenResultIsAsExpected() =
+        runTest {
+            val postId = "1"
+            val otherPostId = "2"
+            every { paginationManager.history } returns
+                listOf(TimelineEntryModel(id = postId, content = ""))
+            every { paginationManager.canFetchMore } returns true
+            everySuspend { paginationManager.loadNextPage() } returns
+                listOf(TimelineEntryModel(id = otherPostId, content = ""))
+
+            val res = sut.getNext(postId)
+
+            assertNotNull(res)
+            assertEquals(otherPostId, res.id)
+
+            verifySuspend {
+                paginationManager.loadNextPage()
+            }
+        }
+
+    @Test
+    fun givenHistory_whenGetPreviousWithNotLastId_thenResultIsAsExpected() =
+        runTest {
+            val otherPostId = "1"
+            val postId = "2"
+            every { paginationManager.history } returns
+                listOf(
+                    TimelineEntryModel(id = postId, content = ""),
+                    TimelineEntryModel(id = otherPostId, content = ""),
+                )
+
+            val res = sut.getNext(postId)
+
+            assertNotNull(res)
+            assertEquals(otherPostId, res.id)
+        }
+}


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds the implementation of the main post "navigation" component, which will be used to hold the history of the current timeline being visited plus the instructions to fetch more pages when the end is reached.

This will be the manager of the new navigation logic between posts in full screen, as requested in #749.

## Technical details
This logic is heavily inspired by RaccoonForLemmy, see [here](https://github.com/LiveFastEatTrashRaccoon/RaccoonForLemmy/blob/master/domain/lemmy/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/pagination/DefaultPostNavigationManager.kt). Two little raccoons are partners in crime, as always. 🦝 🦝
