### PR TITLE
feat: add swipe navigation in post detail and thread detail

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpener.kt
@@ -97,10 +97,15 @@ class DefaultDetailOpener(
     override fun openEntryDetail(
         entry: TimelineEntryModel,
         replaceTop: Boolean,
+        swipeNavigationEnabled: Boolean,
     ) {
         scope.launch {
             entryCache.put(entry.id, entry)
-            val screen = EntryDetailScreen(entry.id)
+            val screen =
+                EntryDetailScreen(
+                    id = entry.id,
+                    swipeNavigationEnabled = swipeNavigationEnabled,
+                )
             if (replaceTop) {
                 navigationCoordinator.replace(screen)
             } else {
@@ -257,10 +262,17 @@ class DefaultDetailOpener(
         navigationCoordinator.push(screen)
     }
 
-    override fun openThread(entry: TimelineEntryModel) {
+    override fun openThread(
+        entry: TimelineEntryModel,
+        swipeNavigationEnabled: Boolean,
+    ) {
         scope.launch {
             entryCache.put(entry.id, entry)
-            val screen = ThreadScreen(entry.id)
+            val screen =
+                ThreadScreen(
+                    entryId = entry.id,
+                    swipeNavigationEnabled = swipeNavigationEnabled
+            )
             navigationCoordinator.push(screen)
         }
     }

--- a/composeApp/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpenerTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultDetailOpenerTest.kt
@@ -154,6 +154,18 @@ class DefaultDetailOpenerTest {
     }
 
     @Test
+    fun `when openEntryDetail with swipeNavigationEnabled then interactions are as expected`() {
+        sut.openEntryDetail(
+            entry = TimelineEntryModel(id = "0", content = ""),
+            swipeNavigationEnabled = true,
+        )
+
+        verify {
+            navigationCoordinator.push(any<EntryDetailScreen>())
+        }
+    }
+
+    @Test
     fun `when openSettings then interactions are as expected`() {
         sut.openSettings()
 
@@ -286,6 +298,17 @@ class DefaultDetailOpenerTest {
     fun `given reply when openThread then interactions are as expected`() {
         val entry = TimelineEntryModel(id = "0", content = "")
         sut.openThread(entry = entry)
+
+        verifySuspend {
+            entryCache.put(entry.id, entry)
+            navigationCoordinator.push(any<ThreadScreen>())
+        }
+    }
+
+    @Test
+    fun `given reply when openThread with swipeNavigationEnabled then interactions are as expected`() {
+        val entry = TimelineEntryModel(id = "0", content = "")
+        sut.openThread(entry = entry, swipeNavigationEnabled = true)
 
         verifySuspend {
             entryCache.put(entry.id, entry)

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DetailOpener.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DetailOpener.kt
@@ -18,6 +18,7 @@ interface DetailOpener {
     fun openEntryDetail(
         entry: TimelineEntryModel,
         replaceTop: Boolean = false,
+        swipeNavigationEnabled: Boolean = false,
     )
 
     fun openSettings()
@@ -67,7 +68,10 @@ interface DetailOpener {
 
     fun openSearch()
 
-    fun openThread(entry: TimelineEntryModel)
+    fun openThread(
+        entry: TimelineEntryModel,
+        swipeNavigationEnabled: Boolean = false,
+    )
 
     fun openImageDetail(url: String)
 

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelineNavigationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelineNavigationManager.kt
@@ -9,6 +9,9 @@ internal class DefaultTimelineNavigationManager(
     override val canNavigate = MutableStateFlow(false)
     private var states: MutableList<TimelinePaginationManagerState> = mutableListOf()
 
+    override val currentList: List<TimelineEntryModel>
+        get() = paginationManager.history
+
     override fun push(state: TimelinePaginationManagerState) {
         states += state
         canNavigate.value = true
@@ -47,12 +50,15 @@ internal class DefaultTimelineNavigationManager(
         return when {
             index < history.lastIndex -> history[index + 1]
             !paginationManager.canFetchMore -> null
-            else ->
-                run {
-                    val newPosts = paginationManager.loadNextPage()
-                    val newIndex = newPosts.indexOfFirst { it.id == postId }
-                    newPosts.getOrNull(newIndex + 1)
-                }
+            else -> {
+                val newPosts = paginationManager.loadNextPage()
+                val newIndex = newPosts.indexOfFirst { it.id == postId }
+                newPosts.getOrNull(newIndex + 1)
+            }
         }
+    }
+
+    override suspend fun loadNextPage() {
+        paginationManager.loadNextPage()
     }
 }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/TimelineNavigationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/TimelineNavigationManager.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.StateFlow
 
 interface TimelineNavigationManager {
     val canNavigate: StateFlow<Boolean>
+    val currentList: List<TimelineEntryModel>
 
     fun push(state: TimelinePaginationManagerState)
 
@@ -13,4 +14,6 @@ interface TimelineNavigationManager {
     suspend fun getPrevious(postId: String): TimelineEntryModel?
 
     suspend fun getNext(postId: String): TimelineEntryModel?
+
+    suspend fun loadNextPage()
 }

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/di/CirclesModule.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/di/CirclesModule.kt
@@ -53,6 +53,7 @@ val circlesModule =
                     toggleEntryFavorite = instance(),
                     toggleEntryDislike = instance(),
                     getTranslation = instance(),
+                    timelineNavigationManager = instance(),
                     notificationCenter = instance(),
                 )
             }

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineMviModel.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineMviModel.kt
@@ -64,6 +64,10 @@ interface CircleTimelineMviModel :
         data class ToggleTranslation(
             val entry: TimelineEntryModel,
         ) : Intent
+
+        data class WillOpenDetail(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -90,6 +94,10 @@ interface CircleTimelineMviModel :
 
         data class TriggerCopy(
             val text: String,
+        ) : Effect
+
+        data class OpenDetail(
+            val entry: TimelineEntryModel,
         ) : Effect
     }
 }

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineScreen.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineScreen.kt
@@ -122,6 +122,13 @@ class CircleTimelineScreen(
                             clipboardManager.setText(AnnotatedString(event.text))
                             snackbarHostState.showSnackbar(copyToClipboardSuccess)
                         }
+
+                        is CircleTimelineMviModel.Effect.OpenDetail -> {
+                            detailOpener.openEntryDetail(
+                                entry = event.entry,
+                                swipeNavigationEnabled = true,
+                            )
+                        }
                     }
                 }.launchIn(this)
         }
@@ -232,7 +239,7 @@ class CircleTimelineScreen(
                             autoloadImages = uiState.autoloadImages,
                             maxBodyLines = uiState.maxBodyLines,
                             onClick = { e ->
-                                detailOpener.openEntryDetail(e)
+                                model.reduce(CircleTimelineMviModel.Intent.WillOpenDetail(e))
                             },
                             onOpenUrl = { url, allowOpenInternal ->
                                 if (allowOpenInternal) {

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineViewModel.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineViewModel.kt
@@ -16,6 +16,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineTyp
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.blurHashParamsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
+import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelineNavigationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationSpecification
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.LocalItemCache
@@ -48,6 +49,7 @@ class CircleTimelineViewModel(
     private val toggleEntryDislike: ToggleEntryDislikeUseCase,
     private val toggleEntryFavorite: ToggleEntryFavoriteUseCase,
     private val getTranslation: GetTranslationUseCase,
+    private val timelineNavigationManager: TimelineNavigationManager,
     private val notificationCenter: NotificationCenter = getNotificationCenter(),
 ) : DefaultMviModel<CircleTimelineMviModel.Intent, CircleTimelineMviModel.State, CircleTimelineMviModel.Effect>(
         initialState = CircleTimelineMviModel.State(),
@@ -141,6 +143,12 @@ class CircleTimelineViewModel(
 
             is CircleTimelineMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
             is CircleTimelineMviModel.Intent.ToggleTranslation -> toggleTranslation(intent.entry)
+            is CircleTimelineMviModel.Intent.WillOpenDetail ->
+                screenModelScope.launch {
+                    val state = paginationManager.extractState()
+                    timelineNavigationManager.push(state)
+                    emitEffect(CircleTimelineMviModel.Effect.OpenDetail(intent.entry))
+                }
         }
     }
 

--- a/feature/entrydetail/build.gradle.kts
+++ b/feature/entrydetail/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
                 implementation(projects.core.utils)
 
                 implementation(projects.domain.content.data)
+                implementation(projects.domain.content.pagination)
                 implementation(projects.domain.content.repository)
                 implementation(projects.domain.content.usecase)
                 implementation(projects.domain.identity.data)

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailMviModel.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailMviModel.kt
@@ -5,7 +5,6 @@ import cafe.adriel.voyager.core.model.ScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.TimelineLayout
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import kotlin.time.Duration
 
 @Stable
@@ -63,14 +62,20 @@ interface EntryDetailMviModel :
         data class ToggleTranslation(
             val entry: TimelineEntryModel,
         ) : Intent
+
+        data class ChangeNavigationIndex(
+            val index: Int,
+        ) : Intent
     }
 
     data class State(
         val currentUserId: String? = null,
         val refreshing: Boolean = false,
         val initial: Boolean = true,
-        val creator: UserModel? = null,
-        val entries: List<TimelineEntryModel> = emptyList(),
+        val initialIndex: Int = 0,
+        val mainEntry: TimelineEntryModel? = null,
+        val entries: List<List<TimelineEntryModel>> = emptyList(),
+        val currentIndex: Int = 0,
         val blurNsfw: Boolean = true,
         val autoloadImages: Boolean = true,
         val hideNavigationBarWhileScrolling: Boolean = true,

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/di/EntryDetailModule.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/di/EntryDetailModule.kt
@@ -7,12 +7,18 @@ import org.kodein.di.bind
 import org.kodein.di.factory
 import org.kodein.di.instance
 
+data class EntryDetailMviModelParams(
+    val id: String,
+    val swipeNavigationEnabled: Boolean,
+)
+
 val entryDetailModule =
     DI.Module("EntryDetailModule") {
         bind<EntryDetailMviModel> {
-            factory { id: String ->
+            factory { params: EntryDetailMviModelParams ->
                 EntryDetailViewModel(
-                    id = id,
+                    id = params.id,
+                    swipeNavigationEnabled = params.swipeNavigationEnabled,
                     timelineEntryRepository = instance(),
                     identityRepository = instance(),
                     settingsRepository = instance(),
@@ -27,6 +33,7 @@ val entryDetailModule =
                     toggleEntryFavorite = instance(),
                     toggleEntryDislike = instance(),
                     getTranslation = instance(),
+                    timelineNavigationManager = instance(),
                     notificationCenter = instance(),
                 )
             }

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesMviModel.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesMviModel.kt
@@ -64,6 +64,10 @@ interface FavoritesMviModel :
         data class ToggleTranslation(
             val entry: TimelineEntryModel,
         ) : Intent
+
+        data class WillOpenDetail(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -88,6 +92,10 @@ interface FavoritesMviModel :
 
         data class TriggerCopy(
             val text: String,
+        ) : Effect
+
+        data class OpenDetail(
+            val entry: TimelineEntryModel,
         ) : Effect
     }
 }

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
@@ -121,6 +121,13 @@ class FavoritesScreen(
                             clipboardManager.setText(AnnotatedString(event.text))
                             snackbarHostState.showSnackbar(copyToClipboardSuccess)
                         }
+
+                        is FavoritesMviModel.Effect.OpenDetail -> {
+                            detailOpener.openEntryDetail(
+                                entry = event.entry,
+                                swipeNavigationEnabled = true,
+                            )
+                        }
                     }
                 }.launchIn(this)
         }
@@ -218,7 +225,7 @@ class FavoritesScreen(
                             autoloadImages = uiState.autoloadImages,
                             maxBodyLines = uiState.maxBodyLines,
                             onClick = { e ->
-                                detailOpener.openEntryDetail(e)
+                                model.reduce(FavoritesMviModel.Intent.WillOpenDetail(e))
                             },
                             onOpenUrl = { url, allowOpenInternal ->
                                 if (allowOpenInternal) {

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesViewModel.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesViewModel.kt
@@ -15,6 +15,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEnt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.blurHashParamsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
+import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelineNavigationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationSpecification
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
@@ -44,6 +45,7 @@ class FavoritesViewModel(
     private val toggleEntryDislike: ToggleEntryDislikeUseCase,
     private val toggleEntryFavorite: ToggleEntryFavoriteUseCase,
     private val getTranslation: GetTranslationUseCase,
+    private val timelineNavigationManager: TimelineNavigationManager,
     private val notificationCenter: NotificationCenter = getNotificationCenter(),
 ) : DefaultMviModel<FavoritesMviModel.Intent, FavoritesMviModel.State, FavoritesMviModel.Effect>(
         initialState = FavoritesMviModel.State(),
@@ -124,6 +126,12 @@ class FavoritesViewModel(
             is FavoritesMviModel.Intent.SubmitPollVote -> submitPoll(intent.entry, intent.choices)
             is FavoritesMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
             is FavoritesMviModel.Intent.ToggleTranslation -> toggleTranslation(intent.entry)
+            is FavoritesMviModel.Intent.WillOpenDetail ->
+                screenModelScope.launch {
+                    val state = paginationManager.extractState()
+                    timelineNavigationManager.push(state)
+                    emitEffect(FavoritesMviModel.Effect.OpenDetail(intent.entry))
+                }
         }
     }
 

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/di/FavoritesModule.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/di/FavoritesModule.kt
@@ -26,6 +26,7 @@ val favoritesModule =
                     toggleEntryFavorite = instance(),
                     toggleEntryDislike = instance(),
                     getTranslation = instance(),
+                    timelineNavigationManager = instance(),
                     notificationCenter = instance(),
                 )
             }

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/di/HashtagModule.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/di/HashtagModule.kt
@@ -40,6 +40,7 @@ val hashtagModule =
                     toggleEntryFavorite = instance(),
                     toggleEntryDislike = instance(),
                     getTranslation = instance(),
+                    timelineNavigationManager = instance(),
                     notificationCenter = instance(),
                 )
             }

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagMviModel.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagMviModel.kt
@@ -68,6 +68,10 @@ interface HashtagMviModel :
         data class ToggleTranslation(
             val entry: TimelineEntryModel,
         ) : Intent
+
+        data class WillOpenDetail(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -92,6 +96,10 @@ interface HashtagMviModel :
 
         data class TriggerCopy(
             val text: String,
+        ) : Effect
+
+        data class OpenDetail(
+            val entry: TimelineEntryModel,
         ) : Effect
     }
 }

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
@@ -124,6 +124,13 @@ class HashtagScreen(
                             clipboardManager.setText(AnnotatedString(event.text))
                             snackbarHostState.showSnackbar(copyToClipboardSuccess)
                         }
+
+                        is HashtagMviModel.Effect.OpenDetail -> {
+                            detailOpener.openEntryDetail(
+                                entry = event.entry,
+                                swipeNavigationEnabled = true,
+                            )
+                        }
                     }
                 }.launchIn(this)
         }
@@ -239,7 +246,7 @@ class HashtagScreen(
                             autoloadImages = uiState.autoloadImages,
                             maxBodyLines = uiState.maxBodyLines,
                             onClick = { e ->
-                                detailOpener.openEntryDetail(e)
+                                model.reduce(HashtagMviModel.Intent.WillOpenDetail(e))
                             },
                             onOpenUrl = { url, allowOpenInternal ->
                                 if (allowOpenInternal) {

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagViewModel.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagViewModel.kt
@@ -15,6 +15,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEnt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.blurHashParamsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
+import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelineNavigationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationSpecification
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TagRepository
@@ -46,6 +47,7 @@ class HashtagViewModel(
     private val toggleEntryDislike: ToggleEntryDislikeUseCase,
     private val toggleEntryFavorite: ToggleEntryFavoriteUseCase,
     private val getTranslation: GetTranslationUseCase,
+    private val timelineNavigationManager: TimelineNavigationManager,
     private val notificationCenter: NotificationCenter = getNotificationCenter(),
 ) : DefaultMviModel<HashtagMviModel.Intent, HashtagMviModel.State, HashtagMviModel.Effect>(
         initialState = HashtagMviModel.State(),
@@ -141,6 +143,12 @@ class HashtagViewModel(
             is HashtagMviModel.Intent.SubmitPollVote -> submitPoll(intent.entry, intent.choices)
             is HashtagMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
             is HashtagMviModel.Intent.ToggleTranslation -> toggleTranslation(intent.entry)
+            is HashtagMviModel.Intent.WillOpenDetail ->
+                screenModelScope.launch {
+                    val state = paginationManager.extractState()
+                    timelineNavigationManager.push(state)
+                    emitEffect(HashtagMviModel.Effect.OpenDetail(intent.entry))
+                }
         }
     }
 

--- a/feature/thread/build.gradle.kts
+++ b/feature/thread/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
                 implementation(projects.core.utils)
 
                 implementation(projects.domain.content.data)
+                implementation(projects.domain.content.pagination)
                 implementation(projects.domain.content.repository)
                 implementation(projects.domain.content.usecase)
                 implementation(projects.domain.identity.data)

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadMviModel.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadMviModel.kt
@@ -62,16 +62,20 @@ interface ThreadMviModel :
         data class ToggleTranslation(
             val entry: TimelineEntryModel,
         ) : Intent
+
+        data class ChangeNavigationIndex(
+            val index: Int,
+        ) : Intent
     }
 
     data class State(
         val currentUserId: String? = null,
         val refreshing: Boolean = false,
-        val loading: Boolean = false,
         val initial: Boolean = true,
         val canFetchMore: Boolean = true,
-        val entry: TimelineEntryModel? = null,
-        val replies: List<TimelineEntryModel> = emptyList(),
+        val mainEntries: List<TimelineEntryModel> = emptyList(),
+        val currentIndex: Int = 0,
+        val replies: List<List<TimelineEntryModel>> = emptyList(),
         val blurNsfw: Boolean = true,
         val autoloadImages: Boolean = true,
         val hideNavigationBarWhileScrolling: Boolean = true,

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/di/ThreadModule.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/di/ThreadModule.kt
@@ -10,6 +10,11 @@ import org.kodein.di.factory
 import org.kodein.di.instance
 import org.kodein.di.singleton
 
+data class ThreadMviModelParams(
+    val entryId: String,
+    val swipeNavigationEnabled: Boolean,
+)
+
 val threadModule =
     DI.Module("ThreadModule") {
         bind<PopulateThreadUseCase> {
@@ -21,9 +26,10 @@ val threadModule =
             }
         }
         bind<ThreadMviModel> {
-            factory { entryId: String ->
+            factory { params: ThreadMviModelParams ->
                 ThreadViewModel(
-                    entryId = entryId,
+                    entryId = params.entryId,
+                    swipeNavigationEnabled = params.swipeNavigationEnabled,
                     populateThreadUseCase = instance(),
                     timelineEntryRepository = instance(),
                     identityRepository = instance(),
@@ -37,6 +43,7 @@ val threadModule =
                     toggleEntryFavorite = instance(),
                     toggleEntryDislike = instance(),
                     getTranslation = instance(),
+                    timelineNavigationManager = instance(),
                     notificationCenter = instance(),
                 )
             }

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineMviModel.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineMviModel.kt
@@ -69,6 +69,10 @@ interface TimelineMviModel :
         data class ToggleTranslation(
             val entry: TimelineEntryModel,
         ) : Intent
+
+        data class WillOpenDetail(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -96,6 +100,10 @@ interface TimelineMviModel :
 
         data class TriggerCopy(
             val text: String,
+        ) : Effect
+
+        data class OpenDetail(
+            val entry: TimelineEntryModel,
         ) : Effect
     }
 }

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
@@ -145,6 +145,12 @@ class TimelineScreen : Screen {
                             clipboardManager.setText(AnnotatedString(event.text))
                             snackbarHostState.showSnackbar(copyToClipboardSuccess)
                         }
+
+                        is TimelineMviModel.Effect.OpenDetail ->
+                            detailOpener.openEntryDetail(
+                                entry = event.entry,
+                                swipeNavigationEnabled = true,
+                            )
                     }
                 }.launchIn(this)
         }
@@ -326,7 +332,7 @@ class TimelineScreen : Screen {
                             autoloadImages = uiState.autoloadImages,
                             maxBodyLines = uiState.maxBodyLines,
                             onClick = { e ->
-                                detailOpener.openEntryDetail(e)
+                                model.reduce(TimelineMviModel.Intent.WillOpenDetail(e))
                             },
                             onOpenUrl = { url, allowOpenInternal ->
                                 if (allowOpenInternal) {

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
@@ -16,6 +16,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.blurHashPar
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toTimelineType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
+import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelineNavigationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationSpecification
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.AnnouncementsManager
@@ -58,6 +59,7 @@ class TimelineViewModel(
     private val toggleEntryDislike: ToggleEntryDislikeUseCase,
     private val toggleEntryFavorite: ToggleEntryFavoriteUseCase,
     private val getTranslation: GetTranslationUseCase,
+    private val timelineNavigationManager: TimelineNavigationManager,
     private val notificationCenter: NotificationCenter = getNotificationCenter(),
 ) : DefaultMviModel<TimelineMviModel.Intent, TimelineMviModel.State, TimelineMviModel.Effect>(
         initialState = TimelineMviModel.State(),
@@ -184,6 +186,12 @@ class TimelineViewModel(
             is TimelineMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
             is TimelineMviModel.Intent.ToggleDislike -> toggleDislike(intent.entry)
             is TimelineMviModel.Intent.ToggleTranslation -> toggleTranslation(intent.entry)
+            is TimelineMviModel.Intent.WillOpenDetail ->
+                screenModelScope.launch {
+                    val state = paginationManager.extractState()
+                    timelineNavigationManager.push(state)
+                    emitEffect(TimelineMviModel.Effect.OpenDetail(intent.entry))
+                }
         }
     }
 

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/di/TimelineModule.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/di/TimelineModule.kt
@@ -28,6 +28,7 @@ val timelineModule =
                     toggleEntryFavorite = instance(),
                     toggleEntryDislike = instance(),
                     getTranslation = instance(),
+                    timelineNavigationManager = instance(),
                     notificationCenter = instance(),
                 )
             }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailMviModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailMviModel.kt
@@ -81,6 +81,10 @@ interface UserDetailMviModel :
         data class ToggleTranslation(
             val entry: TimelineEntryModel,
         ) : Intent
+
+        data class WillOpenDetail(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -112,6 +116,10 @@ interface UserDetailMviModel :
 
         data class TriggerCopy(
             val text: String,
+        ) : Effect
+
+        data class OpenDetail(
+            val entry: TimelineEntryModel,
         ) : Effect
     }
 }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -184,6 +184,13 @@ class UserDetailScreen(
                             clipboardManager.setText(AnnotatedString(event.text))
                             snackbarHostState.showSnackbar(copyToClipboardSuccess)
                         }
+
+                        is UserDetailMviModel.Effect.OpenDetail -> {
+                            detailOpener.openEntryDetail(
+                                entry = event.entry,
+                                swipeNavigationEnabled = true,
+                            )
+                        }
                     }
                 }.launchIn(this)
         }
@@ -582,7 +589,7 @@ class UserDetailScreen(
                             autoloadImages = uiState.autoloadImages,
                             maxBodyLines = uiState.maxBodyLines,
                             onClick = { e ->
-                                detailOpener.openEntryDetail(e)
+                                model.reduce(UserDetailMviModel.Intent.WillOpenDetail(e))
                             },
                             onOpenUrl = { url, allowOpenInternal ->
                                 if (allowOpenInternal) {

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailViewModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailViewModel.kt
@@ -19,6 +19,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toNotificationStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
+import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelineNavigationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationSpecification
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
@@ -56,6 +57,7 @@ class UserDetailViewModel(
     private val toggleEntryDislike: ToggleEntryDislikeUseCase,
     private val toggleEntryFavorite: ToggleEntryFavoriteUseCase,
     private val getTranslation: GetTranslationUseCase,
+    private val timelineNavigationManager: TimelineNavigationManager,
     private val notificationCenter: NotificationCenter = getNotificationCenter(),
 ) : DefaultMviModel<UserDetailMviModel.Intent, UserDetailMviModel.State, UserDetailMviModel.Effect>(
         initialState = UserDetailMviModel.State(),
@@ -154,6 +156,12 @@ class UserDetailViewModel(
             is UserDetailMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
             is UserDetailMviModel.Intent.SetRateLimit -> setRateLimit(intent.value)
             is UserDetailMviModel.Intent.ToggleTranslation -> toggleTranslation(intent.entry)
+            is UserDetailMviModel.Intent.WillOpenDetail ->
+                screenModelScope.launch {
+                    val state = paginationManager.extractState()
+                    timelineNavigationManager.push(state)
+                    emitEffect(UserDetailMviModel.Effect.OpenDetail(intent.entry))
+                }
         }
     }
 

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/di/UserDetailModule.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/di/UserDetailModule.kt
@@ -53,6 +53,7 @@ val userDetailModule =
                     toggleEntryFavorite = instance(),
                     toggleEntryDislike = instance(),
                     getTranslation = instance(),
+                    timelineNavigationManager = instance(),
                     notificationCenter = instance(),
                 )
             }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/di/UserDetailModule.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/di/UserDetailModule.kt
@@ -31,6 +31,7 @@ val userDetailModule =
                     toggleEntryFavorite = instance(),
                     toggleEntryDislike = instance(),
                     getTranslation = instance(),
+                    timelineNavigationManager = instance(),
                     notificationCenter = instance(),
                 )
             }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListMviModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListMviModel.kt
@@ -62,6 +62,10 @@ interface ForumListMviModel :
         data class ToggleTranslation(
             val entry: TimelineEntryModel,
         ) : Intent
+
+        data class WillOpenDetail(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -85,6 +89,10 @@ interface ForumListMviModel :
 
         data class TriggerCopy(
             val text: String,
+        ) : Effect
+
+        data class OpenDetail(
+            val entry: TimelineEntryModel,
         ) : Effect
     }
 }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
@@ -140,6 +140,13 @@ class ForumListScreen(
                             clipboardManager.setText(AnnotatedString(event.text))
                             snackbarHostState.showSnackbar(copyToClipboardSuccess)
                         }
+
+                        is ForumListMviModel.Effect.OpenDetail -> {
+                            detailOpener.openThread(
+                                entry = event.entry,
+                                swipeNavigationEnabled = true,
+                            )
+                        }
                     }
                 }.launchIn(this)
         }
@@ -328,8 +335,8 @@ class ForumListScreen(
                             blurNsfw = uiState.blurNsfw,
                             autoloadImages = uiState.autoloadImages,
                             maxBodyLines = uiState.maxBodyLines,
-                            onClick = { e ->
-                                detailOpener.openThread(e)
+                            onClick = {
+                                model.reduce(ForumListMviModel.Intent.WillOpenDetail(entry))
                             },
                             onOpenUrl = { url, allowOpenInternal ->
                                 if (allowOpenInternal) {

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListViewModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListViewModel.kt
@@ -15,6 +15,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.blurHashParamsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
+import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelineNavigationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationSpecification
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.LocalItemCache
@@ -46,6 +47,7 @@ class ForumListViewModel(
     private val toggleEntryDislike: ToggleEntryDislikeUseCase,
     private val toggleEntryFavorite: ToggleEntryFavoriteUseCase,
     private val getTranslation: GetTranslationUseCase,
+    private val timelineNavigationManager: TimelineNavigationManager,
     private val notificationCenter: NotificationCenter = getNotificationCenter(),
 ) : DefaultMviModel<ForumListMviModel.Intent, ForumListMviModel.State, ForumListMviModel.Effect>(
         initialState = ForumListMviModel.State(),
@@ -127,6 +129,12 @@ class ForumListViewModel(
             is ForumListMviModel.Intent.SubmitPollVote -> submitPoll(intent.entry, intent.choices)
             is ForumListMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
             is ForumListMviModel.Intent.ToggleTranslation -> toggleTranslation(intent.entry)
+            is ForumListMviModel.Intent.WillOpenDetail ->
+                screenModelScope.launch {
+                    val state = paginationManager.extractState()
+                    timelineNavigationManager.push(state)
+                    emitEffect(ForumListMviModel.Effect.OpenDetail(intent.entry))
+                }
         }
     }
 


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR implements "infinite scrolling" with a horizontal pager in the entry detail screen, as requested by #749.

## Additional notes
<!-- Anything to declare for code review? -->
The feature will be available in the following screens:
- Home (main timeline): all, local, subscribed and circle
- Hashtag list
- Bookmarks
- Favorites
- User detail (both in classic and in forum mode)

The current implementation relies on a `HorizontalPager` "tweaked" to scroll among a potentially endless data set (with pagination).