### PR TITLE
feat: add client side filtering for posts (exclude specific words from timelines/searches)

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -213,6 +213,7 @@
     <string name="manage_blocks_section_blocked">Blocked</string>
     <string name="manage_blocks_section_limited">Limited</string>
     <string name="manage_blocks_section_muted">Muted</string>
+    <string name="manage_blocks_section_stop_words">Words</string>
     <string name="manage_circles_title">Circles</string>
     <string name="markup_mode_bbcode">BBCode</string>
     <string name="markup_mode_html">HTML</string>

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/resources/SharedStrings.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/resources/SharedStrings.kt
@@ -242,6 +242,7 @@ import raccoonforfriendica.composeapp.generated.resources.login_title
 import raccoonforfriendica.composeapp.generated.resources.manage_blocks_section_blocked
 import raccoonforfriendica.composeapp.generated.resources.manage_blocks_section_limited
 import raccoonforfriendica.composeapp.generated.resources.manage_blocks_section_muted
+import raccoonforfriendica.composeapp.generated.resources.manage_blocks_section_stop_words
 import raccoonforfriendica.composeapp.generated.resources.manage_circles_title
 import raccoonforfriendica.composeapp.generated.resources.markup_mode_bbcode
 import raccoonforfriendica.composeapp.generated.resources.markup_mode_html
@@ -907,6 +908,8 @@ class SharedStrings : Strings {
         @Composable get() = stringResource(Res.string.manage_blocks_section_limited)
     override val manageBlocksSectionMuted: String
         @Composable get() = stringResource(Res.string.manage_blocks_section_muted)
+    override val manageBlocksSectionStopWords: String
+        @Composable get() = stringResource(Res.string.manage_blocks_section_stop_words)
     override val manageCirclesTitle: String
         @Composable get() = stringResource(Res.string.manage_circles_title)
     override val markupModeBBCode: String

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/Options.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/Options.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.Composable
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 
 sealed interface OptionId {
+    data object Add : OptionId
+
     data object Edit : OptionId
 
     data object Delete : OptionId
@@ -42,6 +44,7 @@ sealed interface OptionId {
 @Composable
 private fun OptionId.toReadableName(): String =
     when (this) {
+        OptionId.Add -> LocalStrings.current.actionAddNew
         OptionId.Edit -> LocalStrings.current.actionEdit
         OptionId.Delete -> LocalStrings.current.actionDelete
         OptionId.Share -> LocalStrings.current.actionShare

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/Strings.kt
@@ -229,6 +229,7 @@ interface Strings {
     val manageBlocksSectionBlocked: String @Composable get
     val manageBlocksSectionLimited: String @Composable get
     val manageBlocksSectionMuted: String @Composable get
+    val manageBlocksSectionStopWords: String @Composable get
     val manageCirclesTitle: String @Composable get
     val markupModeBBCode: String @Composable get
     val markupModeHTML: String @Composable get

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/testutils/MockStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/testutils/MockStrings.kt
@@ -465,6 +465,8 @@ class MockStrings : Strings {
         @Composable get() = retrieve("manageBlocksSectionLimited")
     override val manageBlocksSectionMuted: String
         @Composable get() = retrieve("manageBlocksSectionMuted")
+    override val manageBlocksSectionStopWords: String
+        @Composable get() = retrieve("manageBlocksSectionStopWords")
     override val manageCirclesTitle: String
         @Composable get() = retrieve("manageCirclesTitle")
     override val markupModeBBCode: String

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultExplorePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultExplorePaginationManager.kt
@@ -212,10 +212,14 @@ internal class DefaultExplorePaginationManager(
                 is ExploreItemModel.Entry ->
                     stopWords?.takeIf { it.isNotEmpty() }?.let { stopWordList ->
                         stopWordList.none { word ->
-                            item.entry.content.contains(
-                                other = word,
-                                ignoreCase = true,
-                            )
+                            val entryTexts =
+                                listOfNotNull(
+                                    item.entry.content,
+                                    item.entry.title,
+                                    item.entry.reblog?.content,
+                                    item.entry.reblog?.title,
+                                )
+                            entryTexts.any { it.contains(other = word, ignoreCase = true) }
                         }
                     } ?: true
 

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultSearchPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultSearchPaginationManager.kt
@@ -205,10 +205,14 @@ internal class DefaultSearchPaginationManager(
                 is ExploreItemModel.Entry ->
                     stopWords?.takeIf { it.isNotEmpty() }?.let { stopWordList ->
                         stopWordList.none { word ->
-                            item.entry.content.contains(
-                                other = word,
-                                ignoreCase = true,
-                            )
+                            val entryTexts =
+                                listOfNotNull(
+                                    item.entry.content,
+                                    item.entry.title,
+                                    item.entry.reblog?.content,
+                                    item.entry.reblog?.title,
+                                )
+                            entryTexts.any { it.contains(other = word, ignoreCase = true) }
                         }
                     } ?: true
 

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
@@ -320,10 +320,14 @@ internal class DefaultTimelinePaginationManager(
         filter { entry ->
             stopWords?.takeIf { it.isNotEmpty() }?.let { stopWordList ->
                 stopWordList.none { word ->
-                    entry.content.contains(
-                        other = word,
-                        ignoreCase = true,
-                    )
+                    val entryTexts =
+                        listOfNotNull(
+                            entry.content,
+                            entry.title,
+                            entry.reblog?.content,
+                            entry.reblog?.title,
+                        )
+                    entryTexts.any { it.contains(other = word, ignoreCase = true) }
                 }
             } ?: true
         }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
@@ -15,6 +15,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Timel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRateLimitRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.ListWithPageCursor
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.StopWordRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -32,6 +33,7 @@ internal class DefaultTimelinePaginationManager(
     private val userRateLimitRepository: UserRateLimitRepository,
     private val emojiHelper: EmojiHelper,
     private val replyHelper: ReplyHelper,
+    private val stopWordRepository: StopWordRepository,
     notificationCenter: NotificationCenter = getNotificationCenter(),
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : TimelinePaginationManager {
@@ -42,6 +44,7 @@ internal class DefaultTimelinePaginationManager(
     private val mutex = Mutex()
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
     private val userRateLimits = mutableMapOf<String, Double>()
+    private var stopWords: List<String>? = null
 
     init {
         notificationCenter
@@ -75,6 +78,7 @@ internal class DefaultTimelinePaginationManager(
                 userRateLimitRepository.getAll(accountId).forEach { limit ->
                     userRateLimits[limit.handle] = limit.rate
                 }
+                stopWords = stopWordRepository.get(accountId)
             }
             history.clear()
         }
@@ -172,6 +176,7 @@ internal class DefaultTimelinePaginationManager(
                         ?.filterReplies(included = !specification.excludeReplies)
                         ?.filterNsfw(specification.includeNsfw)
                         ?.filterWithRateLimits()
+                        ?.filterByStopWords()
                         ?.deduplicate()
                         ?.fixupCreatorEmojis()
                         ?.fixupInReplyTo()
@@ -181,6 +186,7 @@ internal class DefaultTimelinePaginationManager(
                         ?.updatePaginationData()
                         ?.filterNsfw(specification.includeNsfw)
                         ?.filterWithRateLimits()
+                        ?.filterByStopWords()
                         ?.deduplicate()
                         ?.fixupCreatorEmojis()
                         ?.fixupInReplyTo()
@@ -191,6 +197,7 @@ internal class DefaultTimelinePaginationManager(
                         ?.deduplicate()
                         ?.updatePaginationData()
                         ?.filterNsfw(specification.includeNsfw)
+                        ?.filterByStopWords()
                         ?.fixupCreatorEmojis()
                         ?.fixupInReplyTo()
 
@@ -199,6 +206,7 @@ internal class DefaultTimelinePaginationManager(
                         ?.updatePaginationData()
                         ?.filterNsfw(specification.includeNsfw)
                         ?.filter { it.reblog != null && it.reblog?.inReplyTo == null }
+                        ?.filterByStopWords()
                         ?.deduplicate()
                         ?.fixupCreatorEmojis()
 
@@ -206,6 +214,7 @@ internal class DefaultTimelinePaginationManager(
                     results
                         ?.updatePaginationData()
                         ?.filterNsfw(specification.includeNsfw)
+                        ?.filterByStopWords()
                         ?.deduplicate()
                         ?.fixupCreatorEmojis()
                         ?.fixupInReplyTo()
@@ -214,6 +223,7 @@ internal class DefaultTimelinePaginationManager(
                     results
                         ?.updatePaginationData()
                         ?.filterNsfw(specification.includeNsfw)
+                        ?.filterByStopWords()
                         ?.deduplicate()
                         ?.fixupCreatorEmojis()
                         ?.fixupInReplyTo()
@@ -228,6 +238,7 @@ internal class DefaultTimelinePaginationManager(
             pageCursor = pageCursor,
             history = history,
             userRateLimits = userRateLimits,
+            stopWords = stopWords,
         )
 
     override fun restoreState(state: TimelinePaginationManagerState) {
@@ -237,6 +248,7 @@ internal class DefaultTimelinePaginationManager(
             history.clear()
             history.addAll(it.history)
             userRateLimits.putAll(it.userRateLimits)
+            stopWords = it.stopWords
         }
     }
 
@@ -302,5 +314,17 @@ internal class DefaultTimelinePaginationManager(
             map {
                 it.withInReplyToIfMissing()
             }
+        }
+
+    private fun List<TimelineEntryModel>.filterByStopWords(): List<TimelineEntryModel> =
+        filter { entry ->
+            stopWords?.takeIf { it.isNotEmpty() }?.let { stopWordList ->
+                stopWordList.none { word ->
+                    entry.content.contains(
+                        other = word,
+                        ignoreCase = true,
+                    )
+                }
+            } ?: true
         }
 }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManagerState.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManagerState.kt
@@ -7,4 +7,5 @@ internal data class DefaultTimelinePaginationManagerState(
     val pageCursor: String? = null,
     val history: List<TimelineEntryModel> = emptyList(),
     val userRateLimits: Map<String, Double> = emptyMap(),
+    val stopWords: List<String>? = null,
 ) : TimelinePaginationManagerState

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
@@ -61,6 +61,8 @@ val contentPaginationModule =
                     userRepository = instance(),
                     emojiHelper = instance(),
                     replyHelper = instance(),
+                    accountRepository = instance(),
+                    stopWordRepository = instance(),
                     notificationCenter = instance(),
                 )
             }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
@@ -110,6 +110,7 @@ val contentPaginationModule =
                     userRateLimitRepository = instance(),
                     emojiHelper = instance(),
                     replyHelper = instance(),
+                    stopWordRepository = instance(),
                     notificationCenter = instance(),
                 )
             }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
@@ -99,6 +99,8 @@ val contentPaginationModule =
                     userRepository = instance(),
                     emojiHelper = instance(),
                     replyHelper = instance(),
+                    accountRepository = instance(),
+                    stopWordRepository = instance(),
                     notificationCenter = instance(),
                 )
             }

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultStopWordRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultStopWordRepository.kt
@@ -1,0 +1,35 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository
+
+import com.livefast.eattrash.raccoonforfriendica.core.preferences.store.TemporaryKeyStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
+
+internal class DefaultStopWordRepository(
+    private val keyStore: TemporaryKeyStore,
+) : StopWordRepository {
+    override suspend fun get(accountId: Long?): List<String> =
+        withContext(Dispatchers.IO) {
+            val key = getKey(accountId)
+            val res = keyStore.get(key, emptyList())
+            res.filter { it.isNotEmpty() }
+        }
+
+    override suspend fun update(
+        accountId: Long?,
+        items: List<String>,
+    ) = withContext(Dispatchers.IO) {
+        val key = getKey(accountId)
+        keyStore.save(key, items)
+    }
+
+    private fun getKey(accountId: Long?): String =
+        buildString {
+            append("StopWordRepository")
+            if (accountId != null) {
+                append(".")
+                append(accountId)
+            }
+            append(".items")
+        }
+}

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/StopWordRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/StopWordRepository.kt
@@ -1,0 +1,10 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository
+
+interface StopWordRepository {
+    suspend fun get(accountId: Long?): List<String>
+
+    suspend fun update(
+        accountId: Long?,
+        items: List<String>,
+    )
+}

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/di/IdentityRepositoryModule.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/di/IdentityRepositoryModule.kt
@@ -11,9 +11,11 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Defa
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultIdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultImageAutoloadObserver
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultSettingsRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.DefaultStopWordRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ImageAutoloadObserver
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.StopWordRepository
 import org.kodein.di.DI
 import org.kodein.di.bind
 import org.kodein.di.instance
@@ -71,6 +73,13 @@ val identityRepositoryModule =
             singleton {
                 DefaultSettingsRepository(
                     settingsDao = instance(),
+                )
+            }
+        }
+        bind<StopWordRepository> {
+            singleton {
+                DefaultStopWordRepository(
+                    keyStore = instance(),
                 )
             }
         }

--- a/domain/identity/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultStopWordRepositoryTest.kt
+++ b/domain/identity/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultStopWordRepositoryTest.kt
@@ -1,0 +1,157 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository
+
+import com.livefast.eattrash.raccoonforfriendica.core.preferences.store.TemporaryKeyStore
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DefaultStopWordRepositoryTest {
+    private val keyStore = mock<TemporaryKeyStore>(MockMode.autoUnit)
+    private val sut =
+        DefaultStopWordRepository(
+            keyStore = keyStore,
+        )
+
+    @Test
+    fun givenNoData_whenGetForAnonymousUser_thenResultAndInteractionsIsAsExpected() =
+        runTest {
+            every { keyStore.get(any(), any<List<String>>()) } returns emptyList()
+
+            val res = sut.get(null)
+
+            assertEquals(emptyList(), res)
+            verify {
+                keyStore.get("$KEY_PREFIX.items", emptyList())
+            }
+        }
+
+    @Test
+    fun givenData_whenGetForAnonymousUser_thenResultAndInteractionsIsAsExpected() =
+        runTest {
+            val fakeList = listOf("word")
+            every { keyStore.get(any(), any<List<String>>()) } returns fakeList
+
+            val res = sut.get(null)
+
+            assertEquals(fakeList, res)
+            verify {
+                keyStore.get("$KEY_PREFIX.items", emptyList())
+            }
+        }
+
+    @Test
+    fun givenNoData_whenGetForLoggedUser_thenResultAndInteractionsIsAsExpected() =
+        runTest {
+            val accountId = 1L
+            every { keyStore.get(any(), any<List<String>>()) } returns emptyList()
+
+            val res = sut.get(accountId)
+
+            assertEquals(emptyList(), res)
+            verify {
+                keyStore.get("$KEY_PREFIX.$accountId.items", emptyList())
+            }
+        }
+
+    @Test
+    fun givenData_whenGetForLoggedUser_thenResultAndInteractionsIsAsExpected() =
+        runTest {
+            val accountId = 1L
+            val fakeList = listOf("word")
+            every { keyStore.get(any(), any<List<String>>()) } returns fakeList
+
+            val res = sut.get(accountId)
+
+            assertEquals(fakeList, res)
+            verify {
+                keyStore.get("$KEY_PREFIX.$accountId.items", emptyList())
+            }
+        }
+
+    @Test
+    fun givenDataForOtherUser_whenGetForLoggedAccount_thenResultAndInteractionsIsAsExpected() =
+        runTest {
+            val otherAccountId = 1L
+            val accountId = 2L
+            val fakeList = listOf("word")
+            every {
+                keyStore.get(
+                    "$KEY_PREFIX.$otherAccountId.items",
+                    any<List<String>>(),
+                )
+            } returns fakeList
+            every {
+                keyStore.get(
+                    "$KEY_PREFIX.$accountId.items",
+                    any<List<String>>(),
+                )
+            } returns emptyList()
+
+            val res = sut.get(accountId)
+
+            assertEquals(emptyList(), res)
+            verify {
+                keyStore.get("$KEY_PREFIX.$accountId.items", emptyList())
+            }
+        }
+
+    @Test
+    fun givenDataForOtherUser_whenGetForAnonymousAccount_thenResultAndInteractionsIsAsExpected() =
+        runTest {
+            val otherAccountId = 1
+            val fakeList = listOf("word")
+            every {
+                keyStore.get(
+                    "$KEY_PREFIX.$otherAccountId.items",
+                    any<List<String>>(),
+                )
+            } returns fakeList
+            every {
+                keyStore.get(
+                    "$KEY_PREFIX.items",
+                    any<List<String>>(),
+                )
+            } returns emptyList()
+
+            val res = sut.get(null)
+
+            assertEquals(emptyList(), res)
+            verify {
+                keyStore.get("$KEY_PREFIX.items", emptyList())
+            }
+        }
+
+    @Test
+    fun whenUpdateAnonymousUser_thenInteractionsAreAsExpected() =
+        runTest {
+            val fakeList = listOf("word")
+            sut.update(accountId = null, items = fakeList)
+
+            verify {
+                keyStore.save("$KEY_PREFIX.items", fakeList)
+            }
+        }
+
+    @Test
+    fun whenUpdateLoggedUser_thenInteractionsAreAsExpected() =
+        runTest {
+            val accountId = 1L
+            val fakeList = listOf("word")
+
+            sut.update(accountId = accountId, items = fakeList)
+
+            verify {
+                keyStore.save("$KEY_PREFIX.$accountId.items", fakeList)
+            }
+        }
+
+    companion object {
+        private const val KEY_PREFIX = "StopWordRepository"
+    }
+}

--- a/domain/pushnotifications/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/manager/DefaultPushNotificationManager.kt
+++ b/domain/pushnotifications/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/manager/DefaultPushNotificationManager.kt
@@ -36,7 +36,9 @@ internal class DefaultPushNotificationManager : PushNotificationManager {
 
     override suspend fun registerEndpoint(
         account: AccountModel,
-        endpoint: String,
+        endpointUrl: String,
+        pubKey: String,
+        auth: String,
     ) {
         // no-op
     }

--- a/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/ManageBlocksMviModel.kt
+++ b/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/ManageBlocksMviModel.kt
@@ -2,7 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.feature.manageblocks
 
 import cafe.adriel.voyager.core.model.ScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import com.livefast.eattrash.raccoonforfriendica.feature.manageblocks.data.ManageBlocksItem
 import com.livefast.eattrash.raccoonforfriendica.feature.manageblocks.data.ManageBlocksSection
 
 interface ManageBlocksMviModel :
@@ -29,6 +29,14 @@ interface ManageBlocksMviModel :
             val handle: String,
             val rate: Double,
         ) : Intent
+
+        data class AddStopWord(
+            val word: String,
+        ) : Intent
+
+        data class RemoveStopWord(
+            val word: String,
+        ) : Intent
     }
 
     data class State(
@@ -37,7 +45,7 @@ interface ManageBlocksMviModel :
         val canFetchMore: Boolean = true,
         val refreshing: Boolean = false,
         val section: ManageBlocksSection = ManageBlocksSection.Muted,
-        val items: List<UserModel> = emptyList(),
+        val items: List<ManageBlocksItem> = emptyList(),
         val autoloadImages: Boolean = true,
         val hideNavigationBarWhileScrolling: Boolean = true,
     )

--- a/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/components/GenericListItem.kt
+++ b/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/components/GenericListItem.kt
@@ -1,0 +1,131 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.manageblocks.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.DpOffset
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomDropDown
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.Option
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
+import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
+
+@Composable
+internal fun GenericListItem(
+    title: String,
+    subtitle: String? = null,
+    modifier: Modifier = Modifier,
+    options: List<Option> = emptyList(),
+    onClick: (() -> Unit)? = null,
+    onOptionSelected: ((OptionId) -> Unit)? = null,
+) {
+    val fullColor = MaterialTheme.colorScheme.onBackground
+    val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha)
+    var optionsOffset by remember { mutableStateOf(Offset.Zero) }
+    var optionsMenuOpen by remember { mutableStateOf(false) }
+
+    Row(
+        modifier =
+            modifier
+                .then(
+                    if (onClick != null) {
+                        Modifier.clickable {
+                            onClick()
+                        }
+                    } else {
+                        Modifier
+                    },
+                ).padding(Spacing.s),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(
+            modifier = Modifier.weight(1f).padding(start = Spacing.xs),
+            verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyMedium,
+                color = fullColor,
+            )
+            if (subtitle != null) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = ancillaryColor,
+                )
+            }
+        }
+
+        if (options.isNotEmpty()) {
+            Box {
+                IconButton(
+                    modifier =
+                        Modifier.onGloballyPositioned {
+                            optionsOffset = it.positionInParent()
+                        },
+                    onClick = {
+                        optionsMenuOpen = true
+                    },
+                ) {
+                    Icon(
+                        modifier = Modifier.size(IconSize.s),
+                        imageVector = Icons.Default.MoreVert,
+                        contentDescription = LocalStrings.current.actionOpenOptions,
+                        tint = MaterialTheme.colorScheme.onBackground,
+                    )
+                }
+
+                CustomDropDown(
+                    expanded = optionsMenuOpen,
+                    onDismiss = {
+                        optionsMenuOpen = false
+                    },
+                    offset =
+                        with(LocalDensity.current) {
+                            DpOffset(
+                                x = optionsOffset.x.toDp(),
+                                y = optionsOffset.y.toDp(),
+                            )
+                        },
+                ) {
+                    options.forEach { option ->
+                        DropdownMenuItem(
+                            text = {
+                                Text(option.label)
+                            },
+                            onClick = {
+                                optionsMenuOpen = false
+                                onOptionSelected?.invoke(option.id)
+                            },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/data/ManageBlocksItem.kt
+++ b/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/data/ManageBlocksItem.kt
@@ -1,0 +1,20 @@
+package com.livefast.eattrash.raccoonforfriendica.feature.manageblocks.data
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+
+sealed interface ManageBlocksItem {
+    data class User(
+        val user: UserModel,
+    ) : ManageBlocksItem
+
+    data class StopWord(
+        val word: String,
+    ) : ManageBlocksItem
+}
+
+internal val ManageBlocksItem.safeKey: String
+    get() =
+        when (this) {
+            is ManageBlocksItem.User -> user.id
+            is ManageBlocksItem.StopWord -> word
+        }

--- a/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/data/ManageBlocksSection.kt
+++ b/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/data/ManageBlocksSection.kt
@@ -9,6 +9,8 @@ sealed interface ManageBlocksSection {
     data object Blocked : ManageBlocksSection
 
     data object Limited : ManageBlocksSection
+
+    data object StopWords : ManageBlocksSection
 }
 
 @Composable
@@ -17,4 +19,5 @@ fun ManageBlocksSection.toReadableName(): String =
         ManageBlocksSection.Blocked -> LocalStrings.current.manageBlocksSectionBlocked
         ManageBlocksSection.Muted -> LocalStrings.current.manageBlocksSectionMuted
         ManageBlocksSection.Limited -> LocalStrings.current.manageBlocksSectionLimited
+        ManageBlocksSection.StopWords -> LocalStrings.current.manageBlocksSectionStopWords
     }

--- a/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/di/ManageBlocksModule.kt
+++ b/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/di/ManageBlocksModule.kt
@@ -19,6 +19,7 @@ val manageBlocksModule =
                     userRateLimitRepository = instance(),
                     imagePreloadManager = instance(),
                     imageAutoloadObserver = instance(),
+                    stopWordRepository = instance(),
                 )
             }
         }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR implements a client-side filtering mechanism useful to exclude certain posts from timelines/searches based on a list of forbidden words.

## Additional notes
<!-- Anything to declare for code review? -->
There is a very similar feature in R4L (see [here](https://github.com/LiveFastEatTrashRaccoon/RaccoonForLemmy/blob/master/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/core/persistence/repository/StopWordRepository.kt) and [here](https://github.com/LiveFastEatTrashRaccoon/RaccoonForLemmy/blob/master/domain/lemmy/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforlemmy/domain/lemmy/pagination/DefaultPostPaginationManager.kt#L318)).
