### PR TITLE
fix: solve crashes when opening entry detail

### DIFF
--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailViewModel.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailViewModel.kt
@@ -176,7 +176,7 @@ class EntryDetailViewModel(
                 } else {
                     currentEntry?.let { listOf(listOf(it)) } ?: listOf(emptyList())
                 }
-            val initialIndex = entries.indexOfFirst { it.first().id == id }
+            val initialIndex = entries.indexOfFirst { it.first().id == id }.coerceAtLeast(0)
             updateState {
                 it.copy(
                     mainEntry = currentEntry,

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailViewModel.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailViewModel.kt
@@ -97,18 +97,14 @@ class EntryDetailViewModel(
                 .subscribe(TimelineEntryCreatedEvent::class)
                 .onEach { event ->
                     val currentEntries = uiState.value.let { it.entries.getOrNull(it.currentIndex) }
-                    val idx = currentEntries?.indexOfFirst { it.id == event.entry.parentId } ?: -1
-                    if (idx >= 0) {
+                    val foundIdx = currentEntries?.indexOfFirst { it.id == event.entry.parentId } ?: -1
+                    if (foundIdx >= 0) {
                         updateState {
                             it.copy(
                                 entries =
                                     it.entries.mapIndexed { idx, entryList ->
                                         if (idx == it.currentIndex) {
-                                            entryList
-                                                .toMutableList()
-                                                .apply {
-                                                    add(idx + 1, event.entry)
-                                                }.toList()
+                                            entryList + event.entry
                                         } else {
                                             entryList
                                         }

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadViewModel.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadViewModel.kt
@@ -160,7 +160,7 @@ class ThreadViewModel(
                 } else {
                     currentEntry?.let { listOf(it) } ?: emptyList()
                 }
-            val initialIndex = mainEntries.indexOfFirst { it.id == entryId }
+            val initialIndex = mainEntries.indexOfFirst { it.id == entryId }.coerceAtLeast(0)
             val replies: List<List<TimelineEntryModel>> = mainEntries.map { emptyList() }
             check(mainEntries.size == replies.size)
             updateState {


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR solves a couple of crashes introduced by #754 when opening the post/thread detail. Overall, considering the adoption, the feature seems to work well in most cases.
