### PR TITLE
fix: post detail cell spacing when opened from inbox, explore and other posts

### DIFF
--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -282,7 +282,6 @@ class EntryDetailScreen(
                     },
                 ) {
                     LazyColumn(
-                        modifier = Modifier.fillMaxSize(),
                         state = lazyListState,
                     ) {
                         itemsIndexed(
@@ -294,6 +293,7 @@ class EntryDetailScreen(
                                 modifier =
                                     Modifier.then(
                                         if (isMainEntry && uiState.layout == TimelineLayout.Card) {
+                                            // since the main entry is forced to "full", recreates card appearance
                                             Modifier
                                                 .padding(horizontal = Spacing.xs)
                                                 .shadow(
@@ -549,7 +549,7 @@ class EntryDetailScreen(
                                     }
                                 },
                             )
-                            if (idx < uiState.entries.lastIndex) {
+                            if (idx < currentEntryList.lastIndex) {
                                 TimelineDivider(layout = uiState.layout)
                             }
                         }

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
@@ -196,7 +196,7 @@ class InboxScreen : Screen {
                 ) {
                     if (uiState.initial) {
                         val placeholderCount = 5
-                        items(placeholderCount) { idx ->
+                        items(placeholderCount) {
                             NotificationItemPlaceholder(modifier = Modifier.fillMaxWidth())
                         }
                     }

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
@@ -711,7 +711,7 @@ class ThreadScreen(
                                     }
                                 }
                             }
-                            if (idx < uiState.replies.lastIndex) {
+                            if (idx < replies.lastIndex) {
                                 TimelineDivider(layout = uiState.layout)
                             }
                         }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR solves a bug due to which there is no divider/spacing in conversation detail between different replies when the screen is opened without the swipe gesture navigation.
