### PR TITLE
fix: change timeline type in homepage

### DIFF
--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -282,6 +282,7 @@ class EntryDetailScreen(
                     },
                 ) {
                     LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
                         state = lazyListState,
                     ) {
                         itemsIndexed(

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
@@ -564,10 +564,11 @@ class TimelineScreen : Screen {
         }
 
         if (timelineTypeSelectorOpen) {
+            val items = uiState.availableTimelineTypes
             CustomModalBottomSheet(
                 title = LocalStrings.current.feedTypeTitle,
                 items =
-                    uiState.availableTimelineTypes.map {
+                    items.map {
                         CustomModalBottomSheetItem(
                             label = it.toReadableName(),
                             trailingContent = {
@@ -583,7 +584,7 @@ class TimelineScreen : Screen {
                 onSelected = { index ->
                     timelineTypeSelectorOpen = false
                     if (index != null) {
-                        val type = uiState.availableTimelineTypes[index]
+                        val type = items[index]
                         model.reduce(TimelineMviModel.Intent.ChangeType(type))
                     }
                 },

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
@@ -13,7 +13,6 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate.HapticFeedba
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.blurHashParamsForPreload
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.nodeName
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toTimelineType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
@@ -208,10 +207,6 @@ class TimelineViewModel(
     }
 
     private suspend fun changeTimelineType(type: TimelineType) {
-        if (uiState.value.loading) {
-            return
-        }
-
         updateState {
             it.copy(
                 initial = true,


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes a bug due to which it was not always possible to change the timeline type (eg. during post pagination which happens under the hood and should not be perceived by users).

Thanks @toas-koas for reporting it!
