### PR TITLE
enhancement: improve support for embedded images in post body

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CardTimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CardTimelineItem.kt
@@ -44,7 +44,6 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEnt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.attachmentsToDisplay
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.contentToDisplay
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.embeddedImageUrls
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.pollToDisplay
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.spoilerToDisplay
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.titleToDisplay

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CompactTimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CompactTimelineItem.kt
@@ -39,7 +39,6 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEnt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.attachmentsToDisplay
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.contentToDisplay
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.embeddedImageUrls
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.pollToDisplay
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.spoilerToDisplay
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.titleToDisplay

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentBody.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentBody.kt
@@ -17,7 +17,8 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.Custom
 import com.livefast.eattrash.raccoonforfriendica.core.htmlparse.parseHtml
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EmojiModel
 
-internal val IMAGE_REGEX = Regex("<img.*?/>")
+// lazy wildcard matcher after element name, optional closing "/"
+internal val IMAGE_REGEX = Regex("<img.*?/?>")
 
 @Composable
 fun ContentBody(

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/FullTimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/FullTimelineItem.kt
@@ -39,7 +39,6 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.attachmentsToDisplay
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.cardToDisplay
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.contentToDisplay
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.embeddedImageUrls
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.pollToDisplay
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.spoilerToDisplay
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.titleToDisplay

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ImageData.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ImageData.kt
@@ -1,5 +1,6 @@
 package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
 
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.mohamedrejeb.ksoup.html.parser.KsoupHtmlHandler
 import com.mohamedrejeb.ksoup.html.parser.KsoupHtmlParser
 
@@ -30,4 +31,43 @@ internal fun extractImageData(html: String): ImageData? {
     }
 
     return url?.let { ImageData(url = it, description = description) }
+}
+
+internal val TimelineEntryModel.embeddedImageUrls: List<String>
+    get() {
+        val data = extractImagesData(content)
+        return data.map { it.url }
+    }
+
+private fun extractImagesData(html: String): List<ImageData> {
+    var url: String? = null
+    var description: String? = null
+    val result = mutableListOf<ImageData>()
+    KsoupHtmlParser(
+        KsoupHtmlHandler
+            .Builder()
+            .onOpenTag { name, attributes, _ ->
+                when (name) {
+                    "img" -> {
+                        url = attributes["src"]
+                        description = attributes["alt"]
+                    }
+
+                    else -> Unit
+                }
+            }.onCloseTag { name, _ ->
+                when (name) {
+                    "img" -> {
+                        url?.let {
+                            result += ImageData(url = it, description = description)
+                        }
+                    }
+                }
+            }.build(),
+    ).apply {
+        write(html)
+        end()
+    }
+
+    return result
 }

--- a/core/htmlparse/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/htmlparse/ParseHtml.kt
+++ b/core/htmlparse/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/htmlparse/ParseHtml.kt
@@ -84,13 +84,11 @@ fun String.parseHtml(
                     "img" -> {
                         val url = attributes["src"]
                         val alt = attributes["alt"]
-                        builder.appendLine()
                         builder.append("<img src=\"$url\"")
                         if (!alt.isNullOrBlank()) {
                             builder.append(" alt=\"$alt\"")
                         }
                         builder.append(" />")
-                        builder.appendLine()
                     }
                     else -> println("onOpenTag: Unhandled tag $name")
                 }

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/TimelineEntryModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/TimelineEntryModel.kt
@@ -2,7 +2,6 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.data
 
 import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.BlurHashParams
 import com.livefast.eattrash.raccoonforfriendica.core.utils.nodeName
-import com.livefast.eattrash.raccoonforfriendica.core.utils.substituteAllOccurrences
 import kotlin.jvm.Transient
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
@@ -111,18 +110,6 @@ val TimelineEntryModel.isNsfw: Boolean get() = reblog?.sensitive ?: sensitive
 
 val Duration.isOldEntry: Boolean
     get() = this > 30.days
-
-private val IMAGE_REGEX = Regex("<img src=\"(?<url>.+?)\"(alt=\"(?<alt>.+?)\")? />")
-
-val TimelineEntryModel.embeddedImageUrls: List<String>
-    get() =
-        buildList {
-            IMAGE_REGEX.substituteAllOccurrences(content) { match ->
-                match.groups["url"]?.value.takeIf { !isNullOrBlank() }?.also { url ->
-                    this@buildList += url
-                }
-            }
-        }
 
 val TimelineEntryModel.titleToDisplay: String?
     get() = translation?.title?.takeIf { isShowingTranslation } ?: title


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR solves another issue with embedded images in posts, which are supported from version 2024.12 of Friendica.

Sometimes the `<img />` tag did not contain the closing "/" character, breaking the naïve regex the app was using to split post content into segments and inserting images between paragraphs.

This PR also attempts to improve "duplicate attachment" detection, i.e. recognize images which appear both embedded and in the `media_attachments` status property. This may continue to fail because URLs can be different (but pointing to different variations of the same image), but there is nothing I can do more than this.[^1]

[^1]: I've already tried matching the alt text instead of the URL but with no success.