### PR TITLE
feat: open post detail as conversation with configurable initial depth

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -326,6 +326,7 @@
     <string name="settings_item_bar_theme">Status and navigation bar theme</string>
     <string name="settings_item_blocked_and_muted">Manage filters</string>
     <string name="settings_item_blur_nsfw">Blur NSFW media</string>
+    <string name="settings_item_conversation_reply_depth">Conversation reply depth</string>
     <string name="settings_item_crash_report_enabled">Enable anonymous crash reports</string>
     <string name="settings_item_default_post_visibility">Default visibility for posts</string>
     <string name="settings_item_default_reply_visibility">Default visibility for replies</string>

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/resources/SharedStrings.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/resources/SharedStrings.kt
@@ -359,6 +359,7 @@ import raccoonforfriendica.composeapp.generated.resources.settings_item_app_icon
 import raccoonforfriendica.composeapp.generated.resources.settings_item_bar_theme
 import raccoonforfriendica.composeapp.generated.resources.settings_item_blocked_and_muted
 import raccoonforfriendica.composeapp.generated.resources.settings_item_blur_nsfw
+import raccoonforfriendica.composeapp.generated.resources.settings_item_conversation_reply_depth
 import raccoonforfriendica.composeapp.generated.resources.settings_item_crash_report_enabled
 import raccoonforfriendica.composeapp.generated.resources.settings_item_default_post_visibility
 import raccoonforfriendica.composeapp.generated.resources.settings_item_default_reply_visibility
@@ -1143,6 +1144,8 @@ class SharedStrings : Strings {
         @Composable get() = stringResource(Res.string.settings_item_blocked_and_muted)
     override val settingsItemBlurNsfw: String
         @Composable get() = stringResource(Res.string.settings_item_blur_nsfw)
+    override val settingsItemConversationReplyDepth: String
+        @Composable get() = stringResource(Res.string.settings_item_conversation_reply_depth)
     override val settingsItemCrashReportEnabled: String
         @Composable get() = stringResource(Res.string.settings_item_crash_report_enabled)
     override val settingsItemDefaultPostVisibility: String

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/DistractionFreeTimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/DistractionFreeTimelineItem.kt
@@ -36,6 +36,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.Custom
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.contentToDisplay
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.pollToDisplay
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.spoilerToDisplay
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.titleToDisplay
 
@@ -45,12 +46,14 @@ internal fun DistractionFreeTimelineItem(
     modifier: Modifier = Modifier,
     actionsEnabled: Boolean = true,
     autoloadImages: Boolean = true,
+    extendedSocialInfoEnabled: Boolean = false,
     maxBodyLines: Int = Int.MAX_VALUE,
     maxTitleLines: Int = Int.MAX_VALUE,
     options: List<Option> = emptyList(),
     optionsMenuOpen: Boolean = false,
     originalCreator: UserModel? = null,
     originalInReplyTo: TimelineEntryModel? = null,
+    pollEnabled: Boolean = true,
     reshareAndReplyVisible: Boolean = true,
     onBookmark: ((TimelineEntryModel) -> Unit)? = null,
     onClick: ((TimelineEntryModel) -> Unit)? = null,
@@ -58,8 +61,11 @@ internal fun DistractionFreeTimelineItem(
     onDislike: ((TimelineEntryModel) -> Unit)? = null,
     onOpenUrl: ((String, Boolean) -> Unit)? = null,
     onOpenUser: ((UserModel) -> Unit)? = null,
+    onOpenUsersFavorite: ((TimelineEntryModel) -> Unit)? = null,
+    onOpenUsersReblog: ((TimelineEntryModel) -> Unit)? = null,
     onOptionSelected: ((OptionId) -> Unit)? = null,
     onOptionsMenuToggled: ((Boolean) -> Unit)? = null,
+    onPollVote: ((TimelineEntryModel, List<Int>) -> Unit)? = null,
     onReblog: ((TimelineEntryModel) -> Unit)? = null,
     onReply: ((TimelineEntryModel) -> Unit)? = null,
     onShowOriginal: (() -> Unit)? = null,
@@ -219,7 +225,39 @@ internal fun DistractionFreeTimelineItem(
                         onOpenUrl = onOpenUrl?.let { block -> { url -> block(url, true) } },
                     )
                 }
+
+                // poll
+                entry.pollToDisplay?.also { poll ->
+                    PollCard(
+                        modifier = Modifier.fillMaxWidth(),
+                        poll = poll,
+                        emojis = entry.emojis,
+                        enabled = pollEnabled,
+                        onVote = { choices ->
+                            onPollVote?.invoke(entry, choices)
+                        },
+                    )
+                }
             }
+        }
+
+        // reblog and favorite info
+        if (extendedSocialInfoEnabled) {
+            ContentExtendedSocialInfo(
+                modifier =
+                    Modifier.padding(
+                        vertical = Spacing.xs,
+                        horizontal = contentHorizontalPadding,
+                    ),
+                reblogCount = entry.reblogCount,
+                favoriteCount = entry.favoriteCount,
+                onOpenUsersReblog = {
+                    onOpenUsersReblog?.invoke(entry)
+                },
+                onOpenUsersFavorite = {
+                    onOpenUsersFavorite?.invoke(entry)
+                },
+            )
         }
 
         TranslationFooter(

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineReplyItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineReplyItem.kt
@@ -36,6 +36,8 @@ fun TimelineReplyItem(
     entry: TimelineEntryModel,
     modifier: Modifier = Modifier,
     actionsEnabled: Boolean = true,
+    pollEnabled: Boolean = true,
+    extendedSocialInfoEnabled: Boolean = false,
     blurNsfw: Boolean = true,
     autoloadImages: Boolean = true,
     layout: TimelineLayout = TimelineLayout.Full,
@@ -48,12 +50,15 @@ fun TimelineReplyItem(
     onFavorite: ((TimelineEntryModel) -> Unit)? = null,
     onDislike: ((TimelineEntryModel) -> Unit)? = null,
     onBookmark: ((TimelineEntryModel) -> Unit)? = null,
+    onOpenUsersFavorite: ((TimelineEntryModel) -> Unit)? = null,
+    onOpenUsersReblog: ((TimelineEntryModel) -> Unit)? = null,
     onOpenImage: ((List<String>, Int, List<Int>) -> Unit)? = null,
     onOptionSelected: ((OptionId) -> Unit)? = null,
+    onPollVote: ((TimelineEntryModel, List<Int>) -> Unit)? = null,
     onShowOriginal: (() -> Unit)? = null,
 ) {
     val entryToDisplay = entry.original
-    val depthZeroBased = entry.depth - 1
+    val depthZeroBased = (entry.depth - 1).coerceAtLeast(0)
     val themeRepository = remember { getThemeRepository() }
     val barWidth = 3.dp
     val barColor = themeRepository.getCommentBarColor(depthZeroBased)
@@ -250,8 +255,10 @@ fun TimelineReplyItem(
                         autoloadImages = autoloadImages,
                         blurNsfw = blurNsfw,
                         entry = entryToDisplay,
+                        extendedSocialInfoEnabled = extendedSocialInfoEnabled,
                         options = options,
                         optionsMenuOpen = optionsMenuOpen,
+                        pollEnabled = pollEnabled,
                         onBookmark = onBookmark,
                         onClick = onClick,
                         onFavorite = onFavorite,
@@ -259,10 +266,13 @@ fun TimelineReplyItem(
                         onOpenImage = onOpenImage,
                         onOpenUrl = onOpenUrl,
                         onOpenUser = onOpenUser,
+                        onOpenUsersFavorite = onOpenUsersFavorite,
+                        onOpenUsersReblog = onOpenUsersReblog,
                         onOptionSelected = onOptionSelected,
                         onOptionsMenuToggled = {
                             optionsMenuOpen = it
                         },
+                        onPollVote = onPollVote,
                         onReblog = onReblog,
                         onReply = onReply,
                         onShowOriginal = onShowOriginal,
@@ -274,6 +284,7 @@ fun TimelineReplyItem(
                         actionsEnabled = actionsEnabled,
                         autoloadImages = autoloadImages,
                         entry = entryToDisplay,
+                        extendedSocialInfoEnabled = extendedSocialInfoEnabled,
                         options = options,
                         optionsMenuOpen = optionsMenuOpen,
                         onBookmark = onBookmark,
@@ -282,10 +293,13 @@ fun TimelineReplyItem(
                         onDislike = onDislike,
                         onOpenUrl = onOpenUrl,
                         onOpenUser = onOpenUser,
+                        onOpenUsersFavorite = onOpenUsersFavorite,
+                        onOpenUsersReblog = onOpenUsersReblog,
                         onOptionSelected = onOptionSelected,
                         onOptionsMenuToggled = {
                             optionsMenuOpen = it
                         },
+                        onPollVote = onPollVote,
                         onReblog = onReblog,
                         onReply = onReply,
                         onShowOriginal = onShowOriginal,
@@ -298,6 +312,7 @@ fun TimelineReplyItem(
                         autoloadImages = autoloadImages,
                         blurNsfw = blurNsfw,
                         entry = entryToDisplay,
+                        extendedSocialInfoEnabled = extendedSocialInfoEnabled,
                         options = options,
                         optionsMenuOpen = optionsMenuOpen,
                         onBookmark = onBookmark,
@@ -307,10 +322,13 @@ fun TimelineReplyItem(
                         onOpenImage = onOpenImage,
                         onOpenUrl = onOpenUrl,
                         onOpenUser = onOpenUser,
+                        onOpenUsersFavorite = onOpenUsersFavorite,
+                        onOpenUsersReblog = onOpenUsersReblog,
                         onOptionSelected = onOptionSelected,
                         onOptionsMenuToggled = {
                             optionsMenuOpen = it
                         },
+                        onPollVote = onPollVote,
                         onReblog = onReblog,
                         onReply = onReply,
                         onShowOriginal = onShowOriginal,

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/Strings.kt
@@ -344,6 +344,7 @@ interface Strings {
     val settingsItemBarTheme: String @Composable get
     val settingsItemBlockedAndMuted: String @Composable get
     val settingsItemBlurNsfw: String @Composable get
+    val settingsItemConversationReplyDepth: String @Composable get
     val settingsItemCrashReportEnabled: String @Composable get
     val settingsItemDefaultPostVisibility: String @Composable get
     val settingsItemDefaultReplyVisibility: String @Composable get

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/testutils/MockStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/testutils/MockStrings.kt
@@ -695,6 +695,8 @@ class MockStrings : Strings {
         @Composable get() = retrieve("settingsItemBlockedAndMuted")
     override val settingsItemBlurNsfw: String
         @Composable get() = retrieve("settingsItemBlurNsfw")
+    override val settingsItemConversationReplyDepth: String
+        @Composable get() = retrieve("settingsItemConversationReplyDepth")
     override val settingsItemCrashReportEnabled: String
         @Composable get() = retrieve("settingsItemCrashReportEnabled")
     override val settingsItemDefaultPostVisibility: String

--- a/core/persistence/schemas/com.livefast.eattrash.raccoonforfriendica.core.persistence.AppDatabase/20.json
+++ b/core/persistence/schemas/com.livefast.eattrash.raccoonforfriendica.core.persistence.AppDatabase/20.json
@@ -1,0 +1,447 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 20,
+    "identityHash": "78227ea11d559e15ae4e0e26979b71c2",
+    "entities": [
+      {
+        "tableName": "AccountEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `handle` TEXT NOT NULL, `active` INTEGER NOT NULL DEFAULT 0, `remoteId` TEXT, `avatar` TEXT, `displayName` TEXT, `pushAuth` TEXT, `pushPubKey` TEXT, `pushPrivKey` TEXT, `pushServerKey` TEXT, `unifiedPushUrl` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "handle",
+            "columnName": "handle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "active",
+            "columnName": "active",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "remoteId",
+            "columnName": "remoteId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "avatar",
+            "columnName": "avatar",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pushAuth",
+            "columnName": "pushAuth",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pushPubKey",
+            "columnName": "pushPubKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pushPrivKey",
+            "columnName": "pushPrivKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pushServerKey",
+            "columnName": "pushServerKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "unifiedPushUrl",
+            "columnName": "unifiedPushUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_AccountEntity_handle",
+            "unique": false,
+            "columnNames": [
+              "handle"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_AccountEntity_handle` ON `${TABLE_NAME}` (`handle`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SettingsEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `accountId` INTEGER NOT NULL DEFAULT 0, `lang` TEXT NOT NULL DEFAULT 'en', `theme` INTEGER NOT NULL DEFAULT 0, `fontFamily` INTEGER NOT NULL DEFAULT 0, `fontScale` INTEGER NOT NULL DEFAULT 0, `dynamicColors` INTEGER NOT NULL DEFAULT 0, `customSeedColor` INTEGER, `defaultTimelineType` INTEGER NOT NULL DEFAULT 0, `includeNsfw` INTEGER NOT NULL DEFAULT 0, `blurNsfw` INTEGER NOT NULL DEFAULT 0, `urlOpeningMode` INTEGER NOT NULL DEFAULT 0, `defaultPostVisibility` INTEGER NOT NULL DEFAULT 0, `defaultReplyVisibility` INTEGER NOT NULL DEFAULT 1, `excludeRepliesFromTimeline` INTEGER NOT NULL DEFAULT 0, `openGroupsInForumModeByDefault` INTEGER NOT NULL DEFAULT 1, `markupMode` INTEGER NOT NULL DEFAULT 0, `maxPostBodyLines` INTEGER NOT NULL DEFAULT 0, `defaultTimelineId` TEXT, `notificationMode` INTEGER NOT NULL DEFAULT 0, `pullNotificationCheckInterval` INTEGER, `autoloadImages` INTEGER NOT NULL DEFAULT 1, `hideNavigationBarWhileScrolling` INTEGER NOT NULL DEFAULT 1, `barTheme` INTEGER NOT NULL DEFAULT 0, `timelineLayout` INTEGER NOT NULL DEFAULT 0, `replyDepth` INTEGER NOT NULL DEFAULT 1, FOREIGN KEY(`accountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lang",
+            "columnName": "lang",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'en'"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "fontScale",
+            "columnName": "fontScale",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "dynamicColors",
+            "columnName": "dynamicColors",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "customSeedColor",
+            "columnName": "customSeedColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "defaultTimelineType",
+            "columnName": "defaultTimelineType",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "includeNsfw",
+            "columnName": "includeNsfw",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "blurNsfw",
+            "columnName": "blurNsfw",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "urlOpeningMode",
+            "columnName": "urlOpeningMode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "defaultPostVisibility",
+            "columnName": "defaultPostVisibility",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "defaultReplyVisibility",
+            "columnName": "defaultReplyVisibility",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "excludeRepliesFromTimeline",
+            "columnName": "excludeRepliesFromTimeline",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "openGroupsInForumModeByDefault",
+            "columnName": "openGroupsInForumModeByDefault",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "markupMode",
+            "columnName": "markupMode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "maxPostBodyLines",
+            "columnName": "maxPostBodyLines",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "defaultTimelineId",
+            "columnName": "defaultTimelineId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notificationMode",
+            "columnName": "notificationMode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "pullNotificationCheckInterval",
+            "columnName": "pullNotificationCheckInterval",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "autoloadImages",
+            "columnName": "autoloadImages",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "hideNavigationBarWhileScrolling",
+            "columnName": "hideNavigationBarWhileScrolling",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "barTheme",
+            "columnName": "barTheme",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "timelineLayout",
+            "columnName": "timelineLayout",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "replyDepth",
+            "columnName": "replyDepth",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_SettingsEntity_accountId",
+            "unique": true,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_SettingsEntity_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "DraftEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `mediaIds` TEXT, `inReplyToId` TEXT, `lang` TEXT, `sensitive` INTEGER, `spoiler` TEXT, `title` TEXT, `text` TEXT, `created` TEXT, `visibility` TEXT, `pollExpiresAt` TEXT, `pollMultiple` INTEGER, `pollOptions` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaIds",
+            "columnName": "mediaIds",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "inReplyToId",
+            "columnName": "inReplyToId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lang",
+            "columnName": "lang",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sensitive",
+            "columnName": "sensitive",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "spoiler",
+            "columnName": "spoiler",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "visibility",
+            "columnName": "visibility",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pollExpiresAt",
+            "columnName": "pollExpiresAt",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pollMultiple",
+            "columnName": "pollMultiple",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pollOptions",
+            "columnName": "pollOptions",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "UserRateLimitEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `accountId` INTEGER NOT NULL DEFAULT 0, `userHandle` TEXT NOT NULL, `rate` REAL NOT NULL DEFAULT 1, FOREIGN KEY(`accountId`) REFERENCES `AccountEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "userHandle",
+            "columnName": "userHandle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_UserRateLimitEntity_userHandle_accountId",
+            "unique": true,
+            "columnNames": [
+              "userHandle",
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_UserRateLimitEntity_userHandle_accountId` ON `${TABLE_NAME}` (`userHandle`, `accountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "AccountEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '78227ea11d559e15ae4e0e26979b71c2')"
+    ]
+  }
+}

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/AppDatabase.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/AppDatabase.kt
@@ -20,7 +20,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.persistence.entities.UserR
         DraftEntity::class,
         UserRateLimitEntity::class,
     ],
-    version = 19,
+    version = 20,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
@@ -40,6 +40,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.persistence.entities.UserR
         AutoMigration(from = 16, to = 17),
         AutoMigration(from = 17, to = 18),
         AutoMigration(from = 18, to = 19),
+        AutoMigration(from = 19, to = 20),
     ],
 )
 @ConstructedBy(AppDatabaseConstructor::class)

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/entities/SettingsEntity.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/entities/SettingsEntity.kt
@@ -48,4 +48,5 @@ data class SettingsEntity(
     @ColumnInfo(defaultValue = "1") val hideNavigationBarWhileScrolling: Boolean = true,
     @ColumnInfo(defaultValue = "0") val barTheme: Int = 0,
     @ColumnInfo(defaultValue = "0") val timelineLayout: Int = 0,
+    @ColumnInfo(defaultValue = "1") val replyDepth: Int = 1,
 )

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/TimelineEntryModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/TimelineEntryModel.kt
@@ -26,6 +26,7 @@ data class TimelineEntryModel(
     val inReplyTo: TimelineEntryModel? = null,
     val lang: String? = null,
     @Transient val loadMoreButtonVisible: Boolean = false,
+    @Transient val loadMoreButtonLoading: Boolean = false,
     val mentions: List<UserModel> = emptyList(),
     val parentId: String? = null,
     val pinned: Boolean = false,

--- a/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/PopulateThreadUseCase.kt
+++ b/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/PopulateThreadUseCase.kt
@@ -1,0 +1,10 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.usecase
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+
+interface PopulateThreadUseCase {
+    suspend operator fun invoke(
+        entry: TimelineEntryModel,
+        maxDepth: Int = 5,
+    ): List<TimelineEntryModel>
+}

--- a/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/di/ContentUseCaseModule.kt
+++ b/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/di/ContentUseCaseModule.kt
@@ -2,11 +2,13 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.di
 
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.DefaultExportUserListUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.DefaultGetTranslationUseCase
+import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.DefaultPopulateThreadUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.DefaultStripMarkupUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.DefaultToggleEntryDislikeUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.DefaultToggleEntryFavoriteUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.ExportUserListUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.GetTranslationUseCase
+import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.PopulateThreadUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.StripMarkupUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.ToggleEntryDislikeUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.ToggleEntryFavoriteUseCase
@@ -63,6 +65,14 @@ val contentUseCaseModule =
                     defaultRepository = instance(tag = "default"),
                     fallbackRepository = instance(tag = "fallback"),
                     stripMarkup = instance(),
+                )
+            }
+        }
+        bind<PopulateThreadUseCase> {
+            singleton {
+                DefaultPopulateThreadUseCase(
+                    timelineEntryRepository = instance(),
+                    emojiHelper = instance(),
                 )
             }
         }

--- a/domain/content/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/DefaultPopulateThreadUseCaseTest.kt
+++ b/domain/content/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/DefaultPopulateThreadUseCaseTest.kt
@@ -1,0 +1,147 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.usecase
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineContextModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.returnsArgAt
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DefaultPopulateThreadUseCaseTest {
+    private val emojiHelper =
+        mock<EmojiHelper> {
+            everySuspend { any<TimelineEntryModel>().withEmojisIfMissing() } returnsArgAt 0
+        }
+    private val timelineEntryRepository = mock<TimelineEntryRepository>()
+    private val sut =
+        DefaultPopulateThreadUseCase(
+            timelineEntryRepository = timelineEntryRepository,
+            emojiHelper = emojiHelper,
+        )
+
+    @Test
+    fun `given terminal entry when invoke then result and interactions are as expected`() =
+        runTest {
+            val root =
+                TimelineEntryModel(
+                    id = "1",
+                    content = "test",
+                )
+
+            val res = sut.invoke(root)
+
+            assertEquals(listOf(root), res)
+            verifySuspend(VerifyMode.not) {
+                timelineEntryRepository.getContext(any())
+            }
+        }
+
+    @Test
+    fun `given max depth reached when invoke then result and interactions are as expected`() =
+        runTest {
+            val root =
+                TimelineEntryModel(
+                    id = "1",
+                    content = "test",
+                    replyCount = 1,
+                )
+            val child1 =
+                TimelineEntryModel(
+                    id = "2",
+                    content = "reply 1",
+                    replyCount = 1,
+                )
+            everySuspend {
+                timelineEntryRepository.getContext(any())
+            } returns
+                TimelineContextModel(
+                    ancestors = listOf(root),
+                    descendants = listOf(child1),
+                )
+
+            val res = sut.invoke(entry = root, maxDepth = 1)
+
+            assertEquals(
+                listOf(
+                    root,
+                    child1.copy(depth = 1, loadMoreButtonVisible = true),
+                ),
+                res,
+            )
+            verifySuspend {
+                timelineEntryRepository.getContext("1")
+            }
+            verifySuspend(VerifyMode.not) {
+                timelineEntryRepository.getContext("2")
+            }
+        }
+
+    @Test
+    fun `when invoke then result and interactions are as expected`() =
+        runTest {
+            val root =
+                TimelineEntryModel(
+                    id = "1",
+                    content = "test",
+                    replyCount = 1,
+                )
+            val child1 =
+                TimelineEntryModel(
+                    id = "2",
+                    content = "reply 1",
+                    replyCount = 1,
+                )
+            val child2 =
+                TimelineEntryModel(
+                    id = "3",
+                    content = "reply 2",
+                )
+            everySuspend {
+                timelineEntryRepository.getContext(any())
+            } calls {
+                val entryId = it.arg<String>(0)
+                when (entryId) {
+                    root.id ->
+                        TimelineContextModel(
+                            ancestors = listOf(root),
+                            descendants = listOf(child1),
+                        )
+
+                    child1.id ->
+                        TimelineContextModel(
+                            ancestors = listOf(child1),
+                            descendants = listOf(child2),
+                        )
+
+                    else -> TimelineContextModel()
+                }
+            }
+
+            val res = sut.invoke(entry = root)
+
+            assertEquals(
+                listOf(
+                    root,
+                    child1.copy(depth = 1),
+                    child2.copy(depth = 2),
+                ),
+                res,
+            )
+            verifySuspend {
+                timelineEntryRepository.getContext("1")
+                timelineEntryRepository.getContext("2")
+            }
+            verifySuspend(VerifyMode.not) {
+                timelineEntryRepository.getContext("3")
+            }
+        }
+}

--- a/domain/identity/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/data/SettingsModel.kt
+++ b/domain/identity/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/data/SettingsModel.kt
@@ -33,6 +33,7 @@ data class SettingsModel(
     val hideNavigationBarWhileScrolling: Boolean = true,
     val barTheme: UiBarTheme = UiBarTheme.Transparent,
     val timelineLayout: TimelineLayout = TimelineLayout.Full,
+    val replyDepth: Int = 1,
 )
 
 fun Int.toDomainMaxLines(): Int =

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultSettingsRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultSettingsRepository.kt
@@ -71,6 +71,7 @@ private fun SettingsEntity.toModel() =
         hideNavigationBarWhileScrolling = hideNavigationBarWhileScrolling,
         barTheme = barTheme.toUIBarTheme(),
         timelineLayout = timelineLayout.toTimelineLayout(),
+        replyDepth = replyDepth,
     )
 
 private fun SettingsModel.toEntity() =
@@ -100,4 +101,5 @@ private fun SettingsModel.toEntity() =
         hideNavigationBarWhileScrolling = hideNavigationBarWhileScrolling,
         barTheme = barTheme.toInt(),
         timelineLayout = timelineLayout.toInt(),
+        replyDepth = replyDepth,
     )

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailMviModel.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailMviModel.kt
@@ -70,12 +70,17 @@ interface EntryDetailMviModel :
         data class AddInstanceShortcut(
             val node: String,
         ) : Intent
+
+        data class LoadMoreReplies(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
         val currentUserId: String? = null,
         val refreshing: Boolean = false,
         val initial: Boolean = true,
+        val loading: Boolean = false,
         val initialIndex: Int = 0,
         val mainEntry: TimelineEntryModel? = null,
         val entries: List<List<TimelineEntryModel>> = emptyList(),

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/di/EntryDetailModule.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/di/EntryDetailModule.kt
@@ -33,6 +33,7 @@ val entryDetailModule =
                     emojiHelper = instance(),
                     replyHelper = instance(),
                     imageAutoloadObserver = instance(),
+                    populateThread = instance(),
                     toggleEntryFavorite = instance(),
                     toggleEntryDislike = instance(),
                     getTranslation = instance(),

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
@@ -272,7 +272,12 @@ class InboxScreen : Screen {
                     if (!uiState.initial && !uiState.loading && !uiState.refreshing && uiState.notifications.isEmpty()) {
                         item {
                             Text(
-                                modifier = Modifier.fillMaxWidth().padding(top = Spacing.m),
+                                modifier =
+                                    Modifier.fillMaxWidth().padding(
+                                        top = Spacing.m,
+                                        start = Spacing.m,
+                                        end = Spacing.m,
+                                    ),
                                 text =
                                     if (uiState.currentUserId != null) {
                                         LocalStrings.current.messageEmptyInbox

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsMviModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsMviModel.kt
@@ -133,6 +133,10 @@ interface SettingsMviModel :
         data class ImportSettings(
             val content: String,
         ) : Intent
+
+        data class ChangeReplyDepth(
+            val depth: Int,
+        ) : Intent
     }
 
     data class State(
@@ -178,6 +182,7 @@ interface SettingsMviModel :
         val timelineLayout: TimelineLayout = TimelineLayout.Full,
         val pushNotificationPermissionState: PermissionState = PermissionState.NotDetermined,
         val isBarThemeSupported: Boolean = false,
+        val replyDepth: Int = 1,
     )
 
     sealed interface Effect {

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
@@ -138,6 +138,7 @@ class SettingsScreen : Screen {
         var fileInputOpened by remember { mutableStateOf(false) }
         var settingsContent by remember { mutableStateOf<String?>(null) }
         var timelineLayoutBottomSheetOpened by remember { mutableStateOf(false) }
+        var replyDepthBottoSheepOpened by remember { mutableStateOf(false) }
 
         BindEffect(permissionsController = controller)
         LaunchedEffect(model) {
@@ -357,6 +358,13 @@ class SettingsScreen : Screen {
                                 )
                             }
                         }
+                        SettingsRow(
+                            title = LocalStrings.current.settingsItemConversationReplyDepth,
+                            value = uiState.replyDepth.toString(),
+                            onTap = {
+                                replyDepthBottoSheepOpened = true
+                            },
+                        )
 
                         // Look & feel section
                         SettingsHeader(
@@ -1063,6 +1071,20 @@ class SettingsScreen : Screen {
                 settingsContent = null
             }
         }
+
+        if (replyDepthBottoSheepOpened) {
+            CustomModalBottomSheet(
+                title = LocalStrings.current.settingsItemConversationReplyDepth,
+                items = REPLY_DEPTH_VALUES.map { CustomModalBottomSheetItem(label = it.toString()) },
+                onSelected = { index ->
+                    replyDepthBottoSheepOpened = false
+                    if (index != null) {
+                        val value = REPLY_DEPTH_VALUES[index]
+                        model.reduce(SettingsMviModel.Intent.ChangeReplyDepth(value))
+                    }
+                },
+            )
+        }
     }
 }
 
@@ -1082,6 +1104,15 @@ private val BACKGROUND_NOTIFICATION_CHECK_INTERVALS =
         30.minutes,
         1.hours,
         4.hours,
+    )
+
+private val REPLY_DEPTH_VALUES =
+    listOf(
+        1,
+        2,
+        3,
+        4,
+        5,
     )
 
 @Composable

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsViewModel.kt
@@ -207,6 +207,7 @@ class SettingsViewModel(
                                 hideNavigationBarWhileScrolling = settings.hideNavigationBarWhileScrolling,
                                 barTheme = settings.barTheme,
                                 timelineLayout = settings.timelineLayout,
+                                replyDepth = settings.replyDepth,
                             )
                         }
                     }
@@ -376,6 +377,10 @@ class SettingsViewModel(
 
             is SettingsMviModel.Intent.ExportSettings -> handleExportSettings()
             is SettingsMviModel.Intent.ImportSettings -> handleImportSettings(intent.content)
+            is SettingsMviModel.Intent.ChangeReplyDepth ->
+                screenModelScope.launch {
+                    changeReplyDepth(intent.depth)
+                }
         }
     }
 
@@ -552,6 +557,12 @@ class SettingsViewModel(
     private suspend fun changeTimelineLayout(value: TimelineLayout) {
         val currentSettings = settingsRepository.current.value ?: return
         val newSettings = currentSettings.copy(timelineLayout = value)
+        saveSettings(newSettings)
+    }
+
+    private suspend fun changeReplyDepth(value: Int) {
+        val currentSettings = settingsRepository.current.value ?: return
+        val newSettings = currentSettings.copy(replyDepth = value)
         saveSettings(newSettings)
     }
 

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -23,6 +24,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Reply
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -47,17 +49,20 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.kodein.rememberScreenModel
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.TimelineLayout
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.getFabNestedScrollConnection
@@ -276,6 +281,7 @@ class ThreadScreen(
                                 TimelineItem(
                                     modifier =
                                         Modifier
+                                            // since the main entry is forced to "full", recreates card appearance
                                             .padding(horizontal = Spacing.xs)
                                             .shadow(
                                                 elevation = 5.dp,
@@ -694,20 +700,32 @@ class ThreadScreen(
                                             )
                                         },
                                     ) {
-                                        Text(
-                                            text =
-                                                buildString {
-                                                    append(LocalStrings.current.buttonLoadMoreReplies)
-                                                    entry.replyCount
-                                                        .takeIf { it > 0 }
-                                                        ?.also { count ->
-                                                            append(" (")
-                                                            append(count)
-                                                            append(")")
-                                                        }
-                                                },
-                                            style = MaterialTheme.typography.labelMedium,
-                                        )
+                                        Row(
+                                            horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+                                            verticalAlignment = Alignment.CenterVertically,
+                                        ) {
+                                            if (entry.loadMoreButtonLoading) {
+                                                CircularProgressIndicator(
+                                                    modifier = Modifier.size(IconSize.s),
+                                                    color = MaterialTheme.colorScheme.onPrimary,
+                                                )
+                                            }
+                                            Text(
+                                                text =
+                                                    buildString {
+                                                        append(LocalStrings.current.buttonLoadMoreReplies)
+                                                        entry.replyCount
+                                                            .takeIf { it > 0 }
+                                                            ?.also { count ->
+                                                                append(" (")
+                                                                append(count)
+                                                                append(")")
+                                                            }
+                                                    },
+                                                maxLines = 1,
+                                                overflow = TextOverflow.Ellipsis,
+                                            )
+                                        }
                                     }
                                 }
                             }

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/data/ConversationNode.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/data/ConversationNode.kt
@@ -1,8 +1,0 @@
-package com.livefast.eattrash.raccoonforfriendica.feature.thread.data
-
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
-
-internal data class ConversationNode(
-    val entry: TimelineEntryModel,
-    val children: MutableList<ConversationNode> = mutableListOf(),
-)

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/di/ThreadModule.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/di/ThreadModule.kt
@@ -2,13 +2,10 @@ package com.livefast.eattrash.raccoonforfriendica.feature.thread.di
 
 import com.livefast.eattrash.raccoonforfriendica.feature.thread.ThreadMviModel
 import com.livefast.eattrash.raccoonforfriendica.feature.thread.ThreadViewModel
-import com.livefast.eattrash.raccoonforfriendica.feature.thread.usecase.DefaultPopulateThreadUseCase
-import com.livefast.eattrash.raccoonforfriendica.feature.thread.usecase.PopulateThreadUseCase
 import org.kodein.di.DI
 import org.kodein.di.bind
 import org.kodein.di.factory
 import org.kodein.di.instance
-import org.kodein.di.singleton
 
 data class ThreadMviModelParams(
     val entryId: String,
@@ -17,14 +14,6 @@ data class ThreadMviModelParams(
 
 val threadModule =
     DI.Module("ThreadModule") {
-        bind<PopulateThreadUseCase> {
-            singleton {
-                DefaultPopulateThreadUseCase(
-                    timelineEntryRepository = instance(),
-                    emojiHelper = instance(),
-                )
-            }
-        }
         bind<ThreadMviModel> {
             factory { params: ThreadMviModelParams ->
                 ThreadViewModel(

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/di/ThreadModule.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/di/ThreadModule.kt
@@ -19,7 +19,6 @@ val threadModule =
                 ThreadViewModel(
                     entryId = params.entryId,
                     swipeNavigationEnabled = params.swipeNavigationEnabled,
-                    populateThreadUseCase = instance(),
                     timelineEntryRepository = instance(),
                     identityRepository = instance(),
                     settingsRepository = instance(),
@@ -32,6 +31,7 @@ val threadModule =
                     imagePreloadManager = instance(),
                     blurHashRepository = instance(),
                     imageAutoloadObserver = instance(),
+                    populateThread = instance(),
                     toggleEntryFavorite = instance(),
                     toggleEntryDislike = instance(),
                     getTranslation = instance(),

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/usecase/PopulateThreadUseCase.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/usecase/PopulateThreadUseCase.kt
@@ -1,7 +1,0 @@
-package com.livefast.eattrash.raccoonforfriendica.feature.thread.usecase
-
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
-
-interface PopulateThreadUseCase {
-    suspend operator fun invoke(entryId: String): List<TimelineEntryModel>
-}


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR makes it possible to open post details in conversation mode (just like it already happens with forum threads). The initial depth of the replies retrieved from the back-end can be configured in the Settings screen.

## Additional notes
<!-- Anything to declare for code review? -->
This PR extends what was already done in `ThreadDetail[Screen|ViewModel]` to `EntryDetail[Screen|ViewModel]`.
