### PR TITLE
enhancement: close drawer and show message on account switch

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/main/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/main/MainScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Snackbar
-import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
@@ -83,12 +82,13 @@ object MainScreen : Screen {
             navigationCoordinator.exitMessageVisible
                 .onEach { visible ->
                     if (visible) {
-                        snackbarHostState.showSnackbar(
-                            message = exitMessage,
-                            duration = SnackbarDuration.Short,
-                        )
+                        snackbarHostState.showSnackbar(message = exitMessage)
                         navigationCoordinator.setExitMessageVisible(false)
                     }
+                }.launchIn(this)
+            navigationCoordinator.globalMessage
+                .onEach { message ->
+                    snackbarHostState.showSnackbar(message = message)
                 }.launchIn(this)
         }
 

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationCoordinator.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationCoordinator.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.getAndUpdate
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlin.time.Duration
 
 internal class DefaultNavigationCoordinator(
     dispatcher: CoroutineDispatcher = Dispatchers.Main,
@@ -21,6 +22,7 @@ internal class DefaultNavigationCoordinator(
     override val canPop = MutableStateFlow(false)
     override val exitMessageVisible = MutableStateFlow(false)
     override val deepLinkUrl = MutableSharedFlow<String>()
+    override val globalMessage = MutableSharedFlow<String>()
 
     private var rootNavigator: NavigatorAdapter? = null
     private var bottomBarScrollConnection: NestedScrollConnection? = null
@@ -84,5 +86,15 @@ internal class DefaultNavigationCoordinator(
     override suspend fun submitDeeplink(url: String) {
         delay(750)
         deepLinkUrl.emit(url)
+    }
+
+    override fun showGlobalMessage(
+        message: String,
+        delay: Duration,
+    ) {
+        scope.launch {
+            delay(delay)
+            globalMessage.emit(message)
+        }
     }
 }

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/NavigationCoordinator.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/NavigationCoordinator.kt
@@ -6,6 +6,7 @@ import cafe.adriel.voyager.core.screen.Screen
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlin.time.Duration
 
 @Stable
 interface NavigationCoordinator {
@@ -14,6 +15,7 @@ interface NavigationCoordinator {
     val canPop: StateFlow<Boolean>
     val exitMessageVisible: StateFlow<Boolean>
     val deepLinkUrl: SharedFlow<String>
+    val globalMessage: Flow<String>
 
     fun setCurrentSection(section: BottomNavigationSection)
 
@@ -38,4 +40,9 @@ interface NavigationCoordinator {
     fun popUntilRoot()
 
     suspend fun submitDeeplink(url: String)
+
+    fun showGlobalMessage(
+        message: String,
+        delay: Duration = Duration.ZERO,
+    )
 }

--- a/core/navigation/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationCoordinatorTest.kt
+++ b/core/navigation/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationCoordinatorTest.kt
@@ -119,6 +119,21 @@ class DefaultNavigationCoordinatorTest {
         }
 
     @Test
+    fun `when showGlobalMessage then value is as expected`() =
+        runTest {
+            val text = "Global message"
+
+            launch {
+                sut.showGlobalMessage(text)
+            }
+
+            sut.globalMessage.test {
+                val item = awaitItem()
+                assertEquals(text, item)
+            }
+        }
+
+    @Test
     fun `when push then interactions are as expected`() =
         runTest {
             val screen =

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerContent.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerContent.kt
@@ -91,6 +91,7 @@ class DrawerContent : Screen {
         var manageAccountsDialogOpened by remember { mutableStateOf(false) }
         var changeInstanceDialogOpened by remember { mutableStateOf(false) }
         var aboutDialogOpened by remember { mutableStateOf(false) }
+        val successMessage = LocalStrings.current.messageSuccess
 
         fun handleAction(action: suspend () -> Unit) {
             scope.launch {
@@ -108,6 +109,12 @@ class DrawerContent : Screen {
                         DrawerMviModel.Effect.AnonymousChangeNodeSuccess -> {
                             changeInstanceDialogOpened = false
                             drawerCoordinator.closeDrawer()
+                            navigationCoordinator.showGlobalMessage(successMessage)
+                        }
+
+                        DrawerMviModel.Effect.AccountChangeSuccess -> {
+                            drawerCoordinator.closeDrawer()
+                            navigationCoordinator.showGlobalMessage(successMessage)
                         }
                     }
                 }.launchIn(this)

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerMviModel.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerMviModel.kt
@@ -39,5 +39,7 @@ interface DrawerMviModel :
 
     sealed interface Effect {
         data object AnonymousChangeNodeSuccess : Effect
+
+        data object AccountChangeSuccess : Effect
     }
 }

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerViewModel.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerViewModel.kt
@@ -95,6 +95,7 @@ class DrawerViewModel(
         }
         screenModelScope.launch {
             switchAccountUseCase(account)
+            emitEffect(DrawerMviModel.Effect.AccountChangeSuccess)
         }
     }
 

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileMviModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileMviModel.kt
@@ -31,5 +31,7 @@ interface ProfileMviModel :
         val hideNavigationBarWhileScrolling: Boolean = true,
     )
 
-    sealed interface Effect
+    sealed interface Effect {
+        data object AccountChangeSuccess : Effect
+    }
 }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -47,9 +48,12 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.Progre
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDrawerCoordinator
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
 import com.livefast.eattrash.raccoonforfriendica.feature.profile.loginintro.LoginIntroScreen
 import com.livefast.eattrash.raccoonforfriendica.feature.profile.myaccount.MyAccountScreen
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 class ProfileScreen : Screen {
@@ -62,9 +66,21 @@ class ProfileScreen : Screen {
         val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
         val scope = rememberCoroutineScope()
         val drawerCoordinator = remember { getDrawerCoordinator() }
+        val navigationCoordinator = remember { getNavigationCoordinator() }
+        val successMessage = LocalStrings.current.messageSuccess
         var confirmLogoutDialogOpened by remember { mutableStateOf(false) }
         var manageAccountsDialogOpened by remember { mutableStateOf(false) }
         var confirmDeleteAccount by remember { mutableStateOf<AccountModel?>(null) }
+
+        LaunchedEffect(model) {
+            model.effects
+                .onEach { event ->
+                    when (event) {
+                        ProfileMviModel.Effect.AccountChangeSuccess ->
+                            navigationCoordinator.showGlobalMessage(successMessage)
+                    }
+                }.launchIn(this)
+        }
 
         CompositionLocalProvider(
             LocalProfileTopAppBarStateWrapper provides

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/ProfileViewModel.kt
@@ -92,6 +92,7 @@ class ProfileViewModel(
                 it.copy(loading = true)
             }
             switchAccountUseCase(account)
+            emitEffect(ProfileMviModel.Effect.AccountChangeSuccess)
         }
     }
 


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR shows a success message when the current instance or account is changed from the navigation drawer, making sure the drawer closes afterwards.

Moreover, the same message is displayed when the account is changed from the profile screen.
