### PR TITLE
refactor: deduplicate results before updating pagination data

### DIFF
--- a/docs/manual/it/main.md
+++ b/docs/manual/it/main.md
@@ -135,7 +135,7 @@ un [problema](https://github.com/friendica/friendica/issues/11093) ben noto).
 Questo avviso non significa in assoluto che queste funzioni non saranno mai supportate. Ad esempio,
 all'inizio l'app non era in grado di mostrare le immagini inserite all'interno del corpo dei post,
 ma gli sviluppatori del backend hanno fatto un lavoro straordinario e hanno modificato la risposta
-dell'API in modo da permettere a qualsiasi app (non solo Racccoon!) di visualizzarle correttamente.
+dell'API in modo da permettere a qualsiasi app (non solo Raccoon!) di visualizzarle correttamente.
 
 [Torna su](#indice)
 

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultEventPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultEventPaginationManager.kt
@@ -35,8 +35,8 @@ internal class DefaultEventPaginationManager(
 
         return mutex.withLock {
             results
-                ?.updatePaginationData()
                 ?.deduplicate()
+                ?.updatePaginationData()
                 ?.also {
                     history.addAll(it)
                 }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFollowRequestPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFollowRequestPaginationManager.kt
@@ -29,8 +29,8 @@ internal class DefaultFollowRequestPaginationManager(
 
         return mutex.withLock {
             results
-                ?.updatePaginationData()
                 ?.deduplicate()
+                ?.updatePaginationData()
                 ?.fixupCreatorEmojis()
                 ?.also { history.addAll(it) }
             // return a copy
@@ -49,6 +49,15 @@ internal class DefaultFollowRequestPaginationManager(
         filter { e1 ->
             history.none { e2 -> e1.id == e2.id }
         }.distinctBy { it.id }
+
+    private fun ListWithPageCursor<UserModel>.deduplicate(): ListWithPageCursor<UserModel> =
+        run {
+            val newList = list.deduplicate()
+            ListWithPageCursor(
+                list = newList,
+                cursor = newList.lastOrNull()?.id,
+            )
+        }
 
     private suspend fun List<UserModel>.fixupCreatorEmojis(): List<UserModel> =
         with(emojiHelper) {

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultNotificationsPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultNotificationsPaginationManager.kt
@@ -49,9 +49,9 @@ internal class DefaultNotificationsPaginationManager(
         return mutex.withLock {
             results
                 .determineRelationshipStatus()
+                .deduplicate()
                 .updatePaginationData()
                 .filterNsfw(specification.includeNsfw)
-                .deduplicate()
                 .fixupCreatorEmojis()
                 .fixupInReplyTo()
                 .also { history.addAll(it) }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
@@ -180,29 +180,28 @@ internal class DefaultTimelinePaginationManager(
             when (specification) {
                 is TimelinePaginationSpecification.Feed ->
                     results
+                        ?.deduplicate()
                         ?.updatePaginationData()
                         ?.filterReplies(included = !specification.excludeReplies)
                         ?.filterNsfw(specification.includeNsfw)
                         ?.filterWithRateLimits()
                         ?.filterByStopWords()
-                        ?.deduplicate()
                         ?.fixupCreatorEmojis()
                         ?.fixupInReplyTo()
                         ?.fixumFollowedHashtags()
 
                 is TimelinePaginationSpecification.Hashtag ->
                     results
+                        ?.deduplicate()
                         ?.updatePaginationData()
                         ?.filterNsfw(specification.includeNsfw)
                         ?.filterWithRateLimits()
                         ?.filterByStopWords()
-                        ?.deduplicate()
                         ?.fixupCreatorEmojis()
                         ?.fixupInReplyTo()
 
                 is TimelinePaginationSpecification.User ->
                     results
-                        // deduplication must be done first (due to a backend bug)
                         ?.deduplicate()
                         ?.updatePaginationData()
                         ?.filterNsfw(specification.includeNsfw)
@@ -212,16 +211,15 @@ internal class DefaultTimelinePaginationManager(
 
                 is TimelinePaginationSpecification.Forum ->
                     results
+                        ?.deduplicate()
                         ?.updatePaginationData()
                         ?.filterNsfw(specification.includeNsfw)
                         ?.filter { it.reblog != null && it.reblog?.inReplyTo == null }
                         ?.filterByStopWords()
-                        ?.deduplicate()
                         ?.fixupCreatorEmojis()
 
                 is TimelinePaginationSpecification.Bookmarks ->
                     results
-                        // deduplication must be done first (due to a backend bug)
                         ?.deduplicate()
                         ?.updatePaginationData()
                         ?.filterNsfw(specification.includeNsfw)
@@ -231,7 +229,6 @@ internal class DefaultTimelinePaginationManager(
 
                 is TimelinePaginationSpecification.Favorites ->
                     results
-                        // deduplication must be done first (due to a backend bug)
                         ?.deduplicate()
                         ?.updatePaginationData()
                         ?.filterNsfw(specification.includeNsfw)

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUnpublishedPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUnpublishedPaginationManager.kt
@@ -78,8 +78,8 @@ internal class DefaultUnpublishedPaginationManager(
 
         return mutex.withLock {
             results
-                .updatePaginationData()
                 .deduplicate()
+                .updatePaginationData()
                 .also { history.addAll(it) }
             // return a copy
             history.map { it }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR make pagination managers uniform in that deduplication is performed before updating pagination cursors. This should solve some issues in timeline loading.