### PR TITLE
fix: calendar event time zones

### DIFF
--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
@@ -19,11 +19,19 @@ import java.time.Duration as JavaDuration
 
 actual fun epochMillis(): Long = System.currentTimeMillis()
 
-private fun getDateTimeFormatter(pattern: String) =
-    DateTimeFormatter
-        .ofPattern(pattern)
-        .withLocale(Locale.US)
-        .withZone(TimeZone.getTimeZone("UTC").toZoneId())
+private fun getDateTimeFormatter(
+    pattern: String,
+    withLocalTimezone: Boolean = false,
+) = DateTimeFormatter
+    .ofPattern(pattern)
+    .withLocale(Locale.US)
+    .run {
+        if (withLocalTimezone) {
+            withZone(TimeZone.getDefault().toZoneId())
+        } else {
+            withZone(TimeZone.getTimeZone("UTC").toZoneId())
+        }
+    }
 
 private val defaultFormatter = getDateTimeFormatter("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'")
 private val backupFormatter = getDateTimeFormatter("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
@@ -107,11 +115,14 @@ actual fun getFormattedDate(
 actual fun parseDate(
     value: String,
     format: String,
+    withLocalTimezone: Boolean,
 ): String =
-    getDateTimeFormatter(format)
-        .runCatching {
-            parse(value)
-        }.getOrNull()
+    getDateTimeFormatter(
+        pattern = format,
+        withLocalTimezone = withLocalTimezone,
+    ).runCatching {
+        parse(value)
+    }.getOrNull()
         ?.let { defaultFormatter.format(it) }
         .orEmpty()
 

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
@@ -51,6 +51,7 @@ expect fun getFormattedDate(
 expect fun parseDate(
     value: String,
     format: String,
+    withLocalTimezone: Boolean = false,
 ): String
 
 /**

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/datetime/DateFunctions.kt
@@ -14,6 +14,7 @@ import platform.Foundation.NSISO8601DateFormatter
 import platform.Foundation.NSLocale
 import platform.Foundation.NSTimeZone
 import platform.Foundation.autoupdatingCurrentLocale
+import platform.Foundation.defaultTimeZone
 import platform.Foundation.localTimeZone
 import platform.Foundation.timeIntervalSince1970
 import platform.Foundation.timeIntervalSinceDate
@@ -23,12 +24,20 @@ import kotlin.time.toDuration
 
 actual fun epochMillis(): Long = (NSDate().timeIntervalSince1970 * 1000).toLong()
 
-private fun getDateFormatter(format: String) =
-    NSDateFormatter().apply {
-        locale = NSLocale.autoupdatingCurrentLocale
-        dateFormat = format
-        calendar = NSCalendar(calendarIdentifier = NSCalendarIdentifierGregorian)
-    }
+private fun getDateFormatter(
+    format: String,
+    withLocalTimezone: Boolean = false,
+) = NSDateFormatter().apply {
+    locale = NSLocale.autoupdatingCurrentLocale
+    timeZone =
+        if (withLocalTimezone) {
+            NSTimeZone.localTimeZone
+        } else {
+            NSTimeZone.defaultTimeZone
+        }
+    dateFormat = format
+    calendar = NSCalendar(calendarIdentifier = NSCalendarIdentifierGregorian)
+}
 
 private val defaultFormatter = getDateFormatter("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'")
 private val backupFormatter = getDateFormatter("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
@@ -135,8 +144,13 @@ actual fun getFormattedDate(
 actual fun parseDate(
     value: String,
     format: String,
+    withLocalTimezone: Boolean,
 ): String {
-    val dateFormatter = getDateFormatter(format)
+    val dateFormatter =
+        getDateFormatter(
+            format = format,
+            withLocalTimezone = withLocalTimezone
+    )
     val date =
         runCatching {
             dateFormatter.dateFromString(value)

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
@@ -135,7 +135,7 @@ internal fun Status.toModel() =
                 } else {
                     platform
                 }
-        },
+            },
         sourceProtocol = addons?.network,
         // needed because, for compatibility, Friendica titles are replicated as spoilers on Mastodon
         spoiler = spoiler.takeIf { it != addons?.title },
@@ -568,12 +568,14 @@ internal fun Event.toModel() =
             parseDate(
                 value = startTime,
                 format = FriendicaDateFormats.PHOTO_ALBUMS,
+                withLocalTimezone = true,
             ),
         endTime =
             endTime?.let { date ->
                 parseDate(
                     value = date,
                     format = FriendicaDateFormats.PHOTO_ALBUMS,
+                    withLocalTimezone = true,
                 ).takeIf {
                     val t = it.toEpochMillis()
                     val (y, _) = t.extractDatePart()


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes a bug with calendar event start/end times which are already returned with the local timezone from the server (they are not UTC dates).
