### PR TITLE
feat: add support local visibility options (local-public, local-unlisted)

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/NodeInfo.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/NodeInfo.kt
@@ -1,0 +1,22 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.jsonObject
+
+@Serializable
+data class NodeInfo(
+    @SerialName("links") val links: List<NodeInfoLink> = emptyList(),
+)
+
+@Serializable
+data class NodeInfoLink(
+    @SerialName("rel") val rel: String? = null,
+    @SerialName("href") val href: String? = null,
+)
+
+object NodeInfoUtils {
+    fun linksFromJson(value: String): NodeInfo = JsonSerializer.decodeFromString<NodeInfo>(value)
+
+    fun dataFromJson(value: String): Map<String, Any?> = JsonSerializer.parseToJsonElement(value).jsonObject.toMap()
+}

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Status.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Status.kt
@@ -34,4 +34,5 @@ data class Status(
     @SerialName("tags") val tags: List<Tag> = emptyList(),
     @SerialName("url") val url: String? = null,
     @SerialName("visibility") val visibility: String = ContentVisibility.PUBLIC,
+    @SerialName("local_only") val localOnly: Boolean = false,
 )

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/form/CreateStatusForm.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/form/CreateStatusForm.kt
@@ -10,6 +10,7 @@ class CreateStatusForm(
     @SerialName("in_reply_to_id") val inReplyTo: String? = null,
     @SerialName("language") val lang: String? = null,
     @SerialName("media_ids") val mediaIds: List<String>? = null,
+    @SerialName("local_only") val localOnly: Boolean? = null,
     @SerialName("scheduled_at") val scheduledAt: String? = null,
     @SerialName("sensitive") val sensitive: Boolean = false,
     @SerialName("spoiler_text") val spoilerText: String? = null,

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/DefaultServiceProvider.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/DefaultServiceProvider.kt
@@ -70,7 +70,7 @@ internal class DefaultServiceProvider(
         private const val REAM_NAME = "Friendica"
     }
 
-    private var currentNode: String = ""
+    override var currentNode: String = ""
 
     override lateinit var announcements: AnnouncementService
     override lateinit var apps: AppService

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/ServiceProvider.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/ServiceProvider.kt
@@ -23,6 +23,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.service.TrendsService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.UserService
 
 interface ServiceProvider {
+    val currentNode: String
     val announcements: AnnouncementService
     val apps: AppService
     val directMessage: DirectMessageService

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/EntryDetailDialog.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/EntryDetailDialog.kt
@@ -102,6 +102,11 @@ fun EntryDetailDialog(
                                 )
                             }
                             Spacer(modifier = Modifier.weight(1f))
+                            Text(
+                                style = MaterialTheme.typography.labelMedium,
+                                text = entry.visibility.toReadableName(),
+                                color = fullColor,
+                            )
                             Icon(
                                 modifier = Modifier.size(IconSize.s),
                                 imageVector = entry.visibility.toIcon(),

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NodeFeatures.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NodeFeatures.kt
@@ -15,4 +15,5 @@ data class NodeFeatures(
     val supportsDislike: Boolean = false,
     val supportsTranslation: Boolean = false,
     val supportsInlineImages: Boolean = false,
+    val supportsLocalVisibility: Boolean = false,
 )

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NodeInfoModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NodeInfoModel.kt
@@ -14,4 +14,5 @@ data class NodeInfoModel(
     val title: String? = null,
     val uri: String? = null,
     val version: String? = null,
+    val software: String? = null,
 )

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/TimelineEntryModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/TimelineEntryModel.kt
@@ -46,6 +46,7 @@ data class TimelineEntryModel(
     val updated: String? = null,
     val url: String? = null,
     val visibility: Visibility = Visibility.Public,
+    val localOnly: Boolean = false,
     @Transient val isShowingTranslation: Boolean = false,
     @Transient val translation: TimelineEntryModel? = null,
     @Transient val translationLoading: Boolean = false,

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/Visibility.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/Visibility.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.data
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AlternateEmail
+import androidx.compose.material.icons.filled.Cottage
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.LockOpen
 import androidx.compose.material.icons.filled.Public
@@ -11,18 +12,29 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 
 sealed interface Visibility {
+    // broadest visibility
     data object Public : Visibility
 
+    // like "Public" but does not appear in timelines
     data object Unlisted : Visibility
 
+    // only followers
     data object Private : Visibility
 
+    // only mentions
     data object Direct : Visibility
 
+    // only inside specific Circle
     data class Circle(
         val id: String? = null,
         val name: String? = null,
     ) : Visibility
+
+    // like "Public" but only in local instance
+    data object LocalPublic : Visibility
+
+    // like "Unlisted" by only in local instance
+    data object LocalUnlisted : Visibility
 }
 
 operator fun Visibility.compareTo(other: Visibility): Int = toSortKey().compareTo(other.toSortKey())
@@ -33,7 +45,9 @@ private fun Visibility.toSortKey() =
         Visibility.Direct -> 200
         Visibility.Private -> 300
         Visibility.Public -> 500
+        Visibility.LocalPublic -> 450
         Visibility.Unlisted -> 400
+        Visibility.LocalUnlisted -> 350
     }
 
 @Composable
@@ -42,7 +56,9 @@ fun Visibility.toIcon(): ImageVector =
         Visibility.Direct -> Icons.Default.AlternateEmail
         Visibility.Private -> Icons.Default.Lock
         Visibility.Public -> Icons.Default.Public
+        Visibility.LocalPublic -> Icons.Default.Cottage
         Visibility.Unlisted -> Icons.Default.LockOpen
+        Visibility.LocalUnlisted -> Icons.Default.Cottage
         is Visibility.Circle -> Icons.Default.Workspaces
     }
 
@@ -52,12 +68,28 @@ fun Visibility.toReadableName(): String =
         Visibility.Direct -> LocalStrings.current.visibilityDirect
         Visibility.Private -> LocalStrings.current.visibilityPrivate
         Visibility.Public -> LocalStrings.current.visibilityPublic
+        Visibility.LocalPublic ->
+            buildString {
+                append(LocalStrings.current.timelineLocal)
+                append(" (")
+                append(LocalStrings.current.visibilityPublic)
+                append(")")
+            }
         Visibility.Unlisted -> LocalStrings.current.visibilityUnlisted
+        Visibility.LocalUnlisted ->
+            buildString {
+                append(LocalStrings.current.timelineLocal)
+                append(" (")
+                append(LocalStrings.current.visibilityUnlisted)
+                append(")")
+            }
         is Visibility.Circle -> name ?: LocalStrings.current.visibilityCircle
     }
 
 fun Visibility.toInt() =
     when (this) {
+        Visibility.LocalUnlisted -> 6
+        Visibility.LocalPublic -> 5
         is Visibility.Circle -> 4
         Visibility.Private -> 3
         Visibility.Direct -> 2
@@ -67,6 +99,8 @@ fun Visibility.toInt() =
 
 fun Int.toVisibility(): Visibility =
     when (this) {
+        6 -> Visibility.LocalUnlisted
+        5 -> Visibility.LocalPublic
         4 -> Visibility.Circle()
         3 -> Visibility.Private
         2 -> Visibility.Direct

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNodeInfoRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNodeInfoRepository.kt
@@ -1,21 +1,37 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.NodeInfoUtils
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
+import com.livefast.eattrash.raccoonforfriendica.core.utils.network.provideHttpClientEngine
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NodeInfoModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.RuleModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
 
 internal class DefaultNodeInfoRepository(
     private val provider: ServiceProvider,
+    private val client: HttpClient = HttpClient(provideHttpClientEngine()),
 ) : NodeInfoRepository {
     override suspend fun getInfo(): NodeInfoModel? =
         withContext(Dispatchers.IO) {
-            runCatching {
-                provider.instance.getInfo().toModel()
-            }.getOrNull()
+            val instanceInfo =
+                runCatching {
+                    provider.instance.getInfo()
+                }.getOrNull()
+
+            val softwareName =
+                runCatching {
+                    extractSoftwareName()
+                }.getOrNull()
+
+            instanceInfo?.toModel()?.copy(
+                software = softwareName,
+            )
         }
 
     override suspend fun getRules(): List<RuleModel>? =
@@ -24,4 +40,20 @@ internal class DefaultNodeInfoRepository(
                 provider.instance.getRules().map { it.toModel() }
             }.getOrNull()
         }
+
+    private suspend fun extractSoftwareName(): String? {
+        val linksJson =
+            client.get("https://${provider.currentNode}/.well-known/nodeinfo").bodyAsText()
+        val url =
+            NodeInfoUtils
+                .linksFromJson(linksJson)
+                .links
+                .lastOrNull()
+                ?.href
+                .orEmpty()
+        val dataJson = client.get(url).bodyAsText()
+        val data = NodeInfoUtils.dataFromJson(dataJson)
+        val softwareInfo = data["software"] as? Map<*, *>
+        return softwareInfo?.get("name").toString().trim('"')
+    }
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepository.kt
@@ -18,26 +18,27 @@ internal class DefaultSupportedFeatureRepository(
                 supportsDirectMessages = info.isFriendica,
                 supportsEntryTitles = info.isFriendica,
                 supportsCustomCircles = info.isFriendica,
-                supportReportCategoryRuleViolation = info.isMastodon,
-                supportsPolls = info.isMastodon,
+                supportReportCategoryRuleViolation = !info.isFriendica,
+                supportsPolls = !info.isFriendica,
                 supportsBBCode = info.isFriendica,
                 supportsMarkdown = true,
                 supportsEntryShare = info.isFriendica,
                 supportsCalendar = info.isFriendica,
-                supportsAnnouncements = info.isMastodon,
+                supportsAnnouncements = !info.isFriendica,
                 supportsDislike = info.isFriendica,
-                supportsTranslation = info.isMastodon,
+                supportsTranslation = !info.isFriendica,
                 supportsInlineImages = info.isFriendica,
+                supportsLocalVisibility = info.isGoToSocial || info.isHomeTown,
             )
         }
     }
 }
 
-private val FRIENDICA_REGEX =
-    Regex("\\(compatible; Friendica (?<version>[a-zA-Z0-9.\\-_]*)\\)")
-
 private val NodeInfoModel?.isFriendica: Boolean
-    get() = this?.version?.contains(FRIENDICA_REGEX) ?: false
+    get() = this?.software?.lowercase() == "friendica"
 
-private val NodeInfoModel?.isMastodon: Boolean
-    get() = !isFriendica
+private val NodeInfoModel?.isGoToSocial: Boolean
+    get() = this?.software?.lowercase() == "gotosocial"
+
+private val NodeInfoModel?.isHomeTown: Boolean
+    get() = this?.software?.lowercase() == "hometown"

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTimelineEntryRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTimelineEntryRepository.kt
@@ -254,6 +254,12 @@ internal class DefaultTimelineEntryRepository(
                         spoilerText = spoilerText,
                         scheduledAt = scheduled,
                         poll = pollData,
+                        localOnly =
+                            when (visibility) {
+                                Visibility.LocalPublic -> true
+                                Visibility.LocalUnlisted -> true
+                                else -> null
+                            },
                     )
                 provider.statuses
                     .create(
@@ -304,6 +310,12 @@ internal class DefaultTimelineEntryRepository(
                         lang = lang,
                         spoilerText = spoilerText,
                         poll = pollData,
+                        localOnly =
+                            when (visibility) {
+                                Visibility.LocalPublic -> true
+                                Visibility.LocalUnlisted -> true
+                                else -> null
+                            },
                     )
                 provider.statuses
                     .update(

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
@@ -119,6 +119,7 @@ internal fun Status.toModel() =
         favoriteCount = favoritesCount,
         id = id,
         lang = lang,
+        localOnly = localOnly,
         mentions = mentions.map { it.toModel() },
         parentId = inReplyToId,
         pinned = pinned,
@@ -144,7 +145,17 @@ internal fun Status.toModel() =
         title = addons?.title.takeIf { !it.isNullOrBlank() },
         updated = editedAt,
         url = url,
-        visibility = visibility.toVisibility(),
+        visibility =
+            visibility.toVisibility().let { visibility ->
+                when {
+                    visibility == Visibility.Unlisted && localOnly -> Visibility.LocalUnlisted
+                    visibility == Visibility.Public && localOnly -> Visibility.LocalPublic
+
+                    else -> {
+                        visibility
+                    }
+                }
+            },
     )
 
 private fun StatusMention.toModel() =
@@ -219,7 +230,9 @@ internal fun Visibility.toDto(): String =
         Visibility.Direct -> ContentVisibility.DIRECT
         Visibility.Private -> ContentVisibility.PRIVATE
         Visibility.Public -> ContentVisibility.PUBLIC
+        Visibility.LocalPublic -> ContentVisibility.PUBLIC
         Visibility.Unlisted -> ContentVisibility.UNLISTED
+        Visibility.LocalUnlisted -> ContentVisibility.UNLISTED
         is Visibility.Circle -> id.orEmpty()
     }
 

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepositoryTest.kt
@@ -49,6 +49,7 @@ class DefaultSupportedFeatureRepositoryTest {
             assertTrue(res.supportsAnnouncements)
             assertFalse(res.supportsDislike)
             assertTrue(res.supportsTranslation)
+            assertFalse(res.supportsLocalVisibility)
             verifySuspend {
                 nodeInfoRepository.getInfo()
             }
@@ -57,7 +58,11 @@ class DefaultSupportedFeatureRepositoryTest {
     @Test
     fun `given Friendica when refresh then result is as expected`() =
         runTest {
-            everySuspend { nodeInfoRepository.getInfo() } returns NodeInfoModel(version = "2.8.0 (compatible; Friendica 2024.09)")
+            everySuspend { nodeInfoRepository.getInfo() } returns
+                NodeInfoModel(
+                    version = "2.8.0 (compatible; Friendica 2024.09)",
+                    software = "friendica",
+                )
             sut.refresh()
             val res = sut.features.value
 
@@ -74,6 +79,7 @@ class DefaultSupportedFeatureRepositoryTest {
             assertFalse(res.supportsAnnouncements)
             assertTrue(res.supportsDislike)
             assertFalse(res.supportsTranslation)
+            assertFalse(res.supportsLocalVisibility)
             verifySuspend {
                 nodeInfoRepository.getInfo()
             }
@@ -82,7 +88,11 @@ class DefaultSupportedFeatureRepositoryTest {
     @Test
     fun `given Friendica RC when refresh then result is as expected`() =
         runTest {
-            everySuspend { nodeInfoRepository.getInfo() } returns NodeInfoModel(version = "2.8.0 (compatible; Friendica 2024.09-rc)")
+            everySuspend { nodeInfoRepository.getInfo() } returns
+                NodeInfoModel(
+                    version = "2.8.0 (compatible; Friendica 2024.09-rc)",
+                    software = "friendica",
+                )
             sut.refresh()
             val res = sut.features.value
 
@@ -99,6 +109,37 @@ class DefaultSupportedFeatureRepositoryTest {
             assertFalse(res.supportsAnnouncements)
             assertTrue(res.supportsDislike)
             assertFalse(res.supportsTranslation)
+            assertFalse(res.supportsLocalVisibility)
+            verifySuspend {
+                nodeInfoRepository.getInfo()
+            }
+        }
+
+    @Test
+    fun `given GoToSocial when refresh then result is as expected`() =
+        runTest {
+            everySuspend { nodeInfoRepository.getInfo() } returns
+                NodeInfoModel(
+                    version = "0.18.2-SNAPSHOT+git-4686217",
+                    software = "gotosocial",
+                )
+            sut.refresh()
+            val res = sut.features.value
+
+            assertFalse(res.supportsPhotoGallery)
+            assertFalse(res.supportsDirectMessages)
+            assertFalse(res.supportsEntryTitles)
+            assertFalse(res.supportsCustomCircles)
+            assertTrue(res.supportReportCategoryRuleViolation)
+            assertTrue(res.supportsPolls)
+            assertFalse(res.supportsBBCode)
+            assertTrue(res.supportsMarkdown)
+            assertFalse(res.supportsEntryShare)
+            assertFalse(res.supportsCalendar)
+            assertTrue(res.supportsAnnouncements)
+            assertFalse(res.supportsDislike)
+            assertTrue(res.supportsTranslation)
+            assertTrue(res.supportsLocalVisibility)
             verifySuspend {
                 nodeInfoRepository.getInfo()
             }

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
@@ -132,7 +132,13 @@ class ComposerViewModel(
                             availableVisibilities =
                                 buildList {
                                     this += Visibility.Public
+                                    if (features.supportsLocalVisibility) {
+                                        this += Visibility.LocalPublic
+                                    }
                                     this += Visibility.Unlisted
+                                    if (features.supportsLocalVisibility) {
+                                        this += Visibility.LocalUnlisted
+                                    }
                                     this += Visibility.Private
                                     this += Visibility.Direct
                                     if (features.supportsCustomCircles && circles.isNotEmpty()) {
@@ -156,15 +162,18 @@ class ComposerViewModel(
             val parentId = inReplyToId.takeIf { it.isNotEmpty() }
             val parent = parentId?.let { e -> entryCache.get(e) }
             val initialVisibility =
-                if (parentId != null) {
-                    currentSettings
-                        ?.defaultReplyVisibility
-                        ?.toVisibility()
-                        // make sure to have a visibility less than or equal to the parent
-                        ?.takeIf { it <= (parent?.visibility ?: Visibility.Unlisted) }
-                        ?: parent?.visibility
-                } else {
-                    currentSettings?.defaultPostVisibility?.toVisibility()
+                when {
+                    editedPostId != null -> uiState.value.visibility
+
+                    parentId != null ->
+                        currentSettings
+                            ?.defaultReplyVisibility
+                            ?.toVisibility()
+                            // make sure to have a visibility less than or equal to the parent
+                            ?.takeIf { it <= (parent?.visibility ?: Visibility.Unlisted) }
+                            ?: parent?.visibility
+
+                    else -> currentSettings?.defaultPostVisibility?.toVisibility()
                 } ?: Visibility.Unlisted
 
             updateState {


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds the support for `local-public` and `local-unlisted` visibility options available in GoToSocial and Hometown. Selecting one of these options will result in posts having the `local_only` flag set to `true`.

The visibility options should be shown if available, sent to server upon creation and retained when posts are edited.

## Additional notes
The way the app determined the backend type was not scalable beyond Friendica and Mastodon until now, and did not allow to distinguish Mastodon forks like these ones.

The only reliable way to determine the backend type is by using the [well-known nodeinfo protocol](https://github.com/jhass/nodeinfo/blob/main/PROTOCOL.md) which should be supported among all Fediverse platforms.

The implementation here is intendedly simplistic and does not attempt to parse the JSON according to the provided schema in the links response, because `data["server"]["name"]` should be enough for what we need currently.
