### PR TITLE
fix: avoid displaying recover page in profile

### DIFF
--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/di/ProfileModule.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/di/ProfileModule.kt
@@ -41,7 +41,6 @@ val profileModule =
                     paginationManager = instance(),
                     timelineEntryRepository = instance(),
                     settingsRepository = instance(),
-                    apiConfigurationRepository = instance(),
                     hapticFeedback = instance(),
                     imagePreloadManager = instance(),
                     blurHashRepository = instance(),


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR simplifies the profile logged screen to avoid showing the recovery screen when it is not actually needed. The bug was originally reported on Friendica.
