### PR TITLE
enhancement: better phrasing for draft mode and confirm exit dialog

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -64,7 +64,7 @@
     <string name="action_report_user">Denunciar usuario</string>
     <string name="action_reveal_content">Mostrar contenido</string>
     <string name="action_save">Guardar</string>
-    <string name="action_save_draft">Guardar borrador</string>
+    <string name="action_save_draft">Modo borrador</string>
     <string name="action_save_to_calendar">Guardar en el calendario</string>
     <string name="action_search">Buscar en</string>
     <string name="action_select">Seleccionar valor</string>

--- a/composeApp/src/commonMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-fr/strings.xml
@@ -64,7 +64,7 @@
     <string name="action_report_user">Signaler utilisateur</string>
     <string name="action_reveal_content">Révéler le contenu</string>
     <string name="action_save">Sauvegarder</string>
-    <string name="action_save_draft">Enregistrer le brouillon</string>
+    <string name="action_save_draft">Mode brouillon</string>
     <string name="action_save_to_calendar">Enregistrer dans le calendrier</string>
     <string name="action_search">Rechercher</string>
     <string name="action_select">Sélectionner la valeur</string>

--- a/composeApp/src/commonMain/composeResources/values-it/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-it/strings.xml
@@ -64,7 +64,7 @@
     <string name="action_report_user">Segnala utente</string>
     <string name="action_reveal_content">Rivela contenuto</string>
     <string name="action_save">Salva</string>
-    <string name="action_save_draft">Salva bozza</string>
+    <string name="action_save_draft">Modalità bozza</string>
     <string name="action_save_to_calendar">Salva su calendario</string>
     <string name="action_search">Cerca</string>
     <string name="action_select">Seleziona valore</string>
@@ -95,6 +95,7 @@
     <string name="button_cancel">Annulla</string>
     <string name="button_close">Chiudi</string>
     <string name="button_confirm">Conferma</string>
+    <string name="button_discard">Scarta</string>
     <string name="button_load">Carica</string>
     <string name="button_load_more_replies">Carica altre risposte</string>
     <string name="button_login">Login</string>
@@ -384,6 +385,7 @@
     <string name="unpublished_title">Non pubblicati</string>
     <string name="unread_notification_title">Controlla le notifiche!</string>
     <string name="unsaved_changes_title">Modifiche non salvate</string>
+    <string name="unsaved_draft_title">Bozza non salvata</string>
     <string name="update_date">data aggiornamento</string>
     <string name="url_opening_mode_custom_tabs">Schede personalizzate</string>
     <string name="url_opening_mode_external">Browser esterno</string>

--- a/composeApp/src/commonMain/composeResources/values-pt/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pt/strings.xml
@@ -64,7 +64,7 @@
     <string name="action_report_user">Denunciar utilizador</string>
     <string name="action_reveal_content">Revelar conteúdo</string>
     <string name="action_save">Guardar</string>
-    <string name="action_save_draft">Guardar rascunho</string>
+    <string name="action_save_draft">Modo rascunho</string>
     <string name="action_save_to_calendar">Guardar no calendário</string>
     <string name="action_search">Pesquisar</string>
     <string name="action_select">Selecionar valor</string>

--- a/composeApp/src/commonMain/composeResources/values-ro/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ro/strings.xml
@@ -147,7 +147,7 @@
     <string name="action_reject">Respinge</string>
     <string name="action_reveal_content">Arată conținutul</string>
     <string name="action_save">Salvează</string>
-    <string name="action_save_draft">Salvează schiță</string>
+    <string name="action_save_draft">Mod schiță</string>
     <string name="action_search">Caută</string>
     <string name="action_select">Selectează valoare</string>
     <string name="action_switch_account">Schimbă contul</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -71,7 +71,7 @@
     <string name="action_report_user">Report user</string>
     <string name="action_reveal_content">Reveal content</string>
     <string name="action_save">Save</string>
-    <string name="action_save_draft">Save draft</string>
+    <string name="action_save_draft">Draft mode</string>
     <string name="action_save_to_calendar">Save to calendar</string>
     <string name="action_search">Search</string>
     <string name="action_select">Select value</string>
@@ -102,6 +102,7 @@
     <string name="button_cancel">Cancel</string>
     <string name="button_close">Close</string>
     <string name="button_confirm">Confirm</string>
+    <string name="button_discard">Discard</string>
     <string name="button_load">Load</string>
     <string name="button_load_more_replies">Load more replies</string>
     <string name="button_login">Login</string>
@@ -408,6 +409,7 @@
     <string name="unpublished_title">Unpublished items</string>
     <string name="unread_notification_title">Check your notifications!</string>
     <string name="unsaved_changes_title">Unsaved changes</string>
+    <string name="unsaved_draft_title">Unsaved draft</string>
     <string name="update_date">update date</string>
     <string name="url_opening_mode_custom_tabs">Custom tabs</string>
     <string name="url_opening_mode_external">External browser</string>

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/resources/SharedStrings.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/resources/SharedStrings.kt
@@ -114,6 +114,7 @@ import raccoonforfriendica.composeapp.generated.resources.bookmarks_title
 import raccoonforfriendica.composeapp.generated.resources.button_cancel
 import raccoonforfriendica.composeapp.generated.resources.button_close
 import raccoonforfriendica.composeapp.generated.resources.button_confirm
+import raccoonforfriendica.composeapp.generated.resources.button_discard
 import raccoonforfriendica.composeapp.generated.resources.button_load
 import raccoonforfriendica.composeapp.generated.resources.button_load_more_replies
 import raccoonforfriendica.composeapp.generated.resources.button_login
@@ -446,6 +447,7 @@ import raccoonforfriendica.composeapp.generated.resources.unread_messages
 import raccoonforfriendica.composeapp.generated.resources.unread_notification_body
 import raccoonforfriendica.composeapp.generated.resources.unread_notification_title
 import raccoonforfriendica.composeapp.generated.resources.unsaved_changes_title
+import raccoonforfriendica.composeapp.generated.resources.unsaved_draft_title
 import raccoonforfriendica.composeapp.generated.resources.update_date
 import raccoonforfriendica.composeapp.generated.resources.url_opening_mode_custom_tabs
 import raccoonforfriendica.composeapp.generated.resources.url_opening_mode_external
@@ -668,6 +670,8 @@ class SharedStrings : Strings {
         @Composable get() = stringResource(Res.string.button_close)
     override val buttonConfirm: String
         @Composable get() = stringResource(Res.string.button_confirm)
+    override val buttonDiscard: String
+        @Composable get() = stringResource(Res.string.button_discard)
     override val buttonLoad: String
         @Composable get() = stringResource(Res.string.button_load)
     override val buttonLoadMoreReplies: String
@@ -1308,6 +1312,8 @@ class SharedStrings : Strings {
         @Composable get() = stringResource(Res.string.unpublished_title)
     override val unsavedChangesTitle: String
         @Composable get() = stringResource(Res.string.unsaved_changes_title)
+    override val unsavedDraftTitle: String
+        @Composable get() = stringResource(Res.string.unsaved_draft_title)
     override val updateDate: String
         @Composable get() = stringResource(Res.string.update_date)
     override val urlOpeningModeCustomTabs: String

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/Strings.kt
@@ -106,6 +106,7 @@ interface Strings {
     val buttonCancel: String @Composable get
     val buttonClose: String @Composable get
     val buttonConfirm: String @Composable get
+    val buttonDiscard: String @Composable get
     val buttonLoad: String @Composable get
     val buttonLoadMoreReplies: String @Composable get
     val buttonLogin: String @Composable get
@@ -426,6 +427,7 @@ interface Strings {
     val unpublishedSectionScheduled: String @Composable get
     val unpublishedTitle: String @Composable get
     val unsavedChangesTitle: String @Composable get
+    val unsavedDraftTitle: String @Composable get
     val updateDate: String @Composable get
     val urlOpeningModeCustomTabs: String @Composable get
     val urlOpeningModeExternal: String @Composable get

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/testutils/MockStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/testutils/MockStrings.kt
@@ -219,6 +219,8 @@ class MockStrings : Strings {
         @Composable get() = retrieve("buttonClose")
     override val buttonConfirm: String
         @Composable get() = retrieve("buttonConfirm")
+    override val buttonDiscard: String
+        @Composable get() = retrieve("buttonDiscard")
     override val buttonLoad: String
         @Composable get() = retrieve("buttonLoad")
     override val buttonLoadMoreReplies: String
@@ -859,6 +861,8 @@ class MockStrings : Strings {
         @Composable get() = retrieve("unpublishedTitle")
     override val unsavedChangesTitle: String
         @Composable get() = retrieve("unsavedChangesTitle")
+    override val unsavedDraftTitle: String
+        @Composable get() = retrieve("unsavedDraftTitle")
     override val updateDate: String
         @Composable get() = retrieve("updateDate")
     override val urlOpeningModeCustomTabs: String

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
@@ -1031,8 +1031,19 @@ class ComposerScreen(
 
         if (confirmBackWithUnsavedChangesDialogOpen) {
             CustomConfirmDialog(
-                title = LocalStrings.current.unsavedChangesTitle,
+                title =
+                    if (uiState.publicationType == PublicationType.Draft) {
+                        LocalStrings.current.unsavedDraftTitle
+                    } else {
+                        LocalStrings.current.unsavedChangesTitle
+                    },
                 body = LocalStrings.current.messageAreYouSureExit,
+                confirmButtonLabel =
+                    if (uiState.publicationType == PublicationType.Draft) {
+                        LocalStrings.current.buttonDiscard
+                    } else {
+                        LocalStrings.current.buttonConfirm
+                    },
                 onClose = { confirm ->
                     confirmBackWithUnsavedChangesDialogOpen = false
                     if (confirm) {


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR changes the draft action label in the composer screen and the confirm dialog title and positive button (when exiting with unsaved changes) to make sure it is clear that you are editing a draft and if you exit without saving it you are discarding all changes.

As a consequence:
- the action is renamed to "draft mode" to avoid confusion (changing the mode is not actually saving anything);
- the dialog title is changed from "Unsaved changes" to "Unsaved draft" in draft mode;
- the dialog positive button is changed from "Confirm" to "Discard" in draft mode.

--- 
Original report: [here](https://poliverso.org/display/0477a01e-1667-c41f-0790-919425214633)
