### PR TITLE
feat: add possibility to open posts in browser

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -50,6 +50,7 @@
     <string name="action_open_detail">Open detail</string>
     <string name="action_open_full_screen">Open full screen</string>
     <string name="action_open_link">Open link</string>
+    <string name="action_open_in_browser">Open in browser</string>
     <string name="action_open_options">Options</string>
     <string name="action_open_preview">Open preview</string>
     <string name="action_open_settings">Open settings</string>

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/resources/SharedStrings.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/resources/SharedStrings.kt
@@ -58,6 +58,7 @@ import raccoonforfriendica.composeapp.generated.resources.action_mute
 import raccoonforfriendica.composeapp.generated.resources.action_mute_notifications
 import raccoonforfriendica.composeapp.generated.resources.action_open_detail
 import raccoonforfriendica.composeapp.generated.resources.action_open_full_screen
+import raccoonforfriendica.composeapp.generated.resources.action_open_in_browser
 import raccoonforfriendica.composeapp.generated.resources.action_open_link
 import raccoonforfriendica.composeapp.generated.resources.action_open_options
 import raccoonforfriendica.composeapp.generated.resources.action_open_preview
@@ -564,6 +565,8 @@ class SharedStrings : Strings {
         @Composable get() = stringResource(Res.string.action_open_full_screen)
     override val actionOpenLink: String
         @Composable get() = stringResource(Res.string.action_open_link)
+    override val actionOpenInBrowser: String
+        @Composable get() = stringResource(Res.string.action_open_in_browser)
     override val actionOpenOptions: String
         @Composable get() = stringResource(Res.string.action_open_options)
     override val actionOpenPreview: String

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/Options.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/Options.kt
@@ -40,6 +40,8 @@ sealed interface OptionId {
 
     data object AddShortcut : OptionId
 
+    data object OpenInBrowser : OptionId
+
     interface Custom : OptionId
 }
 
@@ -62,6 +64,7 @@ private fun OptionId.toReadableName(): String =
         OptionId.ViewDetails -> LocalStrings.current.actionViewDetails
         OptionId.Quote -> LocalStrings.current.actionQuote
         OptionId.CopyToClipboard -> LocalStrings.current.actionCopyToClipboard
+        OptionId.OpenInBrowser -> LocalStrings.current.actionOpenInBrowser
         else -> ""
     }
 

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/Strings.kt
@@ -53,6 +53,7 @@ interface Strings {
     val actionOpenDetail: String @Composable get
     val actionOpenFullScreen: String @Composable get
     val actionOpenLink: String @Composable get
+    val actionOpenInBrowser: String @Composable get
     val actionOpenOptions: String @Composable get
     val actionOpenPreview: String @Composable get
     val actionOpenSettings: String @Composable get

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/testutils/MockStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/testutils/MockStrings.kt
@@ -113,6 +113,8 @@ class MockStrings : Strings {
         @Composable get() = retrieve("actionOpenFullScreen")
     override val actionOpenLink: String
         @Composable get() = retrieve("actionOpenLink")
+    override val actionOpenInBrowser: String
+        @Composable get() = retrieve("actionOpenInBrowser")
     override val actionOpenOptions: String
         @Composable get() = retrieve("actionOpenOptions")
     override val actionOpenPreview: String

--- a/domain/content/usecase/build.gradle.kts
+++ b/domain/content/usecase/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin {
                 implementation(projects.domain.content.data)
                 implementation(projects.domain.content.repository)
                 implementation(projects.domain.identity.data)
+                implementation(projects.domain.identity.repository)
             }
         }
     }

--- a/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/DefaultGetInnerUrlUseCase.kt
+++ b/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/DefaultGetInnerUrlUseCase.kt
@@ -1,0 +1,21 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.usecase
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
+
+internal class DefaultGetInnerUrlUseCase(
+    private val apiConfigurationRepository: ApiConfigurationRepository,
+) : GetInnerUrlUseCase {
+    override suspend fun invoke(entry: TimelineEntryModel): String? {
+        val baseUrl =
+            apiConfigurationRepository.node.value.takeIf { it.isNotEmpty() } ?: return null
+        return buildString {
+            append("https://")
+            append(baseUrl)
+            append("/search?q=${entry.url}")
+            append("&type=statuses")
+            append("&resolve=true")
+            append("&limit=1")
+        }
+    }
+}

--- a/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/GetInnerUrlUseCase.kt
+++ b/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/GetInnerUrlUseCase.kt
@@ -1,0 +1,7 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.usecase
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+
+interface GetInnerUrlUseCase {
+    suspend operator fun invoke(entry: TimelineEntryModel): String?
+}

--- a/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/di/ContentUseCaseModule.kt
+++ b/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/di/ContentUseCaseModule.kt
@@ -1,12 +1,14 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.di
 
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.DefaultExportUserListUseCase
+import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.DefaultGetInnerUrlUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.DefaultGetTranslationUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.DefaultPopulateThreadUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.DefaultStripMarkupUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.DefaultToggleEntryDislikeUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.DefaultToggleEntryFavoriteUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.ExportUserListUseCase
+import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.GetInnerUrlUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.GetTranslationUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.PopulateThreadUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.StripMarkupUseCase
@@ -73,6 +75,13 @@ val contentUseCaseModule =
                 DefaultPopulateThreadUseCase(
                     timelineEntryRepository = instance(),
                     emojiHelper = instance(),
+                )
+            }
+        }
+        bind<GetInnerUrlUseCase> {
+            singleton {
+                DefaultGetInnerUrlUseCase(
+                    apiConfigurationRepository = instance(),
                 )
             }
         }

--- a/domain/content/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/DefaultGetInnerUrlUseCaseTest.kt
+++ b/domain/content/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/DefaultGetInnerUrlUseCaseTest.kt
@@ -1,0 +1,59 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.usecase
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class DefaultGetInnerUrlUseCaseTest {
+    private val apiConfigurationRepository = mock<ApiConfigurationRepository>()
+    private val sut =
+        DefaultGetInnerUrlUseCase(
+            apiConfigurationRepository = apiConfigurationRepository,
+        )
+
+    @Test
+    fun `given base url when invoked then result is as expected`() =
+        runTest {
+            every {
+                apiConfigurationRepository.node
+            } returns mock { every { value } returns FAKE_INSTANCE }
+            val entry = TimelineEntryModel(id = "0", url = FAKE_ENTRY_URL, content = "")
+
+            val res = sut(entry)
+
+            assertEquals(
+                buildString {
+                    append("https://$FAKE_INSTANCE/search?q=")
+                    append(FAKE_ENTRY_URL)
+                    append("&type=statuses")
+                    append("&resolve=true")
+                    append("&limit=1")
+                },
+                res,
+            )
+        }
+
+    @Test
+    fun `given base url not present when invoked then result is as expected`() =
+        runTest {
+            every {
+                apiConfigurationRepository.node
+            } returns mock { every { value } returns "" }
+            val entry = TimelineEntryModel(id = "0", url = FAKE_ENTRY_URL, content = "")
+
+            val res = sut(entry)
+
+            assertNull(res)
+        }
+
+    companion object {
+        private const val FAKE_INSTANCE = "example.com"
+        private const val FAKE_ENTRY_URL = "https://other.com/@someone/124072605638855217"
+    }
+}

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/di/CirclesModule.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/di/CirclesModule.kt
@@ -56,6 +56,7 @@ val circlesModule =
                     toggleEntryFavorite = instance(),
                     toggleEntryDislike = instance(),
                     getTranslation = instance(),
+                    getInnerUrl = instance(),
                     timelineNavigationManager = instance(),
                     notificationCenter = instance(),
                 )

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineMviModel.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineMviModel.kt
@@ -72,6 +72,10 @@ interface CircleTimelineMviModel :
         data class AddInstanceShortcut(
             val node: String,
         ) : Intent
+
+        data class OpenInBrowser(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -103,6 +107,10 @@ interface CircleTimelineMviModel :
 
         data class OpenDetail(
             val entry: TimelineEntryModel,
+        ) : Effect
+
+        data class OpenUrl(
+            val url: String,
         ) : Effect
     }
 }

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineScreen.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineScreen.kt
@@ -130,6 +130,9 @@ class CircleTimelineScreen(
                                 swipeNavigationEnabled = true,
                             )
                         }
+
+                        is CircleTimelineMviModel.Effect.OpenUrl ->
+                            uriHandler.openExternally(event.url)
                     }
                 }.launchIn(this)
         }
@@ -369,6 +372,7 @@ class CircleTimelineScreen(
                                                 LocalStrings.current.actionShortcut(nodeName),
                                             )
                                     }
+                                    this += OptionId.OpenInBrowser.toOption()
                                 },
                             onOptionSelected = { optionId ->
                                 when (optionId) {
@@ -445,6 +449,12 @@ class CircleTimelineScreen(
                                                 entry.nodeName,
                                             ),
                                         )
+
+                                    OptionId.OpenInBrowser ->
+                                        model.reduce(
+                                            CircleTimelineMviModel.Intent.OpenInBrowser(entry),
+                                        )
+
                                     else -> Unit
                                 }
                             },

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineViewModel.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineViewModel.kt
@@ -23,6 +23,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.Timel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.LocalItemCache
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.GetInnerUrlUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.GetTranslationUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.ToggleEntryDislikeUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.ToggleEntryFavoriteUseCase
@@ -56,6 +57,7 @@ class CircleTimelineViewModel(
     private val toggleEntryDislike: ToggleEntryDislikeUseCase,
     private val toggleEntryFavorite: ToggleEntryFavoriteUseCase,
     private val getTranslation: GetTranslationUseCase,
+    private val getInnerUrl: GetInnerUrlUseCase,
     private val timelineNavigationManager: TimelineNavigationManager,
     private val notificationCenter: NotificationCenter = getNotificationCenter(),
 ) : DefaultMviModel<CircleTimelineMviModel.Intent, CircleTimelineMviModel.State, CircleTimelineMviModel.Effect>(
@@ -162,6 +164,7 @@ class CircleTimelineViewModel(
                     emitEffect(CircleTimelineMviModel.Effect.OpenDetail(intent.entry))
                 }
             is CircleTimelineMviModel.Intent.AddInstanceShortcut -> addInstanceShortcut(intent.node)
+            is CircleTimelineMviModel.Intent.OpenInBrowser -> openInBrowser(intent.entry)
         }
     }
 
@@ -335,7 +338,7 @@ class CircleTimelineViewModel(
             } else {
                 updateEntryInState(entry.id) {
                     it.copy(
-                        favoriteLoading = false,
+                        dislikeLoading = false,
                     )
                 }
             }
@@ -516,6 +519,15 @@ class CircleTimelineViewModel(
                     accountId = accountId,
                     node = nodeName,
                 )
+            }
+        }
+    }
+
+    private fun openInBrowser(entry: TimelineEntryModel) {
+        screenModelScope.launch {
+            val url = getInnerUrl(entry)
+            if (url != null) {
+                emitEffect(CircleTimelineMviModel.Effect.OpenUrl(url))
             }
         }
     }

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailMviModel.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailMviModel.kt
@@ -74,6 +74,10 @@ interface EntryDetailMviModel :
         data class LoadMoreReplies(
             val entry: TimelineEntryModel,
         ) : Intent
+
+        data class OpenInBrowser(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -101,6 +105,10 @@ interface EntryDetailMviModel :
 
         data class TriggerCopy(
             val text: String,
+        ) : Effect
+
+        data class OpenUrl(
+            val url: String,
         ) : Effect
     }
 }

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -158,6 +158,8 @@ class EntryDetailScreen(
                             clipboardManager.setText(AnnotatedString(event.text))
                             snackbarHostState.showSnackbar(copyToClipboardSuccess)
                         }
+
+                        is EntryDetailMviModel.Effect.OpenUrl -> uriHandler.openExternally(event.url)
                     }
                 }.launchIn(this)
         }
@@ -360,6 +362,7 @@ class EntryDetailScreen(
                                                     LocalStrings.current.actionShortcut(nodeName),
                                                 )
                                         }
+                                        this += OptionId.OpenInBrowser.toOption()
                                     }
 
                                 fun onOptionSelected(optionId: OptionId) {
@@ -442,6 +445,11 @@ class EntryDetailScreen(
                                                 EntryDetailMviModel.Intent.AddInstanceShortcut(
                                                     entry.nodeName,
                                                 ),
+                                            )
+
+                                        OptionId.OpenInBrowser ->
+                                            model.reduce(
+                                                EntryDetailMviModel.Intent.OpenInBrowser(entry),
                                             )
 
                                         else -> Unit

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailViewModel.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailViewModel.kt
@@ -23,6 +23,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Local
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.ReplyHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.GetInnerUrlUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.GetTranslationUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.PopulateThreadUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.ToggleEntryDislikeUseCase
@@ -59,6 +60,7 @@ class EntryDetailViewModel(
     private val toggleEntryFavorite: ToggleEntryFavoriteUseCase,
     private val getTranslation: GetTranslationUseCase,
     private val populateThread: PopulateThreadUseCase,
+    private val getInnerUrl: GetInnerUrlUseCase,
     private val timelineNavigationManager: TimelineNavigationManager,
     private val notificationCenter: NotificationCenter = getNotificationCenter(),
 ) : DefaultMviModel<EntryDetailMviModel.Intent, EntryDetailMviModel.State, EntryDetailMviModel.Effect>(
@@ -161,6 +163,7 @@ class EntryDetailViewModel(
             is EntryDetailMviModel.Intent.ChangeNavigationIndex ->
                 changeNavigationIndex(intent.index)
             is EntryDetailMviModel.Intent.AddInstanceShortcut -> addInstanceShortcut(intent.node)
+            is EntryDetailMviModel.Intent.OpenInBrowser -> openInBrowser(intent.entry)
         }
     }
 
@@ -489,7 +492,7 @@ class EntryDetailViewModel(
             } else {
                 updateEntryInState(entry.id) {
                     it.copy(
-                        favoriteLoading = false,
+                        dislikeLoading = false,
                     )
                 }
             }
@@ -758,6 +761,15 @@ class EntryDetailViewModel(
                         }
                     },
             )
+        }
+    }
+
+    private fun openInBrowser(entry: TimelineEntryModel) {
+        screenModelScope.launch {
+            val url = getInnerUrl(entry)
+            if (url != null) {
+                emitEffect(EntryDetailMviModel.Effect.OpenUrl(url))
+            }
         }
     }
 }

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/di/EntryDetailModule.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/di/EntryDetailModule.kt
@@ -37,6 +37,7 @@ val entryDetailModule =
                     toggleEntryFavorite = instance(),
                     toggleEntryDislike = instance(),
                     getTranslation = instance(),
+                    getInnerUrl = instance(),
                     timelineNavigationManager = instance(),
                     notificationCenter = instance(),
                 )

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreMviModel.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreMviModel.kt
@@ -82,6 +82,10 @@ interface ExploreMviModel :
         data class AddInstanceShortcut(
             val node: String,
         ) : Intent
+
+        data class OpenInBrowser(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -109,6 +113,10 @@ interface ExploreMviModel :
 
         data class TriggerCopy(
             val text: String,
+        ) : Effect
+
+        data class OpenUrl(
+            val url: String,
         ) : Effect
     }
 }

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
@@ -135,6 +135,8 @@ class ExploreScreen : Screen {
                             clipboardManager.setText(AnnotatedString(event.text))
                             snackbarHostState.showSnackbar(copyToClipboardSuccess)
                         }
+
+                        is ExploreMviModel.Effect.OpenUrl -> uriHandler.openExternally(event.url)
                     }
                 }.launchIn(this)
         }
@@ -440,6 +442,7 @@ class ExploreScreen : Screen {
                                                         LocalStrings.current.actionShortcut(nodeName),
                                                     )
                                             }
+                                            this += OptionId.OpenInBrowser.toOption()
                                         },
                                     onOptionSelected = { optionId ->
                                         when (optionId) {
@@ -509,12 +512,19 @@ class ExploreScreen : Screen {
                                                         item.entry.original,
                                                     ),
                                                 )
+
                                             OptionId.AddShortcut ->
                                                 model.reduce(
                                                     ExploreMviModel.Intent.AddInstanceShortcut(
                                                         item.entry.nodeName,
                                                     ),
                                                 )
+
+                                            OptionId.OpenInBrowser ->
+                                                model.reduce(
+                                                    ExploreMviModel.Intent.OpenInBrowser(item.entry),
+                                                )
+
                                             else -> Unit
                                         }
                                     },

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreViewModel.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreViewModel.kt
@@ -24,6 +24,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.Explo
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.ExplorePaginationSpecification
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.GetInnerUrlUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.GetTranslationUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.ToggleEntryDislikeUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.ToggleEntryFavoriteUseCase
@@ -55,6 +56,7 @@ class ExploreViewModel(
     private val toggleEntryDislike: ToggleEntryDislikeUseCase,
     private val toggleEntryFavorite: ToggleEntryFavoriteUseCase,
     private val getTranslation: GetTranslationUseCase,
+    private val getInnerUrl: GetInnerUrlUseCase,
     private val notificationCenter: NotificationCenter = getNotificationCenter(),
 ) : DefaultMviModel<ExploreMviModel.Intent, ExploreMviModel.State, ExploreMviModel.Effect>(
         initialState = ExploreMviModel.State(),
@@ -171,6 +173,7 @@ class ExploreViewModel(
             is ExploreMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
             is ExploreMviModel.Intent.ToggleTranslation -> toggleTranslation(intent.entry)
             is ExploreMviModel.Intent.AddInstanceShortcut -> addInstanceShortcut(intent.node)
+            is ExploreMviModel.Intent.OpenInBrowser -> openInBrowser(intent.entry)
         }
     }
 
@@ -434,7 +437,7 @@ class ExploreViewModel(
             } else {
                 updateEntryInState(entry.id) {
                     it.copy(
-                        favoriteLoading = false,
+                        dislikeLoading = false,
                     )
                 }
             }
@@ -615,6 +618,15 @@ class ExploreViewModel(
                     accountId = accountId,
                     node = nodeName,
                 )
+            }
+        }
+    }
+
+    private fun openInBrowser(entry: TimelineEntryModel) {
+        screenModelScope.launch {
+            val url = getInnerUrl(entry)
+            if (url != null) {
+                emitEffect(ExploreMviModel.Effect.OpenUrl(url))
             }
         }
     }

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/di/ExploreModule.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/di/ExploreModule.kt
@@ -27,6 +27,7 @@ val exploreModule =
                     toggleEntryFavorite = instance(),
                     toggleEntryDislike = instance(),
                     getTranslation = instance(),
+                    getInnerUrl = instance(),
                     notificationCenter = instance(),
                 )
             }

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesMviModel.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesMviModel.kt
@@ -72,6 +72,10 @@ interface FavoritesMviModel :
         data class AddInstanceShortcut(
             val node: String,
         ) : Intent
+
+        data class OpenInBrowser(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -101,6 +105,10 @@ interface FavoritesMviModel :
 
         data class OpenDetail(
             val entry: TimelineEntryModel,
+        ) : Effect
+
+        data class OpenUrl(
+            val url: String,
         ) : Effect
     }
 }

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
@@ -129,6 +129,8 @@ class FavoritesScreen(
                                 swipeNavigationEnabled = true,
                             )
                         }
+
+                        is FavoritesMviModel.Effect.OpenUrl -> uriHandler.openExternally(event.url)
                     }
                 }.launchIn(this)
         }
@@ -355,6 +357,7 @@ class FavoritesScreen(
                                                 LocalStrings.current.actionShortcut(nodeName),
                                             )
                                     }
+                                    this += OptionId.OpenInBrowser.toOption()
                                 },
                             onOptionSelected = { optionId ->
                                 when (optionId) {
@@ -424,6 +427,12 @@ class FavoritesScreen(
                                         model.reduce(
                                             FavoritesMviModel.Intent.AddInstanceShortcut(entry.nodeName),
                                         )
+
+                                    OptionId.OpenInBrowser ->
+                                        model.reduce(
+                                            FavoritesMviModel.Intent.OpenInBrowser(entry),
+                                        )
+
                                     else -> Unit
                                 }
                             },

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesViewModel.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesViewModel.kt
@@ -13,7 +13,6 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate.HapticFeedba
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.FavoritesType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.blurHashParamsForPreload
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.nodeName
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.urlsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelineNavigationManager
@@ -21,6 +20,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.Timel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.TimelinePaginationSpecification
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.GetInnerUrlUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.GetTranslationUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.ToggleEntryDislikeUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.ToggleEntryFavoriteUseCase
@@ -52,6 +52,7 @@ class FavoritesViewModel(
     private val toggleEntryDislike: ToggleEntryDislikeUseCase,
     private val toggleEntryFavorite: ToggleEntryFavoriteUseCase,
     private val getTranslation: GetTranslationUseCase,
+    private val getInnerUrl: GetInnerUrlUseCase,
     private val timelineNavigationManager: TimelineNavigationManager,
     private val notificationCenter: NotificationCenter = getNotificationCenter(),
 ) : DefaultMviModel<FavoritesMviModel.Intent, FavoritesMviModel.State, FavoritesMviModel.Effect>(
@@ -145,6 +146,7 @@ class FavoritesViewModel(
                     emitEffect(FavoritesMviModel.Effect.OpenDetail(intent.entry))
                 }
             is FavoritesMviModel.Intent.AddInstanceShortcut -> addInstanceShortcut(intent.node)
+            is FavoritesMviModel.Intent.OpenInBrowser -> openInBrowser(intent.entry)
         }
     }
 
@@ -317,7 +319,7 @@ class FavoritesViewModel(
             } else {
                 updateEntryInState(entry.id) {
                     it.copy(
-                        favoriteLoading = false,
+                        dislikeLoading = false,
                     )
                 }
             }
@@ -502,6 +504,15 @@ class FavoritesViewModel(
                     accountId = accountId,
                     node = nodeName,
                 )
+            }
+        }
+    }
+
+    private fun openInBrowser(entry: TimelineEntryModel) {
+        screenModelScope.launch {
+            val url = getInnerUrl(entry)
+            if (url != null) {
+                emitEffect(FavoritesMviModel.Effect.OpenUrl(url))
             }
         }
     }

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/di/FavoritesModule.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/di/FavoritesModule.kt
@@ -29,6 +29,7 @@ val favoritesModule =
                     toggleEntryFavorite = instance(),
                     toggleEntryDislike = instance(),
                     getTranslation = instance(),
+                    getInnerUrl = instance(),
                     timelineNavigationManager = instance(),
                     notificationCenter = instance(),
                 )

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/di/HashtagModule.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/di/HashtagModule.kt
@@ -44,6 +44,7 @@ val hashtagModule =
                     toggleEntryFavorite = instance(),
                     toggleEntryDislike = instance(),
                     getTranslation = instance(),
+                    getInnerUrl = instance(),
                     timelineNavigationManager = instance(),
                     notificationCenter = instance(),
                 )

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagMviModel.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagMviModel.kt
@@ -76,6 +76,10 @@ interface HashtagMviModel :
         data class AddInstanceShortcut(
             val node: String,
         ) : Intent
+
+        data class OpenInBrowser(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -105,6 +109,10 @@ interface HashtagMviModel :
 
         data class OpenDetail(
             val entry: TimelineEntryModel,
+        ) : Effect
+
+        data class OpenUrl(
+            val url: String,
         ) : Effect
     }
 }

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
@@ -132,6 +132,8 @@ class HashtagScreen(
                                 swipeNavigationEnabled = true,
                             )
                         }
+
+                        is HashtagMviModel.Effect.OpenUrl -> uriHandler.openExternally(event.url)
                     }
                 }.launchIn(this)
         }
@@ -377,6 +379,7 @@ class HashtagScreen(
                                                 LocalStrings.current.actionShortcut(nodeName),
                                             )
                                     }
+                                    this += OptionId.OpenInBrowser.toOption()
                                 },
                             onOptionSelected = { optionId ->
                                 when (optionId) {
@@ -444,6 +447,12 @@ class HashtagScreen(
                                         model.reduce(
                                             HashtagMviModel.Intent.AddInstanceShortcut(entry.nodeName),
                                         )
+
+                                    OptionId.OpenInBrowser ->
+                                        model.reduce(
+                                            HashtagMviModel.Intent.OpenInBrowser(entry),
+                                        )
+
                                     else -> Unit
                                 }
                             },

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagViewModel.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagViewModel.kt
@@ -22,6 +22,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.Timel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TagRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.GetInnerUrlUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.GetTranslationUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.ToggleEntryDislikeUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.ToggleEntryFavoriteUseCase
@@ -54,6 +55,7 @@ class HashtagViewModel(
     private val toggleEntryDislike: ToggleEntryDislikeUseCase,
     private val toggleEntryFavorite: ToggleEntryFavoriteUseCase,
     private val getTranslation: GetTranslationUseCase,
+    private val getInnerUrl: GetInnerUrlUseCase,
     private val timelineNavigationManager: TimelineNavigationManager,
     private val notificationCenter: NotificationCenter = getNotificationCenter(),
 ) : DefaultMviModel<HashtagMviModel.Intent, HashtagMviModel.State, HashtagMviModel.Effect>(
@@ -162,6 +164,7 @@ class HashtagViewModel(
                     emitEffect(HashtagMviModel.Effect.OpenDetail(intent.entry))
                 }
             is HashtagMviModel.Intent.AddInstanceShortcut -> addInstanceShortcut(intent.node)
+            is HashtagMviModel.Intent.OpenInBrowser -> openInBrowser(intent.entry)
         }
     }
 
@@ -324,7 +327,7 @@ class HashtagViewModel(
             } else {
                 updateEntryInState(entry.id) {
                     it.copy(
-                        favoriteLoading = false,
+                        dislikeLoading = false,
                     )
                 }
             }
@@ -522,6 +525,15 @@ class HashtagViewModel(
                     accountId = accountId,
                     node = nodeName,
                 )
+            }
+        }
+    }
+
+    private fun openInBrowser(entry: TimelineEntryModel) {
+        screenModelScope.launch {
+            val url = getInnerUrl(entry)
+            if (url != null) {
+                emitEffect(HashtagMviModel.Effect.OpenUrl(url))
             }
         }
     }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/di/ProfileModule.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/di/ProfileModule.kt
@@ -50,6 +50,7 @@ val profileModule =
                     logout = instance(),
                     toggleEntryFavorite = instance(),
                     toggleEntryDislike = instance(),
+                    getInnerUrl = instance(),
                     notificationCenter = instance(),
                 )
             }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountMviModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountMviModel.kt
@@ -50,6 +50,10 @@ interface MyAccountMviModel :
         ) : Intent
 
         data object Logout : Intent
+
+        data class OpenInBrowser(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -74,6 +78,10 @@ interface MyAccountMviModel :
 
         data class TriggerCopy(
             val text: String,
+        ) : Effect
+
+        data class OpenUrl(
+            val url: String,
         ) : Effect
     }
 }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
@@ -147,6 +147,8 @@ object MyAccountScreen : Tab {
                             clipboardManager.setText(AnnotatedString(event.text))
                             snackbarHostState.showSnackbar(copyToClipboardSuccess)
                         }
+
+                        is MyAccountMviModel.Effect.OpenUrl -> uriHandler.openExternally(event.url)
                     }
                 }.launchIn(this)
         }
@@ -445,6 +447,7 @@ object MyAccountScreen : Tab {
                                 }
                                 this += OptionId.ViewDetails.toOption()
                                 this += OptionId.CopyToClipboard.toOption()
+                                this += OptionId.OpenInBrowser.toOption()
                             },
                         onOptionSelected = { optionId ->
                             when (optionId) {
@@ -491,7 +494,15 @@ object MyAccountScreen : Tab {
                                     }
                                 }
                                 OptionId.CopyToClipboard ->
-                                    model.reduce(MyAccountMviModel.Intent.CopyToClipboard(entry.original))
+                                    model.reduce(
+                                        MyAccountMviModel.Intent.CopyToClipboard(entry.original),
+                                    )
+
+                                OptionId.OpenInBrowser ->
+                                    model.reduce(
+                                        MyAccountMviModel.Intent.OpenInBrowser(entry),
+                                    )
+
                                 else -> Unit
                             }
                         },

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchMviModel.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchMviModel.kt
@@ -86,6 +86,10 @@ interface SearchMviModel :
         data class AddInstanceShortcut(
             val node: String,
         ) : Intent
+
+        data class OpenInBrowser(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -114,6 +118,10 @@ interface SearchMviModel :
 
         data class TriggerCopy(
             val text: String,
+        ) : Effect
+
+        data class OpenUrl(
+            val url: String,
         ) : Effect
     }
 }

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
@@ -135,6 +135,7 @@ class SearchScreen : Screen {
                             clipboardManager.setText(AnnotatedString(event.text))
                             snackbarHostState.showSnackbar(copyToClipboardSuccess)
                         }
+                        is SearchMviModel.Effect.OpenUrl -> uriHandler.openExternally(event.url)
                     }
                 }.launchIn(this)
         }
@@ -442,6 +443,7 @@ class SearchScreen : Screen {
                                                         LocalStrings.current.actionShortcut(nodeName),
                                                     )
                                             }
+                                            this += OptionId.OpenInBrowser.toOption()
                                         },
                                     onOptionSelected = { optionId ->
                                         when (optionId) {
@@ -499,6 +501,7 @@ class SearchScreen : Screen {
                                                     )
                                                 }
                                             }
+
                                             OptionId.CopyToClipboard ->
                                                 model.reduce(
                                                     SearchMviModel.Intent.CopyToClipboard(
@@ -512,12 +515,19 @@ class SearchScreen : Screen {
                                                         item.entry.original,
                                                     ),
                                                 )
+
                                             OptionId.AddShortcut ->
                                                 model.reduce(
                                                     SearchMviModel.Intent.AddInstanceShortcut(
                                                         item.entry.nodeName,
                                                     ),
                                                 )
+
+                                            OptionId.OpenInBrowser ->
+                                                model.reduce(
+                                                    SearchMviModel.Intent.OpenInBrowser(item.entry),
+                                                )
+
                                             else -> Unit
                                         }
                                     },

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchViewModel.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchViewModel.kt
@@ -24,6 +24,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.Searc
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.SearchPaginationSpecification
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.GetInnerUrlUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.GetTranslationUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.ToggleEntryDislikeUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.ToggleEntryFavoriteUseCase
@@ -61,6 +62,7 @@ class SearchViewModel(
     private val toggleEntryDislike: ToggleEntryDislikeUseCase,
     private val toggleEntryFavorite: ToggleEntryFavoriteUseCase,
     private val getTranslation: GetTranslationUseCase,
+    private val getInnerUrl: GetInnerUrlUseCase,
     private val notificationCenter: NotificationCenter = getNotificationCenter(),
 ) : DefaultMviModel<SearchMviModel.Intent, SearchMviModel.State, SearchMviModel.Effect>(
         initialState = SearchMviModel.State(),
@@ -183,6 +185,7 @@ class SearchViewModel(
             is SearchMviModel.Intent.CopyToClipboard -> copyToClipboard(intent.entry)
             is SearchMviModel.Intent.ToggleTranslation -> toggleTranslation(intent.entry)
             is SearchMviModel.Intent.AddInstanceShortcut -> addInstanceShortcut(intent.node)
+            is SearchMviModel.Intent.OpenInBrowser -> openInBrowser(intent.entry)
         }
     }
 
@@ -445,7 +448,7 @@ class SearchViewModel(
             } else {
                 updateEntryInState(entry.id) {
                     it.copy(
-                        favoriteLoading = false,
+                        dislikeLoading = false,
                     )
                 }
             }
@@ -626,6 +629,15 @@ class SearchViewModel(
                     accountId = accountId,
                     node = nodeName,
                 )
+            }
+        }
+    }
+
+    private fun openInBrowser(entry: TimelineEntryModel) {
+        screenModelScope.launch {
+            val url = getInnerUrl(entry)
+            if (url != null) {
+                emitEffect(SearchMviModel.Effect.OpenUrl(url))
             }
         }
     }

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/di/SearchModule.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/di/SearchModule.kt
@@ -27,6 +27,7 @@ val searchModule =
                     toggleEntryFavorite = instance(),
                     toggleEntryDislike = instance(),
                     getTranslation = instance(),
+                    getInnerUrl = instance(),
                     notificationCenter = instance(),
                 )
             }

--- a/feature/shortcuts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/shortcuts/di/ShortcutsModule.kt
+++ b/feature/shortcuts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/shortcuts/di/ShortcutsModule.kt
@@ -37,6 +37,7 @@ val shortcutsModule =
                     toggleEntryDislike = instance(),
                     toggleEntryFavorite = instance(),
                     getTranslation = instance(),
+                    getInnerUrl = instance(),
                     timelineNavigationManager = instance(),
                     notificationCenter = instance(),
                 )

--- a/feature/shortcuts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/shortcuts/timeline/ShortcutTimelineMviModel.kt
+++ b/feature/shortcuts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/shortcuts/timeline/ShortcutTimelineMviModel.kt
@@ -46,6 +46,10 @@ interface ShortcutTimelineMviModel :
         data class WillOpenDetail(
             val entry: TimelineEntryModel,
         ) : Intent
+
+        data class OpenInBrowser(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -78,6 +82,10 @@ interface ShortcutTimelineMviModel :
 
         data class OpenDetail(
             val entry: TimelineEntryModel,
+        ) : Effect
+
+        data class OpenUrl(
+            val url: String,
         ) : Effect
     }
 }

--- a/feature/shortcuts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/shortcuts/timeline/ShortcutTimelineScreen.kt
+++ b/feature/shortcuts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/shortcuts/timeline/ShortcutTimelineScreen.kt
@@ -128,6 +128,9 @@ class ShortcutTimelineScreen(
                                 swipeNavigationEnabled = true,
                             )
                         }
+
+                        is ShortcutTimelineMviModel.Effect.OpenUrl ->
+                            uriHandler.openExternally(event.url)
                     }
                 }.launchIn(this)
         }
@@ -342,6 +345,7 @@ class ShortcutTimelineScreen(
                                                     },
                                             )
                                     }
+                                    this += OptionId.OpenInBrowser.toOption()
                                 },
                             onOptionSelected = { optionId ->
                                 when (optionId) {
@@ -379,6 +383,11 @@ class ShortcutTimelineScreen(
                                             ShortcutTimelineMviModel.Intent.ToggleTranslation(
                                                 entry.original,
                                             ),
+                                        )
+
+                                    OptionId.OpenInBrowser ->
+                                        model.reduce(
+                                            ShortcutTimelineMviModel.Intent.OpenInBrowser(entry),
                                         )
 
                                     else -> Unit

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadMviModel.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadMviModel.kt
@@ -70,6 +70,10 @@ interface ThreadMviModel :
         data class AddInstanceShortcut(
             val node: String,
         ) : Intent
+
+        data class OpenInBrowser(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -93,6 +97,10 @@ interface ThreadMviModel :
 
         data class TriggerCopy(
             val text: String,
+        ) : Effect
+
+        data class OpenUrl(
+            val url: String,
         ) : Effect
     }
 }

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
@@ -151,6 +151,8 @@ class ThreadScreen(
                             clipboardManager.setText(AnnotatedString(event.text))
                             snackbarHostState.showSnackbar(copyToClipboardSuccess)
                         }
+
+                        is ThreadMviModel.Effect.OpenUrl -> uriHandler.openExternally(event.url)
                     }
                 }.launchIn(this)
         }
@@ -429,6 +431,7 @@ class ThreadScreen(
                                                         LocalStrings.current.actionShortcut(nodeName),
                                                     )
                                             }
+                                            this += OptionId.OpenInBrowser.toOption()
                                         },
                                     onOptionSelected = { optionId ->
                                         when (optionId) {
@@ -480,6 +483,11 @@ class ThreadScreen(
                                             OptionId.AddShortcut ->
                                                 model.reduce(
                                                     ThreadMviModel.Intent.AddInstanceShortcut(entry.nodeName),
+                                                )
+
+                                            OptionId.OpenInBrowser ->
+                                                model.reduce(
+                                                    ThreadMviModel.Intent.OpenInBrowser(entry),
                                                 )
                                             else -> Unit
                                         }
@@ -618,6 +626,7 @@ class ThreadScreen(
                                                     LocalStrings.current.actionShortcut(nodeName),
                                                 )
                                         }
+                                        this += OptionId.OpenInBrowser.toOption()
                                     },
                                 onOptionSelected = { optionId ->
                                     when (optionId) {
@@ -683,6 +692,12 @@ class ThreadScreen(
                                             model.reduce(
                                                 ThreadMviModel.Intent.AddInstanceShortcut(entry.nodeName),
                                             )
+
+                                        OptionId.OpenInBrowser ->
+                                            model.reduce(
+                                                ThreadMviModel.Intent.OpenInBrowser(entry),
+                                            )
+
                                         else -> Unit
                                     }
                                 },

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadViewModel.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadViewModel.kt
@@ -19,6 +19,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.Timel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.LocalItemCache
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.GetInnerUrlUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.GetTranslationUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.PopulateThreadUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.ToggleEntryDislikeUseCase
@@ -54,6 +55,7 @@ class ThreadViewModel(
     private val toggleEntryDislike: ToggleEntryDislikeUseCase,
     private val toggleEntryFavorite: ToggleEntryFavoriteUseCase,
     private val getTranslation: GetTranslationUseCase,
+    private val getInnerUrl: GetInnerUrlUseCase,
     private val timelineNavigationManager: TimelineNavigationManager,
     private val notificationCenter: NotificationCenter = getNotificationCenter(),
 ) : DefaultMviModel<ThreadMviModel.Intent, ThreadMviModel.State, ThreadMviModel.Effect>(
@@ -147,6 +149,7 @@ class ThreadViewModel(
             is ThreadMviModel.Intent.ChangeNavigationIndex ->
                 changeNavigationIndex(intent.index)
             is ThreadMviModel.Intent.AddInstanceShortcut -> addInstanceShortcut(intent.node)
+            is ThreadMviModel.Intent.OpenInBrowser -> openInBrowser(intent.entry)
         }
     }
 
@@ -443,7 +446,7 @@ class ThreadViewModel(
             } else {
                 updateEntryInState(entry.id) {
                     it.copy(
-                        favoriteLoading = false,
+                        dislikeLoading = false,
                     )
                 }
             }
@@ -659,6 +662,15 @@ class ThreadViewModel(
                     accountId = accountId,
                     node = nodeName,
                 )
+            }
+        }
+    }
+
+    private fun openInBrowser(entry: TimelineEntryModel) {
+        screenModelScope.launch {
+            val url = getInnerUrl(entry)
+            if (url != null) {
+                emitEffect(ThreadMviModel.Effect.OpenUrl(url))
             }
         }
     }

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/di/ThreadModule.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/di/ThreadModule.kt
@@ -35,6 +35,7 @@ val threadModule =
                     toggleEntryFavorite = instance(),
                     toggleEntryDislike = instance(),
                     getTranslation = instance(),
+                    getInnerUrl = instance(),
                     timelineNavigationManager = instance(),
                     notificationCenter = instance(),
                 )

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineMviModel.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineMviModel.kt
@@ -77,6 +77,10 @@ interface TimelineMviModel :
         data class AddInstanceShortcut(
             val node: String,
         ) : Intent
+
+        data class OpenInBrowser(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -109,6 +113,10 @@ interface TimelineMviModel :
 
         data class OpenDetail(
             val entry: TimelineEntryModel,
+        ) : Effect
+
+        data class OpenUrl(
+            val url: String,
         ) : Effect
     }
 }

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
@@ -152,6 +152,8 @@ class TimelineScreen : Screen {
                                 entry = event.entry,
                                 swipeNavigationEnabled = true,
                             )
+
+                        is TimelineMviModel.Effect.OpenUrl -> uriHandler.openExternally(event.url)
                     }
                 }.launchIn(this)
         }
@@ -462,6 +464,7 @@ class TimelineScreen : Screen {
                                                 LocalStrings.current.actionShortcut(nodeName),
                                             )
                                     }
+                                    this += OptionId.OpenInBrowser.toOption()
                                 },
                             onOptionSelected = { optionId ->
                                 when (optionId) {
@@ -529,6 +532,12 @@ class TimelineScreen : Screen {
                                         model.reduce(
                                             TimelineMviModel.Intent.AddInstanceShortcut(entry.nodeName),
                                         )
+
+                                    OptionId.OpenInBrowser ->
+                                        model.reduce(
+                                            TimelineMviModel.Intent.OpenInBrowser(entry),
+                                        )
+
                                     else -> Unit
                                 }
                             },

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
@@ -24,6 +24,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Circl
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.FollowedHashtagCache
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.GetInnerUrlUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.GetTranslationUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.ToggleEntryDislikeUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.ToggleEntryFavoriteUseCase
@@ -64,6 +65,7 @@ class TimelineViewModel(
     private val toggleEntryDislike: ToggleEntryDislikeUseCase,
     private val toggleEntryFavorite: ToggleEntryFavoriteUseCase,
     private val getTranslation: GetTranslationUseCase,
+    private val getInnerUrl: GetInnerUrlUseCase,
     private val timelineNavigationManager: TimelineNavigationManager,
     private val followedHashtagCache: FollowedHashtagCache,
     private val notificationCenter: NotificationCenter = getNotificationCenter(),
@@ -205,6 +207,7 @@ class TimelineViewModel(
                 }
 
             is TimelineMviModel.Intent.AddInstanceShortcut -> addInstanceShortcut(intent.node)
+            is TimelineMviModel.Intent.OpenInBrowser -> openInBrowser(intent.entry)
         }
     }
 
@@ -449,7 +452,7 @@ class TimelineViewModel(
             } else {
                 updateEntryInState(entry.id) {
                     it.copy(
-                        favoriteLoading = false,
+                        dislikeLoading = false,
                     )
                 }
             }
@@ -630,6 +633,15 @@ class TimelineViewModel(
                     accountId = accountId,
                     node = nodeName,
                 )
+            }
+        }
+    }
+
+    private fun openInBrowser(entry: TimelineEntryModel) {
+        screenModelScope.launch {
+            val url = getInnerUrl(entry)
+            if (url != null) {
+                emitEffect(TimelineMviModel.Effect.OpenUrl(url))
             }
         }
     }

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/di/TimelineModule.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/di/TimelineModule.kt
@@ -30,6 +30,7 @@ val timelineModule =
                     toggleEntryFavorite = instance(),
                     toggleEntryDislike = instance(),
                     getTranslation = instance(),
+                    getInnerUrl = instance(),
                     timelineNavigationManager = instance(),
                     followedHashtagCache = instance(),
                     notificationCenter = instance(),

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailMviModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailMviModel.kt
@@ -89,6 +89,10 @@ interface UserDetailMviModel :
         data class AddInstanceShortcut(
             val node: String,
         ) : Intent
+
+        data class OpenInBrowser(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -125,6 +129,10 @@ interface UserDetailMviModel :
 
         data class OpenDetail(
             val entry: TimelineEntryModel,
+        ) : Effect
+
+        data class OpenUrl(
+            val url: String,
         ) : Effect
     }
 }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -193,6 +193,8 @@ class UserDetailScreen(
                                 swipeNavigationEnabled = true,
                             )
                         }
+
+                        is UserDetailMviModel.Effect.OpenUrl -> uriHandler.openExternally(event.url)
                     }
                 }.launchIn(this)
         }
@@ -719,6 +721,7 @@ class UserDetailScreen(
                                                 LocalStrings.current.actionShortcut(nodeName),
                                             )
                                     }
+                                    this += OptionId.OpenInBrowser.toOption()
                                 },
                             onOptionSelected = { optionId ->
                                 when (optionId) {
@@ -764,6 +767,11 @@ class UserDetailScreen(
                                     OptionId.AddShortcut ->
                                         model.reduce(
                                             UserDetailMviModel.Intent.AddInstanceShortcut(entry.nodeName),
+                                        )
+
+                                    OptionId.OpenInBrowser ->
+                                        model.reduce(
+                                            UserDetailMviModel.Intent.OpenInBrowser(entry),
                                         )
                                     else -> Unit
                                 }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailViewModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailViewModel.kt
@@ -15,7 +15,6 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEnt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserRateLimitModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.blurHashParamsForPreload
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.nodeName
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toNotificationStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toStatus
@@ -28,6 +27,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Local
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRateLimitRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.GetInnerUrlUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.GetTranslationUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.ToggleEntryDislikeUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.ToggleEntryFavoriteUseCase
@@ -62,6 +62,7 @@ class UserDetailViewModel(
     private val toggleEntryDislike: ToggleEntryDislikeUseCase,
     private val toggleEntryFavorite: ToggleEntryFavoriteUseCase,
     private val getTranslation: GetTranslationUseCase,
+    private val getInnerUrl: GetInnerUrlUseCase,
     private val timelineNavigationManager: TimelineNavigationManager,
     private val notificationCenter: NotificationCenter = getNotificationCenter(),
 ) : DefaultMviModel<UserDetailMviModel.Intent, UserDetailMviModel.State, UserDetailMviModel.Effect>(
@@ -173,6 +174,7 @@ class UserDetailViewModel(
                     emitEffect(UserDetailMviModel.Effect.OpenDetail(intent.entry))
                 }
             is UserDetailMviModel.Intent.AddInstanceShortcut -> addInstanceShortcut(intent.node)
+            is UserDetailMviModel.Intent.OpenInBrowser -> openInBrowser(intent.entry)
         }
     }
 
@@ -413,7 +415,7 @@ class UserDetailViewModel(
             } else {
                 updateEntryInState(entry.id) {
                     it.copy(
-                        favoriteLoading = false,
+                        dislikeLoading = false,
                     )
                 }
             }
@@ -685,6 +687,15 @@ class UserDetailViewModel(
                     accountId = accountId,
                     node = nodeName,
                 )
+            }
+        }
+    }
+
+    private fun openInBrowser(entry: TimelineEntryModel) {
+        screenModelScope.launch {
+            val url = getInnerUrl(entry)
+            if (url != null) {
+                emitEffect(UserDetailMviModel.Effect.OpenUrl(url))
             }
         }
     }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/di/UserDetailModule.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/di/UserDetailModule.kt
@@ -33,6 +33,7 @@ val userDetailModule =
                     toggleEntryFavorite = instance(),
                     toggleEntryDislike = instance(),
                     getTranslation = instance(),
+                    getInnerUrl = instance(),
                     timelineNavigationManager = instance(),
                     notificationCenter = instance(),
                 )
@@ -58,6 +59,7 @@ val userDetailModule =
                     toggleEntryFavorite = instance(),
                     toggleEntryDislike = instance(),
                     getTranslation = instance(),
+                    getInnerUrl = instance(),
                     timelineNavigationManager = instance(),
                     notificationCenter = instance(),
                 )

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListMviModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListMviModel.kt
@@ -70,6 +70,10 @@ interface ForumListMviModel :
         data class AddInstanceShortcut(
             val node: String,
         ) : Intent
+
+        data class OpenInBrowser(
+            val entry: TimelineEntryModel,
+        ) : Intent
     }
 
     data class State(
@@ -98,6 +102,10 @@ interface ForumListMviModel :
 
         data class OpenDetail(
             val entry: TimelineEntryModel,
+        ) : Effect
+
+        data class OpenUrl(
+            val url: String,
         ) : Effect
     }
 }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
@@ -149,6 +149,8 @@ class ForumListScreen(
                                 swipeNavigationEnabled = true,
                             )
                         }
+
+                        is ForumListMviModel.Effect.OpenUrl -> uriHandler.openExternally(event.url)
                     }
                 }.launchIn(this)
         }
@@ -477,6 +479,7 @@ class ForumListScreen(
                                                 LocalStrings.current.actionShortcut(nodeName),
                                             )
                                     }
+                                    this += OptionId.OpenInBrowser.toOption()
                                 },
                             onOptionSelected = { optionId ->
                                 when (optionId) {
@@ -537,6 +540,11 @@ class ForumListScreen(
                                     OptionId.AddShortcut ->
                                         model.reduce(
                                             ForumListMviModel.Intent.AddInstanceShortcut(entry.nodeName),
+                                        )
+
+                                    OptionId.OpenInBrowser ->
+                                        model.reduce(
+                                            ForumListMviModel.Intent.OpenInBrowser(entry),
                                         )
                                     else -> Unit
                                 }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListViewModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListViewModel.kt
@@ -22,6 +22,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.Timel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.LocalItemCache
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.GetInnerUrlUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.GetTranslationUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.ToggleEntryDislikeUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.ToggleEntryFavoriteUseCase
@@ -54,6 +55,7 @@ class ForumListViewModel(
     private val toggleEntryDislike: ToggleEntryDislikeUseCase,
     private val toggleEntryFavorite: ToggleEntryFavoriteUseCase,
     private val getTranslation: GetTranslationUseCase,
+    private val getInnerUrl: GetInnerUrlUseCase,
     private val timelineNavigationManager: TimelineNavigationManager,
     private val notificationCenter: NotificationCenter = getNotificationCenter(),
 ) : DefaultMviModel<ForumListMviModel.Intent, ForumListMviModel.State, ForumListMviModel.Effect>(
@@ -148,6 +150,7 @@ class ForumListViewModel(
                     emitEffect(ForumListMviModel.Effect.OpenDetail(intent.entry))
                 }
             is ForumListMviModel.Intent.AddInstanceShortcut -> addInstanceShortcut(intent.node)
+            is ForumListMviModel.Intent.OpenInBrowser -> openInBrowser(intent.entry)
         }
     }
 
@@ -325,7 +328,7 @@ class ForumListViewModel(
             } else {
                 updateEntryInState(entry.id) {
                     it.copy(
-                        favoriteLoading = false,
+                        dislikeLoading = false,
                     )
                 }
             }
@@ -488,6 +491,15 @@ class ForumListViewModel(
                     accountId = accountId,
                     node = nodeName,
                 )
+            }
+        }
+    }
+
+    private fun openInBrowser(entry: TimelineEntryModel) {
+        screenModelScope.launch {
+            val url = getInnerUrl(entry)
+            if (url != null) {
+                emitEffect(ForumListMviModel.Effect.OpenUrl(url))
             }
         }
     }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds the possibility to open a post in the browser through your local instance instead of the external URL. The only way to implement this is to open the search page in your instance, which requires you to be logged if you aren't already in the browser.
