### PR TITLE
fix: close unfollow request delete confirmation dialog

### DIFF
--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
@@ -316,7 +316,7 @@ class InboxScreen : Screen {
                 title = LocalStrings.current.actionDeleteFollowRequest,
                 onClose = { confirm ->
                     val userId = confirmUnfollowDialogUserId ?: ""
-                    confirmUnfollowDialogUserId = null
+                    confirmDeleteFollowRequestDialogUserId = null
                     if (confirm && userId.isNotEmpty()) {
                         model.reduce(InboxMviModel.Intent.Unfollow(userId))
                     }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes a bug due to which the confirmation dialog when deleting a follow request from the Inbox section did not close.