### PR TITLE
fix: profile section selector and links

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserFields.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/UserFields.kt
@@ -76,7 +76,7 @@ fun UserFields(
                                     .firstOrNull()
                                     ?.item
                             if (!url.isNullOrBlank()) {
-                                onOpenUrl?.invoke(url, true)
+                                onOpenUrl?.invoke(url, false)
                             }
                         },
                     )

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
@@ -334,7 +334,7 @@ object MyAccountScreen : Tab {
                     }
                 }
 
-                if (uiState.initial || uiState.entries.isNotEmpty()) {
+                if (uiState.initial) {
                     stickyHeader {
                         val titles =
                             listOf(


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes a couple of issues in the profile screen:
- the section selector (Posts, Posts & Replies, etc.) disappeared if a given section was empty;
- the links in custom fields were opened as regular Fediverse link (not externally) which may lead to some latency and give the impression they are not working.
