### PR TITLE
Fix/restore draft options menu

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CardTimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CardTimelineItem.kt
@@ -6,9 +6,17 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -18,11 +26,19 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomDropDown
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
@@ -132,6 +148,60 @@ internal fun CardTimelineItem(
                 isEdited = entry.updated != null,
                 onOpenUser = onOpenUser,
             )
+            if (options.isNotEmpty() && !actionsEnabled) {
+                var optionsOffset by remember { mutableStateOf(Offset.Zero) }
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Box {
+                        IconButton(
+                            modifier =
+                                Modifier
+                                    .padding(bottom = Spacing.xs, end = Spacing.s)
+                                    .size(height = IconSize.m, width = IconSize.l)
+                                    .onGloballyPositioned {
+                                        optionsOffset = it.positionInParent()
+                                    }.clearAndSetSemantics { },
+                            onClick = {
+                                onOptionsMenuToggled?.invoke(true)
+                            },
+                        ) {
+                            Icon(
+                                modifier = Modifier.size(IconSize.s),
+                                imageVector = Icons.Default.MoreVert,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onBackground,
+                            )
+                        }
+
+                        CustomDropDown(
+                            expanded = optionsMenuOpen,
+                            onDismiss = {
+                                onOptionsMenuToggled?.invoke(false)
+                            },
+                            offset =
+                                with(LocalDensity.current) {
+                                    DpOffset(
+                                        x = optionsOffset.x.toDp(),
+                                        y = optionsOffset.y.toDp(),
+                                    )
+                                },
+                        ) {
+                            options.forEach { option ->
+                                DropdownMenuItem(
+                                    text = {
+                                        Text(option.label)
+                                    },
+                                    onClick = {
+                                        onOptionsMenuToggled?.invoke(false)
+                                        onOptionSelected?.invoke(option.id)
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         // post spoiler

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CardTimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CardTimelineItem.kt
@@ -3,8 +3,10 @@ package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -87,6 +89,7 @@ internal fun CardTimelineItem(
         modifier =
             modifier
                 .padding(horizontal = Spacing.xs)
+                .padding(bottom = Spacing.xs)
                 .shadow(
                     elevation = 5.dp,
                     shape = RoundedCornerShape(CornerSize.l),
@@ -94,7 +97,7 @@ internal fun CardTimelineItem(
                     color = MaterialTheme.colorScheme.surfaceColorAtElevation(5.dp),
                     shape = RoundedCornerShape(CornerSize.l),
                 ).padding(
-                    vertical = Spacing.s,
+                    vertical = Spacing.xs,
                     horizontal = Spacing.xxxs,
                 ),
         verticalArrangement = Arrangement.spacedBy(Spacing.xs),
@@ -400,6 +403,8 @@ internal fun CardTimelineItem(
                         null
                     },
             )
+        } else {
+            Spacer(Modifier.height(Spacing.xxs))
         }
     }
 }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CompactTimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CompactTimelineItem.kt
@@ -2,10 +2,21 @@ package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -13,10 +24,18 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.DpOffset
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomDropDown
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
@@ -114,6 +133,60 @@ internal fun CompactTimelineItem(
                 isEdited = entry.updated != null,
                 onOpenUser = onOpenUser,
             )
+            if (options.isNotEmpty() && !actionsEnabled) {
+                var optionsOffset by remember { mutableStateOf(Offset.Zero) }
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Box {
+                        IconButton(
+                            modifier =
+                                Modifier
+                                    .padding(bottom = Spacing.xs, end = Spacing.s)
+                                    .size(height = IconSize.m, width = IconSize.l)
+                                    .onGloballyPositioned {
+                                        optionsOffset = it.positionInParent()
+                                    }.clearAndSetSemantics { },
+                            onClick = {
+                                onOptionsMenuToggled?.invoke(true)
+                            },
+                        ) {
+                            Icon(
+                                modifier = Modifier.size(IconSize.s),
+                                imageVector = Icons.Default.MoreVert,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onBackground,
+                            )
+                        }
+
+                        CustomDropDown(
+                            expanded = optionsMenuOpen,
+                            onDismiss = {
+                                onOptionsMenuToggled?.invoke(false)
+                            },
+                            offset =
+                                with(LocalDensity.current) {
+                                    DpOffset(
+                                        x = optionsOffset.x.toDp(),
+                                        y = optionsOffset.y.toDp(),
+                                    )
+                                },
+                        ) {
+                            options.forEach { option ->
+                                DropdownMenuItem(
+                                    text = {
+                                        Text(option.label)
+                                    },
+                                    onClick = {
+                                        onOptionsMenuToggled?.invoke(false)
+                                        onOptionSelected?.invoke(option.id)
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         // post spoiler
@@ -321,6 +394,8 @@ internal fun CompactTimelineItem(
                         null
                     },
             )
+        } else {
+            Spacer(Modifier.height(Spacing.xxs))
         }
     }
 }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/DistractionFreeTimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/DistractionFreeTimelineItem.kt
@@ -2,10 +2,21 @@ package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -13,9 +24,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.DpOffset
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomDropDown
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.contentToDisplay
@@ -110,6 +129,60 @@ internal fun DistractionFreeTimelineItem(
                 isEdited = entry.updated != null,
                 onOpenUser = onOpenUser,
             )
+            if (options.isNotEmpty() && !actionsEnabled) {
+                var optionsOffset by remember { mutableStateOf(Offset.Zero) }
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Box {
+                        IconButton(
+                            modifier =
+                                Modifier
+                                    .padding(bottom = Spacing.xs, end = Spacing.s)
+                                    .size(height = IconSize.m, width = IconSize.l)
+                                    .onGloballyPositioned {
+                                        optionsOffset = it.positionInParent()
+                                    }.clearAndSetSemantics { },
+                            onClick = {
+                                onOptionsMenuToggled?.invoke(true)
+                            },
+                        ) {
+                            Icon(
+                                modifier = Modifier.size(IconSize.s),
+                                imageVector = Icons.Default.MoreVert,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onBackground,
+                            )
+                        }
+
+                        CustomDropDown(
+                            expanded = optionsMenuOpen,
+                            onDismiss = {
+                                onOptionsMenuToggled?.invoke(false)
+                            },
+                            offset =
+                                with(LocalDensity.current) {
+                                    DpOffset(
+                                        x = optionsOffset.x.toDp(),
+                                        y = optionsOffset.y.toDp(),
+                                    )
+                                },
+                        ) {
+                            options.forEach { option ->
+                                DropdownMenuItem(
+                                    text = {
+                                        Text(option.label)
+                                    },
+                                    onClick = {
+                                        onOptionsMenuToggled?.invoke(false)
+                                        onOptionSelected?.invoke(option.id)
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         // post spoiler
@@ -281,6 +354,8 @@ internal fun DistractionFreeTimelineItem(
                         null
                     },
             )
+        } else {
+            Spacer(Modifier.height(Spacing.xxs))
         }
     }
 }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/FullTimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/FullTimelineItem.kt
@@ -2,10 +2,21 @@ package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -13,9 +24,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.DpOffset
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomDropDown
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
@@ -114,6 +133,60 @@ internal fun FullTimelineItem(
                 isEdited = entry.updated != null,
                 onOpenUser = onOpenUser,
             )
+            if (options.isNotEmpty() && !actionsEnabled) {
+                var optionsOffset by remember { mutableStateOf(Offset.Zero) }
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Box {
+                        IconButton(
+                            modifier =
+                                Modifier
+                                    .padding(bottom = Spacing.xs, end = Spacing.s)
+                                    .size(height = IconSize.m, width = IconSize.l)
+                                    .onGloballyPositioned {
+                                        optionsOffset = it.positionInParent()
+                                    }.clearAndSetSemantics { },
+                            onClick = {
+                                onOptionsMenuToggled?.invoke(true)
+                            },
+                        ) {
+                            Icon(
+                                modifier = Modifier.size(IconSize.s),
+                                imageVector = Icons.Default.MoreVert,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onBackground,
+                            )
+                        }
+
+                        CustomDropDown(
+                            expanded = optionsMenuOpen,
+                            onDismiss = {
+                                onOptionsMenuToggled?.invoke(false)
+                            },
+                            offset =
+                                with(LocalDensity.current) {
+                                    DpOffset(
+                                        x = optionsOffset.x.toDp(),
+                                        y = optionsOffset.y.toDp(),
+                                    )
+                                },
+                        ) {
+                            options.forEach { option ->
+                                DropdownMenuItem(
+                                    text = {
+                                        Text(option.label)
+                                    },
+                                    onClick = {
+                                        onOptionsMenuToggled?.invoke(false)
+                                        onOptionSelected?.invoke(option.id)
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         // post spoiler
@@ -334,6 +407,8 @@ internal fun FullTimelineItem(
                         null
                     },
             )
+        } else {
+            Spacer(Modifier.height(Spacing.xxs))
         }
     }
 }

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -466,6 +466,7 @@ class EntryDetailScreen(
                                                         Modifier
                                                             // since the main entry is forced to "full", recreates card appearance
                                                             .padding(horizontal = Spacing.xs)
+                                                            .padding(bottom = Spacing.xs)
                                                             .shadow(
                                                                 elevation = 5.dp,
                                                                 shape = RoundedCornerShape(CornerSize.l),
@@ -476,7 +477,7 @@ class EntryDetailScreen(
                                                                     ),
                                                                 shape = RoundedCornerShape(CornerSize.l),
                                                             ).padding(
-                                                                vertical = Spacing.s,
+                                                                vertical = Spacing.xs,
                                                                 horizontal = Spacing.xxxs,
                                                             )
                                                     } else {

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationItem.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationItem.kt
@@ -114,6 +114,7 @@ internal fun NotificationItem(
             modifier =
                 Modifier
                     .padding(horizontal = contentHorizontalPadding)
+                    .padding(bottom = Spacing.xs)
                     .shadow(
                         elevation = 5.dp,
                         shape = RoundedCornerShape(CornerSize.l),
@@ -124,6 +125,7 @@ internal fun NotificationItem(
                     .padding(
                         start = Spacing.xxs,
                         end = Spacing.xxs,
+                        top = Spacing.xs,
                         bottom = Spacing.xs,
                     ),
         ) {

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
@@ -285,6 +285,7 @@ class ThreadScreen(
                                         Modifier
                                             // since the main entry is forced to "full", recreates card appearance
                                             .padding(horizontal = Spacing.xs)
+                                            .padding(bottom = Spacing.xs)
                                             .shadow(
                                                 elevation = 5.dp,
                                                 shape = RoundedCornerShape(CornerSize.l),
@@ -295,7 +296,7 @@ class ThreadScreen(
                                                     ),
                                                 shape = RoundedCornerShape(CornerSize.l),
                                             ).padding(
-                                                vertical = Spacing.s,
+                                                vertical = Spacing.xs,
                                                 horizontal = Spacing.xxxs,
                                             ),
                                     entry = entry,


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes some issues with post layouts:
- when actions were disabled (e.g. in inbox or unpublished) the options menu was not showing any more due to a bug introduced in #833;
- card layouts had the shadow weirdly clipped for the last list item.

Thanks to [ernestowg](https://mastodon.la/@ernestowg) for reporting!