### PR TITLE
fix: avoid showing "custom tabs" option if not supported

### DIFF
--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsMviModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsMviModel.kt
@@ -183,6 +183,7 @@ interface SettingsMviModel :
         val pushNotificationPermissionState: PermissionState = PermissionState.NotDetermined,
         val isBarThemeSupported: Boolean = false,
         val replyDepth: Int = 1,
+        val availableUrlOpeningModes: List<UrlOpeningMode> = emptyList(),
     )
 
     sealed interface Effect {

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
@@ -81,7 +81,6 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toIcon
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toReadableName
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.ImageLoadingMode
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.NotificationMode
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.UrlOpeningMode
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.toReadableName
 import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.manager.PushNotificationManagerState
 import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.manager.toReadableName
@@ -753,12 +752,7 @@ class SettingsScreen : Screen {
         }
 
         if (urlOpeningModeBottomSheetOpened) {
-            val types =
-                listOf(
-                    UrlOpeningMode.External,
-                    UrlOpeningMode.CustomTabs,
-                    UrlOpeningMode.Internal,
-                )
+            val types = uiState.availableUrlOpeningModes
             CustomModalBottomSheet(
                 title = LocalStrings.current.settingsItemUrlOpeningMode,
                 items = types.map { CustomModalBottomSheetItem(label = it.toReadableName()) },

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/di/SettingsModule.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/di/SettingsModule.kt
@@ -33,6 +33,7 @@ val settingsModule =
                     importSettings = instance(),
                     exportSettings = instance(),
                     barColorProvider = instance(),
+                    customTabsHelper = instance(),
                 )
             }
         }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR avoids displaying the "Custom tabs" option as URL opening mode if it is not available on the device.
