### PR TITLE
fix: change markdown italic representation

### DIFF
--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
@@ -909,14 +909,14 @@ class ComposerViewModel(
                 when (markupMode) {
                     MarkupMode.HTML -> "<i>"
                     MarkupMode.BBCode -> "[i]"
-                    MarkupMode.Markdown -> "_"
+                    MarkupMode.Markdown -> "*"
                     else -> ""
                 }
             val after =
                 when (markupMode) {
                     MarkupMode.HTML -> "</i>"
                     MarkupMode.BBCode -> "[/i]"
-                    MarkupMode.Markdown -> "_"
+                    MarkupMode.Markdown -> "*"
                     else -> ""
                 }
             val newValue =


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR changes the way italic is represented in markdown, to avoid confusion between underline and italic.
