### PR TITLE
chore: change default instance

### DIFF
--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/FriendicaInstance.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/FriendicaInstance.kt
@@ -6,66 +6,71 @@ data class FriendicaInstance(
     val value: String,
 )
 
+/**
+ * List of predefined Friendica instances in the drop-down menu.
+ *
+ * Source for MAU: https://the-federation.info/platform/11
+ */
 val DefaultFriendicaInstances =
     buildList {
         this +=
             FriendicaInstance(
                 lang = "🇩🇪",
-                mau = 23,
+                mau = 21,
                 value = "friendica.me",
             )
         this +=
             FriendicaInstance(
                 lang = "🇬🇧",
-                mau = 14,
+                mau = 11,
                 value = "friendica.myportal.social",
             )
         this +=
             FriendicaInstance(
                 lang = "🇬🇧",
-                mau = 18,
+                mau = 1176,
                 value = "friendica.world",
             )
         this +=
             FriendicaInstance(
                 lang = "🇬🇧",
-                mau = 194,
+                mau = 154,
                 value = "libranet.de",
             )
         this +=
             FriendicaInstance(
+                lang = "🇬🇧",
+                mau = 206,
+                value = "anonsys.net",
+            )
+        this +=
+            FriendicaInstance(
                 lang = "🇩🇪",
-                mau = 157,
+                mau = 165,
                 value = "loma.ml",
             )
         this +=
             FriendicaInstance(
                 lang = "🇩🇪",
-                mau = 89,
-                value = "nerdica.net",
-            )
-        this +=
-            FriendicaInstance(
-                lang = "🇩🇪",
-                mau = 40,
-                value = "opensocial.at",
+                mau = 101,
+                value = "friendica.opensocial.space",
             )
         this +=
             FriendicaInstance(
                 lang = "🇮🇹",
-                mau = 184,
+                mau = 270,
                 value = "poliverso.org",
             )
         this +=
             FriendicaInstance(
                 lang = "🇬🇧",
-                mau = 54,
+                mau = 78,
                 value = "social.trom.tf",
             )
         this +=
             FriendicaInstance(
                 lang = "🇬🇧",
-                mau = 160,
+                mau = 120,
                 value = "venera.social",
             )
     }.sortedByDescending { it.mau }

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultApiConfigurationRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultApiConfigurationRepository.kt
@@ -108,7 +108,7 @@ internal class DefaultApiConfigurationRepository(
         private const val KEY_METHOD = "lastMethod"
         private const val METHOD_BASIC = "HTTPBasic"
         private const val METHOD_OAUTH_2 = "OAuth2"
-        private const val DEFAULT_NODE = "poliverso.org"
+        private const val DEFAULT_NODE = "friendica.world"
         private const val DEFAULT_METHOD = METHOD_BASIC
         private const val VALIDATE_CREDENTIALS_TIMEOUT = 2000L
     }

--- a/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/oauth/LoginScreen.kt
+++ b/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/oauth/LoginScreen.kt
@@ -194,7 +194,7 @@ class LoginScreen(
                                     buildString {
                                         append(LocalStrings.current.exempliGratia)
                                         append(" ")
-                                        append("poliverso.org")
+                                        append("friendica.world")
                                     },
                             )
                         },


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR changes the default node from `poliverso.org` to `friendica.world`. The reason is that poliverso.org sometimes goes down and, yesterday, this happened while the new beta version of the app was in review, so it got rejected by Google.

Moreover, MAU for the predefined nodes are updates so that more active ones appear higher in the list.
