### PR TITLE
feat: add specific search for groups

### DIFF
--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/SearchPaginationSpecification.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/SearchPaginationSpecification.kt
@@ -13,4 +13,8 @@ sealed interface SearchPaginationSpecification {
     data class Hashtags(
         val query: String,
     ) : SearchPaginationSpecification
+
+    data class Groups(
+        val query: String,
+    ) : SearchPaginationSpecification
 }

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
@@ -217,6 +217,7 @@ class SearchScreen : Screen {
                                 SearchSection.Posts,
                                 SearchSection.Users,
                                 SearchSection.Hashtags,
+                                SearchSection.Groups,
                             )
                         SectionSelector(
                             modifier =
@@ -253,7 +254,7 @@ class SearchScreen : Screen {
                                     }
                                 }
 
-                                SearchSection.Users -> {
+                                SearchSection.Users, SearchSection.Groups -> {
                                     UserItemPlaceholder(modifier = modifier)
                                     Spacer(modifier = Modifier.height(Spacing.interItem))
                                 }

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchViewModel.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchViewModel.kt
@@ -15,7 +15,6 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.ExploreItem
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.blurHashParamsForPreload
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.nodeName
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toNotificationStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toStatus
@@ -201,6 +200,7 @@ class SearchViewModel(
                         includeNsfw = settingsRepository.current.value?.includeNsfw == true,
                     )
                 SearchSection.Users -> SearchPaginationSpecification.Users(query)
+                SearchSection.Groups -> SearchPaginationSpecification.Groups(query)
             },
         )
         loadNextPage()

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/data/SearchSection.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/data/SearchSection.kt
@@ -9,6 +9,8 @@ sealed interface SearchSection {
     data object Users : SearchSection
 
     data object Hashtags : SearchSection
+
+    data object Groups : SearchSection
 }
 
 @Composable
@@ -17,4 +19,5 @@ fun SearchSection.toReadableName(): String =
         SearchSection.Posts -> LocalStrings.current.accountSectionPosts
         SearchSection.Users -> LocalStrings.current.searchSectionUsers
         SearchSection.Hashtags -> LocalStrings.current.exploreSectionHashtags
+        SearchSection.Groups -> LocalStrings.current.circleTypeGroup
     }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR implements a new search tab, called "Groups" which is virtually equal to a reguar User search but only accounts flagged as ActivityPub groups are displayed among results.

## Additional notes
<!-- Anything to declare for code review? -->
Since the APIs do not support such search (yet) a client-side filter is done, which is far from efficient but it works.

<div align="center">
  <img src="https://github.com/user-attachments/assets/545a085b-085a-4444-8b42-30a39131bca2" width ="310" />
</div>
