### PR TITLE
refactor: make TemporaryKeystore methods suspending

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/auth/DefaultAuthManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/auth/DefaultAuthManager.kt
@@ -98,17 +98,17 @@ internal class DefaultAuthManager(
         }
     }
 
-    private fun storeInitialData(node: String, clientId: String, clientSecret: String) {
+    private suspend fun storeInitialData(node: String, clientId: String, clientSecret: String) {
         keyStore.save(KEY_LAST_NODE, node)
         keyStore.save(KEY_CLIENT_ID, clientId)
         keyStore.save(KEY_CLIENT_SECRET, clientSecret)
     }
 
-    private fun retrieveNode(): String = keyStore[KEY_LAST_NODE, ""]
+    private suspend fun retrieveNode(): String = keyStore.get(KEY_LAST_NODE, "")
 
-    private fun retrieveClientId(): String = keyStore[KEY_CLIENT_ID, ""]
+    private suspend fun retrieveClientId(): String = keyStore.get(KEY_CLIENT_ID, "")
 
-    private fun retrieveClientSecret(): String = keyStore[KEY_CLIENT_SECRET, ""]
+    private suspend fun retrieveClientSecret(): String = keyStore.get(KEY_CLIENT_SECRET, "")
 
     companion object {
         private const val AUTH_ENDPOINT = "oauth/authorize"

--- a/core/preferences/build.gradle.kts
+++ b/core/preferences/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
             dependencies {
                 implementation(libs.kodein)
                 implementation(libs.multiplatform.settings)
+                implementation(libs.kotlinx.coroutines)
             }
         }
     }

--- a/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/store/DefaultTemporaryKeyStore.kt
+++ b/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/store/DefaultTemporaryKeyStore.kt
@@ -1,61 +1,101 @@
 package com.livefast.eattrash.raccoonforfriendica.core.preferences.store
 
 import com.livefast.eattrash.raccoonforfriendica.core.preferences.settings.SettingsWrapper
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
 
-internal class DefaultTemporaryKeyStore(private val settings: SettingsWrapper) : TemporaryKeyStore {
-    override fun containsKey(key: String): Boolean = settings.keys.contains(key)
-
-    override fun save(key: String, value: Boolean) {
-        settings[key] = value
+internal class DefaultTemporaryKeyStore(
+    private val settings: SettingsWrapper,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : TemporaryKeyStore {
+    override suspend fun containsKey(key: String): Boolean = withContext(dispatcher) {
+        settings.keys.contains(key)
     }
 
-    override fun get(key: String, default: Boolean): Boolean = settings[key, default]
-
-    override fun save(key: String, value: String) {
-        settings[key] = value
+    override suspend fun save(key: String, value: Boolean) {
+        withContext(dispatcher) {
+            settings[key] = value
+        }
     }
 
-    override fun get(key: String, default: String): String = settings[key, default]
-
-    override fun save(key: String, value: Int) {
-        settings[key] = value
+    override suspend fun get(key: String, default: Boolean): Boolean = withContext(dispatcher) {
+        settings[key, default]
     }
 
-    override fun get(key: String, default: Int): Int = settings[key, default]
-
-    override fun save(key: String, value: Float) {
-        settings[key] = value
+    override suspend fun save(key: String, value: String) {
+        withContext(dispatcher) {
+            settings[key] = value
+        }
     }
 
-    override fun get(key: String, default: Float): Float = settings[key, default]
-
-    override fun save(key: String, value: Double) {
-        settings[key] = value
+    override suspend fun get(key: String, default: String): String = withContext(dispatcher) {
+        settings[key, default]
     }
 
-    override fun get(key: String, default: Double): Double = settings[key, default]
-
-    override fun save(key: String, value: Long) {
-        settings[key] = value
+    override suspend fun save(key: String, value: Int) {
+        withContext(dispatcher) {
+            settings[key] = value
+        }
     }
 
-    override fun get(key: String, default: Long): Long = settings[key, default]
-
-    override fun get(key: String, default: List<String>, delimiter: String): List<String> {
-        check(settings.hasKey(key)) { return default }
-        val joined = settings[key, ""]
-        return joined.split(delimiter)
+    override suspend fun get(key: String, default: Int): Int = withContext(dispatcher) {
+        settings[key, default]
     }
 
-    override fun save(key: String, value: List<String>, delimiter: String) {
-        settings[key] = value.joinToString(delimiter)
+    override suspend fun save(key: String, value: Float) {
+        withContext(dispatcher) {
+            settings[key] = value
+        }
     }
 
-    override fun remove(key: String) {
-        settings.remove(key)
+    override suspend fun get(key: String, default: Float): Float = withContext(dispatcher) {
+        settings[key, default]
     }
 
-    override fun removeAll() {
-        settings.clear()
+    override suspend fun save(key: String, value: Double) {
+        withContext(dispatcher) {
+            settings[key] = value
+        }
+    }
+
+    override suspend fun get(key: String, default: Double): Double = withContext(dispatcher) {
+        settings[key, default]
+    }
+
+    override suspend fun save(key: String, value: Long) {
+        withContext(dispatcher) {
+            settings[key] = value
+        }
+    }
+
+    override suspend fun get(key: String, default: Long): Long = withContext(dispatcher) {
+        settings[key, default]
+    }
+
+    override suspend fun get(key: String, default: List<String>, delimiter: String): List<String> =
+        withContext(dispatcher) {
+            check(settings.hasKey(key)) { return@withContext default }
+            val joined = settings[key, ""]
+            joined.split(delimiter)
+        }
+
+    override suspend fun save(key: String, value: List<String>, delimiter: String) {
+        withContext(dispatcher) {
+            settings[key] = value.joinToString(delimiter)
+        }
+    }
+
+    override suspend fun remove(key: String) {
+        withContext(dispatcher) {
+            settings.remove(key)
+        }
+    }
+
+    override suspend fun removeAll() {
+        withContext(dispatcher) {
+            settings.clear()
+        }
     }
 }

--- a/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/store/TemporaryKeyStore.kt
+++ b/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/store/TemporaryKeyStore.kt
@@ -10,7 +10,7 @@ interface TemporaryKeyStore {
      * @param key Key to check
      * @return true if the key store contains the key, false otherwise
      */
-    fun containsKey(key: String): Boolean
+    suspend fun containsKey(key: String): Boolean
 
     /**
      * Save a boolean value in the keystore under a given key.
@@ -18,7 +18,7 @@ interface TemporaryKeyStore {
      * @param key Key
      * @param value Value
      */
-    fun save(key: String, value: Boolean)
+    suspend fun save(key: String, value: Boolean)
 
     /**
      * Retrieve a boolean value from the key store given its key.
@@ -27,7 +27,7 @@ interface TemporaryKeyStore {
      * @param default Default value
      * @return value saved in the keystore or the default one
      */
-    operator fun get(key: String, default: Boolean): Boolean
+    suspend fun get(key: String, default: Boolean): Boolean
 
     /**
      * Save a string value in the keystore under a given key.
@@ -35,7 +35,7 @@ interface TemporaryKeyStore {
      * @param key Key
      * @param value Value
      */
-    fun save(key: String, value: String)
+    suspend fun save(key: String, value: String)
 
     /**
      * Retrieve a string value from the key store given its key.
@@ -44,7 +44,7 @@ interface TemporaryKeyStore {
      * @param default Default value
      * @return value saved in the keystore or the default one
      */
-    operator fun get(key: String, default: String): String
+    suspend fun get(key: String, default: String): String
 
     /**
      * Save an integer value in the keystore under a given key.
@@ -52,7 +52,7 @@ interface TemporaryKeyStore {
      * @param key Key
      * @param value Value
      */
-    fun save(key: String, value: Int)
+    suspend fun save(key: String, value: Int)
 
     /**
      * Retrieve an integer value from the key store given its key.
@@ -61,7 +61,7 @@ interface TemporaryKeyStore {
      * @param default Default value
      * @return value saved in the keystore or the default one
      */
-    operator fun get(key: String, default: Int): Int
+    suspend fun get(key: String, default: Int): Int
 
     /**
      * Save a floating point value in the keystore under a given key.
@@ -69,7 +69,7 @@ interface TemporaryKeyStore {
      * @param key Key
      * @param value Value
      */
-    fun save(key: String, value: Float)
+    suspend fun save(key: String, value: Float)
 
     /**
      * Retrieve a floating point value from the key store given its key.
@@ -78,7 +78,7 @@ interface TemporaryKeyStore {
      * @param default Default value
      * @return value saved in the keystore or the default one
      */
-    operator fun get(key: String, default: Float): Float
+    suspend fun get(key: String, default: Float): Float
 
     /**
      * Save a floating point (double precision) value in the keystore under a given key.
@@ -86,7 +86,7 @@ interface TemporaryKeyStore {
      * @param key Key
      * @param value Value
      */
-    fun save(key: String, value: Double)
+    suspend fun save(key: String, value: Double)
 
     /**
      * Save a long integer value in the keystore under a given key.
@@ -94,7 +94,7 @@ interface TemporaryKeyStore {
      * @param key Key
      * @param value Value
      */
-    fun save(key: String, value: Long)
+    suspend fun save(key: String, value: Long)
 
     /**
      * Retrieve a floating point (double precision) value from the key store given its key.
@@ -103,7 +103,7 @@ interface TemporaryKeyStore {
      * @param default Default value
      * @return value saved in the keystore or the default one
      */
-    operator fun get(key: String, default: Double): Double
+    suspend fun get(key: String, default: Double): Double
 
     /**
      * Retrieve a long integer value from the key store given its key.
@@ -112,25 +112,25 @@ interface TemporaryKeyStore {
      * @param default Default value
      * @return value saved in the keystore or the default one
      */
-    operator fun get(key: String, default: Long): Long
+    suspend fun get(key: String, default: Long): Long
 
     /**
      * Remove the given key from the repository.
      */
-    fun remove(key: String)
+    suspend fun remove(key: String)
 
     /**
      * Removes all entries from the store.
      */
-    fun removeAll()
+    suspend fun removeAll()
 
     /**
      * Retrieve a string list given its key.
      */
-    fun get(key: String, default: List<String> = emptyList(), delimiter: String = ", "): List<String>
+    suspend fun get(key: String, default: List<String> = emptyList(), delimiter: String = ", "): List<String>
 
     /**
      * Save a string list under a given key.
      */
-    fun save(key: String, value: List<String>, delimiter: String = ", ")
+    suspend fun save(key: String, value: List<String>, delimiter: String = ", ")
 }

--- a/core/preferences/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/settings/DefaultTemporaryKeyStoreTest.kt
+++ b/core/preferences/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/settings/DefaultTemporaryKeyStoreTest.kt
@@ -7,6 +7,8 @@ import dev.mokkery.every
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -18,7 +20,7 @@ class DefaultTemporaryKeyStoreTest {
     private val sut = DefaultTemporaryKeyStore(settings)
 
     @Test
-    fun `given non existing key when contains key then interactions are as expected`() {
+    fun `given non existing key when contains key then interactions are as expected`() = runTest {
         every { settings.hasKey(any()) } returns false
         every { settings.keys } returns setOf()
 
@@ -28,7 +30,7 @@ class DefaultTemporaryKeyStoreTest {
     }
 
     @Test
-    fun `given existing key when contains key then interactions are as expected`() {
+    fun `given existing key when contains key then interactions are as expected`() = runTest {
         every { settings.keys } returns setOf("key")
 
         val res = sut.containsKey("key")
@@ -40,11 +42,11 @@ class DefaultTemporaryKeyStoreTest {
     }
 
     @Test
-    fun `when get Int then result is as expected`() {
+    fun `when get Int then result is as expected`() = runTest {
         every { settings.hasKey(any()) } returns true
         every { settings[any(), any<Int>()] } returns 2
 
-        val res = sut["key", 1]
+        val res = sut.get("key", 1)
         assertEquals(2, res)
         verify {
             settings["key", 1]
@@ -52,7 +54,7 @@ class DefaultTemporaryKeyStoreTest {
     }
 
     @Test
-    fun `when save Int then interactions are as expected`() {
+    fun `when save Int then interactions are as expected`() = runTest {
         sut.save("key", 0)
 
         verify {
@@ -61,11 +63,11 @@ class DefaultTemporaryKeyStoreTest {
     }
 
     @Test
-    fun `when get Long then result is as expected`() {
+    fun `when get Long then result is as expected`() = runTest {
         every { settings.hasKey(any()) } returns true
         every { settings[any(), any<Long>()] } returns 2
 
-        val res = sut["key", 1L]
+        val res = sut.get("key", 1L)
         assertEquals(2L, res)
         verify {
             settings["key", 1L]
@@ -73,7 +75,7 @@ class DefaultTemporaryKeyStoreTest {
     }
 
     @Test
-    fun `when save Long then interactions are as expected`() {
+    fun `when save Long then interactions are as expected`() = runTest {
         sut.save("key", 1L)
         verify {
             settings["key"] = 1L
@@ -81,11 +83,11 @@ class DefaultTemporaryKeyStoreTest {
     }
 
     @Test
-    fun `when get Boolean then result is as expected`() {
+    fun `when get Boolean then result is as expected`() = runTest {
         every { settings.hasKey(any()) } returns true
         every { settings[any(), any<Boolean>()] } returns true
 
-        val res = sut["key", false]
+        val res = sut.get("key", false)
         assertTrue(res)
         verify {
             settings["key", false]
@@ -93,7 +95,7 @@ class DefaultTemporaryKeyStoreTest {
     }
 
     @Test
-    fun `when save Boolean then interactions are as expected`() {
+    fun `when save Boolean then interactions are as expected`() = runTest {
         sut.save("key", true)
 
         verify {
@@ -102,11 +104,11 @@ class DefaultTemporaryKeyStoreTest {
     }
 
     @Test
-    fun `when get String then result is as expected`() {
+    fun `when get String then result is as expected`() = runTest {
         every { settings.hasKey(any()) } returns true
         every { settings[any(), any<String>()] } returns "b"
 
-        val res = sut["key", "a"]
+        val res = sut.get("key", "a")
         assertEquals("b", res)
         verify {
             settings["key", "a"]
@@ -114,7 +116,7 @@ class DefaultTemporaryKeyStoreTest {
     }
 
     @Test
-    fun `when save String then interactions are as expected`() {
+    fun `when save String then interactions are as expected`() = runTest {
         sut.save("key", "value")
 
         verify {
@@ -123,11 +125,11 @@ class DefaultTemporaryKeyStoreTest {
     }
 
     @Test
-    fun `when get Float then result is as expected`() {
+    fun `when get Float then result is as expected`() = runTest {
         every { settings.hasKey(any()) } returns true
         every { settings[any(), any<Float>()] } returns 2.0f
 
-        val res = sut["key", 1.0f]
+        val res = sut.get("key", 1.0f)
         assertEquals(2.0f, res)
         verify {
             settings["key", 1.0f]
@@ -135,7 +137,7 @@ class DefaultTemporaryKeyStoreTest {
     }
 
     @Test
-    fun `when save Float then interactions are as expected`() {
+    fun `when save Float then interactions are as expected`() = runTest {
         sut.save("key", 1.0f)
         verify {
             settings["key"] = 1.0f
@@ -143,11 +145,11 @@ class DefaultTemporaryKeyStoreTest {
     }
 
     @Test
-    fun `when get Double then result is as expected`() {
+    fun `when get Double then result is as expected`() = runTest {
         every { settings.hasKey(any()) } returns true
         every { settings[any(), any<Double>()] } returns 2.0
 
-        val res = sut["key", 1.0]
+        val res = sut.get("key", 1.0)
         assertEquals(2.0, res)
         verify {
             settings["key", 1.0]
@@ -155,7 +157,7 @@ class DefaultTemporaryKeyStoreTest {
     }
 
     @Test
-    fun `when save Double then interactions are as expected`() {
+    fun `when save Double then interactions are as expected`() = runTest {
         sut.save("key", 1.0)
 
         verify {
@@ -164,7 +166,7 @@ class DefaultTemporaryKeyStoreTest {
     }
 
     @Test
-    fun `given non existing key when get string list then result is as expected`() {
+    fun `given non existing key when get String list then result is as expected`() = runTest {
         every { settings.hasKey(any()) } returns false
 
         val res = sut.get("key", listOf(""))
@@ -172,7 +174,7 @@ class DefaultTemporaryKeyStoreTest {
     }
 
     @Test
-    fun `given existing key when get string list then result is as expected`() {
+    fun `given existing key when get String list then result is as expected`() = runTest {
         every { settings.hasKey(any()) } returns true
         every { settings[any(), any<String>()] } returns "a, b"
 
@@ -186,17 +188,17 @@ class DefaultTemporaryKeyStoreTest {
     }
 
     @Test
-    fun `when save String list then interactions are as expected`() {
+    fun `when save String list then interactions are as expected`() = runTest {
         val values = listOf("a", "b", "c")
         sut.save("key", values)
 
-        verify {
-            sut.save(key = "key", value = values, delimiter = ", ")
+        verifySuspend {
+            settings.set(key = "key", value = values.joinToString(", "))
         }
     }
 
     @Test
-    fun `when remove then interactions are as expected`() {
+    fun `when remove then interactions are as expected`() = runTest {
         sut.remove("key")
 
         verify {
@@ -205,7 +207,7 @@ class DefaultTemporaryKeyStoreTest {
     }
 
     @Test
-    fun `when remove all then interactions are as expected`() {
+    fun `when remove all then interactions are as expected`() = runTest {
         sut.removeAll()
 
         verify {

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/AccountCredentialsCache.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/AccountCredentialsCache.kt
@@ -1,9 +1,9 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository
 
 interface AccountCredentialsCache {
-    fun get(accountId: Long): ApiCredentials?
+    suspend fun get(accountId: Long): ApiCredentials?
 
-    fun save(accountId: Long, credentials: ApiCredentials)
+    suspend fun save(accountId: Long, credentials: ApiCredentials)
 
-    fun remove(accountId: Long)
+    suspend fun remove(accountId: Long)
 }

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/ApiConfigurationRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/ApiConfigurationRepository.kt
@@ -7,11 +7,12 @@ import kotlinx.coroutines.flow.StateFlow
 interface ApiConfigurationRepository {
     val node: StateFlow<String>
     val isLogged: StateFlow<Boolean>
-    val defaultNode: String
 
-    fun changeNode(value: String)
+    suspend fun getDefaultNode(): String
 
-    fun setAuth(credentials: ApiCredentials? = null)
+    suspend fun changeNode(value: String)
+
+    suspend fun setAuth(credentials: ApiCredentials? = null)
 
     suspend fun hasCachedAuthCredentials(): Boolean
 }

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultAccountCredentialsCache.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultAccountCredentialsCache.kt
@@ -3,10 +3,10 @@ package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository
 import com.livefast.eattrash.raccoonforfriendica.core.preferences.store.TemporaryKeyStore
 
 internal class DefaultAccountCredentialsCache(private val keyStore: TemporaryKeyStore) : AccountCredentialsCache {
-    override fun get(accountId: Long): ApiCredentials? {
-        val type = keyStore[getKeyForType(accountId), ""]
-        val part1 = keyStore[getKeyForPart1(accountId), ""]
-        val part2 = keyStore[getKeyForPart2(accountId), ""]
+    override suspend fun get(accountId: Long): ApiCredentials? {
+        val type = keyStore.get(getKeyForType(accountId), "")
+        val part1 = keyStore.get(getKeyForPart1(accountId), "")
+        val part2 = keyStore.get(getKeyForPart2(accountId), "")
         return when {
             type == METHOD_BASIC && part1.isNotEmpty() && part2.isNotEmpty() ->
                 ApiCredentials.HttpBasic(
@@ -24,7 +24,7 @@ internal class DefaultAccountCredentialsCache(private val keyStore: TemporaryKey
         }
     }
 
-    override fun save(accountId: Long, credentials: ApiCredentials) {
+    override suspend fun save(accountId: Long, credentials: ApiCredentials) {
         val type: String
         val part1: String
         val part2: String
@@ -46,7 +46,7 @@ internal class DefaultAccountCredentialsCache(private val keyStore: TemporaryKey
         keyStore.save(getKeyForPart2(accountId), part2)
     }
 
-    override fun remove(accountId: Long) {
+    override suspend fun remove(accountId: Long) {
         keyStore.remove(getKeyForType(accountId))
         keyStore.remove(getKeyForPart1(accountId))
         keyStore.remove(getKeyForPart2(accountId))

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultInstanceShortcutRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultInstanceShortcutRepository.kt
@@ -30,7 +30,7 @@ internal class DefaultInstanceShortcutRepository(private val keyStore: Temporary
 
     private fun getKey(accountId: Long) = "InstanceShortcutRepository.$accountId.items"
 
-    private fun updateValues(accountId: Long, values: List<String>) {
+    private suspend fun updateValues(accountId: Long, values: List<String>) {
         val key = getKey(accountId)
         keyStore.save(key = key, values)
     }

--- a/domain/identity/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultAccountCredentialsCacheTest.kt
+++ b/domain/identity/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultAccountCredentialsCacheTest.kt
@@ -3,10 +3,11 @@ package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository
 import com.livefast.eattrash.raccoonforfriendica.core.preferences.store.TemporaryKeyStore
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
-import dev.mokkery.every
+import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
-import dev.mokkery.verify
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -14,13 +15,13 @@ import kotlin.test.assertNull
 class DefaultAccountCredentialsCacheTest {
     private val keyStore =
         mock<TemporaryKeyStore>(MockMode.autoUnit) {
-            every { get(any<String>(), any<String>()) } returns ""
+            everySuspend { get(any<String>(), any<String>()) } returns ""
         }
 
     private val sut = DefaultAccountCredentialsCache(keyStore)
 
     @Test
-    fun `given no credentials stored when get then result is as expected`() {
+    fun `given no credentials stored when get then result is as expected`() = runTest {
         val accountId = 1L
 
         val res = sut.get(accountId)
@@ -29,11 +30,11 @@ class DefaultAccountCredentialsCacheTest {
     }
 
     @Test
-    fun `given OAuth credentials stored when get then result is as expected`() {
+    fun `given OAuth credentials stored when get then result is as expected`() = runTest {
         val accountId = 1L
-        every { keyStore[getKey(accountId, "type"), any<String>()] } returns "OAuth2"
-        every { keyStore[getKey(accountId, "part1"), any<String>()] } returns "fake-access-token"
-        every { keyStore[getKey(accountId, "part2"), any<String>()] } returns ""
+        everySuspend { keyStore.get(getKey(accountId, "type"), any<String>()) } returns "OAuth2"
+        everySuspend { keyStore.get(getKey(accountId, "part1"), any<String>()) } returns "fake-access-token"
+        everySuspend { keyStore.get(getKey(accountId, "part2"), any<String>()) } returns ""
 
         val res = sut.get(accountId)
 
@@ -44,11 +45,11 @@ class DefaultAccountCredentialsCacheTest {
     }
 
     @Test
-    fun `given basic credentials stored when get then result is as expected`() {
+    fun `given basic credentials stored when get then result is as expected`() = runTest {
         val accountId = 1L
-        every { keyStore[getKey(accountId, "type"), any<String>()] } returns "HTTPBasic"
-        every { keyStore[getKey(accountId, "part1"), any<String>()] } returns "fake1"
-        every { keyStore[getKey(accountId, "part2"), any<String>()] } returns "fake2"
+        everySuspend { keyStore.get(getKey(accountId, "type"), any<String>()) } returns "HTTPBasic"
+        everySuspend { keyStore.get(getKey(accountId, "part1"), any<String>()) } returns "fake1"
+        everySuspend { keyStore.get(getKey(accountId, "part2"), any<String>()) } returns "fake2"
 
         val res = sut.get(accountId)
 
@@ -56,7 +57,7 @@ class DefaultAccountCredentialsCacheTest {
     }
 
     @Test
-    fun `when save OAuth credentials then interactions are expected`() {
+    fun `when save OAuth credentials then interactions are expected`() = runTest {
         val accountId = 1L
 
         sut.save(
@@ -64,7 +65,7 @@ class DefaultAccountCredentialsCacheTest {
             ApiCredentials.OAuth2(accessToken = "fake-access-token", refreshToken = ""),
         )
 
-        verify {
+        verifySuspend {
             keyStore.save(getKey(accountId, "type"), "OAuth2")
             keyStore.save(getKey(accountId, "part1"), "fake-access-token")
             keyStore.save(getKey(accountId, "part2"), "")
@@ -72,7 +73,7 @@ class DefaultAccountCredentialsCacheTest {
     }
 
     @Test
-    fun `when save basic credentials then interactions are expected`() {
+    fun `when save basic credentials then interactions are expected`() = runTest {
         val accountId = 1L
 
         sut.save(
@@ -80,7 +81,7 @@ class DefaultAccountCredentialsCacheTest {
             ApiCredentials.HttpBasic(user = "fake1", pass = "fake2"),
         )
 
-        verify {
+        verifySuspend {
             keyStore.save(getKey(accountId, "type"), "HTTPBasic")
             keyStore.save(getKey(accountId, "part1"), "fake1")
             keyStore.save(getKey(accountId, "part2"), "fake2")
@@ -88,12 +89,12 @@ class DefaultAccountCredentialsCacheTest {
     }
 
     @Test
-    fun `when remove then interactions are expected`() {
+    fun `when remove then interactions are expected`() = runTest {
         val accountId = 1L
 
         sut.remove(accountId)
 
-        verify {
+        verifySuspend {
             keyStore.remove(getKey(accountId, "type"))
             keyStore.remove(getKey(accountId, "part1"))
             keyStore.remove(getKey(accountId, "part2"))

--- a/domain/identity/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultApiConfigurationRepositoryTest.kt
+++ b/domain/identity/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultApiConfigurationRepositoryTest.kt
@@ -5,11 +5,9 @@ import com.livefast.eattrash.raccoonforfriendica.core.preferences.store.Temporar
 import dev.mokkery.MockMode
 import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
-import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
-import dev.mokkery.verify
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
@@ -21,10 +19,10 @@ import kotlin.time.Duration.Companion.seconds
 class DefaultApiConfigurationRepositoryTest {
     private val keyStore =
         mock<TemporaryKeyStore>(MockMode.autoUnit) {
-            every { get("lastInstance", any<String>()) } returns "default-instance"
-            every { get("lastMethod", any<String>()) } returns "OAuth2"
-            every { get("lastCred1", any<String>()) } returns "fake-access-token"
-            every { get("lastCred2", any<String>()) } returns ""
+            everySuspend { get("lastInstance", any<String>()) } returns "default-instance"
+            everySuspend { get("lastMethod", any<String>()) } returns "OAuth2"
+            everySuspend { get("lastCred1", any<String>()) } returns "fake-access-token"
+            everySuspend { get("lastCred2", any<String>()) } returns ""
         }
 
     private val serviceProvider = mock<ServiceProvider>(MockMode.autoUnit)
@@ -47,7 +45,7 @@ class DefaultApiConfigurationRepositoryTest {
     fun `when change node then interactions are as expected`() = runTest {
         sut.changeNode("new-instance")
 
-        verify {
+        verifySuspend {
             serviceProvider.changeNode("new-instance")
             keyStore.save("lastInstance", "new-instance")
         }
@@ -60,7 +58,7 @@ class DefaultApiConfigurationRepositoryTest {
         sut.setAuth(credentials)
 
         assertTrue(sut.isLogged.value)
-        verify {
+        verifySuspend {
             serviceProvider.setAuth(credentials.toServiceCredentials())
             keyStore.save("lastMethod", "OAuth2")
             keyStore.save("lastCred1", "fake-access-token-2")
@@ -74,7 +72,7 @@ class DefaultApiConfigurationRepositoryTest {
         sut.setAuth(credentials)
 
         assertTrue(sut.isLogged.value)
-        verify {
+        verifySuspend {
             serviceProvider.setAuth(credentials.toServiceCredentials())
             keyStore.save("lastMethod", "HTTPBasic")
             keyStore.save("lastCred1", "fake1")
@@ -87,7 +85,7 @@ class DefaultApiConfigurationRepositoryTest {
         sut.setAuth(null)
 
         assertFalse(sut.isLogged.value)
-        verify {
+        verifySuspend {
             serviceProvider.setAuth()
             keyStore.remove("lastCred1")
             keyStore.remove("lastCred2")
@@ -116,9 +114,9 @@ class DefaultApiConfigurationRepositoryTest {
 
     @Test
     fun `given invalid basic credentials stored when hasCachedAuthCredentials then result is as expected`() = runTest {
-        every { keyStore["lastMethod", any<String>()] } returns "HTTPBasic"
-        every { keyStore["lastCred1", any<String>()] } returns "fake1"
-        every { keyStore["lastCred2", any<String>()] } returns "fake2"
+        everySuspend { keyStore.get("lastMethod", any<String>()) } returns "HTTPBasic"
+        everySuspend { keyStore.get("lastCred1", any<String>()) } returns "fake1"
+        everySuspend { keyStore.get("lastCred2", any<String>()) } returns "fake2"
         everySuspend {
             credentialsRepository.validateApplicationCredentials(
                 node = any(),

--- a/domain/identity/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultInstanceShortcutRepositoryTest.kt
+++ b/domain/identity/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultInstanceShortcutRepositoryTest.kt
@@ -3,10 +3,10 @@ package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository
 import com.livefast.eattrash.raccoonforfriendica.core.preferences.store.TemporaryKeyStore
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
-import dev.mokkery.every
+import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
-import dev.mokkery.verify
+import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -21,12 +21,12 @@ class DefaultInstanceShortcutRepositoryTest {
     @Test
     fun givenNoData_whenGetAll_thenResultAndInteractionsIsAsExpected() = runTest {
         val accountId = 1L
-        every { keyStore.get(any(), any<List<String>>()) } returns emptyList()
+        everySuspend { keyStore.get(any(), any<List<String>>()) } returns emptyList()
 
         val res = sut.getAll(accountId)
 
         assertEquals(emptyList(), res)
-        verify {
+        verifySuspend {
             keyStore.get("$KEY_PREFIX.$accountId.items", emptyList())
         }
     }
@@ -35,12 +35,12 @@ class DefaultInstanceShortcutRepositoryTest {
     fun givenData_whenGetAll_thenResultAndInteractionsIsAsExpected() = runTest {
         val accountId = 1L
         val fakeList = listOf("node")
-        every { keyStore.get(any(), any<List<String>>()) } returns fakeList
+        everySuspend { keyStore.get(any(), any<List<String>>()) } returns fakeList
 
         val res = sut.getAll(accountId)
 
         assertEquals(fakeList, res)
-        verify {
+        verifySuspend {
             keyStore.get("$KEY_PREFIX.$accountId.items", emptyList())
         }
     }
@@ -50,13 +50,13 @@ class DefaultInstanceShortcutRepositoryTest {
         val otherAccountId = 1L
         val accountId = 2L
         val fakeList = listOf("node")
-        every {
+        everySuspend {
             keyStore.get(
                 "$KEY_PREFIX.$otherAccountId.items",
                 any<List<String>>(),
             )
         } returns fakeList
-        every {
+        everySuspend {
             keyStore.get(
                 "$KEY_PREFIX.$accountId.items",
                 any<List<String>>(),
@@ -66,7 +66,7 @@ class DefaultInstanceShortcutRepositoryTest {
         val res = sut.getAll(accountId)
 
         assertEquals(emptyList(), res)
-        verify {
+        verifySuspend {
             keyStore.get("$KEY_PREFIX.$accountId.items", emptyList())
         }
     }
@@ -75,7 +75,7 @@ class DefaultInstanceShortcutRepositoryTest {
     fun whenCreate_thenInteractionsAreAsExpected() = runTest {
         val accountId = 1L
         val node = "node"
-        every {
+        everySuspend {
             keyStore.get(
                 "$KEY_PREFIX.$accountId.items",
                 any<List<String>>(),
@@ -84,7 +84,7 @@ class DefaultInstanceShortcutRepositoryTest {
 
         sut.create(accountId = accountId, node = node)
 
-        verify {
+        verifySuspend {
             keyStore.save("$KEY_PREFIX.$accountId.items", listOf(node))
         }
     }
@@ -94,7 +94,7 @@ class DefaultInstanceShortcutRepositoryTest {
         val accountId = 1L
         val node = "node"
         val fakeList = listOf(node)
-        every {
+        everySuspend {
             keyStore.get(
                 "$KEY_PREFIX.$accountId.items",
                 any<List<String>>(),
@@ -103,7 +103,7 @@ class DefaultInstanceShortcutRepositoryTest {
 
         sut.create(accountId = accountId, node = node)
 
-        verify {
+        verifySuspend {
             keyStore.save("$KEY_PREFIX.$accountId.items", fakeList)
         }
     }
@@ -113,7 +113,7 @@ class DefaultInstanceShortcutRepositoryTest {
         val accountId = 1L
         val node = "node"
         val fakeList = listOf(node)
-        every {
+        everySuspend {
             keyStore.get(
                 "$KEY_PREFIX.$accountId.items",
                 any<List<String>>(),
@@ -122,7 +122,7 @@ class DefaultInstanceShortcutRepositoryTest {
 
         sut.delete(accountId = accountId, node = node)
 
-        verify {
+        verifySuspend {
             keyStore.save("$KEY_PREFIX.$accountId.items", emptyList())
         }
     }
@@ -132,7 +132,7 @@ class DefaultInstanceShortcutRepositoryTest {
         val accountId = 1L
         val node = "node"
         val fakeList = listOf("other")
-        every {
+        everySuspend {
             keyStore.get(
                 "$KEY_PREFIX.$accountId.items",
                 any<List<String>>(),
@@ -141,7 +141,7 @@ class DefaultInstanceShortcutRepositoryTest {
 
         sut.delete(accountId = accountId, node = node)
 
-        verify {
+        verifySuspend {
             keyStore.save("$KEY_PREFIX.$accountId.items", fakeList)
         }
     }

--- a/domain/identity/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultStopWordRepositoryTest.kt
+++ b/domain/identity/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultStopWordRepositoryTest.kt
@@ -3,10 +3,10 @@ package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository
 import com.livefast.eattrash.raccoonforfriendica.core.preferences.store.TemporaryKeyStore
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
-import dev.mokkery.every
+import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
-import dev.mokkery.verify
+import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -20,12 +20,12 @@ class DefaultStopWordRepositoryTest {
 
     @Test
     fun givenNoData_whenGetForAnonymousUser_thenResultAndInteractionsIsAsExpected() = runTest {
-        every { keyStore.get(any(), any<List<String>>()) } returns emptyList()
+        everySuspend { keyStore.get(any(), any<List<String>>()) } returns emptyList()
 
         val res = sut.get(null)
 
         assertEquals(emptyList(), res)
-        verify {
+        verifySuspend {
             keyStore.get("$KEY_PREFIX.items", emptyList())
         }
     }
@@ -33,12 +33,12 @@ class DefaultStopWordRepositoryTest {
     @Test
     fun givenData_whenGetForAnonymousUser_thenResultAndInteractionsIsAsExpected() = runTest {
         val fakeList = listOf("word")
-        every { keyStore.get(any(), any<List<String>>()) } returns fakeList
+        everySuspend { keyStore.get(any(), any<List<String>>()) } returns fakeList
 
         val res = sut.get(null)
 
         assertEquals(fakeList, res)
-        verify {
+        verifySuspend {
             keyStore.get("$KEY_PREFIX.items", emptyList())
         }
     }
@@ -46,12 +46,12 @@ class DefaultStopWordRepositoryTest {
     @Test
     fun givenNoData_whenGetForLoggedUser_thenResultAndInteractionsIsAsExpected() = runTest {
         val accountId = 1L
-        every { keyStore.get(any(), any<List<String>>()) } returns emptyList()
+        everySuspend { keyStore.get(any(), any<List<String>>()) } returns emptyList()
 
         val res = sut.get(accountId)
 
         assertEquals(emptyList(), res)
-        verify {
+        verifySuspend {
             keyStore.get("$KEY_PREFIX.$accountId.items", emptyList())
         }
     }
@@ -60,12 +60,12 @@ class DefaultStopWordRepositoryTest {
     fun givenData_whenGetForLoggedUser_thenResultAndInteractionsIsAsExpected() = runTest {
         val accountId = 1L
         val fakeList = listOf("word")
-        every { keyStore.get(any(), any<List<String>>()) } returns fakeList
+        everySuspend { keyStore.get(any(), any<List<String>>()) } returns fakeList
 
         val res = sut.get(accountId)
 
         assertEquals(fakeList, res)
-        verify {
+        verifySuspend {
             keyStore.get("$KEY_PREFIX.$accountId.items", emptyList())
         }
     }
@@ -75,13 +75,13 @@ class DefaultStopWordRepositoryTest {
         val otherAccountId = 1L
         val accountId = 2L
         val fakeList = listOf("word")
-        every {
+        everySuspend {
             keyStore.get(
                 "$KEY_PREFIX.$otherAccountId.items",
                 any<List<String>>(),
             )
         } returns fakeList
-        every {
+        everySuspend {
             keyStore.get(
                 "$KEY_PREFIX.$accountId.items",
                 any<List<String>>(),
@@ -91,7 +91,7 @@ class DefaultStopWordRepositoryTest {
         val res = sut.get(accountId)
 
         assertEquals(emptyList(), res)
-        verify {
+        verifySuspend {
             keyStore.get("$KEY_PREFIX.$accountId.items", emptyList())
         }
     }
@@ -100,13 +100,13 @@ class DefaultStopWordRepositoryTest {
     fun givenDataForOtherUser_whenGetForAnonymousAccount_thenResultAndInteractionsIsAsExpected() = runTest {
         val otherAccountId = 1
         val fakeList = listOf("word")
-        every {
+        everySuspend {
             keyStore.get(
                 "$KEY_PREFIX.$otherAccountId.items",
                 any<List<String>>(),
             )
         } returns fakeList
-        every {
+        everySuspend {
             keyStore.get(
                 "$KEY_PREFIX.items",
                 any<List<String>>(),
@@ -116,7 +116,7 @@ class DefaultStopWordRepositoryTest {
         val res = sut.get(null)
 
         assertEquals(emptyList(), res)
-        verify {
+        verifySuspend {
             keyStore.get("$KEY_PREFIX.items", emptyList())
         }
     }
@@ -126,7 +126,7 @@ class DefaultStopWordRepositoryTest {
         val fakeList = listOf("word")
         sut.update(accountId = null, items = fakeList)
 
-        verify {
+        verifySuspend {
             keyStore.save("$KEY_PREFIX.items", fakeList)
         }
     }
@@ -138,7 +138,7 @@ class DefaultStopWordRepositoryTest {
 
         sut.update(accountId = accountId, items = fakeList)
 
-        verify {
+        verifySuspend {
             keyStore.save("$KEY_PREFIX.$accountId.items", fakeList)
         }
     }

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitor.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitor.kt
@@ -70,7 +70,7 @@ internal class DefaultActiveAccountMonitor(
     }
 
     private suspend fun process(account: AccountModel?) {
-        val defaultNode = apiConfigurationRepository.defaultNode
+        val defaultNode = apiConfigurationRepository.getDefaultNode()
         if (account == null) {
             apiConfigurationRepository.changeNode(defaultNode)
             apiConfigurationRepository.setAuth(null)

--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitorTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultActiveAccountMonitorTest.kt
@@ -33,7 +33,7 @@ class DefaultActiveAccountMonitorTest {
     private val accountRepository = mock<AccountRepository>(MockMode.autoUnit)
     private val apiConfigurationRepository =
         mock<ApiConfigurationRepository>(MockMode.autoUnit) {
-            every { defaultNode } returns "default-instance"
+            everySuspend { getDefaultNode() } returns "default-instance"
             every { node } returns MutableStateFlow("test-instance")
         }
     private val identityRepository = mock<IdentityRepository>(MockMode.autoUnit)
@@ -107,7 +107,7 @@ class DefaultActiveAccountMonitorTest {
         every { accountRepository.getActiveAsFlow() } returns accountChannel.receiveAsFlow()
         everySuspend { accountRepository.getActive() } returns account
         val credentials = ApiCredentials.OAuth2("fake-access-token", "")
-        every { accountCredentialsCache.get(any()) } returns credentials
+        everySuspend { accountCredentialsCache.get(any()) } returns credentials
         val settings = SettingsModel()
         everySuspend { settingsRepository.get(any()) } returns settings
 


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR makes methods in `TemporaryKeystore` suspending and main-safe, to make sure preferences are accessed correctly.
