### PR TITLE
refactor: remove useless dispatcher switches 

### DIFF
--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/DefaultBlurHashDecoder.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/DefaultBlurHashDecoder.kt
@@ -4,6 +4,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.toArgb
 import com.livefast.eattrash.raccoonforfriendica.core.utils.cache.LruCache
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
 import kotlin.math.PI
 import kotlin.math.cos
 import kotlin.math.pow
@@ -33,12 +36,12 @@ internal class DefaultBlurHashDecoder(
         height: Int,
         punch: Float,
         useCache: Boolean,
-    ): ImageBitmap? {
-        check(blurHash != null && blurHash.length >= 6) { return null }
+    ): ImageBitmap? = withContext(Dispatchers.IO) {
+        check(blurHash != null && blurHash.length >= 6) { return@withContext null }
         val numCompEnc = decode83(blurHash, 0, 1)
         val numCompX = (numCompEnc % 9) + 1
         val numCompY = (numCompEnc / 9) + 1
-        check(blurHash.length == 4 + 2 * numCompX * numCompY) { return null }
+        check(blurHash.length == 4 + 2 * numCompX * numCompY) { return@withContext null }
         val maxAcEnc = decode83(blurHash, 1, 2)
         val maxAc = (maxAcEnc + 1) / 166f
         val colors =
@@ -52,7 +55,7 @@ internal class DefaultBlurHashDecoder(
                     decodeAc(colorEnc, maxAc * punch)
                 }
             }
-        return runCatching {
+        runCatching {
             composeBitmap(width, height, numCompX, numCompY, colors, useCache)
         }.getOrNull()
     }

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/DefaultBlurHashRepository.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/DefaultBlurHashRepository.kt
@@ -2,15 +2,10 @@ package com.livefast.eattrash.raccoonforfriendica.core.utils.imageload
 
 import androidx.compose.ui.graphics.ImageBitmap
 import com.livefast.eattrash.raccoonforfriendica.core.utils.cache.LruCache
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.withContext
 
 internal class DefaultBlurHashRepository(
     private val decoder: BlurHashDecoder,
     private val cache: LruCache<String, ImageBitmap> = LruCache.factory(CACHE_SIZE),
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : BlurHashRepository {
     override suspend fun preload(params: BlurHashParams) {
         val key = params.hash
@@ -36,13 +31,12 @@ internal class DefaultBlurHashRepository(
             }
     }
 
-    private suspend fun decode(blurHash: String, width: Int, height: Int): ImageBitmap? = withContext(dispatcher) {
+    private suspend fun decode(blurHash: String, width: Int, height: Int): ImageBitmap? =
         decoder.decode(
             blurHash = blurHash,
             width = width,
             height = height,
         )
-    }
 
     companion object {
         private const val CACHE_SIZE = 20

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultAnnouncementRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultAnnouncementRepository.kt
@@ -3,17 +3,14 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.AnnouncementModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
 
 internal class DefaultAnnouncementRepository(private val provider: ServiceProvider) : AnnouncementRepository {
     private val mutex = Mutex()
     private val cachedValues: MutableList<AnnouncementModel> = mutableListOf()
 
-    override suspend fun getAll(refresh: Boolean): List<AnnouncementModel>? = withContext(Dispatchers.IO) {
+    override suspend fun getAll(refresh: Boolean): List<AnnouncementModel>? {
         if (refresh) {
             mutex.withLock {
                 cachedValues.clear()
@@ -21,9 +18,10 @@ internal class DefaultAnnouncementRepository(private val provider: ServiceProvid
         }
         if (cachedValues.isNotEmpty()) {
             // map to a new immutable list or Compose freaks out
-            return@withContext cachedValues.map { it }
+            return cachedValues.map { it }
         }
-        runCatching {
+
+        return runCatching {
             val response = provider.announcements.getAll()
             response
                 .map { it.toModel() }
@@ -35,32 +33,26 @@ internal class DefaultAnnouncementRepository(private val provider: ServiceProvid
         }.getOrNull()
     }
 
-    override suspend fun markAsRead(id: String): Boolean = withContext(Dispatchers.IO) {
-        runCatching {
-            val res = provider.announcements.dismiss(id)
-            res.isSuccessful
-        }.getOrElse { false }
-    }
+    override suspend fun markAsRead(id: String): Boolean = runCatching {
+        val res = provider.announcements.dismiss(id)
+        res.isSuccessful
+    }.getOrElse { false }
 
-    override suspend fun addReaction(id: String, reaction: String): Boolean = withContext(Dispatchers.IO) {
-        runCatching {
-            val res =
-                provider.announcements.addReaction(
-                    id = id,
-                    name = reaction,
-                )
-            res.isSuccessful
-        }.getOrElse { false }
-    }
+    override suspend fun addReaction(id: String, reaction: String): Boolean = runCatching {
+        val res =
+            provider.announcements.addReaction(
+                id = id,
+                name = reaction,
+            )
+        res.isSuccessful
+    }.getOrElse { false }
 
-    override suspend fun removeReaction(id: String, reaction: String): Boolean = withContext(Dispatchers.IO) {
-        runCatching {
-            val res =
-                provider.announcements.removeReaction(
-                    id = id,
-                    name = reaction,
-                )
-            res.isSuccessful
-        }.getOrElse { false }
-    }
+    override suspend fun removeReaction(id: String, reaction: String): Boolean = runCatching {
+        val res =
+            provider.announcements.removeReaction(
+                id = id,
+                name = reaction,
+            )
+        res.isSuccessful
+    }.getOrElse { false }
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultCirclesRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultCirclesRepository.kt
@@ -8,52 +8,26 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.CircleReply
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toDto
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.withContext
 
 internal class DefaultCirclesRepository(private val provider: ServiceProvider) : CirclesRepository {
-    override suspend fun getAll(): List<CircleModel>? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.lists.getAll().map { it.toModel() }
-        }.getOrNull()
-    }
+    override suspend fun getAll(): List<CircleModel>? = runCatching {
+        provider.lists.getAll().map { it.toModel() }
+    }.getOrNull()
 
-    override suspend fun get(id: String): CircleModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.lists.getBy(id).toModel()
-        }.getOrNull()
-    }
+    override suspend fun get(id: String): CircleModel? = runCatching {
+        provider.lists.getBy(id).toModel()
+    }.getOrNull()
 
-    override suspend fun getMembers(id: String, pageCursor: String?): List<UserModel>? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.lists
-                .getMembers(
-                    id = id,
-                    maxId = pageCursor,
-                ).map { it.toModel() }
-        }.getOrNull()
-    }
+    override suspend fun getMembers(id: String, pageCursor: String?): List<UserModel>? = runCatching {
+        provider.lists
+            .getMembers(
+                id = id,
+                maxId = pageCursor,
+            ).map { it.toModel() }
+    }.getOrNull()
 
     override suspend fun create(title: String, replyPolicy: CircleReplyPolicy, exclusive: Boolean): CircleModel? =
-        withContext(Dispatchers.IO) {
-            runCatching {
-                val data =
-                    EditListForm(
-                        title = title,
-                        replyPolicy = replyPolicy.toDto(),
-                        exclusive = exclusive,
-                    )
-                provider.lists.create(data).toModel()
-            }.getOrNull()
-        }
 
-    override suspend fun update(
-        id: String,
-        title: String,
-        replyPolicy: CircleReplyPolicy,
-        exclusive: Boolean,
-    ): CircleModel? = withContext(Dispatchers.IO) {
         runCatching {
             val data =
                 EditListForm(
@@ -61,34 +35,42 @@ internal class DefaultCirclesRepository(private val provider: ServiceProvider) :
                     replyPolicy = replyPolicy.toDto(),
                     exclusive = exclusive,
                 )
-            provider.lists
-                .update(
-                    id = id,
-                    data = data,
-                ).toModel()
+            provider.lists.create(data).toModel()
         }.getOrNull()
-    }
 
-    override suspend fun delete(id: String): Boolean = withContext(Dispatchers.IO) {
-        runCatching {
-            val res = provider.lists.delete(id)
-            res.isSuccessful
-        }.getOrElse { false }
-    }
+    override suspend fun update(
+        id: String,
+        title: String,
+        replyPolicy: CircleReplyPolicy,
+        exclusive: Boolean,
+    ): CircleModel? = runCatching {
+        val data =
+            EditListForm(
+                title = title,
+                replyPolicy = replyPolicy.toDto(),
+                exclusive = exclusive,
+            )
+        provider.lists
+            .update(
+                id = id,
+                data = data,
+            ).toModel()
+    }.getOrNull()
 
-    override suspend fun addMembers(id: String, userIds: List<String>): Boolean = withContext(Dispatchers.IO) {
-        runCatching {
-            val data = EditListMembersForm(accountIds = userIds)
-            val res = provider.lists.addMembers(id = id, data = data)
-            res.isSuccessful
-        }.getOrElse { false }
-    }
+    override suspend fun delete(id: String): Boolean = runCatching {
+        val res = provider.lists.delete(id)
+        res.isSuccessful
+    }.getOrElse { false }
 
-    override suspend fun removeMembers(id: String, userIds: List<String>): Boolean = withContext(Dispatchers.IO) {
-        runCatching {
-            val data = EditListMembersForm(accountIds = userIds)
-            val res = provider.lists.removeMembers(id = id, data = data)
-            res.isSuccessful
-        }.getOrElse { false }
-    }
+    override suspend fun addMembers(id: String, userIds: List<String>): Boolean = runCatching {
+        val data = EditListMembersForm(accountIds = userIds)
+        val res = provider.lists.addMembers(id = id, data = data)
+        res.isSuccessful
+    }.getOrElse { false }
+
+    override suspend fun removeMembers(id: String, userIds: List<String>): Boolean = runCatching {
+        val data = EditListMembersForm(accountIds = userIds)
+        val res = provider.lists.removeMembers(id = id, data = data)
+        res.isSuccessful
+    }.getOrElse { false }
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultDirectMessageRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultDirectMessageRepository.kt
@@ -5,84 +5,67 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.DirectMessa
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.http.Parameters
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.withContext
 
 internal class DefaultDirectMessageRepository(private val provider: ServiceProvider) : DirectMessageRepository {
-    override suspend fun getAll(page: Int, limit: Int?): List<DirectMessageModel>? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.directMessage
-                .getAll(
-                    page = page,
-                    count = limit ?: DEFAULT_PAGE_SIZE,
-                ).map { it.toModel() }
-        }.getOrNull()
-    }
+    override suspend fun getAll(page: Int, limit: Int?): List<DirectMessageModel>? = runCatching {
+        provider.directMessage
+            .getAll(
+                page = page,
+                count = limit ?: DEFAULT_PAGE_SIZE,
+            ).map { it.toModel() }
+    }.getOrNull()
 
-    override suspend fun getReplies(parentUri: String, page: Int): List<DirectMessageModel>? =
-        withContext(Dispatchers.IO) {
-            runCatching {
-                provider.directMessage
-                    .getConversation(
-                        uri = parentUri,
-                        page = page,
-                        count = DEFAULT_PAGE_SIZE,
-                    ).map { it.toModel() }
-            }.getOrNull()
-        }
+    override suspend fun getReplies(parentUri: String, page: Int): List<DirectMessageModel>? = runCatching {
+        provider.directMessage
+            .getConversation(
+                uri = parentUri,
+                page = page,
+                count = DEFAULT_PAGE_SIZE,
+            ).map { it.toModel() }
+    }.getOrNull()
 
-    override suspend fun pollReplies(parentUri: String, minId: String): List<DirectMessageModel>? =
-        withContext(Dispatchers.IO) {
-            runCatching {
-                provider.directMessage
-                    .getConversation(
-                        uri = parentUri,
-                        sinceId = minId.toLongOrNull() ?: 0,
-                        page = 1,
-                        count = DEFAULT_PAGE_SIZE,
-                    ).map { it.toModel() }
-            }.getOrNull()
-        }
+    override suspend fun pollReplies(parentUri: String, minId: String): List<DirectMessageModel>? = runCatching {
+        provider.directMessage
+            .getConversation(
+                uri = parentUri,
+                sinceId = minId.toLongOrNull() ?: 0,
+                page = 1,
+                count = DEFAULT_PAGE_SIZE,
+            ).map { it.toModel() }
+    }.getOrNull()
 
     override suspend fun create(
         recipientId: String,
         text: String,
         title: String?,
         inReplyTo: String?,
-    ): DirectMessageModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            val data =
-                FormDataContent(
-                    formData =
-                    Parameters.build {
-                        if (title != null) {
-                            append("title", title)
-                        }
-                        append("text", text)
-                        if (inReplyTo != null) {
-                            append("replyto", inReplyTo)
-                        }
-                        append("user_id", recipientId)
-                    },
-                )
-            provider.directMessage.create(data).toModel()
-        }.getOrNull()
-    }
+    ): DirectMessageModel? = runCatching {
+        val data =
+            FormDataContent(
+                formData =
+                Parameters.build {
+                    if (title != null) {
+                        append("title", title)
+                    }
+                    append("text", text)
+                    if (inReplyTo != null) {
+                        append("replyto", inReplyTo)
+                    }
+                    append("user_id", recipientId)
+                },
+            )
+        provider.directMessage.create(data).toModel()
+    }.getOrNull()
 
-    override suspend fun delete(id: String): Boolean = withContext(Dispatchers.IO) {
-        runCatching {
-            val res = provider.directMessage.delete(id.toLong())
-            res.result == RESULT_OK
-        }.getOrElse { false }
-    }
+    override suspend fun delete(id: String): Boolean = runCatching {
+        val res = provider.directMessage.delete(id.toLong())
+        res.result == RESULT_OK
+    }.getOrElse { false }
 
-    override suspend fun markAsRead(id: String): Boolean = withContext(Dispatchers.IO) {
-        runCatching {
-            val res = provider.directMessage.markAsRead(id.toLong())
-            res.result == RESULT_OK
-        }.getOrElse { false }
-    }
+    override suspend fun markAsRead(id: String): Boolean = runCatching {
+        val res = provider.directMessage.markAsRead(id.toLong())
+        res.result == RESULT_OK
+    }.getOrElse { false }
 
     companion object {
         private const val DEFAULT_PAGE_SIZE = 20

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultDraftRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultDraftRepository.kt
@@ -10,51 +10,38 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.Visibility
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toDto
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toVisibility
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.withContext
 
 internal class DefaultDraftRepository(private val draftDao: DraftDao, private val provider: ServiceProvider) :
     DraftRepository {
-    override suspend fun getAll(page: Int): List<TimelineEntryModel>? = withContext(Dispatchers.IO) {
-        runCatching {
-            draftDao
-                .getAll(
-                    offset = page * DEFAULT_PAGE_SIZE,
-                    limit = DEFAULT_PAGE_SIZE,
-                ).map { it.toModel() }
-        }.getOrNull()
-    }
+    override suspend fun getAll(page: Int): List<TimelineEntryModel>? = runCatching {
+        draftDao
+            .getAll(
+                offset = page * DEFAULT_PAGE_SIZE,
+                limit = DEFAULT_PAGE_SIZE,
+            ).map { it.toModel() }
+    }.getOrNull()
 
-    override suspend fun getById(id: String): TimelineEntryModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            draftDao.getBy(id)?.toModel()
-        }.getOrNull()
-    }
+    override suspend fun getById(id: String): TimelineEntryModel? = runCatching {
+        draftDao.getBy(id)?.toModel()
+    }.getOrNull()
 
-    override suspend fun create(item: TimelineEntryModel): TimelineEntryModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            val entity = item.toEntity()
-            draftDao.insert(entity)
-            getById(item.id)
-        }.getOrNull()
-    }
+    override suspend fun create(item: TimelineEntryModel): TimelineEntryModel? = runCatching {
+        val entity = item.toEntity()
+        draftDao.insert(entity)
+        getById(item.id)
+    }.getOrNull()
 
-    override suspend fun update(item: TimelineEntryModel): TimelineEntryModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            val entity = item.toEntity()
-            draftDao.update(entity)
-            getById(item.id)
-        }.getOrNull()
-    }
+    override suspend fun update(item: TimelineEntryModel): TimelineEntryModel? = runCatching {
+        val entity = item.toEntity()
+        draftDao.update(entity)
+        getById(item.id)
+    }.getOrNull()
 
-    override suspend fun delete(id: String): Boolean = withContext(Dispatchers.IO) {
-        runCatching {
-            val entity = DraftEntity(id = id)
-            draftDao.delete(entity)
-            true
-        }.getOrElse { false }
-    }
+    override suspend fun delete(id: String): Boolean = runCatching {
+        val entity = DraftEntity(id = id)
+        draftDao.delete(entity)
+        true
+    }.getOrElse { false }
 
     private suspend fun DraftEntity.toModel() = TimelineEntryModel(
         id = id,

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEmojiRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEmojiRepository.kt
@@ -4,9 +4,6 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvid
 import com.livefast.eattrash.raccoonforfriendica.core.utils.cache.LruCache
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EmojiModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.withContext
 
 internal class DefaultEmojiRepository(
     private val provider: ServiceProvider,
@@ -25,16 +22,14 @@ internal class DefaultEmojiRepository(
         }
     }
 
-    private suspend fun retrieve(node: String?): List<EmojiModel>? = withContext(Dispatchers.IO) {
-        runCatching {
-            val res =
-                if (node == null) {
-                    provider.instance.getCustomEmojis()
-                } else {
-                    otherProvider.changeNode(node)
-                    otherProvider.instance.getCustomEmojis()
-                }
-            res.map { it.toModel() }
-        }.getOrElse { null }
-    }
+    private suspend fun retrieve(node: String?): List<EmojiModel>? = runCatching {
+        val res =
+            if (node == null) {
+                provider.instance.getCustomEmojis()
+            } else {
+                otherProvider.changeNode(node)
+                otherProvider.instance.getCustomEmojis()
+            }
+        res.map { it.toModel() }
+    }.getOrElse { null }
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEventRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEventRepository.kt
@@ -3,20 +3,15 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EventModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.withContext
 
 internal class DefaultEventRepository(private val provider: ServiceProvider) : EventRepository {
-    override suspend fun getAll(pageCursor: String?): List<EventModel>? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.events
-                .getAll(
-                    maxId = pageCursor?.toLong(),
-                    count = DEFAULT_PAGE_SIZE,
-                ).map { it.toModel() }
-        }.getOrNull()
-    }
+    override suspend fun getAll(pageCursor: String?): List<EventModel>? = runCatching {
+        provider.events
+            .getAll(
+                maxId = pageCursor?.toLong(),
+                count = DEFAULT_PAGE_SIZE,
+            ).map { it.toModel() }
+    }.getOrNull()
 
     companion object {
         const val DEFAULT_PAGE_SIZE = 20

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMediaRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMediaRepository.kt
@@ -9,72 +9,60 @@ import io.ktor.client.request.forms.formData
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
 import io.ktor.http.parameters
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 
 internal class DefaultMediaRepository(private val provider: ServiceProvider) : MediaRepository {
-    override suspend fun getBy(id: String): AttachmentModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.media.getBy(id)?.toModel()
-        }.getOrNull()
-    }
+    override suspend fun getBy(id: String): AttachmentModel? = runCatching {
+        provider.media.getBy(id)?.toModel()
+    }.getOrNull()
 
-    override suspend fun create(bytes: ByteArray, album: String, alt: String): AttachmentModel? =
-        withContext(Dispatchers.IO) {
-            runCatching {
-                val content =
-                    MultiPartFormDataContent(
-                        formData {
-                            append(
-                                key = "file",
-                                value = bytes,
-                                headers =
-                                Headers.build {
-                                    append(HttpHeaders.ContentType, "image/*")
-                                    append(HttpHeaders.ContentDisposition, "filename=image.jpeg")
-                                },
-                            )
-                            append("description", alt)
+    override suspend fun create(bytes: ByteArray, album: String, alt: String): AttachmentModel? = runCatching {
+        val content =
+            MultiPartFormDataContent(
+                formData {
+                    append(
+                        key = "file",
+                        value = bytes,
+                        headers =
+                        Headers.build {
+                            append(HttpHeaders.ContentType, "image/*")
+                            append(HttpHeaders.ContentDisposition, "filename=image.jpeg")
                         },
                     )
-                val res = provider.media.create(content = content).toModel()
-                val id = res.id
-                val url =
-                    withTimeoutOrNull(5000) {
-                        var url = res.url
-                        while (url.isEmpty()) {
-                            delay(1000)
-                            val pollingRes = getBy(id)
-                            if (pollingRes != null) {
-                                url = pollingRes.url
-                            }
-                        }
-                        url
-                    }.orEmpty()
-                res.copy(url = url)
-            }
-        }.getOrNull()
+                    append("description", alt)
+                },
+            )
+        val res = provider.media.create(content = content).toModel()
+        val id = res.id
+        val url =
+            withTimeoutOrNull(5000) {
+                var url = res.url
+                while (url.isEmpty()) {
+                    delay(1000)
+                    val pollingRes = getBy(id)
+                    if (pollingRes != null) {
+                        url = pollingRes.url
+                    }
+                }
+                url
+            }.orEmpty()
+        res.copy(url = url)
+    }.getOrNull()
 
-    override suspend fun update(id: String, alt: String): Boolean = withContext(Dispatchers.IO) {
-        runCatching {
-            val content =
-                FormDataContent(
-                    parameters {
-                        append("description", alt)
-                    },
-                )
-            provider.media.update(id = id, content = content)
-            true
-        }
+    override suspend fun update(id: String, alt: String): Boolean = runCatching {
+        val content =
+            FormDataContent(
+                parameters {
+                    append("description", alt)
+                },
+            )
+        provider.media.update(id = id, content = content)
+        true
     }.getOrElse { false }
 
-    override suspend fun delete(id: String): Boolean = withContext(Dispatchers.IO) {
-        runCatching {
-            val res = provider.media.delete(id = id)
-            res.isSuccessful
-        }
+    override suspend fun delete(id: String): Boolean = runCatching {
+        val res = provider.media.delete(id = id)
+        res.isSuccessful
     }.getOrElse { false }
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNodeInfoRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNodeInfoRepository.kt
@@ -9,15 +9,12 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.withContext
 
 internal class DefaultNodeInfoRepository(
     private val provider: ServiceProvider,
     private val client: HttpClient = HttpClient(provideHttpClientEngine()),
 ) : NodeInfoRepository {
-    override suspend fun getInfo(): NodeInfoModel? = withContext(Dispatchers.IO) {
+    override suspend fun getInfo(): NodeInfoModel? {
         val instanceInfo =
             runCatching {
                 provider.instance.getInfo()
@@ -28,16 +25,14 @@ internal class DefaultNodeInfoRepository(
                 extractSoftwareName()
             }.getOrNull()
 
-        instanceInfo?.toModel()?.copy(
+        return instanceInfo?.toModel()?.copy(
             software = softwareName,
         )
     }
 
-    override suspend fun getRules(): List<RuleModel>? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.instance.getRules().map { it.toModel() }
-        }.getOrNull()
-    }
+    override suspend fun getRules(): List<RuleModel>? = runCatching {
+        provider.instance.getRules().map { it.toModel() }
+    }.getOrNull()
 
     private suspend fun extractSoftwareName(): String? {
         val linksJson =

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNotificationRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNotificationRepository.kt
@@ -5,11 +5,8 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.Notificatio
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toRawValue
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
 
 internal class DefaultNotificationRepository(private val provider: ServiceProvider) : NotificationRepository {
     private val mutex = Mutex()
@@ -19,16 +16,16 @@ internal class DefaultNotificationRepository(private val provider: ServiceProvid
         types: List<NotificationType>,
         pageCursor: String?,
         refresh: Boolean,
-    ): List<NotificationModel>? = withContext(Dispatchers.IO) {
+    ): List<NotificationModel>? {
         if (refresh) {
             mutex.withLock {
                 cachedValues.clear()
             }
         }
         if (pageCursor == null && cachedValues.isNotEmpty()) {
-            return@withContext cachedValues
+            return cachedValues
         }
-        runCatching {
+        return runCatching {
             val response =
                 provider.notifications.get(
                     types = types.mapNotNull { it.toRawValue() },
@@ -47,19 +44,15 @@ internal class DefaultNotificationRepository(private val provider: ServiceProvid
         }.getOrNull()
     }
 
-    override suspend fun dismiss(id: String): Boolean = withContext(Dispatchers.IO) {
-        runCatching {
-            val res = provider.notifications.dismiss(id)
-            res.isSuccessful
-        }.getOrElse { false }
-    }
+    override suspend fun dismiss(id: String): Boolean = runCatching {
+        val res = provider.notifications.dismiss(id)
+        res.isSuccessful
+    }.getOrElse { false }
 
-    override suspend fun dismissAll(): Boolean = withContext(Dispatchers.IO) {
-        runCatching {
-            val res = provider.notifications.clear()
-            res.isSuccessful
-        }.getOrElse { false }
-    }
+    override suspend fun dismissAll(): Boolean = runCatching {
+        val res = provider.notifications.clear()
+        res.isSuccessful
+    }.getOrElse { false }
 
     companion object {
         const val DEFAULT_PAGE_SIZE = 20

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoAlbumRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoAlbumRepository.kt
@@ -6,56 +6,45 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaAlbumM
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.http.Parameters
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.withContext
 
 internal class DefaultPhotoAlbumRepository(private val provider: ServiceProvider) : PhotoAlbumRepository {
-    override suspend fun getAll(): List<MediaAlbumModel>? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.photoAlbum.getAll().map { it.toModel() }
-        }.getOrNull()
-    }
+    override suspend fun getAll(): List<MediaAlbumModel>? = runCatching {
+        provider.photoAlbum.getAll().map { it.toModel() }
+    }.getOrNull()
 
-    override suspend fun update(oldName: String, newName: String): Boolean = withContext(Dispatchers.IO) {
-        runCatching {
-            val data =
-                FormDataContent(
-                    Parameters.build {
-                        append("album", oldName)
-                        append("album_new", newName)
-                    },
-                )
-            val res = provider.photoAlbum.update(data)
-            res.result == "updated"
-        }.getOrElse { false }
-    }
+    override suspend fun update(oldName: String, newName: String): Boolean = runCatching {
+        val data =
+            FormDataContent(
+                Parameters.build {
+                    append("album", oldName)
+                    append("album_new", newName)
+                },
+            )
+        val res = provider.photoAlbum.update(data)
+        res.result == "updated"
+    }.getOrElse { false }
 
-    override suspend fun delete(name: String): Boolean = withContext(Dispatchers.IO) {
-        runCatching {
-            val data =
-                FormDataContent(
-                    Parameters.build {
-                        append("album", name)
-                    },
-                )
-            val res = provider.photoAlbum.delete(data)
-            res.result == "deleted"
-        }.getOrElse { false }
-    }
+    override suspend fun delete(name: String): Boolean = runCatching {
+        val data =
+            FormDataContent(
+                Parameters.build {
+                    append("album", name)
+                },
+            )
+        val res = provider.photoAlbum.delete(data)
+        res.result == "deleted"
+    }.getOrElse { false }
 
     override suspend fun getPhotos(album: String, pageCursor: String?, latestFirst: Boolean): List<AttachmentModel>? =
-        withContext(Dispatchers.IO) {
-            runCatching {
-                provider.photoAlbum
-                    .getPhotos(
-                        album = album,
-                        maxId = pageCursor,
-                        latestFirst = latestFirst,
-                        limit = DEFAULT_PAGE_SIZE,
-                    ).map { it.toModel() }
-            }.getOrNull()
-        }
+        runCatching {
+            provider.photoAlbum
+                .getPhotos(
+                    album = album,
+                    maxId = pageCursor,
+                    latestFirst = latestFirst,
+                    limit = DEFAULT_PAGE_SIZE,
+                ).map { it.toModel() }
+        }.getOrNull()
 
     companion object {
         private const val DEFAULT_PAGE_SIZE = 20

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoRepository.kt
@@ -7,33 +7,27 @@ import io.ktor.client.request.forms.MultiPartFormDataContent
 import io.ktor.client.request.forms.formData
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.withContext
 
 internal class DefaultPhotoRepository(private val provider: ServiceProvider) : PhotoRepository {
-    override suspend fun create(bytes: ByteArray, album: String, alt: String): AttachmentModel? =
-        withContext(Dispatchers.IO) {
-            runCatching {
-                val content =
-                    MultiPartFormDataContent(
-                        formData {
-                            append(
-                                key = "media",
-                                value = bytes,
-                                headers =
-                                Headers.build {
-                                    append(HttpHeaders.ContentType, "image/*")
-                                    append(HttpHeaders.ContentDisposition, "filename=image.jpeg")
-                                },
-                            )
-                            append("album", album)
-                            append("desc", alt)
+    override suspend fun create(bytes: ByteArray, album: String, alt: String): AttachmentModel? = runCatching {
+        val content =
+            MultiPartFormDataContent(
+                formData {
+                    append(
+                        key = "media",
+                        value = bytes,
+                        headers =
+                        Headers.build {
+                            append(HttpHeaders.ContentType, "image/*")
+                            append(HttpHeaders.ContentDisposition, "filename=image.jpeg")
                         },
                     )
-                provider.photo.create(content = content).toModel()
-            }
-        }.getOrNull()
+                    append("album", album)
+                    append("desc", alt)
+                },
+            )
+        provider.photo.create(content = content).toModel()
+    }.getOrNull()
 
     override suspend fun update(
         id: String,
@@ -41,48 +35,44 @@ internal class DefaultPhotoRepository(private val provider: ServiceProvider) : P
         album: String,
         newAlbum: String?,
         alt: String,
-    ): Boolean = withContext(Dispatchers.IO) {
-        runCatching {
-            val content =
-                MultiPartFormDataContent(
-                    formData {
-                        append("photo_id", id)
-                        if (bytes != null) {
-                            append(
-                                key = "media",
-                                value = bytes,
-                                headers =
-                                Headers.build {
-                                    append(HttpHeaders.ContentType, "image/*")
-                                    append(
-                                        HttpHeaders.ContentDisposition,
-                                        "filename=image.jpeg",
-                                    )
-                                },
-                            )
-                        }
-                        append("album", album)
-                        if (newAlbum != null) {
-                            append("album_new", newAlbum)
-                        }
-                        append("desc", alt)
-                    },
-                )
-            val res = provider.photo.update(content = content)
-            res.result == "updated"
-        }
+    ): Boolean = runCatching {
+        val content =
+            MultiPartFormDataContent(
+                formData {
+                    append("photo_id", id)
+                    if (bytes != null) {
+                        append(
+                            key = "media",
+                            value = bytes,
+                            headers =
+                            Headers.build {
+                                append(HttpHeaders.ContentType, "image/*")
+                                append(
+                                    HttpHeaders.ContentDisposition,
+                                    "filename=image.jpeg",
+                                )
+                            },
+                        )
+                    }
+                    append("album", album)
+                    if (newAlbum != null) {
+                        append("album_new", newAlbum)
+                    }
+                    append("desc", alt)
+                },
+            )
+        val res = provider.photo.update(content = content)
+        res.result == "updated"
     }.getOrElse { false }
 
-    override suspend fun delete(id: String): Boolean = withContext(Dispatchers.IO) {
-        runCatching {
-            val content =
-                MultiPartFormDataContent(
-                    formData {
-                        append("photo_id", id)
-                    },
-                )
-            val res = provider.photo.delete(content)
-            res.result == "deleted"
-        }
+    override suspend fun delete(id: String): Boolean = runCatching {
+        val content =
+            MultiPartFormDataContent(
+                formData {
+                    append("photo_id", id)
+                },
+            )
+        val res = provider.photo.delete(content)
+        res.result == "deleted"
     }.getOrElse { false }
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPushNotificationRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPushNotificationRepository.kt
@@ -7,9 +7,6 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toRawValue
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.http.parameters
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.withContext
 
 internal class DefaultPushNotificationRepository(private val provider: ServiceProvider) : PushNotificationRepository {
     override suspend fun create(
@@ -18,50 +15,43 @@ internal class DefaultPushNotificationRepository(private val provider: ServicePr
         auth: String,
         types: List<NotificationType>,
         policy: NotificationPolicy,
-    ): String? = withContext(Dispatchers.IO) {
-        runCatching {
-            val data =
-                FormDataContent(
-                    parameters {
-                        append("subscription[endpoint]", endpoint)
-                        append("subscription[keys][p256dh]", pubKey)
-                        append("subscription[keys][auth]", auth)
-                        for (type in NotificationType.ALL) {
-                            append(
-                                "data[alerts][${type.toRawValue()}]",
-                                (type in types).toString(),
-                            )
-                        }
-                        append("data[policy]", policy.toDto())
-                    },
-                )
-            provider.push.create(data)?.serverKey
-        }.getOrNull()
-    }
+    ): String? = runCatching {
+        val data =
+            FormDataContent(
+                parameters {
+                    append("subscription[endpoint]", endpoint)
+                    append("subscription[keys][p256dh]", pubKey)
+                    append("subscription[keys][auth]", auth)
+                    for (type in NotificationType.ALL) {
+                        append(
+                            "data[alerts][${type.toRawValue()}]",
+                            (type in types).toString(),
+                        )
+                    }
+                    append("data[policy]", policy.toDto())
+                },
+            )
+        provider.push.create(data)?.serverKey
+    }.getOrNull()
 
-    override suspend fun update(types: List<NotificationType>, policy: NotificationPolicy): String? =
-        withContext(Dispatchers.IO) {
-            runCatching {
-                val data =
-                    FormDataContent(
-                        parameters {
-                            for (type in NotificationType.ALL) {
-                                append(
-                                    "data[alerts][${type.toRawValue()}]",
-                                    (type in types).toString(),
-                                )
-                            }
-                            append("data[policy]", policy.toDto())
-                        },
-                    )
-                provider.push.update(data)?.serverKey
-            }.getOrNull()
-        }
+    override suspend fun update(types: List<NotificationType>, policy: NotificationPolicy): String? = runCatching {
+        val data =
+            FormDataContent(
+                parameters {
+                    for (type in NotificationType.ALL) {
+                        append(
+                            "data[alerts][${type.toRawValue()}]",
+                            (type in types).toString(),
+                        )
+                    }
+                    append("data[policy]", policy.toDto())
+                },
+            )
+        provider.push.update(data)?.serverKey
+    }.getOrNull()
 
-    override suspend fun delete(): Boolean = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.push.delete()
-            true
-        }.getOrElse { false }
-    }
+    override suspend fun delete(): Boolean = runCatching {
+        provider.push.delete()
+        true
+    }.getOrElse { false }
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultReportRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultReportRepository.kt
@@ -5,9 +5,6 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.ReportCateg
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toDto
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.http.Parameters
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.withContext
 
 internal class DefaultReportRepository(private val provider: ServiceProvider) : ReportRepository {
     override suspend fun create(
@@ -17,27 +14,25 @@ internal class DefaultReportRepository(private val provider: ServiceProvider) : 
         forward: Boolean,
         category: ReportCategory,
         ruleIds: List<String>?,
-    ): Boolean = withContext(Dispatchers.IO) {
-        runCatching {
-            val data =
-                FormDataContent(
-                    Parameters.build {
-                        append("account_id", userId)
-                        if (entryIds != null) {
-                            append("status_ids", entryIds.joinToString(","))
-                        }
-                        append("forward", forward.toString())
-                        append("category", category.toDto())
-                        if (comment != null) {
-                            append("comment", comment)
-                        }
-                        if (ruleIds != null) {
-                            append("rule_ids", ruleIds.joinToString(","))
-                        }
-                    },
-                )
-            val res = provider.reports.create(data)
-            res.isSuccessful
-        }.getOrElse { false }
-    }
+    ): Boolean = runCatching {
+        val data =
+            FormDataContent(
+                Parameters.build {
+                    append("account_id", userId)
+                    if (entryIds != null) {
+                        append("status_ids", entryIds.joinToString(","))
+                    }
+                    append("forward", forward.toString())
+                    append("category", category.toDto())
+                    if (comment != null) {
+                        append("comment", comment)
+                    }
+                    if (ruleIds != null) {
+                        append("rule_ids", ruleIds.joinToString(","))
+                    }
+                },
+            )
+        val res = provider.reports.create(data)
+        res.isSuccessful
+    }.getOrElse { false }
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultScheduledEntryRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultScheduledEntryRepository.kt
@@ -5,49 +5,38 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEnt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.http.parameters
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.withContext
 
 internal class DefaultScheduledEntryRepository(private val provider: ServiceProvider) : ScheduledEntryRepository {
-    override suspend fun getAll(pageCursor: String?): List<TimelineEntryModel>? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.statuses
-                .getScheduled(
-                    maxId = pageCursor,
-                    limit = DEFAULT_PAGE_SIZE,
-                ).map { it.toModel() }
-        }.getOrNull()
-    }
+    override suspend fun getAll(pageCursor: String?): List<TimelineEntryModel>? = runCatching {
+        provider.statuses
+            .getScheduled(
+                maxId = pageCursor,
+                limit = DEFAULT_PAGE_SIZE,
+            ).map { it.toModel() }
+    }.getOrNull()
 
-    override suspend fun getById(id: String): TimelineEntryModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.statuses.getScheduledById(id).toModel()
-        }.getOrNull()
-    }
+    override suspend fun getById(id: String): TimelineEntryModel? = runCatching {
+        provider.statuses.getScheduledById(id).toModel()
+    }.getOrNull()
 
-    override suspend fun update(id: String, date: String): TimelineEntryModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            val data =
-                FormDataContent(
-                    parameters {
-                        append("scheduled_at", date)
-                    },
-                )
-            provider.statuses
-                .updateScheduled(
-                    id = id,
-                    data = data,
-                ).toModel()
-        }.getOrNull()
-    }
+    override suspend fun update(id: String, date: String): TimelineEntryModel? = runCatching {
+        val data =
+            FormDataContent(
+                parameters {
+                    append("scheduled_at", date)
+                },
+            )
+        provider.statuses
+            .updateScheduled(
+                id = id,
+                data = data,
+            ).toModel()
+    }.getOrNull()
 
-    override suspend fun delete(id: String): Boolean = withContext(Dispatchers.IO) {
-        runCatching {
-            val res = provider.statuses.deleteScheduled(id)
-            res.isSuccessful
-        }.getOrElse { false }
-    }
+    override suspend fun delete(id: String): Boolean = runCatching {
+        val res = provider.statuses.deleteScheduled(id)
+        res.isSuccessful
+    }.getOrElse { false }
 
     companion object {
         private const val DEFAULT_PAGE_SIZE = 20

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSearchRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSearchRepository.kt
@@ -6,9 +6,6 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.SearchResul
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toDto
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModelWithReply
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.withContext
 
 internal class DefaultSearchRepository(private val provider: ServiceProvider) : SearchRepository {
     override suspend fun search(
@@ -16,35 +13,33 @@ internal class DefaultSearchRepository(private val provider: ServiceProvider) : 
         type: SearchResultType,
         pageCursor: String?,
         resolve: Boolean,
-    ): List<ExploreItemModel>? = withContext(Dispatchers.IO) {
-        runCatching {
-            val response =
-                provider.search
-                    .search(
-                        query = query,
-                        maxId = pageCursor,
-                        limit = DEFAULT_PAGE_SIZE,
-                        type = type.toDto(),
-                        resolve = resolve,
-                    )
-            when (type) {
-                SearchResultType.Entries ->
-                    response.statuses.map {
-                        ExploreItemModel.Entry(it.toModelWithReply())
-                    }
+    ): List<ExploreItemModel>? = runCatching {
+        val response =
+            provider.search
+                .search(
+                    query = query,
+                    maxId = pageCursor,
+                    limit = DEFAULT_PAGE_SIZE,
+                    type = type.toDto(),
+                    resolve = resolve,
+                )
+        when (type) {
+            SearchResultType.Entries ->
+                response.statuses.map {
+                    ExploreItemModel.Entry(it.toModelWithReply())
+                }
 
-                SearchResultType.Hashtags ->
-                    response.hashtags.map {
-                        ExploreItemModel.HashTag(it.toModel())
-                    }
+            SearchResultType.Hashtags ->
+                response.hashtags.map {
+                    ExploreItemModel.HashTag(it.toModel())
+                }
 
-                SearchResultType.Users ->
-                    response.accounts.map {
-                        ExploreItemModel.User(it.toModel())
-                    }
-            }
-        }.getOrNull()
-    }
+            SearchResultType.Users ->
+                response.accounts.map {
+                    ExploreItemModel.User(it.toModel())
+                }
+        }
+    }.getOrNull()
 
     companion object {
         const val DEFAULT_PAGE_SIZE = 20

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTagRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTagRepository.kt
@@ -5,38 +5,27 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TagModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.ListWithPageCursor
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.extractNextIdFromResponseLinkHeader
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.withContext
 
 internal class DefaultTagRepository(private val provider: ServiceProvider) : TagRepository {
-    override suspend fun getFollowed(pageCursor: String?): ListWithPageCursor<TagModel>? = withContext(Dispatchers.IO) {
-        runCatching {
-            val response =
-                provider.tags.getFollowedTags(
-                    maxId = pageCursor,
-                )
-            val list: List<TagModel> = response.body()?.map { it.toModel() }.orEmpty()
-            val nextCursor: String? = response.extractNextIdFromResponseLinkHeader()
-            ListWithPageCursor(list = list, cursor = nextCursor)
-        }.getOrNull()
-    }
+    override suspend fun getFollowed(pageCursor: String?): ListWithPageCursor<TagModel>? = runCatching {
+        val response =
+            provider.tags.getFollowedTags(
+                maxId = pageCursor,
+            )
+        val list: List<TagModel> = response.body()?.map { it.toModel() }.orEmpty()
+        val nextCursor: String? = response.extractNextIdFromResponseLinkHeader()
+        ListWithPageCursor(list = list, cursor = nextCursor)
+    }.getOrNull()
 
-    override suspend fun getBy(name: String): TagModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.tags.get(name)?.toModel()
-        }.getOrNull()
-    }
+    override suspend fun getBy(name: String): TagModel? = runCatching {
+        provider.tags.get(name)?.toModel()
+    }.getOrNull()
 
-    override suspend fun follow(name: String): TagModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.tags.follow(name)?.toModel()
-        }.getOrNull()
-    }
+    override suspend fun follow(name: String): TagModel? = runCatching {
+        provider.tags.follow(name)?.toModel()
+    }.getOrNull()
 
-    override suspend fun unfollow(name: String): TagModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.tags.unfollow(name)?.toModel()
-        }.getOrNull()
-    }
+    override suspend fun unfollow(name: String): TagModel? = runCatching {
+        provider.tags.unfollow(name)?.toModel()
+    }.getOrNull()
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTimelineEntryRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTimelineEntryRepository.kt
@@ -17,11 +17,8 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModelWithReply
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.http.parameters
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
 import kotlin.time.Duration
 
 internal class DefaultTimelineEntryRepository(private val provider: ServiceProvider) : TimelineEntryRepository {
@@ -39,16 +36,16 @@ internal class DefaultTimelineEntryRepository(private val provider: ServiceProvi
         onlyMedia: Boolean,
         enableCache: Boolean,
         refresh: Boolean,
-    ): List<TimelineEntryModel>? = withContext(Dispatchers.IO) {
+    ): List<TimelineEntryModel>? {
         if (refresh) {
             mutex.withLock {
                 cachedValues.clear()
             }
         }
         if (pageCursor == null && cachedValues.isNotEmpty() && enableCache) {
-            return@withContext cachedValues
+            return cachedValues
         }
-        runCatching {
+        return runCatching {
             provider.users
                 .getStatuses(
                     id = userId,
@@ -69,125 +66,93 @@ internal class DefaultTimelineEntryRepository(private val provider: ServiceProvi
         }.getOrNull()
     }
 
-    override suspend fun getById(id: String): TimelineEntryModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.statuses.get(id = id).toModelWithReply()
-        }.getOrNull()
-    }
+    override suspend fun getById(id: String): TimelineEntryModel? = runCatching {
+        provider.statuses.get(id = id).toModelWithReply()
+    }.getOrNull()
 
-    override suspend fun getSource(id: String): TimelineEntryModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.statuses.getSource(id = id).toModel()
-        }.getOrNull()
-    }
+    override suspend fun getSource(id: String): TimelineEntryModel? = runCatching {
+        provider.statuses.getSource(id = id).toModel()
+    }.getOrNull()
 
-    override suspend fun getContext(id: String): TimelineContextModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.statuses.getContext(id = id).toModel()
-        }.getOrNull()
-    }
+    override suspend fun getContext(id: String): TimelineContextModel? = runCatching {
+        provider.statuses.getContext(id = id).toModel()
+    }.getOrNull()
 
-    override suspend fun reblog(id: String): TimelineEntryModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            val data =
-                FormDataContent(
-                    parameters {
-                        append("visibility", ContentVisibility.PUBLIC)
-                    },
-                )
-            provider.statuses
-                .reblog(
-                    id = id,
-                    data = data,
-                ).toModelWithReply()
-        }.getOrNull()
-    }
+    override suspend fun reblog(id: String): TimelineEntryModel? = runCatching {
+        val data =
+            FormDataContent(
+                parameters {
+                    append("visibility", ContentVisibility.PUBLIC)
+                },
+            )
+        provider.statuses
+            .reblog(
+                id = id,
+                data = data,
+            ).toModelWithReply()
+    }.getOrNull()
 
-    override suspend fun unreblog(id: String): TimelineEntryModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.statuses.unreblog(id).toModel()
-        }.getOrNull()
-    }
+    override suspend fun unreblog(id: String): TimelineEntryModel? = runCatching {
+        provider.statuses.unreblog(id).toModel()
+    }.getOrNull()
 
-    override suspend fun pin(id: String): TimelineEntryModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.statuses.pin(id).toModel()
-        }.getOrNull()
-    }
+    override suspend fun pin(id: String): TimelineEntryModel? = runCatching {
+        provider.statuses.pin(id).toModel()
+    }.getOrNull()
 
-    override suspend fun unpin(id: String): TimelineEntryModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.statuses.unpin(id).toModel()
-        }.getOrNull()
-    }
+    override suspend fun unpin(id: String): TimelineEntryModel? = runCatching {
+        provider.statuses.unpin(id).toModel()
+    }.getOrNull()
 
-    override suspend fun favorite(id: String): TimelineEntryModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.statuses.favorite(id).toModel()
-        }.getOrNull()
-    }
+    override suspend fun favorite(id: String): TimelineEntryModel? = runCatching {
+        provider.statuses.favorite(id).toModel()
+    }.getOrNull()
 
-    override suspend fun unfavorite(id: String): TimelineEntryModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.statuses.unfavorite(id).toModel()
-        }.getOrNull()
-    }
+    override suspend fun unfavorite(id: String): TimelineEntryModel? = runCatching {
+        provider.statuses.unfavorite(id).toModel()
+    }.getOrNull()
 
-    override suspend fun bookmark(id: String): TimelineEntryModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.statuses.bookmark(id).toModel()
-        }.getOrNull()
-    }
+    override suspend fun bookmark(id: String): TimelineEntryModel? = runCatching {
+        provider.statuses.bookmark(id).toModel()
+    }.getOrNull()
 
-    override suspend fun unbookmark(id: String): TimelineEntryModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.statuses.unbookmark(id).toModel()
-        }.getOrNull()
-    }
+    override suspend fun unbookmark(id: String): TimelineEntryModel? = runCatching {
+        provider.statuses.unbookmark(id).toModel()
+    }.getOrNull()
 
-    override suspend fun getFavorites(pageCursor: String?): List<TimelineEntryModel>? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.users
-                .getFavorites(
-                    maxId = pageCursor,
-                    limit = DEFAULT_PAGE_SIZE,
-                ).map { it.toModelWithReply() }
-        }.getOrNull()
-    }
+    override suspend fun getFavorites(pageCursor: String?): List<TimelineEntryModel>? = runCatching {
+        provider.users
+            .getFavorites(
+                maxId = pageCursor,
+                limit = DEFAULT_PAGE_SIZE,
+            ).map { it.toModelWithReply() }
+    }.getOrNull()
 
-    override suspend fun getBookmarks(pageCursor: String?): List<TimelineEntryModel>? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.users
-                .getBookmarks(
-                    maxId = pageCursor,
-                    limit = DEFAULT_PAGE_SIZE,
-                ).map { it.toModelWithReply() }
-        }.getOrNull()
-    }
+    override suspend fun getBookmarks(pageCursor: String?): List<TimelineEntryModel>? = runCatching {
+        provider.users
+            .getBookmarks(
+                maxId = pageCursor,
+                limit = DEFAULT_PAGE_SIZE,
+            ).map { it.toModelWithReply() }
+    }.getOrNull()
 
-    override suspend fun getUsersWhoFavorited(id: String, pageCursor: String?): List<UserModel>? =
-        withContext(Dispatchers.IO) {
-            runCatching {
-                provider.statuses
-                    .getFavoritedBy(
-                        id = id,
-                        maxId = pageCursor,
-                        limit = DEFAULT_PAGE_SIZE,
-                    ).map { it.toModel() }
-            }.getOrNull()
-        }
+    override suspend fun getUsersWhoFavorited(id: String, pageCursor: String?): List<UserModel>? = runCatching {
+        provider.statuses
+            .getFavoritedBy(
+                id = id,
+                maxId = pageCursor,
+                limit = DEFAULT_PAGE_SIZE,
+            ).map { it.toModel() }
+    }.getOrNull()
 
-    override suspend fun getUsersWhoReblogged(id: String, pageCursor: String?): List<UserModel>? =
-        withContext(Dispatchers.IO) {
-            runCatching {
-                provider.statuses
-                    .getRebloggedBy(
-                        id = id,
-                        maxId = pageCursor,
-                        limit = DEFAULT_PAGE_SIZE,
-                    ).map { it.toModel() }
-            }.getOrNull()
-        }
+    override suspend fun getUsersWhoReblogged(id: String, pageCursor: String?): List<UserModel>? = runCatching {
+        provider.statuses
+            .getRebloggedBy(
+                id = id,
+                maxId = pageCursor,
+                limit = DEFAULT_PAGE_SIZE,
+            ).map { it.toModel() }
+    }.getOrNull()
 
     override suspend fun create(
         localId: String,
@@ -203,48 +168,46 @@ internal class DefaultTimelineEntryRepository(private val provider: ServiceProvi
         pollOptions: List<String>?,
         pollExpirationDate: String?,
         pollMultiple: Boolean?,
-    ): TimelineEntryModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            val pollData =
-                if (pollOptions != null && pollMultiple != null && pollExpirationDate != null) {
-                    val pollDuration =
-                        getDurationFromNowToDate(
-                            pollExpirationDate,
-                        ) ?: Duration.ZERO
-                    CreatePollForm(
-                        options = pollOptions,
-                        multiple = pollMultiple,
-                        expiresIn = pollDuration.inWholeSeconds,
-                    )
-                } else {
-                    null
-                }
-            val data =
-                CreateStatusForm(
-                    status = text,
-                    addons = StatusAddons(title = title.orEmpty()),
-                    mediaIds = mediaIds,
-                    visibility = visibility.toDto(),
-                    sensitive = sensitive,
-                    inReplyTo = inReplyTo,
-                    lang = lang,
-                    spoilerText = spoilerText,
-                    scheduledAt = scheduled,
-                    poll = pollData,
-                    localOnly =
-                    when (visibility) {
-                        Visibility.LocalPublic -> true
-                        Visibility.LocalUnlisted -> true
-                        else -> null
-                    },
+    ): TimelineEntryModel? = runCatching {
+        val pollData =
+            if (pollOptions != null && pollMultiple != null && pollExpirationDate != null) {
+                val pollDuration =
+                    getDurationFromNowToDate(
+                        pollExpirationDate,
+                    ) ?: Duration.ZERO
+                CreatePollForm(
+                    options = pollOptions,
+                    multiple = pollMultiple,
+                    expiresIn = pollDuration.inWholeSeconds,
                 )
-            provider.statuses
-                .create(
-                    key = localId,
-                    data = data,
-                ).toModel()
-        }.getOrNull()
-    }
+            } else {
+                null
+            }
+        val data =
+            CreateStatusForm(
+                status = text,
+                addons = StatusAddons(title = title.orEmpty()),
+                mediaIds = mediaIds,
+                visibility = visibility.toDto(),
+                sensitive = sensitive,
+                inReplyTo = inReplyTo,
+                lang = lang,
+                spoilerText = spoilerText,
+                scheduledAt = scheduled,
+                poll = pollData,
+                localOnly =
+                when (visibility) {
+                    Visibility.LocalPublic -> true
+                    Visibility.LocalUnlisted -> true
+                    else -> null
+                },
+            )
+        provider.statuses
+            .create(
+                key = localId,
+                data = data,
+            ).toModel()
+    }.getOrNull()
 
     override suspend fun update(
         id: String,
@@ -259,94 +222,84 @@ internal class DefaultTimelineEntryRepository(private val provider: ServiceProvi
         pollOptions: List<String>?,
         pollExpirationDate: String?,
         pollMultiple: Boolean?,
-    ): TimelineEntryModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            val pollData =
-                if (pollOptions != null && pollMultiple != null && pollExpirationDate != null) {
-                    val pollDuration =
-                        getDurationFromNowToDate(
-                            pollExpirationDate,
-                        ) ?: Duration.ZERO
-                    CreatePollForm(
-                        options = pollOptions,
-                        multiple = pollMultiple,
-                        expiresIn = pollDuration.inWholeSeconds,
-                    )
-                } else {
-                    null
-                }
-            val data =
-                CreateStatusForm(
-                    status = text,
-                    addons = StatusAddons(title = title.orEmpty()),
-                    mediaIds = mediaIds,
-                    visibility = visibility.toDto(),
-                    sensitive = sensitive,
-                    inReplyTo = inReplyTo,
-                    lang = lang,
-                    spoilerText = spoilerText,
-                    poll = pollData,
-                    localOnly =
-                    when (visibility) {
-                        Visibility.LocalPublic -> true
-                        Visibility.LocalUnlisted -> true
-                        else -> null
-                    },
+    ): TimelineEntryModel? = runCatching {
+        val pollData =
+            if (pollOptions != null && pollMultiple != null && pollExpirationDate != null) {
+                val pollDuration =
+                    getDurationFromNowToDate(
+                        pollExpirationDate,
+                    ) ?: Duration.ZERO
+                CreatePollForm(
+                    options = pollOptions,
+                    multiple = pollMultiple,
+                    expiresIn = pollDuration.inWholeSeconds,
                 )
-            provider.statuses
-                .update(
-                    id = id,
-                    data = data,
-                ).toModelWithReply()
-        }.getOrNull()
-    }
+            } else {
+                null
+            }
+        val data =
+            CreateStatusForm(
+                status = text,
+                addons = StatusAddons(title = title.orEmpty()),
+                mediaIds = mediaIds,
+                visibility = visibility.toDto(),
+                sensitive = sensitive,
+                inReplyTo = inReplyTo,
+                lang = lang,
+                spoilerText = spoilerText,
+                poll = pollData,
+                localOnly =
+                when (visibility) {
+                    Visibility.LocalPublic -> true
+                    Visibility.LocalUnlisted -> true
+                    else -> null
+                },
+            )
+        provider.statuses
+            .update(
+                id = id,
+                data = data,
+            ).toModelWithReply()
+    }.getOrNull()
 
-    override suspend fun delete(id: String): Boolean = withContext(Dispatchers.IO) {
-        runCatching {
-            val res = provider.statuses.delete(id)
-            res.isSuccessful
-        }.getOrElse { false }
-    }
+    override suspend fun delete(id: String): Boolean = runCatching {
+        val res = provider.statuses.delete(id)
+        res.isSuccessful
+    }.getOrElse { false }
 
-    override suspend fun submitPoll(pollId: String, choices: List<Int>): PollModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            val data =
-                SubmitPollVoteForm(
-                    choices = choices,
-                )
-            provider.polls
-                .vote(
-                    id = pollId,
-                    data = data,
-                ).toModel()
-        }.getOrNull()
-    }
+    override suspend fun submitPoll(pollId: String, choices: List<Int>): PollModel? = runCatching {
+        val data =
+            SubmitPollVoteForm(
+                choices = choices,
+            )
+        provider.polls
+            .vote(
+                id = pollId,
+                data = data,
+            ).toModel()
+    }.getOrNull()
 
-    override suspend fun dislike(id: String): Boolean = withContext(Dispatchers.IO) {
-        runCatching {
-            val data =
-                FormDataContent(
-                    parameters {
-                        append("id", id)
-                    },
-                )
-            val res = provider.statuses.dislike(data)
-            res.isSuccessful
-        }.getOrElse { false }
-    }
+    override suspend fun dislike(id: String): Boolean = runCatching {
+        val data =
+            FormDataContent(
+                parameters {
+                    append("id", id)
+                },
+            )
+        val res = provider.statuses.dislike(data)
+        res.isSuccessful
+    }.getOrElse { false }
 
-    override suspend fun undislike(id: String): Boolean = withContext(Dispatchers.IO) {
-        runCatching {
-            val data =
-                FormDataContent(
-                    parameters {
-                        append("id", id)
-                    },
-                )
-            val res = provider.statuses.undislike(data)
-            res.isSuccessful
-        }.getOrElse { false }
-    }
+    override suspend fun undislike(id: String): Boolean = runCatching {
+        val data =
+            FormDataContent(
+                parameters {
+                    append("id", id)
+                },
+            )
+        val res = provider.statuses.undislike(data)
+        res.isSuccessful
+    }.getOrElse { false }
 
     companion object {
         private const val DEFAULT_PAGE_SIZE = 20

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTranslationRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTranslationRepository.kt
@@ -5,57 +5,52 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEnt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TranslatedTimelineEntryModel
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.http.parameters
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.withContext
 
 internal class DefaultTranslationRepository(private val provider: ServiceProvider) : TranslationRepository {
     override suspend fun getTranslation(entry: TimelineEntryModel, targetLang: String): TranslatedTimelineEntryModel? =
-        withContext(Dispatchers.IO) {
-            runCatching {
-                val res =
-                    provider.statuses.translate(
-                        id = entry.id,
-                        data =
-                        FormDataContent(
-                            parameters {
-                                append("lang", targetLang)
-                            },
-                        ),
-                    )
-                TranslatedTimelineEntryModel(
-                    source = entry,
-                    target =
-                    entry.copy(
-                        content = res.content,
-                        attachments =
-                        entry.attachments.map { att ->
-                            val translatedDescription =
-                                res.attachments.firstOrNull { it.id == att.id }?.description
-                            att.copy(
-                                description = translatedDescription ?: att.description,
-                            )
+        runCatching {
+            val res =
+                provider.statuses.translate(
+                    id = entry.id,
+                    data =
+                    FormDataContent(
+                        parameters {
+                            append("lang", targetLang)
                         },
-                        poll =
-                        entry.poll?.copy(
-                            options =
-                            entry.poll
-                                ?.options
-                                ?.mapIndexed { idx, opt ->
-                                    val translatedTitle =
-                                        res.poll
-                                            ?.options
-                                            ?.getOrNull(idx)
-                                            ?.title
-                                    opt.copy(
-                                        title = translatedTitle ?: opt.title,
-                                    )
-                                }.orEmpty(),
-                        ),
-                        lang = targetLang,
                     ),
-                    provider = res.provider,
                 )
-            }.getOrNull()
-        }
+            TranslatedTimelineEntryModel(
+                source = entry,
+                target =
+                entry.copy(
+                    content = res.content,
+                    attachments =
+                    entry.attachments.map { att ->
+                        val translatedDescription =
+                            res.attachments.firstOrNull { it.id == att.id }?.description
+                        att.copy(
+                            description = translatedDescription ?: att.description,
+                        )
+                    },
+                    poll =
+                    entry.poll?.copy(
+                        options =
+                        entry.poll
+                            ?.options
+                            ?.mapIndexed { idx, opt ->
+                                val translatedTitle =
+                                    res.poll
+                                        ?.options
+                                        ?.getOrNull(idx)
+                                        ?.title
+                                opt.copy(
+                                    title = translatedTitle ?: opt.title,
+                                )
+                            }.orEmpty(),
+                    ),
+                    lang = targetLang,
+                ),
+                provider = res.provider,
+            )
+        }.getOrNull()
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTrendingRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTrendingRepository.kt
@@ -8,38 +8,33 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEnt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModelWithReply
 import io.ktor.client.statement.bodyAsText
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
 
 internal class DefaultTrendingRepository(private val provider: ServiceProvider) : TrendingRepository {
     private val mutex = Mutex()
     private val cachedTags: MutableList<TagModel> = mutableListOf()
 
-    override suspend fun getEntries(offset: Int): List<TimelineEntryModel>? = withContext(Dispatchers.IO) {
-        runCatching {
-            val response =
-                provider.trends
-                    .getStatuses(
-                        offset = offset,
-                        limit = DEFAULT_PAGE_SIZE,
-                    )
-            response.map { it.toModelWithReply() }
-        }.getOrNull()
-    }
+    override suspend fun getEntries(offset: Int): List<TimelineEntryModel>? = runCatching {
+        val response =
+            provider.trends
+                .getStatuses(
+                    offset = offset,
+                    limit = DEFAULT_PAGE_SIZE,
+                )
+        response.map { it.toModelWithReply() }
+    }.getOrNull()
 
-    override suspend fun getHashtags(offset: Int, refresh: Boolean): List<TagModel>? = withContext(Dispatchers.IO) {
+    override suspend fun getHashtags(offset: Int, refresh: Boolean): List<TagModel>? {
         if (refresh) {
             mutex.withLock {
                 cachedTags.clear()
             }
         }
         if (offset == 0 && cachedTags.isNotEmpty()) {
-            return@withContext cachedTags
+            return cachedTags
         }
-        runCatching {
+        return runCatching {
             val response =
                 provider.trends
                     .getHashtags(
@@ -58,20 +53,18 @@ internal class DefaultTrendingRepository(private val provider: ServiceProvider) 
         }.getOrNull()
     }
 
-    override suspend fun getLinks(offset: Int): List<LinkModel>? = withContext(Dispatchers.IO) {
-        runCatching {
-            val response =
-                provider.trends
-                    .getLinks(
-                        offset = offset,
-                        limit = DEFAULT_PAGE_SIZE,
-                    )
-            // workaround for a server bug which inserts empty arrays "[]," among valid results
-            // (at least on some Friendica versions)
-            val body = response.raw().bodyAsText().replace("[],", "")
-            TrendsLink.fromJson(body).map { it.toModel() }
-        }.getOrNull()
-    }
+    override suspend fun getLinks(offset: Int): List<LinkModel>? = runCatching {
+        val response =
+            provider.trends
+                .getLinks(
+                    offset = offset,
+                    limit = DEFAULT_PAGE_SIZE,
+                )
+        // workaround for a server bug which inserts empty arrays "[]," among valid results
+        // (at least on some Friendica versions)
+        val body = response.raw().bodyAsText().replace("[],", "")
+        TrendsLink.fromJson(body).map { it.toModel() }
+    }.getOrNull()
 
     companion object {
         private const val DEFAULT_PAGE_SIZE = 20

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRateLimitRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRateLimitRepository.kt
@@ -3,49 +3,36 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.dao.UserRateLimitDao
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.entities.UserRateLimitEntity
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserRateLimitModel
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.withContext
 
 internal class DefaultUserRateLimitRepository(private val userRateLimitDao: UserRateLimitDao) :
     UserRateLimitRepository {
-    override suspend fun getAll(accountId: Long): List<UserRateLimitModel> = withContext(Dispatchers.IO) {
-        runCatching {
-            userRateLimitDao.getAll(accountId).map { it.toModel() }
-        }.getOrElse { emptyList() }
-    }
+    override suspend fun getAll(accountId: Long): List<UserRateLimitModel> = runCatching {
+        userRateLimitDao.getAll(accountId).map { it.toModel() }
+    }.getOrElse { emptyList() }
 
-    override suspend fun getBy(handle: String, accountId: Long): UserRateLimitModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            userRateLimitDao
-                .getBy(
-                    accountId = accountId,
-                    handle = handle,
-                )?.toModel()
-        }.getOrNull()
-    }
+    override suspend fun getBy(handle: String, accountId: Long): UserRateLimitModel? = runCatching {
+        userRateLimitDao
+            .getBy(
+                accountId = accountId,
+                handle = handle,
+            )?.toModel()
+    }.getOrNull()
 
-    override suspend fun create(model: UserRateLimitModel): UserRateLimitModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            userRateLimitDao.insert(model.toEntity())
-            getBy(handle = model.handle, accountId = model.accountId)
-        }.getOrNull()
-    }
+    override suspend fun create(model: UserRateLimitModel): UserRateLimitModel? = runCatching {
+        userRateLimitDao.insert(model.toEntity())
+        getBy(handle = model.handle, accountId = model.accountId)
+    }.getOrNull()
 
-    override suspend fun update(model: UserRateLimitModel): UserRateLimitModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            userRateLimitDao.update(model.toEntity())
-            getBy(handle = model.handle, accountId = model.accountId)
-        }.getOrNull()
-    }
+    override suspend fun update(model: UserRateLimitModel): UserRateLimitModel? = runCatching {
+        userRateLimitDao.update(model.toEntity())
+        getBy(handle = model.handle, accountId = model.accountId)
+    }.getOrNull()
 
-    override suspend fun delete(id: Long): Boolean = withContext(Dispatchers.IO) {
-        runCatching {
-            val entity = UserRateLimitEntity(id = id, userHandle = "")
-            userRateLimitDao.delete(entity)
-            true
-        }.getOrElse { false }
-    }
+    override suspend fun delete(id: Long): Boolean = runCatching {
+        val entity = UserRateLimitEntity(id = id, userHandle = "")
+        userRateLimitDao.delete(entity)
+        true
+    }.getOrElse { false }
 }
 
 private fun UserRateLimitEntity.toModel() = UserRateLimitModel(

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepository.kt
@@ -17,245 +17,169 @@ import io.ktor.client.request.forms.formData
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
 import io.ktor.http.parameters
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.withContext
 
 internal class DefaultUserRepository(private val provider: ServiceProvider) : UserRepository {
     private var cachedUser: UserModel? = null
 
-    override suspend fun getById(id: String): UserModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            withContext(Dispatchers.IO) {
-                provider.users.getById(id).toModel()
-            }
-        }.getOrNull()
-    }
+    override suspend fun getById(id: String): UserModel? = runCatching {
+        provider.users.getById(id).toModel()
+    }.getOrNull()
 
-    override suspend fun search(query: String, offset: Int, following: Boolean): List<UserModel>? =
-        withContext(Dispatchers.IO) {
-            runCatching {
-                withContext(Dispatchers.IO) {
-                    provider.users
-                        .search(
-                            query = query,
-                            offset = offset,
-                            resolve = true,
-                            following = following,
-                        ).map { it.toModel() }
-                }
-            }.getOrNull()
-        }
+    override suspend fun search(query: String, offset: Int, following: Boolean): List<UserModel>? = runCatching {
+        provider.users
+            .search(
+                query = query,
+                offset = offset,
+                resolve = true,
+                following = following,
+            ).map { it.toModel() }
+    }.getOrNull()
 
-    override suspend fun getByHandle(handle: String): UserModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            withContext(Dispatchers.IO) {
-                provider.users
-                    .search(
-                        query = handle,
-                        resolve = true,
-                    ).first()
-                    .toModel()
-            }
-        }.getOrNull()
-    }
+    override suspend fun getByHandle(handle: String): UserModel? = runCatching {
+        provider.users
+            .search(
+                query = handle,
+                resolve = true,
+            ).first()
+            .toModel()
+    }.getOrNull()
 
-    override suspend fun getCurrent(refresh: Boolean): UserModel? = withContext(Dispatchers.IO) {
+    override suspend fun getCurrent(refresh: Boolean): UserModel? {
         if (refresh) {
             cachedUser = null
         }
         val fromCache = cachedUser
-        check(fromCache == null) { return@withContext fromCache }
-        runCatching {
+        check(fromCache == null) { return fromCache }
+        return runCatching {
             provider.users.verifyCredentials().toModel()
         }.getOrNull().also {
             cachedUser = it
         }
     }
 
-    override suspend fun getRelationships(ids: List<String>): List<RelationshipModel>? = withContext(Dispatchers.IO) {
-        runCatching {
-            withContext(Dispatchers.IO) {
-                provider.users
-                    .getRelationships(ids)
-                    .map { it.toModel() }
-            }
-        }.getOrNull()
-    }
+    override suspend fun getRelationships(ids: List<String>): List<RelationshipModel>? = runCatching {
+        provider.users
+            .getRelationships(ids)
+            .map { it.toModel() }
+    }.getOrNull()
 
-    override suspend fun getSuggestions(): List<UserModel>? = withContext(Dispatchers.IO) {
-        runCatching {
-            withContext(Dispatchers.IO) {
-                provider.users
-                    .getSuggestions(
-                        limit = DEFAULT_PAGE_SIZE,
-                    ).map { it.user.toModel() }
-            }
-        }.getOrNull()
-    }
+    override suspend fun getSuggestions(): List<UserModel>? = runCatching {
+        provider.users
+            .getSuggestions(
+                limit = DEFAULT_PAGE_SIZE,
+            ).map { it.user.toModel() }
+    }.getOrNull()
 
-    override suspend fun getFollowers(id: String, pageCursor: String?): List<UserModel>? = withContext(Dispatchers.IO) {
-        runCatching {
-            withContext(Dispatchers.IO) {
-                provider.users
-                    .getFollowers(
-                        id = id,
-                        maxId = pageCursor,
-                        limit = DEFAULT_PAGE_SIZE,
-                    ).map { it.toModel() }
-            }
-        }.getOrNull()
-    }
+    override suspend fun getFollowers(id: String, pageCursor: String?): List<UserModel>? = runCatching {
+        provider.users
+            .getFollowers(
+                id = id,
+                maxId = pageCursor,
+                limit = DEFAULT_PAGE_SIZE,
+            ).map { it.toModel() }
+    }.getOrNull()
 
-    override suspend fun getFollowing(id: String, pageCursor: String?): List<UserModel>? = withContext(Dispatchers.IO) {
-        runCatching {
-            withContext(Dispatchers.IO) {
-                provider.users
-                    .getFollowing(
-                        id = id,
-                        maxId = pageCursor,
-                        limit = DEFAULT_PAGE_SIZE,
-                    ).map { it.toModel() }
-            }
-        }.getOrNull()
-    }
+    override suspend fun getFollowing(id: String, pageCursor: String?): List<UserModel>? = runCatching {
+        provider.users
+            .getFollowing(
+                id = id,
+                maxId = pageCursor,
+                limit = DEFAULT_PAGE_SIZE,
+            ).map { it.toModel() }
+    }.getOrNull()
 
-    override suspend fun searchMyFollowing(query: String, pageCursor: String?): List<UserModel>? =
-        withContext(Dispatchers.IO) {
-            runCatching {
-                withContext(Dispatchers.IO) {
-                    provider.search
-                        .search(
-                            query = query,
-                            maxId = pageCursor,
-                            type = SearchResultType.Users.toDto(),
-                            following = true,
-                            limit = DEFAULT_PAGE_SIZE,
-                        ).accounts
-                        .map { it.toModel() }
-                }
-            }.getOrNull()
-        }
+    override suspend fun searchMyFollowing(query: String, pageCursor: String?): List<UserModel>? = runCatching {
+        provider.search
+            .search(
+                query = query,
+                maxId = pageCursor,
+                type = SearchResultType.Users.toDto(),
+                following = true,
+                limit = DEFAULT_PAGE_SIZE,
+            ).accounts
+            .map { it.toModel() }
+    }.getOrNull()
 
     override suspend fun follow(id: String, reblogs: Boolean, notifications: Boolean): RelationshipModel? =
-        withContext(Dispatchers.IO) {
-            runCatching {
-                withContext(Dispatchers.IO) {
-                    val data =
-                        FollowUserForm(
-                            reblogs = reblogs,
-                            notify = notifications,
-                        )
-                    provider.users
-                        .follow(
-                            id = id,
-                            data = data,
-                        ).toModel()
-                }
-            }.getOrNull()
-        }
-
-    override suspend fun unfollow(id: String): RelationshipModel? = withContext(Dispatchers.IO) {
         runCatching {
-            withContext(Dispatchers.IO) {
-                provider.users.unfollow(id).toModel()
-            }
+            val data =
+                FollowUserForm(
+                    reblogs = reblogs,
+                    notify = notifications,
+                )
+            provider.users
+                .follow(
+                    id = id,
+                    data = data,
+                ).toModel()
         }.getOrNull()
-    }
 
-    override suspend fun getFollowRequests(pageCursor: String?): ListWithPageCursor<UserModel>? =
-        withContext(Dispatchers.IO) {
-            runCatching {
-                val response =
-                    provider.followRequests.getAll(
-                        maxId = pageCursor,
-                        limit = DEFAULT_PAGE_SIZE,
-                    )
-                val list: List<UserModel> = response.body()?.map { it.toModel() }.orEmpty()
-                val nextCursor: String? = response.extractNextIdFromResponseLinkHeader()
-                ListWithPageCursor(list = list, cursor = nextCursor)
-            }.getOrNull()
-        }
+    override suspend fun unfollow(id: String): RelationshipModel? = runCatching {
+        provider.users.unfollow(id).toModel()
+    }.getOrNull()
 
-    override suspend fun acceptFollowRequest(id: String) = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.followRequests.accept(id)
-            true
-        }.getOrElse { false }
-    }
+    override suspend fun getFollowRequests(pageCursor: String?): ListWithPageCursor<UserModel>? = runCatching {
+        val response =
+            provider.followRequests.getAll(
+                maxId = pageCursor,
+                limit = DEFAULT_PAGE_SIZE,
+            )
+        val list: List<UserModel> = response.body()?.map { it.toModel() }.orEmpty()
+        val nextCursor: String? = response.extractNextIdFromResponseLinkHeader()
+        ListWithPageCursor(list = list, cursor = nextCursor)
+    }.getOrNull()
 
-    override suspend fun rejectFollowRequest(id: String) = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.followRequests.reject(id)
-            true
-        }.getOrElse { false }
-    }
+    override suspend fun acceptFollowRequest(id: String) = runCatching {
+        provider.followRequests.accept(id)
+        true
+    }.getOrElse { false }
+
+    override suspend fun rejectFollowRequest(id: String) = runCatching {
+        provider.followRequests.reject(id)
+        true
+    }.getOrElse { false }
 
     override suspend fun mute(id: String, durationSeconds: Long, notifications: Boolean): RelationshipModel? =
-        withContext(Dispatchers.IO) {
-            runCatching {
-                withContext(Dispatchers.IO) {
-                    val data =
-                        MuteUserForm(
-                            duration = durationSeconds,
-                            notifications = notifications,
-                        )
-                    provider.users
-                        .mute(
-                            id = id,
-                            data = data,
-                        ).toModel()
-                }
-            }.getOrNull()
-        }
-
-    override suspend fun unmute(id: String): RelationshipModel? = withContext(Dispatchers.IO) {
         runCatching {
-            withContext(Dispatchers.IO) {
-                provider.users.unmute(id).toModel()
-            }
+            val data =
+                MuteUserForm(
+                    duration = durationSeconds,
+                    notifications = notifications,
+                )
+            provider.users
+                .mute(
+                    id = id,
+                    data = data,
+                ).toModel()
         }.getOrNull()
-    }
 
-    override suspend fun block(id: String): RelationshipModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            withContext(Dispatchers.IO) {
-                provider.users.block(id).toModel()
-            }
-        }.getOrNull()
-    }
+    override suspend fun unmute(id: String): RelationshipModel? = runCatching {
+        provider.users.unmute(id).toModel()
+    }.getOrNull()
 
-    override suspend fun unblock(id: String): RelationshipModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            withContext(Dispatchers.IO) {
-                provider.users.unblock(id).toModel()
-            }
-        }.getOrNull()
-    }
+    override suspend fun block(id: String): RelationshipModel? = runCatching {
+        provider.users.block(id).toModel()
+    }.getOrNull()
 
-    override suspend fun getMuted(pageCursor: String?): List<UserModel>? = withContext(Dispatchers.IO) {
-        runCatching {
-            withContext(Dispatchers.IO) {
-                provider.users
-                    .getMuted(
-                        maxId = pageCursor,
-                        limit = DEFAULT_PAGE_SIZE,
-                    ).map { it.toModel() }
-            }
-        }.getOrNull()
-    }
+    override suspend fun unblock(id: String): RelationshipModel? = runCatching {
+        provider.users.unblock(id).toModel()
+    }.getOrNull()
 
-    override suspend fun getBlocked(pageCursor: String?): List<UserModel>? = withContext(Dispatchers.IO) {
-        runCatching {
-            withContext(Dispatchers.IO) {
-                provider.users
-                    .getBlocked(
-                        maxId = pageCursor,
-                        limit = DEFAULT_PAGE_SIZE,
-                    ).map { it.toModel() }
-            }
-        }.getOrNull()
-    }
+    override suspend fun getMuted(pageCursor: String?): List<UserModel>? = runCatching {
+        provider.users
+            .getMuted(
+                maxId = pageCursor,
+                limit = DEFAULT_PAGE_SIZE,
+            ).map { it.toModel() }
+    }.getOrNull()
+
+    override suspend fun getBlocked(pageCursor: String?): List<UserModel>? = runCatching {
+        provider.users
+            .getBlocked(
+                maxId = pageCursor,
+                limit = DEFAULT_PAGE_SIZE,
+            ).map { it.toModel() }
+    }.getOrNull()
 
     override suspend fun updateProfile(
         note: String?,
@@ -268,110 +192,103 @@ internal class DefaultUserRepository(private val provider: ServiceProvider) : Us
         hideCollections: Boolean?,
         indexable: Boolean?,
         fields: Map<String, String>?,
-    ) = withContext(Dispatchers.IO) {
-        runCatching {
-            var result: Account
+    ) = runCatching {
+        var result: Account
 
-            // textual data
-            val formData =
-                FormDataContent(
-                    parameters {
-                        if (note != null) {
-                            append("note", note)
-                        }
-                        if (displayName != null) {
-                            append("display_name", displayName)
-                        }
-                        if (locked != null) {
-                            append("locked", if (locked) "1" else "0")
-                        }
-                        if (bot != null) {
-                            append("bot", if (bot) "1" else "0")
-                        }
-                        if (discoverable != null) {
-                            append("discoverable", if (discoverable) "1" else "0")
-                        }
-                        if (hideCollections != null) {
-                            append("hide_collections", if (hideCollections) "1" else "0")
-                        }
-                        if (indexable != null) {
-                            append("indexable", if (indexable) "1" else "0")
-                        }
-                        if (fields != null) {
-                            val serializedFields =
-                                buildList {
-                                    fields.entries.forEachIndexed { idx, entry ->
-                                        val nameKey = "fields_attributes[$idx][name]"
-                                        val nameValue = entry.key
-                                        this += (nameKey to nameValue)
-                                        val valueKey = "fields_attributes[$idx][value]"
-                                        val valueValue = entry.value
-                                        this += (valueKey to valueValue)
-                                    }
+        // textual data
+        val formData =
+            FormDataContent(
+                parameters {
+                    if (note != null) {
+                        append("note", note)
+                    }
+                    if (displayName != null) {
+                        append("display_name", displayName)
+                    }
+                    if (locked != null) {
+                        append("locked", if (locked) "1" else "0")
+                    }
+                    if (bot != null) {
+                        append("bot", if (bot) "1" else "0")
+                    }
+                    if (discoverable != null) {
+                        append("discoverable", if (discoverable) "1" else "0")
+                    }
+                    if (hideCollections != null) {
+                        append("hide_collections", if (hideCollections) "1" else "0")
+                    }
+                    if (indexable != null) {
+                        append("indexable", if (indexable) "1" else "0")
+                    }
+                    if (fields != null) {
+                        val serializedFields =
+                            buildList {
+                                fields.entries.forEachIndexed { idx, entry ->
+                                    val nameKey = "fields_attributes[$idx][name]"
+                                    val nameValue = entry.key
+                                    this += (nameKey to nameValue)
+                                    val valueKey = "fields_attributes[$idx][value]"
+                                    val valueValue = entry.value
+                                    this += (valueKey to valueValue)
                                 }
-                            for (field in serializedFields) {
-                                append(field.first, field.second)
                             }
+                        for (field in serializedFields) {
+                            append(field.first, field.second)
                         }
-                    },
-                )
-            result = provider.users.updateProfile(formData)
+                    }
+                },
+            )
+        result = provider.users.updateProfile(formData)
 
-            // images
-            if (avatar != null) {
-                val multipartFormData =
-                    MultiPartFormDataContent(
-                        formData {
-                            append(
-                                key = "avatar",
-                                value = avatar,
-                                headers =
-                                Headers.build {
-                                    append(HttpHeaders.ContentType, "image/*")
-                                    append(HttpHeaders.ContentDisposition, "filename=avatar.jpeg")
-                                },
-                            )
-                        },
-                    )
-                result = provider.users.updateProfileImage(multipartFormData)
-            }
-
-            if (header != null) {
-                val multipartFormData =
-                    MultiPartFormDataContent(
-                        formData {
-                            append(
-                                key = "header",
-                                value = header,
-                                headers =
-                                Headers.build {
-                                    append(HttpHeaders.ContentType, "image/*")
-                                    append(HttpHeaders.ContentDisposition, "filename=header.jpeg")
-                                },
-                            )
-                        },
-                    )
-                result = provider.users.updateProfileImage(multipartFormData)
-            }
-
-            result.toModel()
-        }.getOrNull()
-    }
-
-    override suspend fun updatePersonalNote(id: String, value: String): RelationshipModel? =
-        withContext(Dispatchers.IO) {
-            runCatching {
-                withContext(Dispatchers.IO) {
-                    val data =
-                        FormDataContent(
-                            parameters {
-                                append("comment", value)
+        // images
+        if (avatar != null) {
+            val multipartFormData =
+                MultiPartFormDataContent(
+                    formData {
+                        append(
+                            key = "avatar",
+                            value = avatar,
+                            headers =
+                            Headers.build {
+                                append(HttpHeaders.ContentType, "image/*")
+                                append(HttpHeaders.ContentDisposition, "filename=avatar.jpeg")
                             },
                         )
-                    provider.users.updatePersonalNote(id = id, data = data).toModel()
-                }
-            }.getOrNull()
+                    },
+                )
+            result = provider.users.updateProfileImage(multipartFormData)
         }
+
+        if (header != null) {
+            val multipartFormData =
+                MultiPartFormDataContent(
+                    formData {
+                        append(
+                            key = "header",
+                            value = header,
+                            headers =
+                            Headers.build {
+                                append(HttpHeaders.ContentType, "image/*")
+                                append(HttpHeaders.ContentDisposition, "filename=header.jpeg")
+                            },
+                        )
+                    },
+                )
+            result = provider.users.updateProfileImage(multipartFormData)
+        }
+
+        result.toModel()
+    }.getOrNull()
+
+    override suspend fun updatePersonalNote(id: String, value: String): RelationshipModel? = runCatching {
+        val data =
+            FormDataContent(
+                parameters {
+                    append("comment", value)
+                },
+            )
+        provider.users.updatePersonalNote(id = id, data = data).toModel()
+    }.getOrNull()
 
     companion object {
         private const val DEFAULT_PAGE_SIZE = 20

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/FallbackTranslationRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/FallbackTranslationRepository.kt
@@ -3,78 +3,73 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.InnerTranslationService
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TranslatedTimelineEntryModel
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.withContext
 
 internal class FallbackTranslationRepository(private val service: InnerTranslationService) : TranslationRepository {
     override suspend fun getTranslation(entry: TimelineEntryModel, targetLang: String): TranslatedTimelineEntryModel? =
-        withContext(Dispatchers.IO) {
-            runCatching {
-                TranslatedTimelineEntryModel(
-                    source = entry,
-                    target =
-                    entry.copy(
-                        content =
-                        entry.content.translate(
-                            sourceLang = entry.lang,
-                            targetLang = targetLang,
-                        ),
-                        title =
-                        entry.title?.translate(
-                            sourceLang = entry.lang,
-                            targetLang = targetLang,
-                        ) ?: entry.title,
-                        spoiler =
-                        entry.spoiler?.translate(
-                            sourceLang = entry.lang,
-                            targetLang = targetLang,
-                        ) ?: entry.spoiler,
-                        card =
-                        entry.card?.let { card ->
-                            card.copy(
-                                title =
-                                card.title.translate(
-                                    sourceLang = entry.lang,
-                                    targetLang = targetLang,
-                                ),
-                                description =
-                                card.description.translate(
-                                    sourceLang = entry.lang,
-                                    targetLang = targetLang,
-                                ),
-                            )
-                        },
-                        attachments =
-                        entry.attachments.map { att ->
-                            val translatedDescription =
-                                att.description?.translate(
-                                    sourceLang = entry.lang,
-                                    targetLang = targetLang,
-                                )
-                            att.copy(
-                                description = translatedDescription ?: att.description,
-                            )
-                        },
-                        poll =
-                        entry.poll?.copy(
-                            options =
-                            entry.poll
-                                ?.options
-                                ?.map { opt ->
-                                    val translatedTitle =
-                                        opt.title.translate(
-                                            sourceLang = entry.lang,
-                                            targetLang = targetLang,
-                                        )
-                                    opt.copy(title = translatedTitle)
-                                }.orEmpty(),
-                        ),
+        runCatching {
+            TranslatedTimelineEntryModel(
+                source = entry,
+                target =
+                entry.copy(
+                    content =
+                    entry.content.translate(
+                        sourceLang = entry.lang,
+                        targetLang = targetLang,
                     ),
-                    provider = PROVIDER_NAME,
-                )
-            }.getOrNull()
-        }
+                    title =
+                    entry.title?.translate(
+                        sourceLang = entry.lang,
+                        targetLang = targetLang,
+                    ) ?: entry.title,
+                    spoiler =
+                    entry.spoiler?.translate(
+                        sourceLang = entry.lang,
+                        targetLang = targetLang,
+                    ) ?: entry.spoiler,
+                    card =
+                    entry.card?.let { card ->
+                        card.copy(
+                            title =
+                            card.title.translate(
+                                sourceLang = entry.lang,
+                                targetLang = targetLang,
+                            ),
+                            description =
+                            card.description.translate(
+                                sourceLang = entry.lang,
+                                targetLang = targetLang,
+                            ),
+                        )
+                    },
+                    attachments =
+                    entry.attachments.map { att ->
+                        val translatedDescription =
+                            att.description?.translate(
+                                sourceLang = entry.lang,
+                                targetLang = targetLang,
+                            )
+                        att.copy(
+                            description = translatedDescription ?: att.description,
+                        )
+                    },
+                    poll =
+                    entry.poll?.copy(
+                        options =
+                        entry.poll
+                            ?.options
+                            ?.map { opt ->
+                                val translatedTitle =
+                                    opt.title.translate(
+                                        sourceLang = entry.lang,
+                                        targetLang = targetLang,
+                                    )
+                                opt.copy(title = translatedTitle)
+                            }.orEmpty(),
+                    ),
+                ),
+                provider = PROVIDER_NAME,
+            )
+        }.getOrNull()
 
     private suspend fun String.translate(sourceLang: String?, targetLang: String): String = service.translate(
         sourceText = this,

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultCredentialsRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultCredentialsRepository.kt
@@ -20,9 +20,6 @@ import io.ktor.http.Parameters
 import io.ktor.http.URLBuilder
 import io.ktor.http.URLProtocol
 import io.ktor.http.path
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.withContext
 
 internal class DefaultCredentialsRepository(
     private val provider: ServiceProvider,
@@ -37,21 +34,17 @@ internal class DefaultCredentialsRepository(
             }
         }
 
-    override suspend fun validate(node: String, credentials: ApiCredentials): UserModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.changeNode(node)
-            provider.setAuth(credentials.toServiceCredentials())
-            provider.users.verifyCredentials().toModel()
-        }.getOrNull()
-    }
+    override suspend fun validate(node: String, credentials: ApiCredentials): UserModel? = runCatching {
+        provider.changeNode(node)
+        provider.setAuth(credentials.toServiceCredentials())
+        provider.users.verifyCredentials().toModel()
+    }.getOrNull()
 
-    override suspend fun validateNode(node: String): Boolean = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.changeNode(node)
-            provider.instance.getInfo()
-            true
-        }.getOrElse { false }
-    }
+    override suspend fun validateNode(node: String): Boolean = runCatching {
+        provider.changeNode(node)
+        provider.instance.getInfo()
+        true
+    }.getOrElse { false }
 
     override suspend fun createApplication(
         node: String,
@@ -59,32 +52,28 @@ internal class DefaultCredentialsRepository(
         website: String,
         redirectUri: String,
         scopes: String,
-    ): ClientApplicationModel? = withContext(Dispatchers.IO) {
-        runCatching {
-            provider.changeNode(node)
-            val data =
-                CreateAppForm(
-                    clientName = clientName,
-                    website = website,
-                    redirectUris = redirectUri,
-                    scopes = scopes,
-                )
-            provider.apps.create(data).toModel()
-        }.getOrNull()
-    }
+    ): ClientApplicationModel? = runCatching {
+        provider.changeNode(node)
+        val data =
+            CreateAppForm(
+                clientName = clientName,
+                website = website,
+                redirectUris = redirectUri,
+                scopes = scopes,
+            )
+        provider.apps.create(data).toModel()
+    }.getOrNull()
 
     override suspend fun validateApplicationCredentials(node: String, credentials: ApiCredentials): Boolean =
-        withContext(Dispatchers.IO) {
-            when (credentials) {
-                is ApiCredentials.HttpBasic -> true
-                is ApiCredentials.OAuth2 -> {
-                    runCatching {
-                        provider.changeNode(node)
-                        provider.setAuth(credentials.toServiceCredentials())
-                        provider.apps.verifyCredentials().toModel()
-                        true
-                    }.getOrElse { false }
-                }
+        when (credentials) {
+            is ApiCredentials.HttpBasic -> true
+            is ApiCredentials.OAuth2 -> {
+                runCatching {
+                    provider.changeNode(node)
+                    provider.setAuth(credentials.toServiceCredentials())
+                    provider.apps.verifyCredentials().toModel()
+                    true
+                }.getOrElse { false }
             }
         }
 
@@ -96,34 +85,32 @@ internal class DefaultCredentialsRepository(
         redirectUri: String,
         grantType: String,
         code: String,
-    ): ApiCredentials? = withContext(Dispatchers.IO) {
-        runCatching {
-            val data =
-                FormDataContent(
-                    Parameters.build {
-                        append("client_id", clientId)
-                        append("client_secret", clientSecret)
-                        append("redirect_uri", redirectUri)
-                        append("grant_type", grantType)
-                        append("code", code)
-                    },
-                )
-            val url =
-                URLBuilder()
-                    .apply {
-                        protocol = URLProtocol.HTTPS
-                        host = node
-                        path(path)
-                    }.toString()
-            val responseBody =
-                httpClient
-                    .preparePost(url) {
-                        setBody(data)
-                    }.execute()
-                    .bodyAsText()
-            responseBody.toOauthToken().toModel()
-        }.getOrNull()
-    }
+    ): ApiCredentials? = runCatching {
+        val data =
+            FormDataContent(
+                Parameters.build {
+                    append("client_id", clientId)
+                    append("client_secret", clientSecret)
+                    append("redirect_uri", redirectUri)
+                    append("grant_type", grantType)
+                    append("code", code)
+                },
+            )
+        val url =
+            URLBuilder()
+                .apply {
+                    protocol = URLProtocol.HTTPS
+                    host = node
+                    path(path)
+                }.toString()
+        val responseBody =
+            httpClient
+                .preparePost(url) {
+                    setBody(data)
+                }.execute()
+                .bodyAsText()
+        responseBody.toOauthToken().toModel()
+    }.getOrNull()
 }
 
 private fun Application.toModel() = ClientApplicationModel(

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultStopWordRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultStopWordRepository.kt
@@ -1,18 +1,15 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository
 
 import com.livefast.eattrash.raccoonforfriendica.core.preferences.store.TemporaryKeyStore
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.withContext
 
 internal class DefaultStopWordRepository(private val keyStore: TemporaryKeyStore) : StopWordRepository {
-    override suspend fun get(accountId: Long?): List<String> = withContext(Dispatchers.IO) {
+    override suspend fun get(accountId: Long?): List<String> {
         val key = getKey(accountId)
         val res = keyStore.get(key, emptyList())
-        res.filter { it.isNotEmpty() }
+        return res.filter { it.isNotEmpty() }
     }
 
-    override suspend fun update(accountId: Long?, items: List<String>) = withContext(Dispatchers.IO) {
+    override suspend fun update(accountId: Long?, items: List<String>) {
         val key = getKey(accountId)
         keyStore.save(key, items)
     }

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultSetupAccountUseCase.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultSetupAccountUseCase.kt
@@ -4,15 +4,12 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountMod
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.withContext
 
 internal class DefaultSetupAccountUseCase(
     private val accountRepository: AccountRepository,
     private val settingsRepository: SettingsRepository,
 ) : SetupAccountUseCase {
-    override suspend fun invoke() = withContext(Dispatchers.IO) {
+    override suspend fun invoke() {
         val accounts = accountRepository.getAll()
         if (accounts.isEmpty()) {
             // create at least an anonymous account

--- a/feature/acknowledgements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feat/acknowledgements/repository/DefaultAcknowledgementsRepository.kt
+++ b/feature/acknowledgements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feat/acknowledgements/repository/DefaultAcknowledgementsRepository.kt
@@ -3,15 +3,10 @@ package com.livefast.eattrash.raccoonforfriendica.feat.acknowledgements.reposito
 import com.livefast.eattrash.raccoonforfriendica.feat.acknowledgements.datasource.Acknowledgement
 import com.livefast.eattrash.raccoonforfriendica.feat.acknowledgements.datasource.AcknowledgementsRemoteDataSource
 import com.livefast.eattrash.raccoonforfriendica.feat.acknowledgements.models.AcknowledgementModel
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.withContext
 
 internal class DefaultAcknowledgementsRepository(private val dataSource: AcknowledgementsRemoteDataSource) :
     AcknowledgementsRepository {
-    override suspend fun getAll(): List<AcknowledgementModel>? = withContext(Dispatchers.IO) {
-        dataSource.getAcknowledgements()?.map { it.toModel() }
-    }
+    override suspend fun getAll(): List<AcknowledgementModel>? = dataSource.getAcknowledgements()?.map { it.toModel() }
 }
 
 private fun Acknowledgement.toModel() = AcknowledgementModel(

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
@@ -453,7 +453,8 @@ class ForumListScreen(private val id: String) : Screen {
                                 this += OptionId.ViewDetails.toOption()
                                 this += OptionId.CopyToClipboard.toOption()
                                 val currentLang = uiState.lang.orEmpty()
-                                if (currentLang.isNotEmpty() && entry.lang != currentLang &&
+                                if (currentLang.isNotEmpty() &&
+                                    entry.lang != currentLang &&
                                     !entry.isShowingTranslation
                                 ) {
                                     this +=
@@ -521,6 +522,7 @@ class ForumListScreen(private val id: String) : Screen {
                                                 )
                                             }
                                         }
+
                                     OptionId.Quote -> {
                                         entry.original.also { entryToShare ->
                                             detailOpener.openComposer(
@@ -528,6 +530,7 @@ class ForumListScreen(private val id: String) : Screen {
                                             )
                                         }
                                     }
+
                                     OptionId.ViewDetails -> seeDetailsEntry = entry.original
                                     OptionId.CopyToClipboard ->
                                         model.reduce(ForumListMviModel.Intent.CopyToClipboard(entry.original))
@@ -546,6 +549,7 @@ class ForumListScreen(private val id: String) : Screen {
                                         model.reduce(
                                             ForumListMviModel.Intent.OpenInBrowser(entry),
                                         )
+
                                     else -> Unit
                                 }
                             },


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR continues the work started in #935 and removes all the unneeded `withContext(Dispatchers.IO)`, mainly from repositories in the domain layer.

Since both Room and Ktorfit methods are main-safe, there is no need to for manual dispatcher switch on the client side.