### PR TITLE
fix: safe ime padding on Android <= 10

### DIFF
--- a/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/DefaultBarColorProvider.kt
+++ b/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/DefaultBarColorProvider.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.core.appearance.theme
 
 import android.app.Activity
 import android.os.Build
+import android.view.WindowManager
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -50,6 +51,12 @@ internal class DefaultBarColorProvider : BarColorProvider {
                         isStatusBarContrastEnforced = true
                     }
                     isNavigationBarContrastEnforced = true
+                }
+                // configure window for consistent behavior across Android versions (see safeImePadding modifier)
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+                    setSoftInputMode(
+                        WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE,
+                    )
                 }
 
                 val forceLight = baseColor == Color.White

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/compose/SafeImePadding.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/compose/SafeImePadding.kt
@@ -1,8 +1,13 @@
 package com.livefast.eattrash.raccoonforfriendica.core.utils.compose
 
 import android.os.Build
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 
 /*
  * There is a weird bug on Android Q and below due to which the IME padding is added twice and
@@ -10,10 +15,19 @@ import androidx.compose.ui.Modifier
  *
  * This workaround simply ignores the imePadding() modifier in those cases.
  */
+@Composable
 actual fun Modifier.safeImePadding(): Modifier = then(
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
         Modifier.imePadding()
     } else {
-        Modifier
+        // custom approach for older android versions
+        val insets = WindowInsets.ime
+        val density = LocalDensity.current
+
+        Modifier.padding(
+            bottom = with(density) {
+                (insets.getBottom(density) * 0.5f).toDp()
+            },
+        )
     },
 )

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/compose/SafeImePadding.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/compose/SafeImePadding.kt
@@ -1,5 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.core.utils.compose
 
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
+@Composable
 expect fun Modifier.safeImePadding(): Modifier

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/compose/SafeImePadding.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/compose/SafeImePadding.kt
@@ -1,6 +1,8 @@
 package com.livefast.eattrash.raccoonforfriendica.core.utils.compose
 
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
+@Composable
 actual fun Modifier.safeImePadding(): Modifier = then(Modifier.imePadding())


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR refines the workaround to avoid double keyboard insets from being applied on Android 10 and below. Instead of doing nothing, the idea is to:
- have a consistent soft input mode applied to the Window (to the same value used from Android 11 onwards)
- manually apply a padding to the content. 
