### PR TITLE
fix: handle single-line quotes in Markdown preview

### DIFF
--- a/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/converters/DefaultMarkdownConverter.kt
+++ b/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/converters/DefaultMarkdownConverter.kt
@@ -57,6 +57,11 @@ internal class DefaultMarkdownConverter : MarkdownConverter {
                 append("<h5>$content</h5>\n")
             }
         }.run {
+            Regex("(?<=^|\n)> (?<text>.*?)(?=\$|\n)").substituteAllOccurrences(this) { match ->
+                val content = match.groups["text"]?.value.orEmpty()
+                append("<blockquote>$content</blockquote>\n")
+            }
+        }.run {
             ContentRegexes.BBCODE_SHARE.substituteAllOccurrences(this) { match ->
                 val url = match.groups["url"]?.value.orEmpty()
                 append(url)


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds the management of single-line quotes in Markdown previews for posts.

This solves the first issue reported in #885.