### PR TITLE
fix: link banner position in preview

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentPreview.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentPreview.kt
@@ -57,7 +57,7 @@ fun ContentPreview(
     val cornerSize = CornerSize.xl
     val contentPadding = 12.dp
 
-    Box(modifier = modifier) {
+    Column(modifier = modifier) {
         if (hasMediaInfo || hasTextualInfo) {
             Column(
                 modifier =


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes a layout bug introduced in #932 due to which the link banner was displayed over the preview image (if both image and link were present).
