### PR TITLE
fix: restore possibility to share images from other apps

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/MainActivity.kt
@@ -116,13 +116,13 @@ class MainActivity : ComponentActivity() {
 
     private fun handleIncomingAttachment(intent: Intent) {
         lifecycleScope.launch {
-            // if the root navigator has not been set yet, rootNavigator?.push does nothing
+            // workaround: wait until the root NavigationAdapter has been set
             delay(750)
+            val mainRouter = getMainRouter()
             when {
                 "text/plain" == intent.type -> {
                     intent.getStringExtra(Intent.EXTRA_TEXT)?.also { content ->
-                        val detailOpener = getMainRouter()
-                        detailOpener.openComposer(initialText = content.trim('"'))
+                        mainRouter.openComposer(initialText = content.trim('"'))
                     }
                 }
 
@@ -132,13 +132,9 @@ class MainActivity : ComponentActivity() {
                     } else {
                         intent.getParcelableExtra(Intent.EXTRA_STREAM) as? Uri
                     }?.also { uri ->
-                        val bytes =
-                            contentResolver.openInputStream(uri)?.use {
-                                it.readBytes()
-                            }
+                        val bytes = contentResolver.openInputStream(uri)?.use { it.readBytes() }
                         if (bytes != null) {
-                            val detailOpener = getMainRouter()
-                            detailOpener.openComposer(initialAttachment = bytes)
+                            mainRouter.openComposer(initialAttachment = bytes)
                         }
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/MainRouterModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/MainRouterModule.kt
@@ -19,6 +19,7 @@ internal val mainRouterModule =
                     entryCache = instance(),
                     eventCache = instance(),
                     circleCache = instance(),
+                    attachmentCache = instance(),
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultMainRouter.kt
+++ b/composeApp/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultMainRouter.kt
@@ -11,6 +11,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.Unpublished
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserListType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toInt
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.AttachmentCache
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.LocalItemCache
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
@@ -29,6 +30,7 @@ class DefaultMainRouter(
     private val entryCache: LocalItemCache<TimelineEntryModel>,
     private val eventCache: LocalItemCache<EventModel>,
     private val circleCache: LocalItemCache<CircleModel>,
+    private val attachmentCache: AttachmentCache,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : MainRouter {
     private val currentUserId: String? get() = identityRepository.currentUser.value?.id
@@ -163,7 +165,9 @@ class DefaultMainRouter(
             }
         }
         val isGroup = inReplyToUser?.group == true && inGroup
-        // TODO: handle initialAttachment with cache
+        if (initialAttachment != null) {
+            attachmentCache.put(initialAttachment)
+        }
         navigationCoordinator.push(
             Destination.Composer(
                 inReplyToId = inReplyTo?.id,

--- a/composeApp/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultMainRouterTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultMainRouterTest.kt
@@ -13,6 +13,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.Unpublished
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserListType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toInt
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.AttachmentCache
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.LocalItemCache
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.SettingsModel
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
@@ -76,6 +77,7 @@ class DefaultMainRouterTest {
     private val entryCache = mock<LocalItemCache<TimelineEntryModel>>(mode = MockMode.autoUnit)
     private val eventCache = mock<LocalItemCache<EventModel>>(mode = MockMode.autoUnit)
     private val circleCache = mock<LocalItemCache<CircleModel>>(mode = MockMode.autoUnit)
+    private val attachmentCache = mock<AttachmentCache>(mode = MockMode.autoUnit)
     private val sut =
         DefaultMainRouter(
             navigationCoordinator = navigationCoordinator,
@@ -85,6 +87,7 @@ class DefaultMainRouterTest {
             entryCache = entryCache,
             eventCache = eventCache,
             circleCache = circleCache,
+            attachmentCache = attachmentCache,
             dispatcher = UnconfinedTestDispatcher(),
         )
 

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/AttachmentCache.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/AttachmentCache.kt
@@ -1,0 +1,9 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+interface AttachmentCache {
+    fun put(bytes: ByteArray)
+
+    fun get(): ByteArray?
+
+    fun clear()
+}

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultAttachmentCache.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultAttachmentCache.kt
@@ -1,0 +1,15 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
+
+internal class DefaultAttachmentCache : AttachmentCache {
+    private var value: ByteArray? = null
+
+    override fun put(bytes: ByteArray) {
+        value = bytes
+    }
+
+    override fun get(): ByteArray? = value
+
+    override fun clear() {
+        value = null
+    }
+}

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
@@ -6,9 +6,11 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEnt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.AnnouncementRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.AnnouncementsManager
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.AttachmentCache
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.CirclesRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultAnnouncementRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultAnnouncementsManager
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultAttachmentCache
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultCirclesRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultDirectMessageRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DefaultDraftRepository
@@ -295,6 +297,11 @@ val contentRepositoryModule =
                 DefaultFollowedHashtagCache(
                     tagRepository = instance(),
                 )
+            }
+        }
+        bind<AttachmentCache> {
+            singleton {
+                DefaultAttachmentCache()
             }
         }
     }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/Utils.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/Utils.kt
@@ -1,0 +1,10 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.repository.di
+
+import com.livefast.eattrash.raccoonforfriendica.core.di.RootDI
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.AttachmentCache
+import org.kodein.di.instance
+
+fun getAttachmentCache(): AttachmentCache {
+    val res by RootDI.di.instance<AttachmentCache>()
+    return res
+}

--- a/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/list/CalendarScreen.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/list/CalendarScreen.kt
@@ -63,7 +63,7 @@ fun CalendarScreen(modifier: Modifier = Modifier) {
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val uriHandler = LocalUriHandler.current
-    val detailOpener = getMainRouter()
+    val mainRouter = remember { getMainRouter() }
     val navigationCoordinator = remember { getNavigationCoordinator() }
     val lazyListState = rememberLazyListState()
     val scope = rememberCoroutineScope()
@@ -183,7 +183,7 @@ fun CalendarScreen(modifier: Modifier = Modifier) {
                                     }
                                 },
                                 onClick = {
-                                    detailOpener.openEvent(event = item.event)
+                                    mainRouter.openEvent(event = item.event)
                                 },
                                 options =
                                 buildList {

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/editmembers/CircleMembersScreen.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/editmembers/CircleMembersScreen.kt
@@ -75,7 +75,7 @@ fun CircleMembersScreen(id: String, modifier: Modifier = Modifier) {
     val isFabVisible by fabNestedScrollConnection.isFabVisible.collectAsState()
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     val genericError = LocalStrings.current.messageGenericError
     var confirmRemoveUserId by remember { mutableStateOf<String?>(null) }
 
@@ -203,7 +203,7 @@ fun CircleMembersScreen(id: String, modifier: Modifier = Modifier) {
                         user = user,
                         autoloadImages = uiState.autoloadImages,
                         onClick = {
-                            detailOpener.openUserDetail(user)
+                            mainRouter.openUserDetail(user)
                         },
                         options =
                         buildList {

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/list/CirclesScreen.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/list/CirclesScreen.kt
@@ -75,7 +75,7 @@ fun CirclesScreen(modifier: Modifier = Modifier) {
     val fabNestedScrollConnection = remember { getFabNestedScrollConnection() }
     val isFabVisible by fabNestedScrollConnection.isFabVisible.collectAsState()
     val scope = rememberCoroutineScope()
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     var confirmDeleteItemId by remember { mutableStateOf<String?>(null) }
     val snackbarHostState = remember { SnackbarHostState() }
     val genericError = LocalStrings.current.messageGenericError
@@ -98,10 +98,10 @@ fun CirclesScreen(modifier: Modifier = Modifier) {
                         snackbarHostState.showSnackbar(genericError)
 
                     is CirclesMviModel.Effect.OpenUser ->
-                        detailOpener.openUserDetail(event.user)
+                        mainRouter.openUserDetail(event.user)
 
                     is CirclesMviModel.Effect.OpenCircle ->
-                        detailOpener.openCircleTimeline(event.circle)
+                        mainRouter.openCircleTimeline(event.circle)
                 }
             }.launchIn(this)
     }
@@ -243,7 +243,7 @@ fun CirclesScreen(modifier: Modifier = Modifier) {
                                         }
 
                                         CustomOptions.EditMembers -> {
-                                            detailOpener.openCircleEditMembers(item.circle.id)
+                                            mainRouter.openCircleEditMembers(item.circle.id)
                                         }
 
                                         OptionId.Delete -> confirmDeleteItemId = item.circle.id

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineScreen.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineScreen.kt
@@ -85,7 +85,7 @@ fun CircleTimelineScreen(id: String, modifier: Modifier = Modifier) {
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val connection = navigationCoordinator.getBottomBarScrollConnection()
     val uriHandler = LocalUriHandler.current
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     val scope = rememberCoroutineScope()
     val lazyListState = rememberLazyListState()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -123,7 +123,7 @@ fun CircleTimelineScreen(id: String, modifier: Modifier = Modifier) {
                     }
 
                     is CircleTimelineMviModel.Effect.OpenDetail -> {
-                        detailOpener.openEntryDetail(
+                        mainRouter.openEntryDetail(
                             entry = event.entry,
                             swipeNavigationEnabled = true,
                         )
@@ -252,10 +252,10 @@ fun CircleTimelineScreen(id: String, modifier: Modifier = Modifier) {
                             }
                         },
                         onOpenUser = {
-                            detailOpener.openUserDetail(it)
+                            mainRouter.openUserDetail(it)
                         },
                         onOpenImage = { urls, imageIdx, videoIndices ->
-                            detailOpener.openImageDetail(
+                            mainRouter.openImageDetail(
                                 urls = urls,
                                 initialIndex = imageIdx,
                                 videoIndices = videoIndices,
@@ -291,7 +291,7 @@ fun CircleTimelineScreen(id: String, modifier: Modifier = Modifier) {
                         }.takeIf { actionRepository.canDislike(entry.original) },
                         onReply =
                         { e: TimelineEntryModel ->
-                            detailOpener.openComposer(
+                            mainRouter.openComposer(
                                 inReplyTo = e,
                                 inReplyToUser = e.creator,
                             )
@@ -393,7 +393,7 @@ fun CircleTimelineScreen(id: String, modifier: Modifier = Modifier) {
 
                                 OptionId.Edit -> {
                                     entry.original.also { entryToEdit ->
-                                        detailOpener.openComposer(
+                                        mainRouter.openComposer(
                                             inReplyTo = entryToEdit.inReplyTo,
                                             inReplyToUser = entryToEdit.inReplyTo?.creator,
                                             editedPostId = entryToEdit.id,
@@ -409,13 +409,13 @@ fun CircleTimelineScreen(id: String, modifier: Modifier = Modifier) {
 
                                 OptionId.ReportUser ->
                                     entry.original.creator?.also { userToReport ->
-                                        detailOpener.openCreateReport(user = userToReport)
+                                        mainRouter.openCreateReport(user = userToReport)
                                     }
 
                                 OptionId.ReportEntry ->
                                     entry.original.also { entryToReport ->
                                         entryToReport.creator?.also { userToReport ->
-                                            detailOpener.openCreateReport(
+                                            mainRouter.openCreateReport(
                                                 user = userToReport,
                                                 entry = entryToReport,
                                             )
@@ -424,7 +424,7 @@ fun CircleTimelineScreen(id: String, modifier: Modifier = Modifier) {
 
                                 OptionId.Quote -> {
                                     entry.original.also { entryToShare ->
-                                        detailOpener.openComposer(
+                                        mainRouter.openComposer(
                                             urlToShare = entryToShare.url,
                                         )
                                     }

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
@@ -84,6 +84,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEnt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.Visibility
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toIcon
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toReadableName
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.di.getAttachmentCache
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.toReadableName
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.components.AttachmentsGrid
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.components.CreateInGroupInfo
@@ -115,7 +116,6 @@ fun ComposerScreen(
     draftId: String? = null,
     urlToShare: String? = null,
     initialText: String? = null,
-    initialAttachment: ByteArray? = null,
 ) {
     val model: ComposerMviModel = getViewModel<ComposerViewModel>(arg = ComposerViewModelArgs(inReplyToId.orEmpty()))
     val uiState by model.uiState.collectAsState()
@@ -124,6 +124,7 @@ fun ComposerScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     val navigationCoordinator = remember { getNavigationCoordinator() }
     val galleryHelper = remember { getGalleryHelper() }
+    val attachmentCache = remember { getAttachmentCache() }
     val focusManager = LocalFocusManager.current
     val missingDataError = LocalStrings.current.messagePostEmptyText
     val invalidVisibilityError = LocalStrings.current.messagePostInvalidVisibility
@@ -177,6 +178,9 @@ fun ComposerScreen(
     var changeMarkupModeBottomSheetOpened by remember { mutableStateOf(false) }
 
     LaunchedEffect(model) {
+        val initialAttachment = attachmentCache.get()
+        attachmentCache.clear()
+
         when {
             draftId != null ->
                 model.reduce(ComposerMviModel.Intent.LoadDraft(draftId))

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/list/ConversationListScreen.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/list/ConversationListScreen.kt
@@ -63,7 +63,7 @@ fun ConversationListScreen(modifier: Modifier = Modifier) {
     val model: ConversationListMviModel = getViewModel<ConversationListViewModel>()
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = remember { getNavigationCoordinator() }
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val lazyListState = rememberLazyListState()
@@ -200,7 +200,7 @@ fun ConversationListScreen(modifier: Modifier = Modifier) {
                                 model.reduce(
                                     ConversationListMviModel.Intent.MarkConversationAsRead(idx),
                                 )
-                                detailOpener.openConversation(
+                                mainRouter.openConversation(
                                     otherUser = conversation.otherUser,
                                     parentUri = parentUri,
                                 )
@@ -258,7 +258,7 @@ fun ConversationListScreen(modifier: Modifier = Modifier) {
                 if (userId != null) {
                     val existingConversation =
                         uiState.items.firstOrNull { it.otherUser.id == userId }
-                    detailOpener.openConversation(
+                    mainRouter.openConversation(
                         otherUser = user,
                         parentUri = existingConversation?.lastMessage?.parentUri.orEmpty(),
                     )

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerContent.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerContent.kt
@@ -84,7 +84,7 @@ fun DrawerContent(modifier: Modifier = Modifier) {
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = remember { getNavigationCoordinator() }
     val drawerCoordinator = remember { getDrawerCoordinator() }
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     val scope = rememberCoroutineScope()
     var manageAccountsDialogOpened by remember { mutableStateOf(false) }
     var changeInstanceDialogOpened by remember { mutableStateOf(false) }
@@ -148,35 +148,35 @@ fun DrawerContent(modifier: Modifier = Modifier) {
                     title = LocalStrings.current.favoritesTitle,
                     icon = Icons.Default.Favorite,
                     onSelect = {
-                        handleAction { detailOpener.openFavorites() }
+                        handleAction { mainRouter.openFavorites() }
                     },
                 )
                 DrawerShortcut(
                     title = LocalStrings.current.bookmarksTitle,
                     icon = Icons.Default.Bookmarks,
                     onSelect = {
-                        handleAction { detailOpener.openBookmarks() }
+                        handleAction { mainRouter.openBookmarks() }
                     },
                 )
                 DrawerShortcut(
                     title = LocalStrings.current.followedHashtagsTitle,
                     icon = Icons.Default.Tag,
                     onSelect = {
-                        handleAction { detailOpener.openFollowedHashtags() }
+                        handleAction { mainRouter.openFollowedHashtags() }
                     },
                 )
                 DrawerShortcut(
                     title = LocalStrings.current.followRequestsTitle,
                     icon = Icons.Default.Flaky,
                     onSelect = {
-                        handleAction { detailOpener.openFollowRequests() }
+                        handleAction { mainRouter.openFollowRequests() }
                     },
                 )
                 DrawerShortcut(
                     title = LocalStrings.current.manageCirclesTitle,
                     icon = Icons.Default.Workspaces,
                     onSelect = {
-                        handleAction { detailOpener.openCircles() }
+                        handleAction { mainRouter.openCircles() }
                     },
                 )
                 if (uiState.hasAnnouncements) {
@@ -184,7 +184,7 @@ fun DrawerContent(modifier: Modifier = Modifier) {
                         title = LocalStrings.current.announcementsTitle,
                         icon = Icons.Default.Campaign,
                         onSelect = {
-                            handleAction { detailOpener.openAnnouncements() }
+                            handleAction { mainRouter.openAnnouncements() }
                         },
                     )
                 }
@@ -193,7 +193,7 @@ fun DrawerContent(modifier: Modifier = Modifier) {
                         title = LocalStrings.current.directMessagesTitle,
                         icon = Icons.AutoMirrored.Default.Chat,
                         onSelect = {
-                            handleAction { detailOpener.openDirectMessages() }
+                            handleAction { mainRouter.openDirectMessages() }
                         },
                     )
                 }
@@ -202,7 +202,7 @@ fun DrawerContent(modifier: Modifier = Modifier) {
                         title = LocalStrings.current.galleryTitle,
                         icon = Icons.Default.Dashboard,
                         onSelect = {
-                            handleAction { detailOpener.openGallery() }
+                            handleAction { mainRouter.openGallery() }
                         },
                     )
                 }
@@ -210,7 +210,7 @@ fun DrawerContent(modifier: Modifier = Modifier) {
                     title = LocalStrings.current.unpublishedTitle,
                     icon = Icons.Default.Drafts,
                     onSelect = {
-                        handleAction { detailOpener.openUnpublished() }
+                        handleAction { mainRouter.openUnpublished() }
                     },
                 )
                 if (uiState.hasCalendar) {
@@ -218,7 +218,7 @@ fun DrawerContent(modifier: Modifier = Modifier) {
                         title = LocalStrings.current.calendarTitle,
                         icon = Icons.Default.CalendarMonth,
                         onSelect = {
-                            handleAction { detailOpener.openCalendar() }
+                            handleAction { mainRouter.openCalendar() }
                         },
                     )
                 }
@@ -226,7 +226,7 @@ fun DrawerContent(modifier: Modifier = Modifier) {
                     title = LocalStrings.current.shortcutsTitle,
                     icon = Icons.Default.TravelExplore,
                     onSelect = {
-                        handleAction { detailOpener.openShortcuts() }
+                        handleAction { mainRouter.openShortcuts() }
                     },
                 )
             }
@@ -235,7 +235,7 @@ fun DrawerContent(modifier: Modifier = Modifier) {
                 title = LocalStrings.current.nodeInfoTitle,
                 icon = Icons.Default.Info,
                 onSelect = {
-                    handleAction { detailOpener.openNodeInfo() }
+                    handleAction { mainRouter.openNodeInfo() }
                 },
             )
 
@@ -256,7 +256,7 @@ fun DrawerContent(modifier: Modifier = Modifier) {
                 title = LocalStrings.current.settingsTitle,
                 icon = Icons.Default.Settings,
                 onSelect = {
-                    handleAction { detailOpener.openSettings() }
+                    handleAction { mainRouter.openSettings() }
                 },
             )
         }

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/about/AboutDialog.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/about/AboutDialog.kt
@@ -49,7 +49,7 @@ fun AboutDialog(modifier: Modifier = Modifier, onClose: (() -> Unit)? = null) {
     val uriHandler = LocalUriHandler.current
     val appInfoRepository = remember { getAppInfoRepository() }
     val appInfo by appInfoRepository.appInfo.collectAsState()
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
 
     fun handleAction(block: () -> Unit) {
         onClose?.invoke()
@@ -104,7 +104,7 @@ fun AboutDialog(modifier: Modifier = Modifier, onClose: (() -> Unit)? = null) {
                     Button(
                         onClick = {
                             handleAction {
-                                detailOpener.openUserFeedback()
+                                mainRouter.openUserFeedback()
                             }
                         },
                     ) {
@@ -180,7 +180,7 @@ fun AboutDialog(modifier: Modifier = Modifier, onClose: (() -> Unit)? = null) {
                         textDecoration = TextDecoration.Underline,
                         onClick = {
                             handleAction {
-                                detailOpener.openAcknowledgements()
+                                mainRouter.openAcknowledgements()
                             }
                         },
                     )
@@ -192,7 +192,7 @@ fun AboutDialog(modifier: Modifier = Modifier, onClose: (() -> Unit)? = null) {
                         textDecoration = TextDecoration.Underline,
                         onClick = {
                             handleAction {
-                                detailOpener.openLicences()
+                                mainRouter.openLicences()
                             }
                         },
                     )

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -105,7 +105,7 @@ fun EntryDetailScreen(id: String, swipeNavigationEnabled: Boolean, modifier: Mod
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val navigationCoordinator = remember { getNavigationCoordinator() }
     val uriHandler = LocalUriHandler.current
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     val fabNestedScrollConnection = remember { getFabNestedScrollConnection() }
     val isFabVisible by fabNestedScrollConnection.isFabVisible.collectAsState()
     val scope = rememberCoroutineScope()
@@ -208,7 +208,7 @@ fun EntryDetailScreen(id: String, swipeNavigationEnabled: Boolean, modifier: Mod
                         onClick = {
                             val entry = uiState.mainEntry
                             if (entry != null) {
-                                detailOpener.openComposer(
+                                mainRouter.openComposer(
                                     inReplyTo = entry,
                                     inReplyToUser = entry.creator,
                                 )
@@ -374,7 +374,7 @@ fun EntryDetailScreen(id: String, swipeNavigationEnabled: Boolean, modifier: Mod
 
                                     OptionId.Edit -> {
                                         entry.original.also { entryToEdit ->
-                                            detailOpener.openComposer(
+                                            mainRouter.openComposer(
                                                 inReplyTo = entryToEdit.inReplyTo,
                                                 inReplyToUser = entryToEdit.inReplyTo?.creator,
                                                 editedPostId = entryToEdit.id,
@@ -394,13 +394,13 @@ fun EntryDetailScreen(id: String, swipeNavigationEnabled: Boolean, modifier: Mod
 
                                     OptionId.ReportUser ->
                                         entry.original.creator?.also { userToReport ->
-                                            detailOpener.openCreateReport(user = userToReport)
+                                            mainRouter.openCreateReport(user = userToReport)
                                         }
 
                                     OptionId.ReportEntry ->
                                         entry.original.also { entryToReport ->
                                             entryToReport.creator?.also { userToReport ->
-                                                detailOpener.openCreateReport(
+                                                mainRouter.openCreateReport(
                                                     user = userToReport,
                                                     entry = entryToReport,
                                                 )
@@ -410,7 +410,7 @@ fun EntryDetailScreen(id: String, swipeNavigationEnabled: Boolean, modifier: Mod
                                     OptionId.ViewDetails -> seeDetailsEntry = entry.original
                                     OptionId.Quote -> {
                                         entry.original.also { entryToShare ->
-                                            detailOpener.openComposer(
+                                            mainRouter.openComposer(
                                                 urlToShare = entryToShare.url,
                                             )
                                         }
@@ -490,17 +490,17 @@ fun EntryDetailScreen(id: String, swipeNavigationEnabled: Boolean, modifier: Mod
                                         },
                                         onClick = { e ->
                                             if (e.id != uiState.mainEntry?.id) {
-                                                detailOpener.openEntryDetail(
+                                                mainRouter.openEntryDetail(
                                                     entry = e,
                                                     replaceTop = true,
                                                 )
                                             }
                                         },
                                         onOpenUser = {
-                                            detailOpener.openUserDetail(it)
+                                            mainRouter.openUserDetail(it)
                                         },
                                         onOpenImage = { urls, imageIdx, videoIndices ->
-                                            detailOpener.openImageDetail(
+                                            mainRouter.openImageDetail(
                                                 urls = urls,
                                                 initialIndex = imageIdx,
                                                 videoIndices = videoIndices,
@@ -549,20 +549,20 @@ fun EntryDetailScreen(id: String, swipeNavigationEnabled: Boolean, modifier: Mod
                                             )
                                         }.takeIf { actionRepository.canDislike(entry.original) },
                                         onOpenUsersFavorite = { e ->
-                                            detailOpener.openEntryUsersFavorite(
+                                            mainRouter.openEntryUsersFavorite(
                                                 entryId = e.id,
                                                 count = e.favoriteCount,
                                             )
                                         },
                                         onOpenUsersReblog = { e ->
-                                            detailOpener.openEntryUsersReblog(
+                                            mainRouter.openEntryUsersReblog(
                                                 entryId = e.id,
                                                 count = e.reblogCount,
                                             )
                                         },
                                         onReply =
                                         { e: TimelineEntryModel ->
-                                            detailOpener.openComposer(
+                                            mainRouter.openComposer(
                                                 inReplyTo = e,
                                                 inReplyToUser = e.creator,
                                             )
@@ -618,17 +618,17 @@ fun EntryDetailScreen(id: String, swipeNavigationEnabled: Boolean, modifier: Mod
                                     },
                                     onClick = { e ->
                                         if (e.id != uiState.mainEntry?.id) {
-                                            detailOpener.openEntryDetail(
+                                            mainRouter.openEntryDetail(
                                                 entry = entry,
                                                 replaceTop = true,
                                             )
                                         }
                                     },
                                     onOpenUser = {
-                                        detailOpener.openUserDetail(it)
+                                        mainRouter.openUserDetail(it)
                                     },
                                     onOpenImage = { urls, imageIdx, videoIndices ->
-                                        detailOpener.openImageDetail(
+                                        mainRouter.openImageDetail(
                                             urls = urls,
                                             initialIndex = imageIdx,
                                             videoIndices = videoIndices,
@@ -663,20 +663,20 @@ fun EntryDetailScreen(id: String, swipeNavigationEnabled: Boolean, modifier: Mod
                                         model.reduce(EntryDetailMviModel.Intent.ToggleDislike(e))
                                     }.takeIf { actionRepository.canDislike(entry.original) },
                                     onOpenUsersFavorite = { e ->
-                                        detailOpener.openEntryUsersFavorite(
+                                        mainRouter.openEntryUsersFavorite(
                                             entryId = e.id,
                                             count = e.favoriteCount,
                                         )
                                     },
                                     onOpenUsersReblog = { e ->
-                                        detailOpener.openEntryUsersReblog(
+                                        mainRouter.openEntryUsersReblog(
                                             entryId = e.id,
                                             count = e.reblogCount,
                                         )
                                     },
                                     onReply =
                                     { e: TimelineEntryModel ->
-                                        detailOpener.openComposer(
+                                        mainRouter.openComposer(
                                             inReplyTo = e,
                                             inReplyToUser = e.creator,
                                         )

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
@@ -99,7 +99,7 @@ fun ExploreScreen(
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val connection = navigationCoordinator.getBottomBarScrollConnection()
     val uriHandler = LocalUriHandler.current
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     val scope = rememberCoroutineScope()
     val drawerCoordinator = remember { getDrawerCoordinator() }
     val snackbarHostState = remember { SnackbarHostState() }
@@ -180,7 +180,7 @@ fun ExploreScreen(
                         // only logged users can call the v2/search API
                         IconButton(
                             onClick = {
-                                detailOpener.openSearch()
+                                mainRouter.openSearch()
                             },
                         ) {
                             Icon(
@@ -310,7 +310,7 @@ fun ExploreScreen(
                                 autoloadImages = uiState.autoloadImages,
                                 maxBodyLines = uiState.maxBodyLines,
                                 onClick = { e ->
-                                    detailOpener.openEntryDetail(e)
+                                    mainRouter.openEntryDetail(e)
                                 },
                                 onOpenUrl = { url, allowOpenInternal ->
                                     if (allowOpenInternal) {
@@ -320,10 +320,10 @@ fun ExploreScreen(
                                     }
                                 },
                                 onOpenUser = {
-                                    detailOpener.openUserDetail(it)
+                                    mainRouter.openUserDetail(it)
                                 },
                                 onOpenImage = { urls, imageIdx, videoIndices ->
-                                    detailOpener.openImageDetail(
+                                    mainRouter.openImageDetail(
                                         urls = urls,
                                         initialIndex = imageIdx,
                                         videoIndices = videoIndices,
@@ -359,7 +359,7 @@ fun ExploreScreen(
                                 }.takeIf { actionRepository.canDislike(item.entry.original) },
                                 onReply =
                                 { e: TimelineEntryModel ->
-                                    detailOpener.openComposer(
+                                    mainRouter.openComposer(
                                         inReplyTo = e,
                                         inReplyToUser = e.creator,
                                     )
@@ -466,7 +466,7 @@ fun ExploreScreen(
 
                                         OptionId.Edit -> {
                                             item.entry.original.also { entryToEdit ->
-                                                detailOpener.openComposer(
+                                                mainRouter.openComposer(
                                                     inReplyTo = entryToEdit.inReplyTo,
                                                     inReplyToUser = entryToEdit.inReplyTo?.creator,
                                                     editedPostId = entryToEdit.id,
@@ -484,13 +484,13 @@ fun ExploreScreen(
 
                                         OptionId.ReportUser ->
                                             item.entry.original.creator?.also { userToReport ->
-                                                detailOpener.openCreateReport(user = userToReport)
+                                                mainRouter.openCreateReport(user = userToReport)
                                             }
 
                                         OptionId.ReportEntry ->
                                             item.entry.original.also { entryToReport ->
                                                 entryToReport.creator?.also { userToReport ->
-                                                    detailOpener.openCreateReport(
+                                                    mainRouter.openCreateReport(
                                                         user = userToReport,
                                                         entry = entryToReport,
                                                     )
@@ -500,7 +500,7 @@ fun ExploreScreen(
                                         OptionId.ViewDetails -> seeDetailsEntry = item.entry.original
                                         OptionId.Quote -> {
                                             item.entry.original.also { entryToShare ->
-                                                detailOpener.openComposer(
+                                                mainRouter.openComposer(
                                                     urlToShare = entryToShare.url,
                                                 )
                                             }
@@ -545,7 +545,7 @@ fun ExploreScreen(
                             HashtagItem(
                                 hashtag = item.hashtag,
                                 onOpen = {
-                                    detailOpener.openHashtag(it)
+                                    mainRouter.openHashtag(it)
                                 },
                             )
                             Spacer(modifier = Modifier.height(Spacing.interItem))
@@ -567,12 +567,12 @@ fun ExploreScreen(
                                 user = item.user,
                                 autoloadImages = uiState.autoloadImages,
                                 onClick = {
-                                    detailOpener.openUserDetail(item.user)
+                                    mainRouter.openUserDetail(item.user)
                                 },
                                 onRelationshipClick = { nextAction ->
                                     when (nextAction) {
                                         RelationshipStatusNextAction.AcceptRequest -> {
-                                            detailOpener.openFollowRequests()
+                                            mainRouter.openFollowRequests()
                                         }
 
                                         RelationshipStatusNextAction.ConfirmUnfollow -> {

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
@@ -85,7 +85,7 @@ fun FavoritesScreen(type: Int, modifier: Modifier = Modifier) {
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val uriHandler = LocalUriHandler.current
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     val lazyListState = rememberLazyListState()
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -122,7 +122,7 @@ fun FavoritesScreen(type: Int, modifier: Modifier = Modifier) {
                     }
 
                     is FavoritesMviModel.Effect.OpenDetail -> {
-                        detailOpener.openEntryDetail(
+                        mainRouter.openEntryDetail(
                             entry = event.entry,
                             swipeNavigationEnabled = true,
                         )
@@ -237,10 +237,10 @@ fun FavoritesScreen(type: Int, modifier: Modifier = Modifier) {
                             }
                         },
                         onOpenUser = {
-                            detailOpener.openUserDetail(it)
+                            mainRouter.openUserDetail(it)
                         },
                         onOpenImage = { urls, imageIdx, videoIndices ->
-                            detailOpener.openImageDetail(
+                            mainRouter.openImageDetail(
                                 urls = urls,
                                 initialIndex = imageIdx,
                                 videoIndices = videoIndices,
@@ -276,7 +276,7 @@ fun FavoritesScreen(type: Int, modifier: Modifier = Modifier) {
                         }.takeIf { actionRepository.canDislike(entry.original) },
                         onReply =
                         { e: TimelineEntryModel ->
-                            detailOpener.openComposer(
+                            mainRouter.openComposer(
                                 inReplyTo = e,
                                 inReplyToUser = e.creator,
                             )
@@ -378,7 +378,7 @@ fun FavoritesScreen(type: Int, modifier: Modifier = Modifier) {
 
                                 OptionId.Edit -> {
                                     entry.original.also { entryToEdit ->
-                                        detailOpener.openComposer(
+                                        mainRouter.openComposer(
                                             inReplyTo = entryToEdit.inReplyTo,
                                             inReplyToUser = entryToEdit.inReplyTo?.creator,
                                             editedPostId = entryToEdit.id,
@@ -394,13 +394,13 @@ fun FavoritesScreen(type: Int, modifier: Modifier = Modifier) {
 
                                 OptionId.ReportUser ->
                                     entry.original.creator?.also { userToReport ->
-                                        detailOpener.openCreateReport(user = userToReport)
+                                        mainRouter.openCreateReport(user = userToReport)
                                     }
 
                                 OptionId.ReportEntry ->
                                     entry.original.also { entryToReport ->
                                         entryToReport.creator?.also { userToReport ->
-                                            detailOpener.openCreateReport(
+                                            mainRouter.openCreateReport(
                                                 user = userToReport,
                                                 entry = entryToReport,
                                             )
@@ -410,7 +410,7 @@ fun FavoritesScreen(type: Int, modifier: Modifier = Modifier) {
                                 OptionId.ViewDetails -> seeDetailsEntry = entry.original
                                 OptionId.Quote -> {
                                     entry.original.also { entryToShare ->
-                                        detailOpener.openComposer(
+                                        mainRouter.openComposer(
                                             urlToShare = entryToShare.url,
                                         )
                                     }

--- a/feature/followrequests/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/followrequests/FollowRequestsScreen.kt
+++ b/feature/followrequests/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/followrequests/FollowRequestsScreen.kt
@@ -52,7 +52,7 @@ fun FollowRequestsScreen(modifier: Modifier = Modifier) {
     val navigationCoordinator = remember { getNavigationCoordinator() }
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     val lazyListState = rememberLazyListState()
     val scope = rememberCoroutineScope()
 
@@ -153,7 +153,7 @@ fun FollowRequestsScreen(modifier: Modifier = Modifier) {
                             model.reduce(FollowRequestsMviModel.Intent.Reject(user.id))
                         },
                         onClick = {
-                            detailOpener.openUserDetail(user)
+                            mainRouter.openUserDetail(user)
                         },
                     )
 

--- a/feature/gallery/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/gallery/detail/AlbumDetailScreen.kt
+++ b/feature/gallery/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/gallery/detail/AlbumDetailScreen.kt
@@ -84,7 +84,7 @@ fun AlbumDetailScreen(name: String, modifier: Modifier = Modifier) {
     val snackbarHostState = remember { SnackbarHostState() }
     val lazyGridState = rememberLazyStaggeredGridState()
     val fabNestedScrollConnection = remember { getFabNestedScrollConnection() }
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     val galleryHelper = remember { getGalleryHelper() }
     val isFabVisible by fabNestedScrollConnection.isFabVisible.collectAsState()
     val scope = rememberCoroutineScope()
@@ -243,7 +243,7 @@ fun AlbumDetailScreen(name: String, modifier: Modifier = Modifier) {
                         onClick = {
                             val url = attachment.thumbnail ?: attachment.url
                             if (url.isNotEmpty()) {
-                                detailOpener.openImageDetail(url)
+                                mainRouter.openImageDetail(url)
                             }
                         },
                         options =

--- a/feature/gallery/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/gallery/list/GalleryScreen.kt
+++ b/feature/gallery/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/gallery/list/GalleryScreen.kt
@@ -69,7 +69,7 @@ fun GalleryScreen(modifier: Modifier = Modifier) {
     val model: GalleryMviModel = getViewModel<GalleryViewModel>()
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = remember { getNavigationCoordinator() }
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val snackbarHostState = remember { SnackbarHostState() }
@@ -217,7 +217,7 @@ fun GalleryScreen(modifier: Modifier = Modifier) {
                     MediaAlbumItem(
                         album = album,
                         onClick = {
-                            detailOpener.openAlbum(album.name)
+                            mainRouter.openAlbum(album.name)
                         },
                         options =
                         buildList {
@@ -273,7 +273,7 @@ fun GalleryScreen(modifier: Modifier = Modifier) {
             onClose = { name ->
                 createDialogOpened = false
                 if (!name.isNullOrBlank()) {
-                    detailOpener.openAlbum(name = name)
+                    mainRouter.openAlbum(name = name)
                 }
             },
         )

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/followed/FollowedHashtagsScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/followed/FollowedHashtagsScreen.kt
@@ -54,7 +54,7 @@ fun FollowedHashtagsScreen(modifier: Modifier = Modifier) {
     val navigationCoordinator = remember { getNavigationCoordinator() }
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     val lazyListState = rememberLazyListState()
     val scope = rememberCoroutineScope()
     var confirmUnfollowHashtagName by remember { mutableStateOf<String?>(null) }
@@ -137,7 +137,7 @@ fun FollowedHashtagsScreen(modifier: Modifier = Modifier) {
                     FollowHashtagItem(
                         hashtag = tag,
                         onOpen = {
-                            detailOpener.openHashtag(tag.name)
+                            mainRouter.openHashtag(tag.name)
                         },
                         onToggleFollow = { newFollow ->
                             if (newFollow) {

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
@@ -83,7 +83,7 @@ fun HashtagScreen(tag: String, modifier: Modifier = Modifier) {
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val uriHandler = LocalUriHandler.current
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     val lazyListState = rememberLazyListState()
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -120,7 +120,7 @@ fun HashtagScreen(tag: String, modifier: Modifier = Modifier) {
                     }
 
                     is HashtagMviModel.Effect.OpenDetail -> {
-                        detailOpener.openEntryDetail(
+                        mainRouter.openEntryDetail(
                             entry = event.entry,
                             swipeNavigationEnabled = true,
                         )
@@ -254,10 +254,10 @@ fun HashtagScreen(tag: String, modifier: Modifier = Modifier) {
                             }
                         },
                         onOpenUser = {
-                            detailOpener.openUserDetail(it)
+                            mainRouter.openUserDetail(it)
                         },
                         onOpenImage = { urls, imageIdx, videoIndices ->
-                            detailOpener.openImageDetail(
+                            mainRouter.openImageDetail(
                                 urls = urls,
                                 initialIndex = imageIdx,
                                 videoIndices = videoIndices,
@@ -293,7 +293,7 @@ fun HashtagScreen(tag: String, modifier: Modifier = Modifier) {
                         }.takeIf { actionRepository.canDislike(entry.original) },
                         onReply =
                         { e: TimelineEntryModel ->
-                            detailOpener.openComposer(
+                            mainRouter.openComposer(
                                 inReplyTo = e,
                                 inReplyToUser = e.creator,
                             )
@@ -395,7 +395,7 @@ fun HashtagScreen(tag: String, modifier: Modifier = Modifier) {
 
                                 OptionId.Edit -> {
                                     entry.original.also { entryToEdit ->
-                                        detailOpener.openComposer(
+                                        mainRouter.openComposer(
                                             inReplyTo = entryToEdit.inReplyTo,
                                             inReplyToUser = entryToEdit.inReplyTo?.creator,
                                             editedPostId = entryToEdit.id,
@@ -411,13 +411,13 @@ fun HashtagScreen(tag: String, modifier: Modifier = Modifier) {
 
                                 OptionId.ReportUser ->
                                     entry.original.creator?.also { userToReport ->
-                                        detailOpener.openCreateReport(user = userToReport)
+                                        mainRouter.openCreateReport(user = userToReport)
                                     }
 
                                 OptionId.ReportEntry ->
                                     entry.original.also { entryToReport ->
                                         entryToReport.creator?.also { userToReport ->
-                                            detailOpener.openCreateReport(
+                                            mainRouter.openCreateReport(
                                                 user = userToReport,
                                                 entry = entryToReport,
                                             )
@@ -427,7 +427,7 @@ fun HashtagScreen(tag: String, modifier: Modifier = Modifier) {
                                 OptionId.ViewDetails -> seeDetailsEntry = entry.original
                                 OptionId.Quote -> {
                                     entry.original.also { entryToShare ->
-                                        detailOpener.openComposer(
+                                        mainRouter.openComposer(
                                             urlToShare = entryToShare.url,
                                         )
                                     }

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
@@ -75,7 +75,7 @@ fun InboxScreen(
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val connection = navigationCoordinator.getBottomBarScrollConnection()
     val uriHandler = LocalUriHandler.current
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     val scope = rememberCoroutineScope()
     val drawerCoordinator = remember { getDrawerCoordinator() }
     var confirmUnfollowDialogUserId by remember { mutableStateOf<String?>(null) }
@@ -213,7 +213,7 @@ fun InboxScreen(
                         autoloadImages = uiState.autoloadImages,
                         maxBodyLines = uiState.maxBodyLines,
                         onOpenEntry = { entry ->
-                            detailOpener.openEntryDetail(entry.original)
+                            mainRouter.openEntryDetail(entry.original)
                             model.reduce(InboxMviModel.Intent.MarkAsRead(notification))
                         },
                         onOpenUrl = { url, allowOpenInternal ->
@@ -224,14 +224,14 @@ fun InboxScreen(
                             }
                         },
                         onOpenUser = {
-                            detailOpener.openUserDetail(it)
+                            mainRouter.openUserDetail(it)
                             model.reduce(InboxMviModel.Intent.MarkAsRead(notification))
                         },
                         onClickUserRelationship = { userId, nextAction ->
                             model.reduce(InboxMviModel.Intent.MarkAsRead(notification))
                             when (nextAction) {
                                 RelationshipStatusNextAction.AcceptRequest -> {
-                                    detailOpener.openFollowRequests()
+                                    mainRouter.openFollowRequests()
                                 }
 
                                 RelationshipStatusNextAction.ConfirmUnfollow -> {

--- a/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/ManageBlocksScreen.kt
+++ b/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/ManageBlocksScreen.kt
@@ -83,7 +83,7 @@ fun ManageBlocksScreen(modifier: Modifier = Modifier) {
     val navigationCoordinator = remember { getNavigationCoordinator() }
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     val lazyListState = rememberLazyListState()
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -302,7 +302,7 @@ fun ManageBlocksScreen(modifier: Modifier = Modifier) {
                                 autoloadImages = uiState.autoloadImages,
                                 withSubtitle = uiState.section != ManageBlocksSection.Limited,
                                 onClick = {
-                                    detailOpener.openUserDetail(item.user)
+                                    mainRouter.openUserDetail(item.user)
                                 },
                                 options =
                                 buildList {

--- a/feature/nodeinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/NodeInfoScreen.kt
+++ b/feature/nodeinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/NodeInfoScreen.kt
@@ -88,7 +88,7 @@ fun NodeInfoScreenScaffold(state: NodeInfoMviModel.State, modifier: Modifier = M
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val navigationCoordinator = remember { getNavigationCoordinator() }
     val uriHandler = LocalUriHandler.current
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     val lazyListState = rememberLazyListState()
     val scope = rememberCoroutineScope()
 
@@ -240,7 +240,7 @@ fun NodeInfoScreenScaffold(state: NodeInfoMviModel.State, modifier: Modifier = M
                                 user = contact,
                                 autoloadImages = state.autoloadImages,
                                 onClick = {
-                                    detailOpener.openUserDetail(contact)
+                                    mainRouter.openUserDetail(contact)
                                 },
                             )
                         }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
@@ -89,7 +89,7 @@ fun MyAccountScreen(
     val navigationCoordinator = remember { getNavigationCoordinator() }
     val connection = navigationCoordinator.getBottomBarScrollConnection()
     val uriHandler = LocalUriHandler.current
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
     val shareHelper = remember { getShareHelper() }
@@ -192,7 +192,7 @@ fun MyAccountScreen(
                         },
                         onOpenFollowers = {
                             uiState.user?.also { user ->
-                                detailOpener.openFollowers(
+                                mainRouter.openFollowers(
                                     user = user,
                                     enableExport = true,
                                 )
@@ -200,14 +200,14 @@ fun MyAccountScreen(
                         },
                         onOpenFollowing = {
                             uiState.user?.also { user ->
-                                detailOpener.openFollowing(
+                                mainRouter.openFollowing(
                                     user = user,
                                     enableExport = true,
                                 )
                             }
                         },
                         onEditClick = {
-                            detailOpener.openEditProfile()
+                            mainRouter.openEditProfile()
                         },
                     )
                 }
@@ -374,7 +374,7 @@ fun MyAccountScreen(
                     pollEnabled = false,
                     maxBodyLines = uiState.maxBodyLines,
                     onClick = { e ->
-                        detailOpener.openEntryDetail(e)
+                        mainRouter.openEntryDetail(e)
                     },
                     onOpenUrl = { url, allowOpenInternal ->
                         if (allowOpenInternal) {
@@ -384,10 +384,10 @@ fun MyAccountScreen(
                         }
                     },
                     onOpenUser = {
-                        detailOpener.openUserDetail(it)
+                        mainRouter.openUserDetail(it)
                     },
                     onOpenImage = { urls, imageIdx, videoIndices ->
-                        detailOpener.openImageDetail(
+                        mainRouter.openImageDetail(
                             urls = urls,
                             initialIndex = imageIdx,
                             videoIndices = videoIndices,
@@ -407,7 +407,7 @@ fun MyAccountScreen(
                         }.takeIf { actionRepository.canDislike(entry.original) },
                     onReply =
                         { e: TimelineEntryModel ->
-                            detailOpener.openComposer(
+                            mainRouter.openComposer(
                                 inReplyTo = e,
                                 inReplyToUser = e.creator,
                             )
@@ -443,14 +443,14 @@ fun MyAccountScreen(
                             OptionId.Edit -> {
                                 if (entry.creator?.group == true) {
                                     // edit the original post reblogged by the group
-                                    detailOpener.openComposer(
+                                    mainRouter.openComposer(
                                         inReplyTo = entry.inReplyTo,
                                         inReplyToUser = entry.creator,
                                         editedPostId = entry.reblog?.id,
                                         inGroup = true,
                                     )
                                 } else {
-                                    detailOpener.openComposer(
+                                    mainRouter.openComposer(
                                         inReplyTo = entry.inReplyTo,
                                         inReplyToUser = entry.inReplyTo?.creator,
                                         editedPostId = entry.id,
@@ -480,7 +480,7 @@ fun MyAccountScreen(
                             OptionId.ViewDetails -> seeDetailsEntry = entry.original
                             OptionId.Quote -> {
                                 entry.original.also { entryToShare ->
-                                    detailOpener.openComposer(
+                                    mainRouter.openComposer(
                                         urlToShare = entryToShare.url,
                                     )
                                 }

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
@@ -96,7 +96,7 @@ fun SearchScreen(modifier: Modifier = Modifier) {
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val uriHandler = LocalUriHandler.current
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     val lazyListState = rememberLazyListState()
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -316,7 +316,7 @@ fun SearchScreen(modifier: Modifier = Modifier) {
                                 autoloadImages = uiState.autoloadImages,
                                 maxBodyLines = uiState.maxBodyLines,
                                 onClick = { e ->
-                                    detailOpener.openEntryDetail(e)
+                                    mainRouter.openEntryDetail(e)
                                 },
                                 onOpenUrl = { url, allowOpenInternal ->
                                     if (allowOpenInternal) {
@@ -326,10 +326,10 @@ fun SearchScreen(modifier: Modifier = Modifier) {
                                     }
                                 },
                                 onOpenUser = {
-                                    detailOpener.openUserDetail(it)
+                                    mainRouter.openUserDetail(it)
                                 },
                                 onOpenImage = { urls, imageIdx, videoIndices ->
-                                    detailOpener.openImageDetail(
+                                    mainRouter.openImageDetail(
                                         urls = urls,
                                         initialIndex = imageIdx,
                                         videoIndices = videoIndices,
@@ -365,7 +365,7 @@ fun SearchScreen(modifier: Modifier = Modifier) {
                                 }.takeIf { actionRepository.canDislike(item.entry.original) },
                                 onReply =
                                 { e: TimelineEntryModel ->
-                                    detailOpener.openComposer(
+                                    mainRouter.openComposer(
                                         inReplyTo = e,
                                         inReplyToUser = e.creator,
                                     )
@@ -473,7 +473,7 @@ fun SearchScreen(modifier: Modifier = Modifier) {
                                                 item.entry.reblog
                                                     ?: item.entry
                                                 ).also { entryToEdit ->
-                                                detailOpener.openComposer(
+                                                mainRouter.openComposer(
                                                     inReplyTo = entryToEdit.inReplyTo,
                                                     inReplyToUser = entryToEdit.inReplyTo?.creator,
                                                     editedPostId = entryToEdit.id,
@@ -491,13 +491,13 @@ fun SearchScreen(modifier: Modifier = Modifier) {
 
                                         OptionId.ReportUser ->
                                             item.entry.original.creator?.also { userToReport ->
-                                                detailOpener.openCreateReport(user = userToReport)
+                                                mainRouter.openCreateReport(user = userToReport)
                                             }
 
                                         OptionId.ReportEntry ->
                                             item.entry.original.also { entryToReport ->
                                                 entryToReport.creator?.also { userToReport ->
-                                                    detailOpener.openCreateReport(
+                                                    mainRouter.openCreateReport(
                                                         user = userToReport,
                                                         entry = entryToReport,
                                                     )
@@ -507,7 +507,7 @@ fun SearchScreen(modifier: Modifier = Modifier) {
                                         OptionId.ViewDetails -> seeDetailsEntry = item.entry.original
                                         OptionId.Quote -> {
                                             item.entry.original.also { entryToShare ->
-                                                detailOpener.openComposer(
+                                                mainRouter.openComposer(
                                                     urlToShare = entryToShare.url,
                                                 )
                                             }
@@ -552,7 +552,7 @@ fun SearchScreen(modifier: Modifier = Modifier) {
                             HashtagItem(
                                 hashtag = item.hashtag,
                                 onOpen = {
-                                    detailOpener.openHashtag(it)
+                                    mainRouter.openHashtag(it)
                                 },
                             )
                             Spacer(modifier = Modifier.height(Spacing.interItem))
@@ -563,12 +563,12 @@ fun SearchScreen(modifier: Modifier = Modifier) {
                                 user = item.user,
                                 autoloadImages = uiState.autoloadImages,
                                 onClick = {
-                                    detailOpener.openUserDetail(item.user)
+                                    mainRouter.openUserDetail(item.user)
                                 },
                                 onRelationshipClick = { nextAction ->
                                     when (nextAction) {
                                         RelationshipStatusNextAction.AcceptRequest -> {
-                                            detailOpener.openFollowRequests()
+                                            mainRouter.openFollowRequests()
                                         }
 
                                         RelationshipStatusNextAction.ConfirmUnfollow -> {

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
@@ -108,7 +108,7 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val navigationCoordinator = remember { getNavigationCoordinator() }
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     val coreResources = remember { getCoreResources() }
     val scope = rememberCoroutineScope()
     val fileSystemManager = remember { getFileSystemManager() }
@@ -464,7 +464,7 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
                             title = LocalStrings.current.settingsItemBlockedAndMuted,
                             disclosureIndicator = true,
                             onTap = {
-                                detailOpener.openBlockedAndMuted()
+                                mainRouter.openBlockedAndMuted()
                             },
                         )
                     }

--- a/feature/shortcuts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/shortcuts/list/ShortcutListScreen.kt
+++ b/feature/shortcuts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/shortcuts/list/ShortcutListScreen.kt
@@ -62,7 +62,7 @@ fun ShortcutListScreen(modifier: Modifier = Modifier) {
     val navigationCoordinator = remember { getNavigationCoordinator() }
     val lazyListState = rememberLazyListState()
     val scope = rememberCoroutineScope()
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     var confirmDeleteItem by remember { mutableStateOf<String?>(null) }
     val snackbarHostState = remember { SnackbarHostState() }
     val genericError = LocalStrings.current.messageGenericError
@@ -179,7 +179,7 @@ fun ShortcutListScreen(modifier: Modifier = Modifier) {
                             .fillMaxWidth()
                             .clip(RoundedCornerShape(CornerSize.xl))
                             .clickable {
-                                detailOpener.openShortcut(item)
+                                mainRouter.openShortcut(item)
                             },
                         title = item,
                         options =

--- a/feature/shortcuts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/shortcuts/timeline/ShortcutTimelineScreen.kt
+++ b/feature/shortcuts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/shortcuts/timeline/ShortcutTimelineScreen.kt
@@ -83,7 +83,7 @@ fun ShortcutTimelineScreen(node: String, modifier: Modifier = Modifier) {
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val connection = navigationCoordinator.getBottomBarScrollConnection()
     val uriHandler = LocalUriHandler.current
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     val scope = rememberCoroutineScope()
     val lazyListState = rememberLazyListState()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -121,7 +121,7 @@ fun ShortcutTimelineScreen(node: String, modifier: Modifier = Modifier) {
                     }
 
                     is ShortcutTimelineMviModel.Effect.OpenDetail -> {
-                        detailOpener.openEntryDetail(
+                        mainRouter.openEntryDetail(
                             entry = event.entry,
                             swipeNavigationEnabled = true,
                         )
@@ -255,10 +255,10 @@ fun ShortcutTimelineScreen(node: String, modifier: Modifier = Modifier) {
                             }
                         },
                         onOpenUser = {
-                            detailOpener.openUserDetail(it)
+                            mainRouter.openUserDetail(it)
                         },
                         onOpenImage = { urls, imageIdx, videoIndices ->
-                            detailOpener.openImageDetail(
+                            mainRouter.openImageDetail(
                                 urls = urls,
                                 initialIndex = imageIdx,
                                 videoIndices = videoIndices,
@@ -294,7 +294,7 @@ fun ShortcutTimelineScreen(node: String, modifier: Modifier = Modifier) {
                         }.takeIf { actionRepository.canDislike(entry.original) },
                         onReply =
                         { e: TimelineEntryModel ->
-                            detailOpener.openComposer(
+                            mainRouter.openComposer(
                                 inReplyTo = e,
                                 inReplyToUser = e.creator,
                             )
@@ -366,7 +366,7 @@ fun ShortcutTimelineScreen(node: String, modifier: Modifier = Modifier) {
 
                                 OptionId.Quote -> {
                                     entry.original.also { entryToShare ->
-                                        detailOpener.openComposer(
+                                        mainRouter.openComposer(
                                             urlToShare = entryToShare.url,
                                         )
                                     }

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
@@ -110,7 +110,7 @@ fun ThreadScreen(entryId: String, swipeNavigationEnabled: Boolean, modifier: Mod
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val navigationCoordinator = remember { getNavigationCoordinator() }
     val uriHandler = LocalUriHandler.current
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     val scope = rememberCoroutineScope()
     val fabNestedScrollConnection = remember { getFabNestedScrollConnection() }
     val isFabVisible by fabNestedScrollConnection.isFabVisible.collectAsState()
@@ -199,7 +199,7 @@ fun ThreadScreen(entryId: String, swipeNavigationEnabled: Boolean, modifier: Mod
                         onClick = {
                             val mainEntry = uiState.mainEntries.getOrNull(uiState.currentIndex)
                             if (mainEntry != null) {
-                                detailOpener.openComposer(
+                                mainRouter.openComposer(
                                     inReplyTo = mainEntry,
                                     inReplyToUser = mainEntry.creator,
                                 )
@@ -310,10 +310,10 @@ fun ThreadScreen(entryId: String, swipeNavigationEnabled: Boolean, modifier: Mod
                                     }
                                 },
                                 onOpenUser = {
-                                    detailOpener.openUserDetail(it)
+                                    mainRouter.openUserDetail(it)
                                 },
                                 onOpenImage = { urls, imageIdx, videoIndices ->
-                                    detailOpener.openImageDetail(
+                                    mainRouter.openImageDetail(
                                         urls = urls,
                                         initialIndex = imageIdx,
                                         videoIndices = videoIndices,
@@ -356,13 +356,13 @@ fun ThreadScreen(entryId: String, swipeNavigationEnabled: Boolean, modifier: Mod
                                     actionRepository.canDislike(entry)
                                 },
                                 onOpenUsersFavorite = { e ->
-                                    detailOpener.openEntryUsersFavorite(
+                                    mainRouter.openEntryUsersFavorite(
                                         entryId = e.id,
                                         count = e.favoriteCount,
                                     )
                                 },
                                 onOpenUsersReblog = { e ->
-                                    detailOpener.openEntryUsersReblog(
+                                    mainRouter.openEntryUsersReblog(
                                         entryId = e.id,
                                         count = e.reblogCount,
                                     )
@@ -370,7 +370,7 @@ fun ThreadScreen(entryId: String, swipeNavigationEnabled: Boolean, modifier: Mod
                                 onReply =
                                 uiState.currentUserId?.let {
                                     { e ->
-                                        detailOpener.openComposer(
+                                        mainRouter.openComposer(
                                             inReplyTo = e,
                                             inReplyToUser = e.creator,
                                         )
@@ -456,7 +456,7 @@ fun ThreadScreen(entryId: String, swipeNavigationEnabled: Boolean, modifier: Mod
 
                                         OptionId.Quote -> {
                                             entry.original.also { entryToShare ->
-                                                detailOpener.openComposer(
+                                                mainRouter.openComposer(
                                                     urlToShare = entryToShare.url,
                                                 )
                                             }
@@ -526,10 +526,10 @@ fun ThreadScreen(entryId: String, swipeNavigationEnabled: Boolean, modifier: Mod
                                 }
                             },
                             onOpenUser = {
-                                detailOpener.openUserDetail(it)
+                                mainRouter.openUserDetail(it)
                             },
                             onOpenImage = { urls, imageIdx, videoIndices ->
-                                detailOpener.openImageDetail(
+                                mainRouter.openImageDetail(
                                     urls = urls,
                                     initialIndex = imageIdx,
                                     videoIndices = videoIndices,
@@ -565,7 +565,7 @@ fun ThreadScreen(entryId: String, swipeNavigationEnabled: Boolean, modifier: Mod
                             }.takeIf { actionRepository.canDislike(entry.original) },
                             onReply =
                             { e: TimelineEntryModel ->
-                                detailOpener.openComposer(
+                                mainRouter.openComposer(
                                     inReplyTo = e,
                                     inReplyToUser = e.creator,
                                 )
@@ -650,7 +650,7 @@ fun ThreadScreen(entryId: String, swipeNavigationEnabled: Boolean, modifier: Mod
                                     }
 
                                     OptionId.Edit -> {
-                                        detailOpener.openComposer(
+                                        mainRouter.openComposer(
                                             inReplyToUser = entry.creator,
                                             editedPostId = entry.reblog?.id,
                                             inGroup = true,
@@ -662,13 +662,13 @@ fun ThreadScreen(entryId: String, swipeNavigationEnabled: Boolean, modifier: Mod
                                     OptionId.Block -> confirmBlockEntry = entry
                                     OptionId.ReportUser ->
                                         entry.original.creator?.also { userToReport ->
-                                            detailOpener.openCreateReport(user = userToReport)
+                                            mainRouter.openCreateReport(user = userToReport)
                                         }
 
                                     OptionId.ReportEntry ->
                                         entry.original.also { entryToReport ->
                                             entryToReport.creator?.also { userToReport ->
-                                                detailOpener.openCreateReport(
+                                                mainRouter.openCreateReport(
                                                     user = userToReport,
                                                     entry = entryToReport,
                                                 )
@@ -678,7 +678,7 @@ fun ThreadScreen(entryId: String, swipeNavigationEnabled: Boolean, modifier: Mod
                                     OptionId.ViewDetails -> seeDetailsEntry = entry.original
                                     OptionId.Quote -> {
                                         entry.original.also { entryToShare ->
-                                            detailOpener.openComposer(
+                                            mainRouter.openComposer(
                                                 urlToShare = entryToShare.url,
                                             )
                                         }

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
@@ -106,7 +106,7 @@ fun TimelineScreen(
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val connection = navigationCoordinator.getBottomBarScrollConnection()
     val uriHandler = LocalUriHandler.current
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     val scope = rememberCoroutineScope()
     val drawerCoordinator = remember { getDrawerCoordinator() }
     val fabNestedScrollConnection = remember { getFabNestedScrollConnection() }
@@ -148,7 +148,7 @@ fun TimelineScreen(
                     }
 
                     is TimelineMviModel.Effect.OpenDetail ->
-                        detailOpener.openEntryDetail(
+                        mainRouter.openEntryDetail(
                             entry = event.entry,
                             swipeNavigationEnabled = true,
                         )
@@ -204,7 +204,7 @@ fun TimelineScreen(
                         IconButton(
                             onClick = {
                                 scope.launch {
-                                    detailOpener.openAnnouncements()
+                                    mainRouter.openAnnouncements()
                                 }
                             },
                         ) {
@@ -255,7 +255,7 @@ fun TimelineScreen(
                             bottom = Dimensions.floatingActionButtonBottomInset + bottomNavigationInset,
                         ),
                         onClick = {
-                            detailOpener.openComposer()
+                            mainRouter.openComposer()
                         },
                     ) {
                         Icon(
@@ -346,10 +346,10 @@ fun TimelineScreen(
                             }
                         },
                         onOpenUser = {
-                            detailOpener.openUserDetail(it)
+                            mainRouter.openUserDetail(it)
                         },
                         onOpenImage = { urls, imageIdx, videoIndices ->
-                            detailOpener.openImageDetail(
+                            mainRouter.openImageDetail(
                                 urls = urls,
                                 initialIndex = imageIdx,
                                 videoIndices = videoIndices,
@@ -385,7 +385,7 @@ fun TimelineScreen(
                         }.takeIf { actionRepository.canDislike(entry.original) },
                         onReply =
                         { e: TimelineEntryModel ->
-                            detailOpener.openComposer(
+                            mainRouter.openComposer(
                                 inReplyTo = e,
                                 inReplyToUser = e.creator,
                             )
@@ -487,7 +487,7 @@ fun TimelineScreen(
 
                                 OptionId.Edit -> {
                                     entry.original.also { entryToEdit ->
-                                        detailOpener.openComposer(
+                                        mainRouter.openComposer(
                                             inReplyTo = entryToEdit.inReplyTo,
                                             inReplyToUser = entryToEdit.inReplyTo?.creator,
                                             editedPostId = entryToEdit.id,
@@ -503,13 +503,13 @@ fun TimelineScreen(
 
                                 OptionId.ReportUser ->
                                     entry.original.creator?.also { userToReport ->
-                                        detailOpener.openCreateReport(user = userToReport)
+                                        mainRouter.openCreateReport(user = userToReport)
                                     }
 
                                 OptionId.ReportEntry ->
                                     entry.original.also { entryToReport ->
                                         entryToReport.creator?.also { userToReport ->
-                                            detailOpener.openCreateReport(
+                                            mainRouter.openCreateReport(
                                                 user = userToReport,
                                                 entry = entryToReport,
                                             )
@@ -518,7 +518,7 @@ fun TimelineScreen(
 
                                 OptionId.Quote -> {
                                     entry.original.also { entryToShare ->
-                                        detailOpener.openComposer(
+                                        mainRouter.openComposer(
                                             urlToShare = entryToShare.url,
                                         )
                                     }

--- a/feature/unpublished/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/unpublished/UnpublishedScreen.kt
+++ b/feature/unpublished/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/unpublished/UnpublishedScreen.kt
@@ -63,7 +63,7 @@ fun UnpublishedScreen(modifier: Modifier = Modifier) {
     val navigationCoordinator = remember { getNavigationCoordinator() }
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     val lazyListState = rememberLazyListState()
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -213,7 +213,7 @@ fun UnpublishedScreen(modifier: Modifier = Modifier) {
                         onSelectOption = { optionId ->
                             when (optionId) {
                                 OptionId.Edit ->
-                                    detailOpener.openEditUnpublished(
+                                    mainRouter.openEditUnpublished(
                                         entry = entry,
                                         type = uiState.section,
                                     )

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -123,7 +123,7 @@ fun UserDetailScreen(id: String, modifier: Modifier = Modifier) {
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val navigationCoordinator = remember { getNavigationCoordinator() }
     val uriHandler = LocalUriHandler.current
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     val lazyListState = rememberLazyListState()
     val fabNestedScrollConnection = remember { getFabNestedScrollConnection() }
     val isFabVisible by fabNestedScrollConnection.isFabVisible.collectAsState()
@@ -183,7 +183,7 @@ fun UserDetailScreen(id: String, modifier: Modifier = Modifier) {
                     }
 
                     is UserDetailMviModel.Effect.OpenDetail -> {
-                        detailOpener.openEntryDetail(
+                        mainRouter.openEntryDetail(
                             entry = event.entry,
                             swipeNavigationEnabled = true,
                         )
@@ -344,12 +344,12 @@ fun UserDetailScreen(id: String, modifier: Modifier = Modifier) {
 
                                                 OptionId.ReportUser ->
                                                     uiState.user?.also { userToReport ->
-                                                        detailOpener.openCreateReport(user = userToReport)
+                                                        mainRouter.openCreateReport(user = userToReport)
                                                     }
 
                                                 CustomOptions.SwitchToForumMode -> {
                                                     uiState.user?.also { user ->
-                                                        detailOpener.switchUserDetailToForumMode(user)
+                                                        mainRouter.switchUserDetailToForumMode(user)
                                                     }
                                                 }
 
@@ -392,7 +392,7 @@ fun UserDetailScreen(id: String, modifier: Modifier = Modifier) {
             ) {
                 FloatingActionButton(
                     onClick = {
-                        detailOpener.openComposer(
+                        mainRouter.openComposer(
                             inReplyToUser = uiState.user,
                         )
                     },
@@ -449,12 +449,12 @@ fun UserDetailScreen(id: String, modifier: Modifier = Modifier) {
                                 }
                             },
                             onOpenImage = { url ->
-                                detailOpener.openImageDetail(url)
+                                mainRouter.openImageDetail(url)
                             },
                             onRelationshipClick = { nextAction ->
                                 when (nextAction) {
                                     RelationshipStatusNextAction.AcceptRequest -> {
-                                        detailOpener.openFollowRequests()
+                                        mainRouter.openFollowRequests()
                                     }
 
                                     RelationshipStatusNextAction.ConfirmUnfollow -> {
@@ -487,12 +487,12 @@ fun UserDetailScreen(id: String, modifier: Modifier = Modifier) {
                             },
                             onOpenFollowers = {
                                 uiState.user?.also { user ->
-                                    detailOpener.openFollowers(user)
+                                    mainRouter.openFollowers(user)
                                 }
                             },
                             onOpenFollowing = {
                                 uiState.user?.also { user ->
-                                    detailOpener.openFollowing(user)
+                                    mainRouter.openFollowing(user)
                                 }
                             },
                         )
@@ -618,11 +618,11 @@ fun UserDetailScreen(id: String, modifier: Modifier = Modifier) {
                         },
                         onOpenUser = { user ->
                             if (user.id != uiState.user?.id) {
-                                detailOpener.openUserDetail(user)
+                                mainRouter.openUserDetail(user)
                             }
                         },
                         onOpenImage = { urls, imageIdx, videoIndices ->
-                            detailOpener.openImageDetail(
+                            mainRouter.openImageDetail(
                                 urls = urls,
                                 initialIndex = imageIdx,
                                 videoIndices = videoIndices,
@@ -658,7 +658,7 @@ fun UserDetailScreen(id: String, modifier: Modifier = Modifier) {
                         }.takeIf { actionRepository.canDislike(entry.original) },
                         onReply =
                         { e: TimelineEntryModel ->
-                            detailOpener.openComposer(
+                            mainRouter.openComposer(
                                 inReplyTo = e,
                                 inReplyToUser = e.creator,
                             )
@@ -743,7 +743,7 @@ fun UserDetailScreen(id: String, modifier: Modifier = Modifier) {
                                 OptionId.ReportEntry ->
                                     entry.original.also { entryToReport ->
                                         entryToReport.creator?.also { userToReport ->
-                                            detailOpener.openCreateReport(
+                                            mainRouter.openCreateReport(
                                                 user = userToReport,
                                                 entry = entryToReport,
                                             )
@@ -753,7 +753,7 @@ fun UserDetailScreen(id: String, modifier: Modifier = Modifier) {
                                 OptionId.ViewDetails -> seeDetailsEntry = entry.original
                                 OptionId.Quote -> {
                                     entry.original.also { entryToShare ->
-                                        detailOpener.openComposer(
+                                        mainRouter.openComposer(
                                             urlToShare = entryToShare.url,
                                         )
                                     }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
@@ -99,7 +99,7 @@ fun ForumListScreen(id: String, modifier: Modifier = Modifier) {
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val navigationCoordinator = remember { getNavigationCoordinator() }
     val uriHandler = LocalUriHandler.current
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     val lazyListState = rememberLazyListState()
     val scope = rememberCoroutineScope()
     val fabNestedScrollConnection = remember { getFabNestedScrollConnection() }
@@ -137,7 +137,7 @@ fun ForumListScreen(id: String, modifier: Modifier = Modifier) {
                     }
 
                     is ForumListMviModel.Effect.OpenDetail -> {
-                        detailOpener.openThread(
+                        mainRouter.openThread(
                             entry = event.entry,
                             swipeNavigationEnabled = true,
                         )
@@ -242,7 +242,7 @@ fun ForumListScreen(id: String, modifier: Modifier = Modifier) {
                                         when (option.id) {
                                             CustomOptions.SwitchToClassicMode -> {
                                                 uiState.user?.also { user ->
-                                                    detailOpener.switchUserDetailToClassicMode(
+                                                    mainRouter.switchUserDetailToClassicMode(
                                                         user,
                                                     )
                                                 }
@@ -282,7 +282,7 @@ fun ForumListScreen(id: String, modifier: Modifier = Modifier) {
                 ) {
                     FloatingActionButton(
                         onClick = {
-                            detailOpener.openComposer(
+                            mainRouter.openComposer(
                                 inReplyToUser = uiState.user,
                                 inGroup = true,
                             )
@@ -361,10 +361,10 @@ fun ForumListScreen(id: String, modifier: Modifier = Modifier) {
                             }
                         },
                         onOpenUser = {
-                            detailOpener.openUserDetail(it)
+                            mainRouter.openUserDetail(it)
                         },
                         onOpenImage = { urls, imageIdx, videoIndices ->
-                            detailOpener.openImageDetail(
+                            mainRouter.openImageDetail(
                                 urls = urls,
                                 initialIndex = imageIdx,
                                 videoIndices = videoIndices,
@@ -400,7 +400,7 @@ fun ForumListScreen(id: String, modifier: Modifier = Modifier) {
                         }.takeIf { actionRepository.canDislike(entry.original) },
                         onReply =
                         { e: TimelineEntryModel ->
-                            detailOpener.openComposer(
+                            mainRouter.openComposer(
                                 inReplyTo = e,
                                 inReplyToUser = e.creator,
                             )
@@ -494,7 +494,7 @@ fun ForumListScreen(id: String, modifier: Modifier = Modifier) {
                                 }
 
                                 OptionId.Edit -> {
-                                    detailOpener.openComposer(
+                                    mainRouter.openComposer(
                                         inReplyToUser = entry.creator,
                                         editedPostId = entry.reblog?.id,
                                         inGroup = true,
@@ -506,13 +506,13 @@ fun ForumListScreen(id: String, modifier: Modifier = Modifier) {
                                 OptionId.Block -> confirmBlockEntry = entry
                                 OptionId.ReportUser ->
                                     entry.original.creator?.also { userToReport ->
-                                        detailOpener.openCreateReport(user = userToReport)
+                                        mainRouter.openCreateReport(user = userToReport)
                                     }
 
                                 OptionId.ReportEntry ->
                                     entry.original.also { entryToReport ->
                                         entryToReport.creator?.also { userToReport ->
-                                            detailOpener.openCreateReport(
+                                            mainRouter.openCreateReport(
                                                 user = userToReport,
                                                 entry = entryToReport,
                                             )
@@ -521,7 +521,7 @@ fun ForumListScreen(id: String, modifier: Modifier = Modifier) {
 
                                 OptionId.Quote -> {
                                     entry.original.also { entryToShare ->
-                                        detailOpener.openComposer(
+                                        mainRouter.openComposer(
                                             urlToShare = entryToShare.url,
                                         )
                                     }

--- a/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListScreen.kt
+++ b/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListScreen.kt
@@ -91,7 +91,7 @@ fun UserListScreen(
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val snackbarHostState = remember { SnackbarHostState() }
     val navigationCoordinator = remember { getNavigationCoordinator() }
-    val detailOpener = remember { getMainRouter() }
+    val mainRouter = remember { getMainRouter() }
     val fileSystemManager = remember { getFileSystemManager() }
     val lazyListState = rememberLazyListState()
     val scope = rememberCoroutineScope()
@@ -325,12 +325,12 @@ fun UserListScreen(
                         user = user,
                         autoloadImages = uiState.autoloadImages,
                         onClick = {
-                            detailOpener.openUserDetail(user)
+                            mainRouter.openUserDetail(user)
                         },
                         onRelationshipClick = { nextAction ->
                             when (nextAction) {
                                 RelationshipStatusNextAction.AcceptRequest -> {
-                                    detailOpener.openFollowRequests()
+                                    mainRouter.openFollowRequests()
                                 }
 
                                 RelationshipStatusNextAction.ConfirmUnfollow -> {


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR restores the possibility to pass an initial image attachment from the system "share" menu. This had been temporarily disabled after #956 because its implementation was relying on a Voyager-specific feature.

Additionally, since `MainRouter` usages were still referring to it as "detail opener" variables have been renamed to match their new type name (first commit).
