### PR TITLE
fix: navigation issues (login, drawer, etc.)

### DIFF
--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationCoordinator.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationCoordinator.kt
@@ -48,10 +48,9 @@ internal class DefaultNavigationCoordinator(dispatcher: CoroutineDispatcher = Di
         refreshCanPop()
     }
 
-    private fun refreshCanPop() {
-        canPop.update {
-            rootNavController?.canPop ?: false
-        }
+    override fun popUntilRoot() {
+        rootNavController?.popUntilRoot()
+        refreshCanPop()
     }
 
     override fun setExitMessageVisible(value: Boolean) {
@@ -78,11 +77,6 @@ internal class DefaultNavigationCoordinator(dispatcher: CoroutineDispatcher = Di
         refreshCanPop()
     }
 
-    override fun popUntilRoot() {
-        rootNavController?.popUntilRoot()
-        refreshCanPop()
-    }
-
     override suspend fun submitDeeplink(url: String) {
         delay(750)
         deepLinkUrl.emit(url)
@@ -92,6 +86,12 @@ internal class DefaultNavigationCoordinator(dispatcher: CoroutineDispatcher = Di
         scope.launch {
             delay(delay)
             globalMessage.emit(message)
+        }
+    }
+
+    private fun refreshCanPop() {
+        canPop.update {
+            rootNavController?.canPop ?: false
         }
     }
 }

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/NavigationAdapter.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/NavigationAdapter.kt
@@ -13,24 +13,23 @@ interface NavigationAdapter {
 }
 
 class DefaultNavigationAdapter(private val navController: NavController) : NavigationAdapter {
-    override var canPop: Boolean = false
+    override val canPop: Boolean get() = navController.currentBackStack.value.size > 1
 
     override fun navigate(destination: Destination, replaceTop: Boolean) {
-        if (replaceTop) {
+        if (replaceTop && canPop) {
             navController.popBackStack()
         }
         navController.navigate(destination)
-        canPop = navController.currentBackStack.value.size > 1
     }
 
     override fun pop() {
+        if (!canPop) {
+            return
+        }
         navController.popBackStack()
-        canPop = navController.currentBackStack.value.size > 1
     }
 
     override fun popUntilRoot() {
-        do {
-            pop()
-        } while (canPop)
+        navController.popBackStack(route = Destination.Main, inclusive = false)
     }
 }

--- a/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/EntryProcessor.kt
+++ b/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/EntryProcessor.kt
@@ -1,14 +1,22 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor
 
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.MainRouter
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 internal interface EntryProcessor : UrlProcessor
 
-internal class DefaultEntryProcessor(private val mainRouter: MainRouter, private val fetchEntry: FetchEntryUseCase) :
-    EntryProcessor {
+internal class DefaultEntryProcessor(
+    private val mainRouter: MainRouter,
+    private val fetchEntry: FetchEntryUseCase,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.Main,
+) : EntryProcessor {
     override suspend fun process(uri: String): Boolean {
         val remoteEntry = fetchEntry(uri) ?: return false
-        mainRouter.openEntryDetail(remoteEntry)
+        withContext(dispatcher) {
+            mainRouter.openEntryDetail(remoteEntry)
+        }
         return true
     }
 }

--- a/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/HashtagProcessor.kt
+++ b/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/HashtagProcessor.kt
@@ -3,18 +3,25 @@ package com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.MainRouter
 import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor.UriHandlerConstants.DETAIL_FRAGMENT
 import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor.UriHandlerConstants.INSTANCE_FRAGMENT
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 internal interface HashtagProcessor : UrlProcessor
 
-internal class DefaultHashtagProcessor(private val mainRouter: MainRouter) : HashtagProcessor {
+internal class DefaultHashtagProcessor(
+    private val mainRouter: MainRouter,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.Main,
+) : HashtagProcessor {
     override suspend fun process(uri: String): Boolean {
         val tag =
             listOfNotNull(
                 REGEX_1.find(uri)?.groups?.let { it["tag"]?.value },
                 REGEX_2.find(uri)?.groups?.let { it["tag"]?.value },
             ).firstOrNull() ?: return false
-
-        mainRouter.openHashtag(tag)
+        withContext(dispatcher) {
+            mainRouter.openHashtag(tag)
+        }
         return true
     }
 

--- a/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/UserProcessor.kt
+++ b/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/UserProcessor.kt
@@ -1,14 +1,22 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor
 
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.MainRouter
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 internal interface UserProcessor : UrlProcessor
 
-internal class DefaultUserProcessor(private val mainRouter: MainRouter, private val fetchUser: FetchUserUseCase) :
-    UserProcessor {
+internal class DefaultUserProcessor(
+    private val mainRouter: MainRouter,
+    private val fetchUser: FetchUserUseCase,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.Main,
+) : UserProcessor {
     override suspend fun process(uri: String): Boolean {
         val remoteUser = fetchUser(uri) ?: return false
-        mainRouter.openUserDetail(remoteUser)
+        withContext(dispatcher) {
+            mainRouter.openUserDetail(remoteUser)
+        }
         return true
     }
 }

--- a/domain/urlhandler/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/DefaultEntryProcessorTest.kt
+++ b/domain/urlhandler/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/DefaultEntryProcessorTest.kt
@@ -10,11 +10,14 @@ import dev.mokkery.mock
 import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class DefaultEntryProcessorTest {
     private val mainRouter = mock<MainRouter>(mode = MockMode.autoUnit)
     private val fetchEntry = mock<FetchEntryUseCase>()
@@ -22,6 +25,7 @@ class DefaultEntryProcessorTest {
         DefaultEntryProcessor(
             mainRouter = mainRouter,
             fetchEntry = fetchEntry,
+            dispatcher = UnconfinedTestDispatcher(),
         )
 
     @Test

--- a/domain/urlhandler/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/DefaultHashtagProcessorTest.kt
+++ b/domain/urlhandler/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/DefaultHashtagProcessorTest.kt
@@ -6,15 +6,21 @@ import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class DefaultHashtagProcessorTest {
     private val mainRouter = mock<MainRouter>(mode = MockMode.autoUnit)
 
-    private val sut = DefaultHashtagProcessor(mainRouter = mainRouter)
+    private val sut = DefaultHashtagProcessor(
+        mainRouter = mainRouter,
+        dispatcher = UnconfinedTestDispatcher(),
+    )
 
     @Test
     fun `given valid URL in format 1 when process URL then interactions are as expected`() = runTest {

--- a/domain/urlhandler/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/DefaultUserProcessorTest.kt
+++ b/domain/urlhandler/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/DefaultUserProcessorTest.kt
@@ -10,11 +10,14 @@ import dev.mokkery.mock
 import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class DefaultUserProcessorTest {
     private val mainRouter = mock<MainRouter>(mode = MockMode.autoUnit)
     private val fetchUser = mock<FetchUserUseCase>()
@@ -22,6 +25,7 @@ class DefaultUserProcessorTest {
         DefaultUserProcessor(
             mainRouter = mainRouter,
             fetchUser = fetchUser,
+            dispatcher = UnconfinedTestDispatcher(),
         )
 
     @Test

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerContent.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerContent.kt
@@ -72,7 +72,6 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.DefaultFrie
 import com.livefast.eattrash.raccoonforfriendica.feature.drawer.about.AboutDialog
 import com.livefast.eattrash.raccoonforfriendica.feature.drawer.components.DrawerHeader
 import com.livefast.eattrash.raccoonforfriendica.feature.drawer.components.DrawerShortcut
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -95,7 +94,6 @@ fun DrawerContent(modifier: Modifier = Modifier) {
         scope.launch {
             navigationCoordinator.popUntilRoot()
             drawerCoordinator.toggleDrawer()
-            delay(50)
             action()
         }
     }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes a couple of navigation issues arising from the fact that the `pop()` and `popUntilRoot()` implementations of `DefaultNavigationAdapter` were a little buggy, so you could end up with a completely empty backstack (and therefore no content).
