### PR TITLE
chore: add UnifiedPush embedded FCM distributor

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -4,16 +4,17 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.VIBRATE"/>
-    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <queries>
         <intent>
-            <action android:name="android.support.customtabs.action.CustomTabsService"/>
+            <action android:name="android.support.customtabs.action.CustomTabsService" />
         </intent>
     </queries>
 
     <application
+        android:name="com.livefast.eattrash.raccoonforfriendica.MainApplication"
         android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="false"
@@ -21,12 +22,11 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:name="com.livefast.eattrash.raccoonforfriendica.MainApplication"
         android:theme="@style/Theme.AppSplash">
         <activity
-            android:exported="true"
-            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|mnc|colorMode|density|fontScale|fontWeightAdjustment|keyboard|layoutDirection|locale|mcc|navigation|smallestScreenSize|touchscreen|uiMode"
             android:name="com.livefast.eattrash.raccoonforfriendica.MainActivity"
+            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|mnc|colorMode|density|fontScale|fontWeightAdjustment|keyboard|layoutDirection|locale|mcc|navigation|smallestScreenSize|touchscreen|uiMode"
+            android:exported="true"
             android:launchMode="singleTop"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
@@ -127,6 +127,15 @@
                 <action android:name="org.unifiedpush.android.connector.REGISTRATION_REFUSED" />
             </intent-filter>
         </receiver>
+
+        <!-- UnifiedPush service -->
+        <service
+            android:name="com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.service.DefaultPushService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="org.unifiedpush.android.connector.PUSH_EVENT" />
+            </intent-filter>
+        </service>
     </application>
 
 </manifest>

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/InstanceConfiguration.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/InstanceConfiguration.kt
@@ -4,4 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class InstanceConfiguration(@SerialName("statuses") val statuses: InstanceConfigurationStatuses? = null)
+data class InstanceConfiguration(
+    @SerialName("statuses") val statuses: InstanceConfigurationStatuses? = null,
+    @SerialName("vapid") val vapid: VapidKey? = null,
+)

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/PushSubscription.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/PushSubscription.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.Serializable
 data class PushSubscription(
     @SerialName("id") val id: String,
     @SerialName("endpoint") val endpoint: String? = null,
+    // corresponds to the server's VAPID key
     @SerialName("server_key") val serverKey: String? = null,
     @SerialName("alerts") val alerts: PushSubscriptionAlerts? = null,
 )

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/VapidKey.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/VapidKey.kt
@@ -1,0 +1,7 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class VapidKey(@SerialName("public_key") val publicKey: String? = null)

--- a/domain/pushnotifications/build.gradle.kts
+++ b/domain/pushnotifications/build.gradle.kts
@@ -9,9 +9,14 @@ kotlin {
     sourceSets {
         val androidMain by getting {
             dependencies {
-                implementation(libs.unifiedpush.get().toString()) {
+                implementation(
+                    libs.unifiedpush.connector
+                        .get()
+                        .toString(),
+                ) {
                     exclude("com.google.crypto.tink", "tink")
                 }
+                implementation(libs.unifiedpush.fcm.distributor)
             }
         }
         val commonMain by getting {

--- a/domain/pushnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/common/UnifiedPushInteractor.kt
+++ b/domain/pushnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/common/UnifiedPushInteractor.kt
@@ -1,0 +1,63 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.common
+
+import android.content.Context
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications.PullNotificationManager
+import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.manager.PushNotificationManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import org.unifiedpush.android.connector.FailedReason
+import org.unifiedpush.android.connector.data.PushEndpoint
+import org.unifiedpush.android.connector.data.PushMessage
+
+interface UnifiedPushInteractor {
+    fun onMessage(context: Context, message: PushMessage, instance: String)
+    fun onNewEndpoint(context: Context, endpoint: PushEndpoint, instance: String)
+    fun onRegistrationFailed(context: Context, reason: FailedReason, instance: String)
+    fun onUnregistered(context: Context, instance: String)
+}
+
+class DefaultUnifiedPushInteractor(
+    private val pullNotificationManager: PullNotificationManager,
+    private val pushNotificationManager: PushNotificationManager,
+    private val accountRepository: AccountRepository,
+) : UnifiedPushInteractor {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    override fun onMessage(context: Context, message: PushMessage, instance: String) {
+        pullNotificationManager.oneshotCheck()
+    }
+
+    override fun onNewEndpoint(context: Context, endpoint: PushEndpoint, instance: String) {
+        val accountId = instance.toLongOrNull() ?: return
+        scope.launch {
+            val account = accountRepository.getBy(accountId) ?: return@launch
+            endpoint.pubKeySet
+            pushNotificationManager.registerEndpoint(
+                account = account,
+                endpointUrl = endpoint.url,
+                pubKey = endpoint.pubKeySet?.pubKey.orEmpty(),
+                auth = endpoint.pubKeySet?.auth.orEmpty(),
+            )
+        }
+    }
+
+    override fun onRegistrationFailed(context: Context, reason: FailedReason, instance: String) {
+        val accountId = instance.toLongOrNull() ?: return
+        scope.launch {
+            val account = accountRepository.getBy(accountId) ?: return@launch
+            pushNotificationManager.unregisterEndpoint(account)
+        }
+    }
+
+    override fun onUnregistered(context: Context, instance: String) {
+        val accountId = instance.toLongOrNull() ?: return
+        scope.launch {
+            val account = accountRepository.getBy(accountId) ?: return@launch
+            pushNotificationManager.unregisterEndpoint(account)
+        }
+    }
+}

--- a/domain/pushnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/di/NativePushNotificationsModule.kt
+++ b/domain/pushnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/di/NativePushNotificationsModule.kt
@@ -1,5 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.di
 
+import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.common.DefaultUnifiedPushInteractor
+import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.common.UnifiedPushInteractor
 import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.manager.DefaultPushNotificationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.manager.PushNotificationManager
 import org.kodein.di.DI
@@ -14,6 +16,15 @@ internal actual val nativePushNotificationsModule =
                 DefaultPushNotificationManager(
                     context = instance(),
                     pushNotificationRepository = instance(),
+                    accountRepository = instance(),
+                )
+            }
+        }
+        bind<UnifiedPushInteractor> {
+            singleton {
+                DefaultUnifiedPushInteractor(
+                    pullNotificationManager = instance(),
+                    pushNotificationManager = instance(),
                     accountRepository = instance(),
                 )
             }

--- a/domain/pushnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/receiver/UnifiedPushBroadcastReceiver.kt
+++ b/domain/pushnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/receiver/UnifiedPushBroadcastReceiver.kt
@@ -2,13 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.recei
 
 import android.content.Context
 import com.livefast.eattrash.raccoonforfriendica.core.di.RootDI
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications.PullNotificationManager
-import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.manager.PushNotificationManager
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
+import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.common.UnifiedPushInteractor
 import org.kodein.di.instance
 import org.unifiedpush.android.connector.FailedReason
 import org.unifiedpush.android.connector.MessagingReceiver
@@ -16,42 +10,21 @@ import org.unifiedpush.android.connector.data.PushEndpoint
 import org.unifiedpush.android.connector.data.PushMessage
 
 class UnifiedPushBroadcastReceiver : MessagingReceiver() {
-    private val pullNotificationManager by RootDI.di.instance<PullNotificationManager>()
-    private val pushNotificationManager by RootDI.di.instance<PushNotificationManager>()
-    private val accountRepository by RootDI.di.instance<AccountRepository>()
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val interactor by RootDI.di.instance<UnifiedPushInteractor>()
 
     override fun onMessage(context: Context, message: PushMessage, instance: String) {
-        pullNotificationManager.oneshotCheck()
+        interactor.onMessage(context = context, message = message, instance = instance)
     }
 
     override fun onNewEndpoint(context: Context, endpoint: PushEndpoint, instance: String) {
-        val accountId = instance.toLongOrNull() ?: return
-        scope.launch {
-            val account = accountRepository.getBy(accountId) ?: return@launch
-            endpoint.pubKeySet
-            pushNotificationManager.registerEndpoint(
-                account = account,
-                endpointUrl = endpoint.url,
-                pubKey = endpoint.pubKeySet?.pubKey.orEmpty(),
-                auth = endpoint.pubKeySet?.auth.orEmpty(),
-            )
-        }
+        interactor.onNewEndpoint(context = context, endpoint = endpoint, instance = instance)
     }
 
     override fun onRegistrationFailed(context: Context, reason: FailedReason, instance: String) {
-        val accountId = instance.toLongOrNull() ?: return
-        scope.launch {
-            val account = accountRepository.getBy(accountId) ?: return@launch
-            pushNotificationManager.unregisterEndpoint(account)
-        }
+        interactor.onRegistrationFailed(context = context, reason = reason, instance = instance)
     }
 
     override fun onUnregistered(context: Context, instance: String) {
-        val accountId = instance.toLongOrNull() ?: return
-        scope.launch {
-            val account = accountRepository.getBy(accountId) ?: return@launch
-            pushNotificationManager.unregisterEndpoint(account)
-        }
+        interactor.onUnregistered(context = context, instance = instance)
     }
 }

--- a/domain/pushnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/service/DefaultPushService.kt
+++ b/domain/pushnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/service/DefaultPushService.kt
@@ -1,0 +1,29 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.service
+
+import com.livefast.eattrash.raccoonforfriendica.core.di.RootDI
+import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.common.UnifiedPushInteractor
+import org.kodein.di.instance
+import org.unifiedpush.android.connector.FailedReason
+import org.unifiedpush.android.connector.PushService
+import org.unifiedpush.android.connector.data.PushEndpoint
+import org.unifiedpush.android.connector.data.PushMessage
+
+class DefaultPushService : PushService() {
+    private val interactor by RootDI.di.instance<UnifiedPushInteractor>()
+
+    override fun onMessage(message: PushMessage, instance: String) {
+        interactor.onMessage(context = this, message = message, instance = instance)
+    }
+
+    override fun onNewEndpoint(endpoint: PushEndpoint, instance: String) {
+        interactor.onNewEndpoint(context = this, endpoint = endpoint, instance = instance)
+    }
+
+    override fun onRegistrationFailed(reason: FailedReason, instance: String) {
+        interactor.onRegistrationFailed(context = this, reason = reason, instance = instance)
+    }
+
+    override fun onUnregistered(instance: String) {
+        interactor.onUnregistered(context = this, instance = instance)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,7 +41,8 @@ sentry = "0.12.0"
 spotless = "7.0.4"
 stately = "2.1.0"
 turbine = "1.2.1"
-unifiedpush = "3.0.10"
+unifiedpush-connector = "3.0.10"
+unifiedpush-fcm-distributor = "3.0.0"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
@@ -121,7 +122,8 @@ room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 
-unifiedpush = { module = "org.unifiedpush.android:connector", version.ref = "unifiedpush" }
+unifiedpush-connector = { module = "org.unifiedpush.android:connector", version.ref = "unifiedpush-connector" }
+unifiedpush-fcm-distributor = { module = "org.unifiedpush.android:embedded-fcm-distributor", version.ref = "unifiedpush-fcm-distributor" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds the UnifiedPush embedded FCM distributor and implements `PushService` to handle incoming notifications. Since its logic should be similar to the already defined broadcast receiver, the common parts were factored out into `DefaultUnifiedPushInteractor`. 
