### PR TITLE
fix: inbox navigation,  lint

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/MainActivity.kt
@@ -119,7 +119,7 @@ class MainActivity : ComponentActivity() {
     private fun handleIncomingAttachment(intent: Intent) {
         lifecycleScope.launch {
             // workaround: wait until the root NavigationAdapter has been set
-            delay(NAVIGATION_WARMUP)
+            delay(750L)
             val mainRouter = getMainRouter()
             when {
                 "text/plain" == intent.type -> {
@@ -147,14 +147,10 @@ class MainActivity : ComponentActivity() {
     private fun handleOpenInboxAtStartup() {
         lifecycleScope.launch {
             // workaround: wait until the root NavigationAdapter has been set
-            delay(NAVIGATION_WARMUP)
+            delay(1000L)
             val navigationCoordinator = getNavigationCoordinator()
             navigationCoordinator.popUntilRoot()
             navigationCoordinator.setCurrentSection(BottomNavigationSection.Inbox())
         }
-    }
-
-    companion object {
-        private const val NAVIGATION_WARMUP = 750L
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,5 @@ kotlin.mpp.enableCInteropCommonization=true
 kotlin.native.disableCompilerDaemon = true
 # disable native cache
 kotlin.native.cacheKind=none
+# lint crash NonNullableMutableLiveDataDetector in AndroidX lifecycle (remove after AGP upgrade)
+android.experimental.lint.version=8.11.0


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR tries to fix a crash when opening the app from a push notification. Moreover it enables and experimental version of the lint Gradle plugin because apparently this breaks with AndroidX lifecycle and I can not upgrade AGP due to #957 still failing to merge.
