### PR TITLE
fix: add throttling behaviour to navigation

### DIFF
--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationAdapter.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationAdapter.kt
@@ -1,0 +1,61 @@
+package com.livefast.eattrash.raccoonforfriendica.core.navigation
+
+import androidx.navigation.NavController
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+class DefaultNavigationAdapter(
+    private val navController: NavController,
+    dispatcher: CoroutineDispatcher = Dispatchers.Main,
+) : NavigationAdapter {
+    override val canPop: Boolean get() = navController.currentBackStack.value.size > 1
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+    private var job: Job? = null
+
+    override fun navigate(destination: Destination, replaceTop: Boolean) {
+        if (job?.isActive == true) {
+            return
+        }
+        perform {
+            if (replaceTop && canPop) {
+                navController.popBackStack()
+            }
+            navController.navigate(destination)
+        }
+    }
+
+    override fun pop() {
+        if (job?.isActive == true) {
+            return
+        }
+        perform {
+            if (canPop) {
+                navController.popBackStack()
+            }
+        }
+    }
+
+    override fun popUntilRoot() {
+        if (job?.isActive == true) {
+            return
+        }
+        perform {
+            navController.popBackStack(route = Destination.Main, inclusive = false)
+        }
+    }
+
+    private fun perform(interval: Duration = 250.milliseconds, action: () -> Unit) {
+        job = scope.launch {
+            action()
+            delay(interval)
+            job = null
+        }
+    }
+}

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/NavigationAdapter.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/NavigationAdapter.kt
@@ -1,7 +1,5 @@
 package com.livefast.eattrash.raccoonforfriendica.core.navigation
 
-import androidx.navigation.NavController
-
 interface NavigationAdapter {
     val canPop: Boolean
 
@@ -10,26 +8,4 @@ interface NavigationAdapter {
     fun pop()
 
     fun popUntilRoot()
-}
-
-class DefaultNavigationAdapter(private val navController: NavController) : NavigationAdapter {
-    override val canPop: Boolean get() = navController.currentBackStack.value.size > 1
-
-    override fun navigate(destination: Destination, replaceTop: Boolean) {
-        if (replaceTop && canPop) {
-            navController.popBackStack()
-        }
-        navController.navigate(destination)
-    }
-
-    override fun pop() {
-        if (!canPop) {
-            return
-        }
-        navController.popBackStack()
-    }
-
-    override fun popUntilRoot() {
-        navController.popBackStack(route = Destination.Main, inclusive = false)
-    }
 }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR solves a bug due to which, after #956, tapping twice on the back button can pop all entries from the backstack. The solution is adding a throttling behaviour to the nav controller management.

This is the counterpart of https://github.com/LiveFastEatTrashRaccoon/RaccoonForLemmy/pull/469.
