### PR TITLE
fix(ui): navigation drawer flicker when opened from top bar

### DIFF
--- a/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/AppTheme.kt
+++ b/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/AppTheme.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialExpressiveTheme
 import androidx.compose.material3.MaterialTheme.shapes
+import androidx.compose.material3.MotionScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -16,11 +17,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.di.getThemeRepo
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun AppTheme(useDynamicColors: Boolean, barTheme: UiBarTheme, content: @Composable () -> Unit) {
-    val repository =
-        remember {
-            getThemeRepository()
-        }
-
+    val repository = remember { getThemeRepository() }
     val themeState by repository.theme.collectAsState()
     val customSeedColor by repository.customSeedColor.collectAsState()
     val colorSchemeProvider = remember { getColorSchemeProvider() }
@@ -46,5 +43,6 @@ fun AppTheme(useDynamicColors: Boolean, barTheme: UiBarTheme, content: @Composab
         typography = typography,
         shapes = shapes,
         content = content,
+        motionScheme = MotionScheme.expressive(),
     )
 }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes a glitch in the navigation drawer which became apparent after #975 but was pre-existing causing the scrim to flicker when it was opened from the hamburger button in the top app bar.

Moreover, it cleans up a little bit the main `App.kt` file.
