### PR TITLE
feat: open profile from drawer header

### DIFF
--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationCoordinator.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationCoordinator.kt
@@ -32,12 +32,13 @@ internal class DefaultNavigationCoordinator(dispatcher: CoroutineDispatcher = Di
     }
 
     override fun setCurrentSection(section: BottomNavigationSection) {
-        bottomNavController?.navigate(section)
         currentBottomNavSection.getAndUpdate { old ->
             if (old == section) {
                 scope.launch {
                     onDoubleTabSelection.emit(section)
                 }
+            } else {
+                bottomNavController?.navigate(section)
             }
             section
         }

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerContent.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/DrawerContent.kt
@@ -64,6 +64,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.Custom
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.PlaceholderImage
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.SpinnerField
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.BottomNavigationSection
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDrawerCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getMainRouter
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
@@ -124,6 +125,12 @@ fun DrawerContent(modifier: Modifier = Modifier) {
             canSwitchAccount = uiState.availableAccounts.size > 1,
             onOpenChangeInstance = {
                 changeInstanceDialogOpened = true
+            },
+            onOpenProfile = {
+                scope.launch {
+                    drawerCoordinator.toggleDrawer()
+                    navigationCoordinator.setCurrentSection(BottomNavigationSection.Profile)
+                }
             },
             onOpenSwitchAccount = {
                 manageAccountsDialogOpened = true

--- a/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/components/DrawerHeader.kt
+++ b/feature/drawer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/drawer/components/DrawerHeader.kt
@@ -1,5 +1,6 @@
 package com.livefast.eattrash.raccoonforfriendica.feature.drawer.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -38,6 +39,7 @@ internal fun DrawerHeader(
     autoloadImages: Boolean = true,
     onOpenChangeInstance: (() -> Unit)? = null,
     onOpenSwitchAccount: (() -> Unit)? = null,
+    onOpenProfile: (() -> Unit)? = null,
 ) {
     val avatarSize = 52.dp
     val fullColor = MaterialTheme.colorScheme.onBackground
@@ -56,10 +58,13 @@ internal fun DrawerHeader(
         if (user != null) {
             val username = user.displayName ?: user.username ?: ""
             val userAvatar = user.avatar.orEmpty()
+            val baseAvatarModifier = Modifier.clickable {
+                onOpenProfile?.invoke()
+            }
             if (userAvatar.isNotEmpty() && autoloadImages) {
                 CustomImage(
                     modifier =
-                    Modifier
+                    baseAvatarModifier
                         .padding(Spacing.xxxs)
                         .size(avatarSize)
                         .clip(RoundedCornerShape(avatarSize / 2)),
@@ -69,6 +74,7 @@ internal fun DrawerHeader(
                 )
             } else {
                 PlaceholderImage(
+                    modifier = baseAvatarModifier,
                     size = avatarSize,
                     title = username,
                 )


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds the possibility to open the profile section from the navigation drawer, as requested by #950.
