### PR TITLE
fix: instance type detection

### DIFF
--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepository.kt
@@ -34,10 +34,20 @@ internal class DefaultSupportedFeatureRepository(private val nodeInfoRepository:
 }
 
 private val NodeInfoModel?.isFriendica: Boolean
-    get() = this?.software?.lowercase() == "friendica"
+    get() = this?.software?.lowercase() == SoftwareNames.FRIENDICA ||
+        this?.version?.lowercase()?.contains(SoftwareNames.FRIENDICA) == true
 
 private val NodeInfoModel?.isGoToSocial: Boolean
-    get() = this?.software?.lowercase() == "gotosocial"
+    get() = this?.software?.lowercase() == SoftwareNames.GO_TO_SOCIAL
 
 private val NodeInfoModel?.isHomeTown: Boolean
-    get() = this?.software?.lowercase() == "hometown"
+    get() = this?.software?.lowercase() == SoftwareNames.HOMETOWN
+
+/**
+ * Instance type names.
+ */
+private object SoftwareNames {
+    const val FRIENDICA = "friendica"
+    const val GO_TO_SOCIAL = "gotosocial"
+    const val HOMETOWN = "hometown"
+}


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes a bug due to which Friendica instances are not detected and are "treated" as Mastodon instances.
