### PR TITLE
Chore/migrate to clipboard

### DIFF
--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/clipboard/DefaultClipboardHelper.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/clipboard/DefaultClipboardHelper.kt
@@ -1,0 +1,25 @@
+package com.livefast.eattrash.raccoonforfriendica.core.utils.clipboard
+
+import android.content.ClipData
+import android.content.Context
+import androidx.compose.ui.platform.Clipboard
+import androidx.compose.ui.platform.toClipEntry
+
+class DefaultClipboardHelper(
+    private val clipboard: Clipboard,
+    private val context: Context,
+) : ClipboardHelper {
+    override suspend fun setText(text: String) {
+        val newEntry = ClipData.newPlainText("", text).toClipEntry()
+        clipboard.setClipEntry(newEntry)
+    }
+
+    override suspend fun getText(): String? {
+        val data = clipboard.getClipEntry()?.clipData ?: return null
+        val count = data.itemCount
+        check(count > 0) { return null }
+
+        val item = data.getItemAt(count - 1)
+        return item.coerceToText(context).toString()
+    }
+}

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeClipboardModule.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeClipboardModule.kt
@@ -1,0 +1,20 @@
+package com.livefast.eattrash.raccoonforfriendica.core.utils.di
+
+import androidx.compose.ui.platform.Clipboard
+import com.livefast.eattrash.raccoonforfriendica.core.utils.clipboard.ClipboardHelper
+import com.livefast.eattrash.raccoonforfriendica.core.utils.clipboard.DefaultClipboardHelper
+import org.kodein.di.DI
+import org.kodein.di.bind
+import org.kodein.di.factory
+import org.kodein.di.instance
+
+actual val nativeClipboardModule = DI.Module("NativeClipboardModule") {
+    bind<ClipboardHelper> {
+        factory<Any, Clipboard, ClipboardHelper> { clipboard: Clipboard ->
+            DefaultClipboardHelper(
+                clipboard = clipboard,
+                context = instance(),
+            )
+        }
+    }
+}

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/clipboard/ClipboardHelper.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/clipboard/ClipboardHelper.kt
@@ -1,0 +1,7 @@
+package com.livefast.eattrash.raccoonforfriendica.core.utils.clipboard
+
+interface ClipboardHelper {
+    suspend fun setText(text: String)
+
+    suspend fun getText(): String?
+}

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeClipboardModule.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeClipboardModule.kt
@@ -1,0 +1,5 @@
+package com.livefast.eattrash.raccoonforfriendica.core.utils.di
+
+import org.kodein.di.DI
+
+internal expect val nativeClipboardModule: DI.Module

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/Utils.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/Utils.kt
@@ -1,8 +1,10 @@
 package com.livefast.eattrash.raccoonforfriendica.core.utils.di
 
+import androidx.compose.ui.platform.Clipboard
 import com.livefast.eattrash.raccoonforfriendica.core.di.RootDI
 import com.livefast.eattrash.raccoonforfriendica.core.utils.appinfo.AppInfoRepository
 import com.livefast.eattrash.raccoonforfriendica.core.utils.calendar.CalendarHelper
+import com.livefast.eattrash.raccoonforfriendica.core.utils.clipboard.ClipboardHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.debug.CrashReportManager
 import com.livefast.eattrash.raccoonforfriendica.core.utils.gallery.GalleryHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.BlurHashRepository
@@ -48,5 +50,10 @@ fun getCalendarHelper(): CalendarHelper {
 
 fun getNetworkStateObserver(): NetworkStateObserver {
     val res by RootDI.di.instance<NetworkStateObserver>()
+    return res
+}
+
+fun getClipboardHelper(clipboard: Clipboard): ClipboardHelper {
+    val res by RootDI.di.instance<Clipboard, ClipboardHelper>(arg = clipboard)
     return res
 }

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/UtilsModule.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/UtilsModule.kt
@@ -21,6 +21,7 @@ val utilsModule =
             nativeAppIconModule,
             nativeAppInfoModule,
             nativeCalendarModule,
+            nativeClipboardModule,
             nativeDebugModule,
             nativeFileSystemModule,
             nativeGalleryModule,

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/clipboard/DefaultClipboardHelper.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/clipboard/DefaultClipboardHelper.kt
@@ -1,0 +1,19 @@
+package com.livefast.eattrash.raccoonforfriendica.core.utils.clipboard
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.Clipboard
+
+@OptIn(ExperimentalComposeUiApi::class)
+class DefaultClipboardHelper(
+    private val clipboard: Clipboard,
+) : ClipboardHelper {
+
+    override suspend fun setText(text: String) {
+        val newEntry = ClipEntry.withPlainText(text)
+        clipboard.setClipEntry(newEntry)
+    }
+
+    override suspend fun getText(): String? =
+        clipboard.getClipEntry()?.getPlainText()
+}

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeClipboardModule.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeClipboardModule.kt
@@ -1,0 +1,16 @@
+package com.livefast.eattrash.raccoonforfriendica.core.utils.di
+
+import androidx.compose.ui.platform.Clipboard
+import com.livefast.eattrash.raccoonforfriendica.core.utils.clipboard.ClipboardHelper
+import com.livefast.eattrash.raccoonforfriendica.core.utils.clipboard.DefaultClipboardHelper
+import org.kodein.di.DI
+import org.kodein.di.bind
+import org.kodein.di.factory
+
+actual val nativeClipboardModule = DI.Module("NativeClipboardModule") {
+    bind<ClipboardHelper> {
+        factory<Any, Clipboard, ClipboardHelper> { clipboard: Clipboard ->
+            DefaultClipboardHelper(clipboard = clipboard)
+        }
+    }
+}

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineScreen.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineScreen.kt
@@ -36,9 +36,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
@@ -59,6 +58,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getMainRouter
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.getDurationFromDateToNow
+import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getClipboardHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getShareHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.isNearTheEnd
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
@@ -92,7 +92,8 @@ fun CircleTimelineScreen(id: String, modifier: Modifier = Modifier) {
     val shareHelper = remember { getShareHelper() }
     val actionRepository = remember { getEntryActionRepository() }
     val copyToClipboardSuccess = LocalStrings.current.messageTextCopiedToClipboard
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val clipboardHelper = remember { getClipboardHelper(clipboard) }
     var confirmDeleteEntryId by remember { mutableStateOf<String?>(null) }
     var confirmMuteEntry by remember { mutableStateOf<TimelineEntryModel?>(null) }
     var confirmBlockEntry by remember { mutableStateOf<TimelineEntryModel?>(null) }
@@ -118,7 +119,7 @@ fun CircleTimelineScreen(id: String, modifier: Modifier = Modifier) {
                             true
 
                     is CircleTimelineMviModel.Effect.TriggerCopy -> {
-                        clipboardManager.setText(AnnotatedString(event.text))
+                        clipboardHelper.setText(event.text)
                         snackbarHostState.showSnackbar(copyToClipboardSuccess)
                     }
 
@@ -385,8 +386,8 @@ fun CircleTimelineScreen(id: String, modifier: Modifier = Modifier) {
 
                                 OptionId.CopyUrl -> {
                                     val urlString = entry.url.orEmpty()
-                                    clipboardManager.setText(AnnotatedString(urlString))
                                     scope.launch {
+                                        clipboardHelper.setText(urlString)
                                         snackbarHostState.showSnackbar(copyToClipboardSuccess)
                                     }
                                 }

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -53,9 +53,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.TimelineLayout
@@ -80,6 +79,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getMainRouter
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.getDurationFromDateToNow
+import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getClipboardHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getShareHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isOldEntry
@@ -113,7 +113,8 @@ fun EntryDetailScreen(id: String, swipeNavigationEnabled: Boolean, modifier: Mod
     val shareHelper = remember { getShareHelper() }
     val actionRepository = remember { getEntryActionRepository() }
     val copyToClipboardSuccess = LocalStrings.current.messageTextCopiedToClipboard
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val clipboardHelper = remember { getClipboardHelper(clipboard) }
     var confirmDeleteEntryId by remember { mutableStateOf<String?>(null) }
     var confirmMuteEntry by remember { mutableStateOf<TimelineEntryModel?>(null) }
     var confirmBlockEntry by remember { mutableStateOf<TimelineEntryModel?>(null) }
@@ -141,7 +142,7 @@ fun EntryDetailScreen(id: String, swipeNavigationEnabled: Boolean, modifier: Mod
 
                     EntryDetailMviModel.Effect.PollVoteFailure -> pollErrorDialogOpened = true
                     is EntryDetailMviModel.Effect.TriggerCopy -> {
-                        clipboardManager.setText(AnnotatedString(event.text))
+                        clipboardHelper.setText(event.text)
                         snackbarHostState.showSnackbar(copyToClipboardSuccess)
                     }
 
@@ -364,11 +365,9 @@ fun EntryDetailScreen(id: String, swipeNavigationEnabled: Boolean, modifier: Mod
 
                                     OptionId.CopyUrl -> {
                                         val urlString = entry.url.orEmpty()
-                                        clipboardManager.setText(AnnotatedString(urlString))
                                         scope.launch {
-                                            snackbarHostState.showSnackbar(
-                                                copyToClipboardSuccess,
-                                            )
+                                            clipboardHelper.setText(urlString)
+                                            snackbarHostState.showSnackbar(copyToClipboardSuccess)
                                         }
                                     }
 

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
@@ -38,9 +38,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Dimensions
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
@@ -68,6 +67,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDrawerCoo
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getMainRouter
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.getDurationFromDateToNow
+import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getClipboardHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getShareHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.isNearTheEnd
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.ExploreItemModel
@@ -106,7 +106,8 @@ fun ExploreScreen(
     val shareHelper = remember { getShareHelper() }
     val actionRepository = remember { getEntryActionRepository() }
     val copyToClipboardSuccess = LocalStrings.current.messageTextCopiedToClipboard
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val clipboardHelper = remember { getClipboardHelper(clipboard) }
     var confirmUnfollowDialogUserId by remember { mutableStateOf<String?>(null) }
     var confirmDeleteFollowRequestDialogUserId by remember { mutableStateOf<String?>(null) }
     var confirmDeleteEntryId by remember { mutableStateOf<String?>(null) }
@@ -131,7 +132,7 @@ fun ExploreScreen(
                     ExploreMviModel.Effect.BackToTop -> goBackToTop()
                     ExploreMviModel.Effect.PollVoteFailure -> pollErrorDialogOpened = true
                     is ExploreMviModel.Effect.TriggerCopy -> {
-                        clipboardManager.setText(AnnotatedString(event.text))
+                        clipboardHelper.setText(event.text)
                         snackbarHostState.showSnackbar(copyToClipboardSuccess)
                     }
 
@@ -456,11 +457,9 @@ fun ExploreScreen(
 
                                         OptionId.CopyUrl -> {
                                             val urlString = item.entry.url.orEmpty()
-                                            clipboardManager.setText(AnnotatedString(urlString))
                                             scope.launch {
-                                                snackbarHostState.showSnackbar(
-                                                    copyToClipboardSuccess,
-                                                )
+                                                clipboardHelper.setText(urlString)
+                                                snackbarHostState.showSnackbar(copyToClipboardSuccess)
                                             }
                                         }
 

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
@@ -36,9 +36,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
@@ -58,6 +57,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getMainRouter
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.getDurationFromDateToNow
+import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getClipboardHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getShareHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.isNearTheEnd
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
@@ -92,7 +92,8 @@ fun FavoritesScreen(type: Int, modifier: Modifier = Modifier) {
     val shareHelper = remember { getShareHelper() }
     val actionRepository = remember { getEntryActionRepository() }
     val copyToClipboardSuccess = LocalStrings.current.messageTextCopiedToClipboard
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val clipboardHelper = remember { getClipboardHelper(clipboard) }
     var confirmDeleteEntryId by remember { mutableStateOf<String?>(null) }
     var confirmMuteEntry by remember { mutableStateOf<TimelineEntryModel?>(null) }
     var confirmBlockEntry by remember { mutableStateOf<TimelineEntryModel?>(null) }
@@ -117,7 +118,7 @@ fun FavoritesScreen(type: Int, modifier: Modifier = Modifier) {
                     FavoritesMviModel.Effect.BackToTop -> goBackToTop()
                     FavoritesMviModel.Effect.PollVoteFailure -> pollErrorDialogOpened = true
                     is FavoritesMviModel.Effect.TriggerCopy -> {
-                        clipboardManager.setText(AnnotatedString(event.text))
+                        clipboardHelper.setText(event.text)
                         snackbarHostState.showSnackbar(copyToClipboardSuccess)
                     }
 
@@ -370,8 +371,8 @@ fun FavoritesScreen(type: Int, modifier: Modifier = Modifier) {
 
                                 OptionId.CopyUrl -> {
                                     val urlString = entry.url.orEmpty()
-                                    clipboardManager.setText(AnnotatedString(urlString))
                                     scope.launch {
+                                        clipboardHelper.setText(urlString)
                                         snackbarHostState.showSnackbar(copyToClipboardSuccess)
                                     }
                                 }

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
@@ -36,9 +36,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
@@ -59,6 +58,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getMainRouter
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.getDurationFromDateToNow
+import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getClipboardHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getShareHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.isNearTheEnd
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
@@ -90,7 +90,8 @@ fun HashtagScreen(tag: String, modifier: Modifier = Modifier) {
     val shareHelper = remember { getShareHelper() }
     val actionRepository = remember { getEntryActionRepository() }
     val copyToClipboardSuccess = LocalStrings.current.messageTextCopiedToClipboard
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val clipboardHelper = remember { getClipboardHelper(clipboard) }
     var confirmUnfollowHashtagDialogOpen by remember { mutableStateOf(false) }
     var confirmDeleteEntryId by remember { mutableStateOf<String?>(null) }
     var confirmMuteEntry by remember { mutableStateOf<TimelineEntryModel?>(null) }
@@ -115,7 +116,7 @@ fun HashtagScreen(tag: String, modifier: Modifier = Modifier) {
                 when (event) {
                     HashtagMviModel.Effect.PollVoteFailure -> pollErrorDialogOpened = true
                     is HashtagMviModel.Effect.TriggerCopy -> {
-                        clipboardManager.setText(AnnotatedString(event.text))
+                        clipboardHelper.setText(event.text)
                         snackbarHostState.showSnackbar(copyToClipboardSuccess)
                     }
 
@@ -387,8 +388,8 @@ fun HashtagScreen(tag: String, modifier: Modifier = Modifier) {
 
                                 OptionId.CopyUrl -> {
                                     val urlString = entry.url.orEmpty()
-                                    clipboardManager.setText(AnnotatedString(urlString))
                                     scope.launch {
+                                        clipboardHelper.setText(urlString)
                                         snackbarHostState.showSnackbar(copyToClipboardSuccess)
                                     }
                                 }

--- a/feature/imagedetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/imagedetail/ImageDetailScreen.kt
+++ b/feature/imagedetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/imagedetail/ImageDetailScreen.kt
@@ -90,14 +90,10 @@ fun ImageDetailScreen(
             .onEach {
                 when (it) {
                     ImageDetailMviModel.Effect.ShareSuccess ->
-                        snackbarHostState.showSnackbar(
-                            successMessage,
-                        )
+                        snackbarHostState.showSnackbar(successMessage)
 
                     ImageDetailMviModel.Effect.ShareFailure ->
-                        snackbarHostState.showSnackbar(
-                            errorMessage,
-                        )
+                        snackbarHostState.showSnackbar(errorMessage)
                 }
             }.launchIn(this)
     }

--- a/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/legacy/LegacyLoginScreen.kt
+++ b/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/legacy/LegacyLoginScreen.kt
@@ -85,15 +85,11 @@ fun LegacyLoginScreen(modifier: Modifier = Modifier) {
             .onEach { event ->
                 when (event) {
                     is LegacyLoginMviModel.Effect.Failure -> {
-                        snackbarHostState.showSnackbar(
-                            message = event.message ?: genericError,
-                        )
+                        snackbarHostState.showSnackbar(message = event.message ?: genericError)
                     }
 
                     LegacyLoginMviModel.Effect.Success -> {
-                        snackbarHostState.showSnackbar(
-                            message = successMessage,
-                        )
+                        snackbarHostState.showSnackbar(message = successMessage)
                         navigationCoordinator.pop()
                     }
                 }

--- a/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/oauth/LoginScreen.kt
+++ b/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/oauth/LoginScreen.kt
@@ -83,14 +83,10 @@ fun LoginScreen(loginType: Int, modifier: Modifier = Modifier) {
                 when (event) {
                     is LoginMviModel.Effect.OpenUrl -> uriHandler.openUri(event.url)
                     is LoginMviModel.Effect.Failure ->
-                        snackbarHostState.showSnackbar(
-                            message = event.message ?: genericError,
-                        )
+                        snackbarHostState.showSnackbar(message = event.message ?: genericError)
 
                     LoginMviModel.Effect.Success -> {
-                        snackbarHostState.showSnackbar(
-                            message = successMessage,
-                        )
+                        snackbarHostState.showSnackbar(message = successMessage)
                         navigationCoordinator.popUntilRoot()
                     }
 

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
@@ -33,9 +33,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -65,6 +64,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.navigation.BottomNavigatio
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getMainRouter
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.prettifyDate
+import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getClipboardHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getShareHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.isNearTheEnd
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.FieldModel
@@ -96,7 +96,8 @@ fun MyAccountScreen(
     val actionRepository = remember { getEntryActionRepository() }
     val genericError = LocalStrings.current.messageGenericError
     val copyToClipboardSuccess = LocalStrings.current.messageTextCopiedToClipboard
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val clipboardHelper = remember { getClipboardHelper(clipboard) }
     var confirmDeleteEntryId by remember { mutableStateOf<String?>(null) }
     var confirmReblogEntry by remember { mutableStateOf<TimelineEntryModel?>(null) }
     val topAppBarState = LocalProfileTopAppBarStateWrapper.current.topAppBarState
@@ -135,7 +136,7 @@ fun MyAccountScreen(
                         snackbarHostState.showSnackbar(message = genericError)
 
                     is MyAccountMviModel.Effect.TriggerCopy -> {
-                        clipboardManager.setText(AnnotatedString(event.text))
+                        clipboardHelper.setText(event.text)
                         snackbarHostState.showSnackbar(copyToClipboardSuccess)
                     }
 
@@ -466,8 +467,8 @@ fun MyAccountScreen(
 
                             OptionId.CopyUrl -> {
                                 val urlString = entry.url.orEmpty()
-                                clipboardManager.setText(AnnotatedString(urlString))
                                 scope.launch {
+                                    clipboardHelper.setText(urlString)
                                     snackbarHostState.showSnackbar(copyToClipboardSuccess)
                                 }
                             }

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
@@ -39,9 +39,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Dimensions
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
@@ -69,6 +68,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getMainRoute
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.utils.compose.getAnimatedDots
 import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.getDurationFromDateToNow
+import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getClipboardHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getShareHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.isNearTheEnd
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.ExploreItemModel
@@ -104,7 +104,8 @@ fun SearchScreen(modifier: Modifier = Modifier) {
     val actionRepository = remember { getEntryActionRepository() }
     val searchFieldFocusRequester = remember { FocusRequester() }
     val copyToClipboardSuccess = LocalStrings.current.messageTextCopiedToClipboard
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val clipboardHelper = remember { getClipboardHelper(clipboard) }
     var confirmUnfollowDialogUserId by remember { mutableStateOf<String?>(null) }
     var confirmDeleteFollowRequestDialogUserId by remember { mutableStateOf<String?>(null) }
     var confirmDeleteEntryId by remember { mutableStateOf<String?>(null) }
@@ -129,7 +130,7 @@ fun SearchScreen(modifier: Modifier = Modifier) {
                     SearchMviModel.Effect.BackToTop -> goBackToTop()
                     SearchMviModel.Effect.PollVoteFailure -> pollErrorDialogOpened = true
                     is SearchMviModel.Effect.TriggerCopy -> {
-                        clipboardManager.setText(AnnotatedString(event.text))
+                        clipboardHelper.setText(event.text)
                         snackbarHostState.showSnackbar(copyToClipboardSuccess)
                     }
 
@@ -462,8 +463,8 @@ fun SearchScreen(modifier: Modifier = Modifier) {
 
                                         OptionId.CopyUrl -> {
                                             val urlString = item.entry.url.orEmpty()
-                                            clipboardManager.setText(AnnotatedString(urlString))
                                             scope.launch {
+                                                clipboardHelper.setText(urlString)
                                                 snackbarHostState.showSnackbar(copyToClipboardSuccess)
                                             }
                                         }

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/feedback/UserFeedbackScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/feedback/UserFeedbackScreen.kt
@@ -67,9 +67,7 @@ fun UserFeedbackScreen(modifier: Modifier = Modifier) {
             .onEach { event ->
                 when (event) {
                     is UserFeedbackMviModel.Effect.Failure -> {
-                        snackbarHostState.showSnackbar(
-                            message = event.message ?: genericError,
-                        )
+                        snackbarHostState.showSnackbar(message = event.message ?: genericError)
                     }
 
                     UserFeedbackMviModel.Effect.Success -> {

--- a/feature/shortcuts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/shortcuts/timeline/ShortcutTimelineScreen.kt
+++ b/feature/shortcuts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/shortcuts/timeline/ShortcutTimelineScreen.kt
@@ -36,9 +36,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
@@ -58,6 +57,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getMainRouter
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.getDurationFromDateToNow
+import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getClipboardHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getShareHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.isNearTheEnd
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
@@ -90,7 +90,8 @@ fun ShortcutTimelineScreen(node: String, modifier: Modifier = Modifier) {
     val shareHelper = remember { getShareHelper() }
     val actionRepository = remember { getEntryActionRepository() }
     val copyToClipboardSuccess = LocalStrings.current.messageTextCopiedToClipboard
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val clipboardHelper = remember { getClipboardHelper(clipboard) }
     var confirmReblogEntry by remember { mutableStateOf<TimelineEntryModel?>(null) }
     var pollErrorDialogOpened by remember { mutableStateOf(false) }
     var seeDetailsEntry by remember { mutableStateOf<TimelineEntryModel?>(null) }
@@ -116,7 +117,7 @@ fun ShortcutTimelineScreen(node: String, modifier: Modifier = Modifier) {
                         snackbarHostState.showSnackbar(message = genericError)
 
                     is ShortcutTimelineMviModel.Effect.TriggerCopy -> {
-                        clipboardManager.setText(AnnotatedString(event.text))
+                        clipboardHelper.setText(event.text)
                         snackbarHostState.showSnackbar(copyToClipboardSuccess)
                     }
 
@@ -358,8 +359,8 @@ fun ShortcutTimelineScreen(node: String, modifier: Modifier = Modifier) {
 
                                 OptionId.CopyUrl -> {
                                     val urlString = entry.url.orEmpty()
-                                    clipboardManager.setText(AnnotatedString(urlString))
                                     scope.launch {
+                                        clipboardHelper.setText(urlString)
                                         snackbarHostState.showSnackbar(copyToClipboardSuccess)
                                     }
                                 }

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
@@ -53,9 +53,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.TimelineLayout
@@ -80,6 +79,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getMainRouter
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.getDurationFromDateToNow
+import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getClipboardHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getShareHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isOldEntry
@@ -118,7 +118,8 @@ fun ThreadScreen(entryId: String, swipeNavigationEnabled: Boolean, modifier: Mod
     val shareHelper = remember { getShareHelper() }
     val actionRepository = remember { getEntryActionRepository() }
     val copyToClipboardSuccess = LocalStrings.current.messageTextCopiedToClipboard
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val clipboardHelper = remember { getClipboardHelper(clipboard) }
     var confirmDeleteEntryId by remember { mutableStateOf<String?>(null) }
     var confirmMuteEntry by remember { mutableStateOf<TimelineEntryModel?>(null) }
     var confirmBlockEntry by remember { mutableStateOf<TimelineEntryModel?>(null) }
@@ -143,7 +144,7 @@ fun ThreadScreen(entryId: String, swipeNavigationEnabled: Boolean, modifier: Mod
                 when (event) {
                     ThreadMviModel.Effect.PollVoteFailure -> pollErrorDialogOpened = true
                     is ThreadMviModel.Effect.TriggerCopy -> {
-                        clipboardManager.setText(AnnotatedString(event.text))
+                        clipboardHelper.setText(event.text)
                         snackbarHostState.showSnackbar(copyToClipboardSuccess)
                     }
 
@@ -442,11 +443,9 @@ fun ThreadScreen(entryId: String, swipeNavigationEnabled: Boolean, modifier: Mod
 
                                         OptionId.CopyUrl -> {
                                             val urlString = entry.url.orEmpty()
-                                            clipboardManager.setText(AnnotatedString(urlString))
                                             scope.launch {
-                                                snackbarHostState.showSnackbar(
-                                                    copyToClipboardSuccess,
-                                                )
+                                                clipboardHelper.setText(urlString)
+                                                snackbarHostState.showSnackbar(copyToClipboardSuccess)
                                             }
                                         }
 
@@ -641,11 +640,9 @@ fun ThreadScreen(entryId: String, swipeNavigationEnabled: Boolean, modifier: Mod
 
                                     OptionId.CopyUrl -> {
                                         val urlString = entry.url.orEmpty()
-                                        clipboardManager.setText(AnnotatedString(urlString))
                                         scope.launch {
-                                            snackbarHostState.showSnackbar(
-                                                copyToClipboardSuccess,
-                                            )
+                                            clipboardHelper.setText(urlString)
+                                            snackbarHostState.showSnackbar(copyToClipboardSuccess)
                                         }
                                     }
 

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
@@ -47,10 +47,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.sp
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Dimensions
@@ -77,6 +76,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getDrawerCoo
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getMainRouter
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.getDurationFromDateToNow
+import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getClipboardHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getShareHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.isNearTheEnd
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
@@ -119,7 +119,8 @@ fun TimelineScreen(
     val shareHelper = remember { getShareHelper() }
     val actionRepository = remember { getEntryActionRepository() }
     val copyToClipboardSuccess = LocalStrings.current.messageTextCopiedToClipboard
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val clipboardHelper = remember { getClipboardHelper(clipboard) }
     var timelineTypeSelectorOpen by remember { mutableStateOf(false) }
     var confirmDeleteEntryId by remember { mutableStateOf<String?>(null) }
     var confirmMuteEntry by remember { mutableStateOf<TimelineEntryModel?>(null) }
@@ -143,7 +144,7 @@ fun TimelineScreen(
                     TimelineMviModel.Effect.BackToTop -> goBackToTop()
                     TimelineMviModel.Effect.PollVoteFailure -> pollErrorDialogOpened = true
                     is TimelineMviModel.Effect.TriggerCopy -> {
-                        clipboardManager.setText(AnnotatedString(event.text))
+                        clipboardHelper.setText(event.text)
                         snackbarHostState.showSnackbar(copyToClipboardSuccess)
                     }
 
@@ -479,8 +480,8 @@ fun TimelineScreen(
 
                                 OptionId.CopyUrl -> {
                                     val urlString = entry.url.orEmpty()
-                                    clipboardManager.setText(AnnotatedString(urlString))
                                     scope.launch {
+                                        clipboardHelper.setText(urlString)
                                         snackbarHostState.showSnackbar(copyToClipboardSuccess)
                                     }
                                 }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -51,11 +51,10 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpOffset
@@ -94,6 +93,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigatio
 import com.livefast.eattrash.raccoonforfriendica.core.utils.compose.safeImePadding
 import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.getDurationFromDateToNow
 import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.prettifyDate
+import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getClipboardHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getShareHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.isNearTheEnd
 import com.livefast.eattrash.raccoonforfriendica.core.utils.nodeName
@@ -139,7 +139,8 @@ fun UserDetailScreen(id: String, modifier: Modifier = Modifier) {
         },
     )
     val copyToClipboardSuccess = LocalStrings.current.messageTextCopiedToClipboard
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val clipboardHelper = remember { getClipboardHelper(clipboard) }
     val genericError = LocalStrings.current.messageGenericError
     val focusManager = LocalFocusManager.current
     var confirmUnfollowDialogOpen by remember { mutableStateOf(false) }
@@ -178,7 +179,7 @@ fun UserDetailScreen(id: String, modifier: Modifier = Modifier) {
                         snackbarHostState.showSnackbar(genericError)
 
                     is UserDetailMviModel.Effect.TriggerCopy -> {
-                        clipboardManager.setText(AnnotatedString(event.text))
+                        clipboardHelper.setText(event.text)
                         snackbarHostState.showSnackbar(copyToClipboardSuccess)
                     }
 
@@ -732,11 +733,9 @@ fun UserDetailScreen(id: String, modifier: Modifier = Modifier) {
 
                                 OptionId.CopyUrl -> {
                                     val urlString = entry.url.orEmpty()
-                                    clipboardManager.setText(AnnotatedString(urlString))
                                     scope.launch {
-                                        snackbarHostState.showSnackbar(
-                                            copyToClipboardSuccess,
-                                        )
+                                        clipboardHelper.setText(urlString)
+                                        snackbarHostState.showSnackbar(copyToClipboardSuccess)
                                     }
                                 }
 

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
@@ -46,10 +46,9 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpOffset
@@ -74,6 +73,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getMainRouter
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.getDurationFromDateToNow
+import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getClipboardHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getShareHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.ellipsize
 import com.livefast.eattrash.raccoonforfriendica.core.utils.isNearTheEnd
@@ -108,7 +108,8 @@ fun ForumListScreen(id: String, modifier: Modifier = Modifier) {
     val shareHelper = remember { getShareHelper() }
     val actionRepository = remember { getEntryActionRepository() }
     val copyToClipboardSuccess = LocalStrings.current.messageTextCopiedToClipboard
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val clipboardHelper = remember { getClipboardHelper(clipboard) }
     var confirmDeleteEntryId by remember { mutableStateOf<String?>(null) }
     var confirmMuteEntry by remember { mutableStateOf<TimelineEntryModel?>(null) }
     var confirmBlockEntry by remember { mutableStateOf<TimelineEntryModel?>(null) }
@@ -132,7 +133,7 @@ fun ForumListScreen(id: String, modifier: Modifier = Modifier) {
                 when (event) {
                     ForumListMviModel.Effect.PollVoteFailure -> pollErrorDialogOpened = true
                     is ForumListMviModel.Effect.TriggerCopy -> {
-                        clipboardManager.setText(AnnotatedString(event.text))
+                        clipboardHelper.setText(event.text)
                         snackbarHostState.showSnackbar(copyToClipboardSuccess)
                     }
 
@@ -487,8 +488,8 @@ fun ForumListScreen(id: String, modifier: Modifier = Modifier) {
 
                                 OptionId.CopyUrl -> {
                                     val urlString = entry.url.orEmpty()
-                                    clipboardManager.setText(AnnotatedString(urlString))
                                     scope.launch {
+                                        clipboardHelper.setText(urlString)
                                         snackbarHostState.showSnackbar(copyToClipboardSuccess)
                                     }
                                 }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
Compose 1.8.0 deprecated ClipboardManager in favor of Clipboard, which exposes a suspending API (changelog [here](https://developer.android.com/jetpack/androidx/releases/compose-ui#1.8.0)).

With a delay of some month, I finally took the time to complete the migration. This involves using a helper (multiplatform) class, because native APIs are not equal (and in iOS it is still experimental).

## Additional notes
<!-- Anything to declare for code review? -->
This is the counterpart of https://github.com/LiveFastEatTrashRaccoon/RaccoonForLemmy/pull/509
