### PR TITLE
feat: add support for translation using LibreTranslate instances

### DIFF
--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/CustomModalBottomSheet.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/CustomModalBottomSheet.kt
@@ -51,6 +51,7 @@ fun CustomModalBottomSheet(
     items: List<CustomModalBottomSheetItem> = emptyList(),
     onSelect: ((Int?) -> Unit)? = null,
     onLongPress: ((Int) -> Unit)? = null,
+    shouldHideOnSelect: ((Int) -> Boolean) = { true },
 ) {
     val fullColor = MaterialTheme.colorScheme.onBackground
     val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha)
@@ -85,7 +86,9 @@ fun CustomModalBottomSheet(
                                     onClick = {
                                         sheetScope
                                             .launch {
-                                                sheetState.hide()
+                                                if (shouldHideOnSelect(idx)) {
+                                                    sheetState.hide()
+                                                }
                                             }.invokeOnCompletion {
                                                 onSelect?.invoke(idx)
                                             }
@@ -95,7 +98,9 @@ fun CustomModalBottomSheet(
                                         {
                                             sheetScope
                                                 .launch {
-                                                    sheetState.hide()
+                                                    if (shouldHideOnSelect(idx)) {
+                                                        sheetState.hide()
+                                                    }
                                                 }.invokeOnCompletion {
                                                     onLongPress(idx)
                                                 }

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/EditTwoTextualInfosDialog.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/EditTwoTextualInfosDialog.kt
@@ -1,0 +1,154 @@
+package com.livefast.eattrash.raccoonforfriendica.core.commonui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.surfaceColorAtElevation
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EditTwoTextualInfosDialog(
+    modifier: Modifier = Modifier,
+    title: String = LocalStrings.current.actionEdit,
+    label1: String = "",
+    label2: String = "",
+    placeHolder1: String? = null,
+    placeHolder2: String? = null,
+    value1: String = "",
+    value2: String = "",
+    minLines: Int = 1,
+    maxLines: Int = 20,
+    isError1: Boolean = false,
+    keyboardType1: KeyboardType = KeyboardType.Text,
+    keyboardType2: KeyboardType = KeyboardType.Text,
+    isError2: Boolean = false,
+    singleLine: Boolean = false,
+    onClose: ((String?, String?) -> Unit)? = null,
+) {
+    var textFieldValue1 by remember {
+        mutableStateOf(TextFieldValue(text = value1))
+    }
+    var textFieldValue2 by remember {
+        mutableStateOf(TextFieldValue(text = value2))
+    }
+
+    BasicAlertDialog(
+        modifier = modifier.clip(RoundedCornerShape(CornerSize.xxl)),
+        onDismissRequest = {
+            onClose?.invoke(null, null)
+        },
+    ) {
+        Column(
+            modifier =
+            Modifier
+                .background(color = MaterialTheme.colorScheme.surfaceColorAtElevation(5.dp))
+                .padding(Spacing.m),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+            Spacer(modifier = Modifier.height(Spacing.s))
+
+            TextField(
+                modifier = Modifier.fillMaxWidth(),
+                minLines = minLines,
+                maxLines = maxLines,
+                singleLine = singleLine,
+                isError = isError1,
+                colors =
+                TextFieldDefaults.colors(
+                    focusedContainerColor = Color.Transparent,
+                    unfocusedContainerColor = Color.Transparent,
+                    disabledContainerColor = Color.Transparent,
+                ),
+                label = {
+                    Text(
+                        text = label1,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                },
+                textStyle = MaterialTheme.typography.bodyMedium,
+                value = textFieldValue1,
+                placeholder = placeHolder1?.let { { Text(text = it) } },
+                keyboardOptions =
+                KeyboardOptions(
+                    keyboardType = keyboardType1,
+                ),
+                onValueChange = { value ->
+                    textFieldValue1 = value
+                },
+            )
+
+            TextField(
+                modifier = Modifier.fillMaxWidth(),
+                minLines = minLines,
+                maxLines = maxLines,
+                singleLine = singleLine,
+                isError = isError2,
+                colors =
+                TextFieldDefaults.colors(
+                    focusedContainerColor = Color.Transparent,
+                    unfocusedContainerColor = Color.Transparent,
+                    disabledContainerColor = Color.Transparent,
+                ),
+                label = {
+                    Text(
+                        text = label2,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                },
+                textStyle = MaterialTheme.typography.bodyMedium,
+                value = textFieldValue2,
+                placeholder = placeHolder2?.let { { Text(text = it) } },
+                keyboardOptions =
+                KeyboardOptions(
+                    keyboardType = keyboardType2,
+                ),
+                onValueChange = { value ->
+                    textFieldValue2 = value
+                },
+            )
+
+            Spacer(modifier = Modifier.height(Spacing.xs))
+            Button(
+                onClick = {
+                    onClose?.invoke(textFieldValue1.text, textFieldValue2.text)
+                },
+            ) {
+                Text(text = LocalStrings.current.buttonConfirm)
+            }
+        }
+    }
+}

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/Strings.kt
@@ -380,6 +380,7 @@ interface Strings {
     val settingsItemTheme: String @Composable get
     val settingsItemThemeColor: String @Composable get
     val settingsItemThemeColorSubtitle: String @Composable get
+    val settingsItemTranslationProvider: String @Composable get
     val settingsItemTimelineLayout: String @Composable get
     val settingsItemUrlOpeningMode: String @Composable get
     val settingsNotificationModeDisabled: String @Composable get
@@ -435,6 +436,9 @@ interface Strings {
     val timelineLocal: String @Composable get
     val timelineSubscriptions: String @Composable get
     val topicTitle: String @Composable get
+    val translationProviderConfigDialogTitle: String @Composable get
+    val translationProviderConfigFieldApiKey: String @Composable get
+    val translationProviderConfigFieldServerUrl: String @Composable get
     val unpublishedSectionDrafts: String @Composable get
     val unpublishedSectionScheduled: String @Composable get
     val unpublishedTitle: String @Composable get

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/testutils/MockStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/testutils/MockStrings.kt
@@ -138,7 +138,6 @@ class MockStrings : Strings {
         @Composable get() = retrieve("actionReblog")
     override val actionReject: String
         @Composable get() = retrieve("actionReject")
-
     override val actionRemove: String
         @Composable get() = retrieve("actionRemove")
     override val actionRemoveDislike: String
@@ -765,6 +764,8 @@ class MockStrings : Strings {
         @Composable get() = retrieve("settingsItemThemeColor")
     override val settingsItemThemeColorSubtitle: String
         @Composable get() = retrieve("settingsItemThemeColorSubtitle")
+    override val settingsItemTranslationProvider: String
+        @Composable get() = retrieve("settingsItemTranslationProvider")
     override val settingsItemTimelineLayout: String
         @Composable get() = retrieve("settingsItemTimelineLayout")
     override val settingsItemUrlOpeningMode: String
@@ -875,6 +876,12 @@ class MockStrings : Strings {
         @Composable get() = retrieve("timelineSubscriptions")
     override val topicTitle: String
         @Composable get() = retrieve("topicTitle")
+    override val translationProviderConfigDialogTitle: String
+        @Composable get() = retrieve("translationProviderConfigDialogTitle")
+    override val translationProviderConfigFieldApiKey: String
+        @Composable get() = retrieve("translationProviderConfigFieldApiKey")
+    override val translationProviderConfigFieldServerUrl: String
+        @Composable get() = retrieve("translationProviderConfigFieldServerUrl")
     override val unpublishedSectionDrafts: String
         @Composable get() = retrieve("unpublishedSectionDrafts")
     override val unpublishedSectionScheduled: String

--- a/core/translation/build.gradle.kts
+++ b/core/translation/build.gradle.kts
@@ -1,25 +1,27 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
+    id("com.livefast.eattrash.serialization")
     id("com.livefast.eattrash.test")
     id("com.livefast.eattrash.spotless")
-    id("com.livefast.eattrash.serialization")
 }
-
 kotlin {
     sourceSets {
         commonMain {
             dependencies {
                 implementation(libs.kodein)
-                implementation(libs.kotlinx.coroutines)
                 implementation(libs.ktor.client.core)
+                implementation(libs.ktor.contentnegotiation)
+                implementation(libs.ktor.json)
+                implementation(libs.ktor.serialization)
 
-                implementation(projects.core.api)
                 implementation(projects.core.di)
-                implementation(projects.core.translation)
+                implementation(projects.core.preferences)
                 implementation(projects.core.utils)
-
-                implementation(projects.core.persistence)
-                implementation(projects.domain.content.data)
+            }
+        }
+        commonTest {
+            dependencies {
+                implementation(libs.ktor.mock)
             }
         }
     }

--- a/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/DefaultTranslationProviderFactory.kt
+++ b/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/DefaultTranslationProviderFactory.kt
@@ -1,0 +1,13 @@
+package com.livefast.eattrash.raccoonforfriendica.core.translation
+
+import com.livefast.eattrash.raccoonforfriendica.core.translation.libretranslate.LibreTranslateProvider
+
+internal class DefaultTranslationProviderFactory : TranslationProviderFactory {
+    override fun create(config: TranslationProviderConfig): TranslationProvider = when (config.name) {
+        TranslationProviderTypes.LibreTranslate.name -> LibreTranslateProvider(
+            apiKey = config.apiKey,
+            baseUrl = config.url,
+        )
+        else -> throw IllegalArgumentException("Unknown translation provider: ${config.name}")
+    }
+}

--- a/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/TranslationProvider.kt
+++ b/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/TranslationProvider.kt
@@ -1,0 +1,5 @@
+package com.livefast.eattrash.raccoonforfriendica.core.translation
+
+interface TranslationProvider {
+    suspend fun translate(sourceText: String, sourceLang: String, targetLang: String): String
+}

--- a/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/TranslationProviderConfig.kt
+++ b/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/TranslationProviderConfig.kt
@@ -1,0 +1,14 @@
+package com.livefast.eattrash.raccoonforfriendica.core.translation
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+
+@Serializable
+data class TranslationProviderConfig(
+    val name: String,
+    val url: String,
+    val id: String = "",
+    val apiKey: String? = null,
+    @Transient
+    val default: Boolean = false,
+)

--- a/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/TranslationProviderFactory.kt
+++ b/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/TranslationProviderFactory.kt
@@ -1,0 +1,5 @@
+package com.livefast.eattrash.raccoonforfriendica.core.translation
+
+interface TranslationProviderFactory {
+    fun create(config: TranslationProviderConfig): TranslationProvider
+}

--- a/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/TranslationProviderTypes.kt
+++ b/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/TranslationProviderTypes.kt
@@ -1,0 +1,9 @@
+package com.livefast.eattrash.raccoonforfriendica.core.translation
+
+sealed interface TranslationProviderTypes {
+    val name: String
+
+    object LibreTranslate : TranslationProviderTypes {
+        override val name = "LibreTranslate"
+    }
+}

--- a/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/di/TranslationModule.kt
+++ b/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/di/TranslationModule.kt
@@ -1,0 +1,23 @@
+package com.livefast.eattrash.raccoonforfriendica.core.translation.di
+
+import com.livefast.eattrash.raccoonforfriendica.core.translation.DefaultTranslationProviderFactory
+import com.livefast.eattrash.raccoonforfriendica.core.translation.TranslationProviderFactory
+import com.livefast.eattrash.raccoonforfriendica.core.translation.store.DefaultTranslationProviderConfigStore
+import com.livefast.eattrash.raccoonforfriendica.core.translation.store.TranslationProviderConfigStore
+import org.kodein.di.DI
+import org.kodein.di.bind
+import org.kodein.di.instance
+import org.kodein.di.singleton
+
+val translationModule = DI.Module("TranslationModule") {
+    bind<TranslationProviderFactory> {
+        singleton {
+            DefaultTranslationProviderFactory()
+        }
+    }
+    bind<TranslationProviderConfigStore> {
+        singleton {
+            DefaultTranslationProviderConfigStore(keyStore = instance())
+        }
+    }
+}

--- a/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/libretranslate/LibreTranslateProvider.kt
+++ b/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/libretranslate/LibreTranslateProvider.kt
@@ -1,0 +1,65 @@
+package com.livefast.eattrash.raccoonforfriendica.core.translation.libretranslate
+
+import com.livefast.eattrash.raccoonforfriendica.core.translation.TranslationProvider
+import com.livefast.eattrash.raccoonforfriendica.core.translation.libretranslate.dto.TranslationRequestBody
+import com.livefast.eattrash.raccoonforfriendica.core.translation.libretranslate.dto.TranslationResponseBody
+import com.livefast.eattrash.raccoonforfriendica.core.utils.network.provideHttpClientEngine
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+
+class LibreTranslateProvider(
+    private val baseUrl: String,
+    private val apiKey: String? = null,
+    factory: HttpClientEngine = provideHttpClientEngine(),
+) : TranslationProvider {
+
+    private val client = HttpClient(factory) {
+        install(HttpTimeout) {
+            requestTimeoutMillis = 600_000
+            connectTimeoutMillis = 30_000
+            socketTimeoutMillis = 30_000
+        }
+        install(HttpRequestRetry) {
+            retryOnServerErrors(maxRetries = 3)
+            exponentialDelay()
+        }
+        install(ContentNegotiation) {
+            json(
+                Json {
+                    isLenient = true
+                    ignoreUnknownKeys = true
+                },
+            )
+        }
+    }
+
+    override suspend fun translate(sourceText: String, sourceLang: String, targetLang: String): String {
+        val inputData = TranslationRequestBody(
+            text = sourceText,
+            source = sourceLang,
+            target = targetLang,
+            format = DEFAULT_FORMAT,
+            apiKey = apiKey.orEmpty(),
+        )
+        val response = client.post("$baseUrl/translate") {
+            contentType(ContentType.Application.Json)
+            setBody(inputData)
+        }
+        val outputData: TranslationResponseBody = response.body()
+        return outputData.text.orEmpty()
+    }
+
+    companion object {
+        private const val DEFAULT_FORMAT = "text"
+    }
+}

--- a/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/libretranslate/dto/TranslationRequestBody.kt
+++ b/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/libretranslate/dto/TranslationRequestBody.kt
@@ -1,0 +1,13 @@
+package com.livefast.eattrash.raccoonforfriendica.core.translation.libretranslate.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TranslationRequestBody(
+    @SerialName("q") val text: String,
+    @SerialName("source") val source: String,
+    @SerialName("target") val target: String,
+    @SerialName("format") val format: String,
+    @SerialName("api_key")val apiKey: String,
+)

--- a/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/libretranslate/dto/TranslationResponseBody.kt
+++ b/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/libretranslate/dto/TranslationResponseBody.kt
@@ -1,0 +1,7 @@
+package com.livefast.eattrash.raccoonforfriendica.core.translation.libretranslate.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TranslationResponseBody(@SerialName("translatedText") val text: String? = null)

--- a/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/store/DefaultTranslationProviderConfigStore.kt
+++ b/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/store/DefaultTranslationProviderConfigStore.kt
@@ -1,0 +1,91 @@
+package com.livefast.eattrash.raccoonforfriendica.core.translation.store
+
+import com.livefast.eattrash.raccoonforfriendica.core.preferences.store.TemporaryKeyStore
+import com.livefast.eattrash.raccoonforfriendica.core.translation.TranslationProviderConfig
+import com.livefast.eattrash.raccoonforfriendica.core.utils.uuid.getUuid
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.onStart
+import kotlinx.serialization.json.Json
+
+internal class DefaultTranslationProviderConfigStore(private val keyStore: TemporaryKeyStore) :
+    TranslationProviderConfigStore {
+    private val valuesFlow = MutableSharedFlow<List<TranslationProviderConfig>>(replay = 1)
+
+    override suspend fun getAll(): List<TranslationProviderConfig> = getStoredIds()
+        .mapNotNull { id ->
+            getById(id)
+        }
+
+    override suspend fun observe(): Flow<List<TranslationProviderConfig>> = valuesFlow.asSharedFlow().onStart {
+        emitUpdate()
+    }
+
+    override suspend fun getById(id: String): TranslationProviderConfig? {
+        val defaultId = getDefaultId()
+        val key = getKey(id)
+        val rawValue = keyStore.get(key, "{}")
+        return runCatching {
+            JsonSerializer.decodeFromString<TranslationProviderConfig>(rawValue)
+        }.getOrNull()?.let {
+            it.copy(default = it.id == defaultId)
+        }
+    }
+
+    override suspend fun getDefaultId(): String? {
+        val key = getKey(KEY_DEFAULT_ID)
+        return keyStore.get(key, "").takeIf { it.isNotEmpty() }
+    }
+
+    override suspend fun setDefaultId(id: String) {
+        val key = getKey(KEY_DEFAULT_ID)
+        keyStore.save(key, id)
+        emitUpdate()
+    }
+
+    override suspend fun create(config: TranslationProviderConfig): String {
+        val id = generateId()
+        update(id, config.copy(id = id))
+        val storedIds = getStoredIds()
+        keyStore.save(getKey(KEY_INDEX), storedIds + id)
+        emitUpdate()
+        return id
+    }
+
+    override suspend fun update(id: String, config: TranslationProviderConfig) {
+        val key = getKey(id)
+        val rawValue = JsonSerializer.encodeToString(config)
+        keyStore.save(key, rawValue)
+        emitUpdate()
+    }
+
+    override suspend fun delete(id: String) {
+        val key = getKey(id)
+        keyStore.remove(key)
+        val storedIds = getStoredIds()
+        keyStore.save(getKey(KEY_INDEX), storedIds - id)
+        emitUpdate()
+    }
+
+    private fun getKey(key: String): String = "$KEY_PREFIX.$key"
+
+    private fun generateId(): String = getUuid()
+
+    private suspend fun getStoredIds(): List<String> {
+        val indexKey = getKey(KEY_INDEX)
+        return keyStore.get(indexKey, emptyList())
+    }
+
+    private suspend fun emitUpdate() {
+        val values = getAll()
+        valuesFlow.emit(values)
+    }
+
+    companion object {
+        private const val KEY_PREFIX = "translation_provider_config"
+        private const val KEY_INDEX = "index"
+        private const val KEY_DEFAULT_ID = "default_id"
+        private val JsonSerializer = Json { ignoreUnknownKeys = true }
+    }
+}

--- a/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/store/TranslationProviderConfigStore.kt
+++ b/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/store/TranslationProviderConfigStore.kt
@@ -1,0 +1,68 @@
+package com.livefast.eattrash.raccoonforfriendica.core.translation.store
+
+import com.livefast.eattrash.raccoonforfriendica.core.translation.TranslationProviderConfig
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Interface for managing the persistence of translation provider configurations.
+ */
+interface TranslationProviderConfigStore {
+    /**
+     * Retrieves all stored translation provider configurations.
+     *
+     * @return a list of all [TranslationProviderConfig] objects
+     */
+    suspend fun getAll(): List<TranslationProviderConfig>
+
+    /**
+     * Observes changes to the list of translation provider configurations.
+     *
+     * @return a [Flow] emitting a list of all [TranslationProviderConfig] objects
+     */
+    suspend fun observe(): Flow<List<TranslationProviderConfig>>
+
+    /**
+     * Retrieves a specific translation provider configuration by its unique identifier.
+     *
+     * @param id unique identifier of the configuration to retrieve
+     * @return a [TranslationProviderConfig] if found, or null if no configuration exists with the given [id]
+     */
+    suspend fun getById(id: String): TranslationProviderConfig?
+
+    /**
+     * Retrieves the identifier of the translation provider configuration currently set as default.
+     *
+     * @return the unique identifier of the default translation provider, or null if no default is set
+     */
+    suspend fun getDefaultId(): String?
+
+    /**
+     * Sets a specific translation provider configuration as the default one.
+     *
+     * @param id unique identifier of the translation provider to set as default
+     */
+    suspend fun setDefaultId(id: String)
+
+    /**
+     * Persists a new translation provider configuration.
+     *
+     * @param config [TranslationProviderConfig] to create
+     * @return the unique identifier assigned to the newly created configuration
+     */
+    suspend fun create(config: TranslationProviderConfig): String
+
+    /**
+     * Updates an existing translation provider configuration.
+     *
+     * @param id unique identifier of the configuration to update
+     * @param config new [TranslationProviderConfig] data
+     */
+    suspend fun update(id: String, config: TranslationProviderConfig)
+
+    /**
+     * Deletes a translation provider configuration from the store.
+     *
+     * @param id unique identifier of the configuration to delete
+     */
+    suspend fun delete(id: String)
+}

--- a/core/translation/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/DefaultTranslationProviderFactoryTest.kt
+++ b/core/translation/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/DefaultTranslationProviderFactoryTest.kt
@@ -1,0 +1,35 @@
+package com.livefast.eattrash.raccoonforfriendica.core.translation
+
+import com.livefast.eattrash.raccoonforfriendica.core.translation.libretranslate.LibreTranslateProvider
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+class DefaultTranslationProviderFactoryTest {
+    private val sut = DefaultTranslationProviderFactory()
+
+    @Test
+    fun `given LibreTranslate config when create then return LibreTranslateProvider`() {
+        val config = TranslationProviderConfig(
+            name = TranslationProviderTypes.LibreTranslate.name,
+            url = "https://libretranslate.com",
+            apiKey = "fake-api-key",
+        )
+
+        val result = sut.create(config)
+
+        assertIs<LibreTranslateProvider>(result)
+    }
+
+    @Test
+    fun `given unknown config when create then throw IllegalArgumentException`() {
+        val config = TranslationProviderConfig(
+            name = "UnknownProvider",
+            url = "https://example.com",
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            sut.create(config)
+        }
+    }
+}

--- a/core/translation/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/libretranslate/LibreTranslateProviderTest.kt
+++ b/core/translation/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/libretranslate/LibreTranslateProviderTest.kt
@@ -1,0 +1,68 @@
+package com.livefast.eattrash.raccoonforfriendica.core.translation.libretranslate
+
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LibreTranslateProviderTest {
+
+    private val baseUrl = "https://libretranslate.com"
+    private val apiKey = "fake-api-key"
+
+    @Test
+    fun `given success response when translate then return translated text`() = runTest {
+        val sourceText = "Hello"
+        val sourceLang = "en"
+        val targetLang = "it"
+        val expectedTranslation = "Ciao"
+
+        val mockEngine = MockEngine {
+            respond(
+                content = """{"translatedText":"$expectedTranslation"}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+
+        val sut = LibreTranslateProvider(
+            baseUrl = baseUrl,
+            apiKey = apiKey,
+            factory = mockEngine,
+        )
+
+        val result = sut.translate(sourceText, sourceLang, targetLang)
+
+        assertEquals(expectedTranslation, result)
+    }
+
+    @Test
+    fun `given forbidden response when translate then return empty string`() = runTest {
+        val sourceText = "Hello"
+        val sourceLang = "en"
+        val targetLang = "it"
+
+        val mockEngine = MockEngine {
+            respond(
+                content = "{message: \"exceeded quota\"}",
+                status = HttpStatusCode.Forbidden,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+
+        val sut = LibreTranslateProvider(
+            baseUrl = baseUrl,
+            apiKey = apiKey,
+            factory = mockEngine,
+        )
+
+        val result = sut.translate(sourceText, sourceLang, targetLang)
+
+        assertEquals("", result)
+    }
+}

--- a/core/translation/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/store/DefaultTranslationProviderConfigStoreTest.kt
+++ b/core/translation/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/store/DefaultTranslationProviderConfigStoreTest.kt
@@ -1,0 +1,100 @@
+package com.livefast.eattrash.raccoonforfriendica.core.translation.store
+
+import com.livefast.eattrash.raccoonforfriendica.core.preferences.store.TemporaryKeyStore
+import com.livefast.eattrash.raccoonforfriendica.core.translation.TranslationProviderConfig
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class DefaultTranslationProviderConfigStoreTest {
+    private val keyStore = mock<TemporaryKeyStore>(mode = MockMode.autofill)
+    private val sut = DefaultTranslationProviderConfigStore(keyStore = keyStore)
+
+    @Test
+    fun `given no stored ids when getAll then return empty list`() = runTest {
+        everySuspend { keyStore.get(key = any(), default = any<List<String>>(), any()) } returns emptyList()
+
+        val result = sut.getAll()
+
+        assertEquals(emptyList(), result)
+    }
+
+    @Test
+    fun `given stored ids when getAll then return configs`() = runTest {
+        val id = "1"
+        val config = TranslationProviderConfig(id = id, name = "LibreTranslate", url = "http://localhost")
+        val json = """{"id":"$id","name":"LibreTranslate","url":"http://localhost"}"""
+
+        everySuspend {
+            keyStore.get(key = "translation_provider_config.index", default = any<List<String>>(), any())
+        } returns
+            listOf(id)
+        everySuspend { keyStore.get(key = "translation_provider_config.default_id", default = "") } returns ""
+        everySuspend { keyStore.get(key = "translation_provider_config.$id", default = "{}") } returns json
+
+        val result = sut.getAll()
+
+        assertEquals(1, result.size)
+        assertEquals(config, result.first())
+    }
+
+    @Test
+    fun `given existing id when getById then return config`() = runTest {
+        val id = "1"
+        val config = TranslationProviderConfig(id = id, name = "LibreTranslate", url = "http://localhost")
+        val json = """{"id":"$id","name":"LibreTranslate","url":"http://localhost"}"""
+
+        everySuspend { keyStore.get(key = "translation_provider_config.default_id", default = "") } returns ""
+        everySuspend { keyStore.get(key = "translation_provider_config.$id", default = "{}") } returns json
+
+        val result = sut.getById(id)
+
+        assertEquals(config, result)
+    }
+
+    @Test
+    fun `given non existing id when getById then return null`() = runTest {
+        val id = "non-existing"
+        everySuspend { keyStore.get(key = "translation_provider_config.default_id", default = "") } returns ""
+        everySuspend { keyStore.get(key = "translation_provider_config.$id", default = "{}") } returns "{}"
+
+        val result = sut.getById(id)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `when setDefaultId then verify keystore interaction`() = runTest {
+        val id = "1"
+        everySuspend { keyStore.get(key = any(), default = any<List<String>>(), any()) } returns emptyList()
+
+        sut.setDefaultId(id)
+
+        verifySuspend {
+            keyStore.save("translation_provider_config.default_id", id)
+        }
+    }
+
+    @Test
+    fun `when delete then verify keystore interaction`() = runTest {
+        val id = "1"
+        everySuspend {
+            keyStore.get(key = "translation_provider_config.index", default = any<List<String>>(), any())
+        } returns
+            listOf(id)
+
+        sut.delete(id)
+
+        verifySuspend {
+            keyStore.remove("translation_provider_config.$id")
+            keyStore.save("translation_provider_config.index", emptyList<String>(), ", ")
+        }
+    }
+}

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultFallbackTranslationRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultFallbackTranslationRepository.kt
@@ -1,13 +1,17 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 
+import com.livefast.eattrash.raccoonforfriendica.core.translation.TranslationProviderConfig
+import com.livefast.eattrash.raccoonforfriendica.core.translation.TranslationProviderFactory
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TranslatedTimelineEntryModel
 
-internal class DefaultFallbackTranslationRepository : FallbackTranslationRepository {
+internal class DefaultFallbackTranslationRepository(
+    private val translationProviderFactory: TranslationProviderFactory,
+) : FallbackTranslationRepository {
     override suspend fun getTranslation(
         entry: TimelineEntryModel,
         targetLang: String,
-        config: FallbackTranslationProviderConfig?,
+        config: TranslationProviderConfig?,
     ): TranslatedTimelineEntryModel? = runCatching {
         TranslatedTimelineEntryModel(
             source = entry,
@@ -17,16 +21,19 @@ internal class DefaultFallbackTranslationRepository : FallbackTranslationReposit
                 entry.content.translate(
                     sourceLang = entry.lang,
                     targetLang = targetLang,
+                    config = config,
                 ),
                 title =
                 entry.title?.translate(
                     sourceLang = entry.lang,
                     targetLang = targetLang,
+                    config = config,
                 ) ?: entry.title,
                 spoiler =
                 entry.spoiler?.translate(
                     sourceLang = entry.lang,
                     targetLang = targetLang,
+                    config = config,
                 ) ?: entry.spoiler,
                 card =
                 entry.card?.let { card ->
@@ -35,11 +42,13 @@ internal class DefaultFallbackTranslationRepository : FallbackTranslationReposit
                         card.title.translate(
                             sourceLang = entry.lang,
                             targetLang = targetLang,
+                            config = config,
                         ),
                         description =
                         card.description.translate(
                             sourceLang = entry.lang,
                             targetLang = targetLang,
+                            config = config,
                         ),
                     )
                 },
@@ -49,6 +58,7 @@ internal class DefaultFallbackTranslationRepository : FallbackTranslationReposit
                         att.description?.translate(
                             sourceLang = entry.lang,
                             targetLang = targetLang,
+                            config = config,
                         )
                     att.copy(
                         description = translatedDescription ?: att.description,
@@ -64,6 +74,7 @@ internal class DefaultFallbackTranslationRepository : FallbackTranslationReposit
                                 opt.title.translate(
                                     sourceLang = entry.lang,
                                     targetLang = targetLang,
+                                    config = config,
                                 )
                             opt.copy(title = translatedTitle)
                         }.orEmpty(),
@@ -73,7 +84,15 @@ internal class DefaultFallbackTranslationRepository : FallbackTranslationReposit
         )
     }.getOrNull()
 
-    private suspend fun String.translate(sourceLang: String?, targetLang: String): String =
-        // TODO: implement translation
-        this
+    private suspend fun String.translate(
+        sourceLang: String?,
+        targetLang: String,
+        config: TranslationProviderConfig?,
+    ): String {
+        if (sourceLang == null || config == null) {
+            return this
+        }
+        val translationProvider = translationProviderFactory.create(config)
+        return translationProvider.translate(this, sourceLang, targetLang)
+    }
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/FallbackTranslationRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/FallbackTranslationRepository.kt
@@ -1,14 +1,13 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 
+import com.livefast.eattrash.raccoonforfriendica.core.translation.TranslationProviderConfig
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TranslatedTimelineEntryModel
-
-data class FallbackTranslationProviderConfig(val name: String, val url: String, val apiKey: String)
 
 interface FallbackTranslationRepository {
     suspend fun getTranslation(
         entry: TimelineEntryModel,
         targetLang: String,
-        config: FallbackTranslationProviderConfig?,
+        config: TranslationProviderConfig?,
     ): TranslatedTimelineEntryModel?
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
@@ -293,7 +293,9 @@ val contentRepositoryModule =
         }
         bind<FallbackTranslationRepository> {
             singleton {
-                DefaultFallbackTranslationRepository()
+                DefaultFallbackTranslationRepository(
+                    translationProviderFactory = instance(),
+                )
             }
         }
         bind<FollowedHashtagCache> {

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultFallbackTranslationRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultFallbackTranslationRepositoryTest.kt
@@ -1,22 +1,40 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 
+import com.livefast.eattrash.raccoonforfriendica.core.translation.TranslationProvider
+import com.livefast.eattrash.raccoonforfriendica.core.translation.TranslationProviderConfig
+import com.livefast.eattrash.raccoonforfriendica.core.translation.TranslationProviderFactory
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.AttachmentModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.PollModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.PollOptionModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.PreviewCardModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.returnsArgAt
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 class DefaultFallbackTranslationRepositoryTest {
-    private val sut = DefaultFallbackTranslationRepository()
+    private val translationProvider = mock<TranslationProvider> {
+        everySuspend { translate(sourceText = any(), sourceLang = any(), targetLang = any()) } returnsArgAt 0
+    }
+
+    private val translationProviderFactory = mock<TranslationProviderFactory> {
+        every { create(any()) } returns translationProvider
+    }
+
+    private val sut = DefaultFallbackTranslationRepository(translationProviderFactory)
 
     @Test
     fun `given success when getTranslation then result and interactions are as expected`() = runTest {
         val targetLang = "it"
-        val config = FallbackTranslationProviderConfig(name = "DUMMY", url = "", apiKey = "")
+        val config = TranslationProviderConfig(name = "DUMMY", url = "")
         val sourceLang = "en"
         val sourceContent = "source content"
         val entry =
@@ -37,13 +55,21 @@ class DefaultFallbackTranslationRepositoryTest {
         assertEquals(sourceContent, res.target.content)
         assertEquals(sourceLang, res.target.lang)
         assertEquals(config.name, res.provider)
+        verifySuspend {
+            translationProviderFactory.create(config)
+            translationProvider.translate(
+                sourceText = sourceContent,
+                sourceLang = sourceLang,
+                targetLang = targetLang,
+            )
+        }
     }
 
     @Test
     fun `given entry with title card and spoiler when getTranslation then result and interactions are as expected`() =
         runTest {
             val targetLang = "it"
-            val config = FallbackTranslationProviderConfig(name = "DUMMY", url = "", apiKey = "")
+            val config = TranslationProviderConfig(name = "DUMMY", url = "")
             val sourceLang = "en"
             val sourceTitle = "source title"
             val sourceSpoiler = "source spoiler"
@@ -87,12 +113,35 @@ class DefaultFallbackTranslationRepositoryTest {
             )
             assertEquals(sourceLang, res.target.lang)
             assertEquals(config.name, res.provider)
+            verifySuspend {
+                translationProviderFactory.create(config)
+                translationProvider.translate(
+                    sourceText = sourceTitle,
+                    sourceLang = sourceLang,
+                    targetLang = targetLang,
+                )
+                translationProvider.translate(
+                    sourceText = sourceSpoiler,
+                    sourceLang = sourceLang,
+                    targetLang = targetLang,
+                )
+                translationProvider.translate(
+                    sourceText = sourceCardTitle,
+                    sourceLang = sourceLang,
+                    targetLang = targetLang,
+                )
+                translationProvider.translate(
+                    sourceText = sourceCardDescription,
+                    sourceLang = sourceLang,
+                    targetLang = targetLang,
+                )
+            }
         }
 
     @Test
     fun `given entry with poll when getTranslation then result and interactions are as expected`() = runTest {
         val targetLang = "it"
-        val config = FallbackTranslationProviderConfig(name = "DUMMY", url = "", apiKey = "")
+        val config = TranslationProviderConfig(name = "DUMMY", url = "")
         val sourceLang = "en"
         val sourceOption = "source option 1"
         val entry =
@@ -125,12 +174,20 @@ class DefaultFallbackTranslationRepositoryTest {
         )
         assertEquals(sourceLang, res.target.lang)
         assertEquals(config.name, res.provider)
+        verifySuspend {
+            translationProviderFactory.create(config)
+            translationProvider.translate(
+                sourceText = sourceOption,
+                sourceLang = sourceLang,
+                targetLang = targetLang,
+            )
+        }
     }
 
     @Test
     fun `given entry with attachments when getTranslation then result and interactions are as expected`() = runTest {
         val targetLang = "it"
-        val config = FallbackTranslationProviderConfig(name = "DUMMY", url = "", apiKey = "")
+        val config = TranslationProviderConfig(name = "DUMMY", url = "")
         val sourceLang = "en"
         val sourceDescription = "source description"
         val entry =
@@ -165,5 +222,13 @@ class DefaultFallbackTranslationRepositoryTest {
         )
         assertEquals(sourceLang, res.target.lang)
         assertEquals(config.name, res.provider)
+        verifySuspend {
+            translationProviderFactory.create(config)
+            translationProvider.translate(
+                sourceText = sourceDescription,
+                sourceLang = sourceLang,
+                targetLang = targetLang,
+            )
+        }
     }
 }

--- a/domain/content/usecase/build.gradle.kts
+++ b/domain/content/usecase/build.gradle.kts
@@ -14,6 +14,7 @@ kotlin {
                 implementation(libs.ksoup.html)
 
                 implementation(projects.core.htmlparse)
+                implementation(projects.core.translation)
                 implementation(projects.core.utils)
 
                 implementation(projects.domain.content.data)

--- a/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/DefaultGetTranslationUseCase.kt
+++ b/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/DefaultGetTranslationUseCase.kt
@@ -1,8 +1,8 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.usecase
 
+import com.livefast.eattrash.raccoonforfriendica.core.translation.store.TranslationProviderConfigStore
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TranslatedTimelineEntryModel
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.FallbackTranslationProviderConfig
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.FallbackTranslationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SupportedFeatureRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TranslationRepository
@@ -13,6 +13,7 @@ internal class DefaultGetTranslationUseCase(
     private val defaultRepository: TranslationRepository,
     private val fallbackRepository: FallbackTranslationRepository,
     private val stripMarkup: StripMarkupUseCase,
+    private val translationProviderConfigStore: TranslationProviderConfigStore,
 ) : GetTranslationUseCase {
     override suspend fun invoke(entry: TimelineEntryModel, targetLang: String): TranslatedTimelineEntryModel? {
         val nativeTranslationSupported =
@@ -32,32 +33,36 @@ internal class DefaultGetTranslationUseCase(
     private suspend fun getFallbackTranslation(
         entry: TimelineEntryModel,
         targetLang: String,
-    ): TranslatedTimelineEntryModel? = fallbackRepository.getTranslation(
-        entry =
-        entry.copy(
-            title = entry.title?.stripMarkup(),
-            content = entry.content.stripMarkup(),
-            spoiler = entry.spoiler?.stripMarkup(),
-            card =
-            entry.card?.let { card ->
-                card.copy(
-                    title = card.title.stripMarkup(),
-                    description = card.description.stripMarkup(),
-                )
-            },
-            poll =
-            entry.poll?.let { poll ->
-                poll.copy(
-                    options = poll.options.map { opt -> opt.copy(title = opt.title.stripMarkup()) },
-                )
-            },
-            attachments = entry.attachments.map { att ->
-                att.copy(description = att.description?.stripMarkup())
-            },
-        ),
-        targetLang = targetLang,
-        config = FallbackTranslationProviderConfig(name = "DUMMY", url = "", apiKey = ""),
-    )
+    ): TranslatedTimelineEntryModel? {
+        val configId = translationProviderConfigStore.getDefaultId() ?: return null
+        val providerConfig = translationProviderConfigStore.getById(configId) ?: return null
+        return fallbackRepository.getTranslation(
+            config = providerConfig,
+            targetLang = targetLang,
+            entry =
+            entry.copy(
+                title = entry.title?.stripMarkup(),
+                content = entry.content.stripMarkup(),
+                spoiler = entry.spoiler?.stripMarkup(),
+                card =
+                entry.card?.let { card ->
+                    card.copy(
+                        title = card.title.stripMarkup(),
+                        description = card.description.stripMarkup(),
+                    )
+                },
+                poll =
+                entry.poll?.let { poll ->
+                    poll.copy(
+                        options = poll.options.map { opt -> opt.copy(title = opt.title.stripMarkup()) },
+                    )
+                },
+                attachments = entry.attachments.map { att ->
+                    att.copy(description = att.description?.stripMarkup())
+                },
+            ),
+        )
+    }
 
     private fun String.stripMarkup(): String = stripMarkup(
         text = this,

--- a/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/di/ContentUseCaseModule.kt
+++ b/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/di/ContentUseCaseModule.kt
@@ -67,6 +67,7 @@ val contentUseCaseModule =
                     defaultRepository = instance(),
                     fallbackRepository = instance(),
                     stripMarkup = instance(),
+                    translationProviderConfigStore = instance(),
                 )
             }
         }

--- a/domain/content/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/DefaultGetTranslationUseCaseTest.kt
+++ b/domain/content/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/DefaultGetTranslationUseCaseTest.kt
@@ -1,5 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.usecase
 
+import com.livefast.eattrash.raccoonforfriendica.core.translation.TranslationProviderConfig
+import com.livefast.eattrash.raccoonforfriendica.core.translation.store.TranslationProviderConfigStore
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NodeFeatures
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TranslatedTimelineEntryModel
@@ -24,16 +26,19 @@ class DefaultGetTranslationUseCaseTest {
     private val supportedFeatureRepository = mock<SupportedFeatureRepository>()
     private val defaultRepository = mock<TranslationRepository>()
     private val fallbackRepository = mock<FallbackTranslationRepository>()
-    private val stripMarkupUseCase =
-        mock<StripMarkupUseCase> {
-            every { invoke(any(), any()) } returnsArgAt 0
-        }
+    private val stripMarkupUseCase = mock<StripMarkupUseCase> {
+        every { invoke(any(), any()) } returnsArgAt 0
+    }
+
+    private val translationProviderConfigStore = mock<TranslationProviderConfigStore>()
+
     private val sut =
         DefaultGetTranslationUseCase(
             supportedFeatureRepository = supportedFeatureRepository,
             defaultRepository = defaultRepository,
             fallbackRepository = fallbackRepository,
             stripMarkup = stripMarkupUseCase,
+            translationProviderConfigStore = translationProviderConfigStore,
         )
 
     @Test
@@ -75,6 +80,8 @@ class DefaultGetTranslationUseCaseTest {
             }
             verifySuspend(VerifyMode.not) {
                 stripMarkupUseCase(any(), any())
+                translationProviderConfigStore.getDefaultId()
+                translationProviderConfigStore.setDefaultId(any())
                 fallbackRepository.getTranslation(any(), any(), any())
             }
         }
@@ -103,6 +110,10 @@ class DefaultGetTranslationUseCaseTest {
                 supportedFeatureRepository.features
             } returns MutableStateFlow(NodeFeatures(supportsTranslation = true))
             everySuspend { defaultRepository.getTranslation(any(), any()) } returns null
+            val defaultConfigId = "default-config-id"
+            val defaultConfig = TranslationProviderConfig(name = "DUMMY", url = "")
+            everySuspend { translationProviderConfigStore.getDefaultId() } returns defaultConfigId
+            everySuspend { translationProviderConfigStore.getById(defaultConfigId) } returns defaultConfig
             everySuspend {
                 fallbackRepository.getTranslation(any(), any(), any())
             } returns expected
@@ -117,7 +128,9 @@ class DefaultGetTranslationUseCaseTest {
             verifySuspend {
                 stripMarkupUseCase("source text", MarkupMode.HTML)
                 defaultRepository.getTranslation(any(), any())
-                fallbackRepository.getTranslation(entry, targetLang, any())
+                translationProviderConfigStore.getDefaultId()
+                translationProviderConfigStore.getById(defaultConfigId)
+                fallbackRepository.getTranslation(entry, targetLang, defaultConfig)
             }
         }
 
@@ -142,6 +155,10 @@ class DefaultGetTranslationUseCaseTest {
                     target = targetEntry,
                 )
             every { supportedFeatureRepository.features } returns MutableStateFlow(NodeFeatures())
+            val defaultConfigId = "default-config-id"
+            val defaultConfig = TranslationProviderConfig(name = "DUMMY", url = "")
+            everySuspend { translationProviderConfigStore.getDefaultId() } returns defaultConfigId
+            everySuspend { translationProviderConfigStore.getById(defaultConfigId) } returns defaultConfig
             everySuspend {
                 fallbackRepository.getTranslation(any(), any(), any())
             } returns expected
@@ -158,7 +175,9 @@ class DefaultGetTranslationUseCaseTest {
             }
             verifySuspend {
                 stripMarkupUseCase("source text", MarkupMode.HTML)
-                fallbackRepository.getTranslation(entry, targetLang, any())
+                translationProviderConfigStore.getDefaultId()
+                translationProviderConfigStore.getById(defaultConfigId)
+                fallbackRepository.getTranslation(entry, targetLang, defaultConfig)
             }
         }
 }

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineViewModel.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineViewModel.kt
@@ -468,24 +468,19 @@ class CircleTimelineViewModel(
 
         viewModelScope.launch {
             updateEntryInState(entry.id) { entry.copy(translationLoading = true) }
-            val isBeingTranslated = !entry.isShowingTranslation
-
             val (translation, provider) =
                 when {
-                    isBeingTranslated && entry.translation == null -> {
+                    !entry.isShowingTranslation && entry.translation == null -> {
                         val result = getTranslation(entry = entry, targetLang = targetLang)
                         result?.target to result?.provider
                     }
-
-                    isBeingTranslated -> entry.translation to entry.translationProvider
-
-                    else -> entry to entry.translationProvider
+                    else -> entry.translation to entry.translationProvider
                 }
             val newEntry =
                 entry.copy(
-                    isShowingTranslation = isBeingTranslated,
+                    isShowingTranslation = translation != null && !entry.isShowingTranslation,
                     translation = translation,
-                    translationProvider = provider,
+                    translationProvider = provider.takeIf { translation != null },
                     translationLoading = false,
                 )
             updateEntryInState(entry.id) { newEntry }

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailViewModel.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailViewModel.kt
@@ -624,24 +624,19 @@ class EntryDetailViewModel(
 
         viewModelScope.launch {
             updateEntryInState(entry.id) { entry.copy(translationLoading = true) }
-            val isBeingTranslated = !entry.isShowingTranslation
-
             val (translation, provider) =
                 when {
-                    isBeingTranslated && entry.translation == null -> {
+                    !entry.isShowingTranslation && entry.translation == null -> {
                         val result = getTranslation(entry = entry, targetLang = targetLang)
                         result?.target to result?.provider
                     }
-
-                    isBeingTranslated -> entry.translation to entry.translationProvider
-
-                    else -> entry to entry.translationProvider
+                    else -> entry.translation to entry.translationProvider
                 }
             val newEntry =
                 entry.copy(
-                    isShowingTranslation = isBeingTranslated,
+                    isShowingTranslation = translation != null && !entry.isShowingTranslation,
                     translation = translation,
-                    translationProvider = provider,
+                    translationProvider = provider.takeIf { translation != null },
                     translationLoading = false,
                 )
             updateEntryInState(entry.id) { newEntry }

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreViewModel.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreViewModel.kt
@@ -576,24 +576,19 @@ class ExploreViewModel(
 
         viewModelScope.launch {
             updateEntryInState(entry.id) { entry.copy(translationLoading = true) }
-            val isBeingTranslated = !entry.isShowingTranslation
-
             val (translation, provider) =
                 when {
-                    isBeingTranslated && entry.translation == null -> {
+                    !entry.isShowingTranslation && entry.translation == null -> {
                         val result = getTranslation(entry = entry, targetLang = targetLang)
                         result?.target to result?.provider
                     }
-
-                    isBeingTranslated -> entry.translation to entry.translationProvider
-
-                    else -> entry to entry.translationProvider
+                    else -> entry.translation to entry.translationProvider
                 }
             val newEntry =
                 entry.copy(
-                    isShowingTranslation = isBeingTranslated,
+                    isShowingTranslation = translation != null && !entry.isShowingTranslation,
                     translation = translation,
-                    translationProvider = provider,
+                    translationProvider = provider.takeIf { translation != null },
                     translationLoading = false,
                 )
             updateEntryInState(entry.id) { newEntry }

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesViewModel.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesViewModel.kt
@@ -457,22 +457,17 @@ class FavoritesViewModel(
 
         viewModelScope.launch {
             updateEntryInState(entry.id) { entry.copy(translationLoading = true) }
-            val isBeingTranslated = !entry.isShowingTranslation
-
             val (translation, provider) =
                 when {
-                    isBeingTranslated && entry.translation == null -> {
+                    !entry.isShowingTranslation && entry.translation == null -> {
                         val result = getTranslation(entry = entry, targetLang = targetLang)
                         result?.target to result?.provider
                     }
-
-                    isBeingTranslated -> entry.translation to entry.translationProvider
-
-                    else -> entry to entry.translationProvider
+                    else -> entry.translation to entry.translationProvider
                 }
             val newEntry =
                 entry.copy(
-                    isShowingTranslation = isBeingTranslated,
+                    isShowingTranslation = !entry.isShowingTranslation,
                     translation = translation,
                     translationProvider = provider,
                     translationLoading = false,

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagViewModel.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagViewModel.kt
@@ -477,24 +477,19 @@ class HashtagViewModel(
 
         viewModelScope.launch {
             updateEntryInState(entry.id) { entry.copy(translationLoading = true) }
-            val isBeingTranslated = !entry.isShowingTranslation
-
             val (translation, provider) =
                 when {
-                    isBeingTranslated && entry.translation == null -> {
+                    !entry.isShowingTranslation && entry.translation == null -> {
                         val result = getTranslation(entry = entry, targetLang = targetLang)
                         result?.target to result?.provider
                     }
-
-                    isBeingTranslated -> entry.translation to entry.translationProvider
-
-                    else -> entry to entry.translationProvider
+                    else -> entry.translation to entry.translationProvider
                 }
             val newEntry =
                 entry.copy(
-                    isShowingTranslation = isBeingTranslated,
+                    isShowingTranslation = translation != null && !entry.isShowingTranslation,
                     translation = translation,
-                    translationProvider = provider,
+                    translationProvider = provider.takeIf { translation != null },
                     translationLoading = false,
                 )
             updateEntryInState(entry.id) { newEntry }

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchViewModel.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchViewModel.kt
@@ -577,24 +577,19 @@ class SearchViewModel(
 
         viewModelScope.launch {
             updateEntryInState(entry.id) { entry.copy(translationLoading = true) }
-            val isBeingTranslated = !entry.isShowingTranslation
-
             val (translation, provider) =
                 when {
-                    isBeingTranslated && entry.translation == null -> {
+                    !entry.isShowingTranslation && entry.translation == null -> {
                         val result = getTranslation(entry = entry, targetLang = targetLang)
                         result?.target to result?.provider
                     }
-
-                    isBeingTranslated -> entry.translation to entry.translationProvider
-
-                    else -> entry to entry.translationProvider
+                    else -> entry.translation to entry.translationProvider
                 }
             val newEntry =
                 entry.copy(
-                    isShowingTranslation = isBeingTranslated,
+                    isShowingTranslation = translation != null && !entry.isShowingTranslation,
                     translation = translation,
-                    translationProvider = provider,
+                    translationProvider = provider.takeIf { translation != null },
                     translationLoading = false,
                 )
             updateEntryInState(entry.id) { newEntry }

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -17,6 +17,7 @@ kotlin {
                 implementation(projects.core.l10n)
                 implementation(projects.core.navigation)
                 implementation(projects.core.resources)
+                implementation(projects.core.translation)
                 implementation(projects.core.utils)
 
                 implementation(projects.domain.content.data)

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsMviModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsMviModel.kt
@@ -10,6 +10,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.UiFontFami
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.UiFontScale
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.UiTheme
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
+import com.livefast.eattrash.raccoonforfriendica.core.translation.TranslationProviderConfig
 import com.livefast.eattrash.raccoonforfriendica.core.utils.appicon.AppIconVariant
 import com.livefast.eattrash.raccoonforfriendica.core.utils.permissions.PermissionState
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineType
@@ -83,6 +84,10 @@ interface SettingsMviModel : MviModel<SettingsMviModel.Intent, SettingsMviModel.
         data class ChangeReplyDepth(val depth: Int) : Intent
 
         data class ChangeCommentBarTheme(val commentBarTheme: CommentBarTheme) : Intent
+
+        data class SwitchDefaultTranslationProvider(val config: TranslationProviderConfig) : Intent
+        data class AddTranslationProviderConfig(val url: String, val apiKey: String) : Intent
+        data class DeleteTranslationProviderConfig(val config: TranslationProviderConfig) : Intent
     }
 
     data class State(
@@ -131,6 +136,8 @@ interface SettingsMviModel : MviModel<SettingsMviModel.Intent, SettingsMviModel.
         val replyDepth: Int = 1,
         val availableUrlOpeningModes: List<UrlOpeningMode> = emptyList(),
         val commentBarTheme: CommentBarTheme = CommentBarTheme.Rainbow,
+        val defaultTranslationProviderId: List<TranslationProviderConfig> = emptyList(),
+        val translationProviderConfigs: List<TranslationProviderConfig> = emptyList(),
     )
 
     sealed interface Effect {

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
@@ -12,10 +12,12 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
@@ -35,7 +37,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.CommentBarTheme
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.data.TimelineLayout
@@ -55,16 +64,21 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toTypogra
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.di.getViewModel
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomColorPickerDialog
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomDropDown
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomModalBottomSheet
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomModalBottomSheetItem
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.EditTwoTextualInfosDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.MultiColorPreview
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ProgressHud
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.AboutDialog
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.SettingsColorRow
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.SettingsHeader
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.SettingsMultiColorRow
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.SettingsRow
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.SettingsSwitchRow
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toOption
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.Locales
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.toLanguageFlag
@@ -72,6 +86,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.l10n.toLanguageName
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.rememberMainRouter
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.rememberNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.resources.LocalResources
+import com.livefast.eattrash.raccoonforfriendica.core.translation.TranslationProviderConfig
 import com.livefast.eattrash.raccoonforfriendica.core.utils.appicon.AppIconVariant
 import com.livefast.eattrash.raccoonforfriendica.core.utils.appicon.toReadableName
 import com.livefast.eattrash.raccoonforfriendica.core.utils.compose.isWidthSizeClassBelow
@@ -141,6 +156,9 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
     var timelineLayoutBottomSheetOpened by remember { mutableStateOf(false) }
     var replyDepthBottomSheepOpened by remember { mutableStateOf(false) }
     var aboutDialogOpened by remember { mutableStateOf(false) }
+    var manageTranslationProvidersOpened by remember { mutableStateOf(false) }
+    var translationProviderConfigToDelete by remember { mutableStateOf<TranslationProviderConfig?>(null) }
+    var addTranslationProviderConfigDialogOpened by remember { mutableStateOf(false) }
 
     PermissionControllerWrapperBindEffect(controller = controller)
     LaunchedEffect(model) {
@@ -370,6 +388,16 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
                         value = uiState.replyDepth.toString(),
                         onTap = {
                             replyDepthBottomSheepOpened = true
+                        },
+                    )
+                    SettingsRow(
+                        title = LocalStrings.current.settingsItemTranslationProvider,
+                        value = uiState.translationProviderConfigs
+                            .firstOrNull { it.default }?.url
+                            ?.replace("http://", "")
+                            ?.replace("https://", "") ?: LocalStrings.current.shortUnavailable,
+                        onTap = {
+                            manageTranslationProvidersOpened = true
                         },
                     )
 
@@ -1150,6 +1178,151 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
         AboutDialog(
             onClose = {
                 aboutDialogOpened = false
+            },
+        )
+    }
+
+    if (manageTranslationProvidersOpened) {
+        var optionsOffset by remember { mutableStateOf(Offset.Zero) }
+        var optionsMenuOpen by remember { mutableStateOf(false) }
+        val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+        val items = uiState.translationProviderConfigs.map { config ->
+            CustomModalBottomSheetItem(
+                label = config.url,
+                subtitle = config.name,
+                leadingContent = {
+                    RadioButton(
+                        selected = config.default,
+                        onClick = {},
+                    )
+                },
+                trailingContent = {
+                    val options =
+                        buildList {
+                            if (!config.default) {
+                                this += OptionId.Delete.toOption()
+                            }
+                        }
+
+                    Box {
+                        if (options.isNotEmpty()) {
+                            IconButton(
+                                modifier = Modifier.onGloballyPositioned {
+                                    optionsOffset = it.positionInParent()
+                                }.clearAndSetSemantics { },
+                                onClick = {
+                                    optionsMenuOpen = true
+                                },
+                            ) {
+                                Icon(
+                                    imageVector = LocalResources.current.moreVert,
+                                    contentDescription = LocalStrings.current.moreInfo,
+                                )
+                            }
+                        }
+
+                        CustomDropDown(
+                            expanded = optionsMenuOpen,
+                            onDismiss = {
+                                optionsMenuOpen = false
+                            },
+                            offset =
+                            with(LocalDensity.current) {
+                                DpOffset(
+                                    x = optionsOffset.x.toDp(),
+                                    y = optionsOffset.y.toDp(),
+                                )
+                            },
+                        ) {
+                            for (option in options) {
+                                DropdownMenuItem(
+                                    text = {
+                                        Text(option.label)
+                                    },
+                                    onClick = {
+                                        optionsMenuOpen = false
+                                        when (option.id) {
+                                            OptionId.Delete -> {
+                                                translationProviderConfigToDelete = config
+                                            }
+
+                                            else -> Unit
+                                        }
+                                    },
+                                )
+                            }
+                        }
+                    }
+                },
+            )
+        } + CustomModalBottomSheetItem(
+            label = LocalStrings.current.actionAddNew,
+            leadingContent = {
+                IconButton(
+                    onClick = {},
+                ) {
+                    Icon(
+                        imageVector = LocalResources.current.addCircle,
+                        contentDescription = LocalStrings.current.actionAddNew,
+                    )
+                }
+            },
+        )
+        CustomModalBottomSheet(
+            title = LocalStrings.current.settingsItemTranslationProvider,
+            sheetState = sheetState,
+            items = items,
+            shouldHideOnSelect = { index ->
+                // do not hide the bottom sheet when selection the last "add" action
+                index in uiState.translationProviderConfigs.indices
+            },
+            onSelect = { index ->
+                if (index != null) {
+                    val configs = uiState.translationProviderConfigs
+                    if (index in configs.indices) {
+                        manageTranslationProvidersOpened = false
+                        val selectedConfig = configs[index]
+                        model.reduce(SettingsMviModel.Intent.SwitchDefaultTranslationProvider(selectedConfig))
+                    } else {
+                        addTranslationProviderConfigDialogOpened = true
+                    }
+                } else {
+                    manageTranslationProvidersOpened = false
+                }
+            },
+        )
+    }
+
+    if (addTranslationProviderConfigDialogOpened) {
+        EditTwoTextualInfosDialog(
+            title = LocalStrings.current.translationProviderConfigDialogTitle,
+            label1 = LocalStrings.current.translationProviderConfigFieldServerUrl,
+            placeHolder1 = buildString {
+                append(LocalStrings.current.exempliGratia)
+                append(" ")
+                append("https://libretranslate.com")
+            },
+            label2 = LocalStrings.current.translationProviderConfigFieldApiKey,
+            keyboardType1 = KeyboardType.Uri,
+            keyboardType2 = KeyboardType.Text,
+            onClose = { url, key ->
+                addTranslationProviderConfigDialogOpened = false
+                if (url != null && key != null) {
+                    model.reduce(SettingsMviModel.Intent.AddTranslationProviderConfig(url = url, apiKey = key))
+                }
+            },
+        )
+    }
+
+    if (translationProviderConfigToDelete != null) {
+        CustomConfirmDialog(
+            title = LocalStrings.current.actionDelete,
+            onClose = { confirm ->
+                val config = translationProviderConfigToDelete
+                translationProviderConfigToDelete = null
+                if (confirm && config != null) {
+                    model.reduce(SettingsMviModel.Intent.DeleteTranslationProviderConfig(config))
+                }
             },
         )
     }

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsViewModel.kt
@@ -17,6 +17,9 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ColorSche
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModelDelegate
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModelDelegate
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.L10nManager
+import com.livefast.eattrash.raccoonforfriendica.core.translation.TranslationProviderConfig
+import com.livefast.eattrash.raccoonforfriendica.core.translation.TranslationProviderTypes
+import com.livefast.eattrash.raccoonforfriendica.core.translation.store.TranslationProviderConfigStore
 import com.livefast.eattrash.raccoonforfriendica.core.utils.appicon.AppIconManager
 import com.livefast.eattrash.raccoonforfriendica.core.utils.appicon.AppIconVariant
 import com.livefast.eattrash.raccoonforfriendica.core.utils.debug.CrashReportManager
@@ -71,6 +74,7 @@ class SettingsViewModel(
     private val permissionController: PermissionControllerWrapper,
     private val barColorProvider: BarColorProvider,
     private val customTabsHelper: CustomTabsHelper,
+    private val translationProviderConfigStore: TranslationProviderConfigStore,
 ) : ViewModel(),
     MviModelDelegate<SettingsMviModel.Intent, SettingsMviModel.State, SettingsMviModel.Effect>
     by DefaultMviModelDelegate(initialState = SettingsMviModel.State()),
@@ -263,6 +267,10 @@ class SettingsViewModel(
                 .onEach { state ->
                     updateState { it.copy(pushNotificationState = state) }
                 }.launchIn(this)
+
+            translationProviderConfigStore.observe().onEach { configs ->
+                updateState { it.copy(translationProviderConfigs = configs) }
+            }.launchIn(this)
         }
     }
 
@@ -406,6 +414,21 @@ class SettingsViewModel(
                 viewModelScope.launch {
                     changeReplyDepth(intent.depth)
                 }
+
+            is SettingsMviModel.Intent.SwitchDefaultTranslationProvider -> viewModelScope.launch {
+                translationProviderConfigStore.setDefaultId(intent.config.id)
+            }
+            is SettingsMviModel.Intent.AddTranslationProviderConfig -> viewModelScope.launch {
+                val config = TranslationProviderConfig(
+                    name = TranslationProviderTypes.LibreTranslate.name,
+                    url = intent.url,
+                    apiKey = intent.apiKey,
+                )
+                translationProviderConfigStore.create(config)
+            }
+            is SettingsMviModel.Intent.DeleteTranslationProviderConfig -> viewModelScope.launch {
+                translationProviderConfigStore.delete(intent.config.id)
+            }
         }
     }
 

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/di/SettingsModule.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/di/SettingsModule.kt
@@ -33,6 +33,7 @@ val settingsModule =
                 exportSettings = instance(),
                 barColorProvider = instance(),
                 customTabsHelper = instance(),
+                translationProviderConfigStore = instance(),
             )
         }
         bindViewModel {

--- a/feature/shortcuts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/shortcuts/timeline/ShortcutTimelineViewModel.kt
+++ b/feature/shortcuts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/shortcuts/timeline/ShortcutTimelineViewModel.kt
@@ -387,24 +387,19 @@ class ShortcutTimelineViewModel(
 
         viewModelScope.launch {
             updateEntryInState(entry.id) { entry.copy(translationLoading = true) }
-            val isBeingTranslated = !entry.isShowingTranslation
-
             val (translation, provider) =
                 when {
-                    isBeingTranslated && entry.translation == null -> {
+                    !entry.isShowingTranslation && entry.translation == null -> {
                         val result = getTranslation(entry = entry, targetLang = targetLang)
                         result?.target to result?.provider
                     }
-
-                    isBeingTranslated -> entry.translation to entry.translationProvider
-
-                    else -> entry to entry.translationProvider
+                    else -> entry.translation to entry.translationProvider
                 }
             val newEntry =
                 entry.copy(
-                    isShowingTranslation = isBeingTranslated,
+                    isShowingTranslation = translation != null && !entry.isShowingTranslation,
                     translation = translation,
-                    translationProvider = provider,
+                    translationProvider = provider.takeIf { translation != null },
                     translationLoading = false,
                 )
             updateEntryInState(entry.id) { newEntry }

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadViewModel.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadViewModel.kt
@@ -562,24 +562,19 @@ class ThreadViewModel(
 
         viewModelScope.launch {
             updateEntryInState(entry.id) { entry.copy(translationLoading = true) }
-            val isBeingTranslated = !entry.isShowingTranslation
-
             val (translation, provider) =
                 when {
-                    isBeingTranslated && entry.translation == null -> {
+                    !entry.isShowingTranslation && entry.translation == null -> {
                         val result = getTranslation(entry = entry, targetLang = targetLang)
                         result?.target to result?.provider
                     }
-
-                    isBeingTranslated -> entry.translation to entry.translationProvider
-
-                    else -> entry to entry.translationProvider
+                    else -> entry.translation to entry.translationProvider
                 }
             val newEntry =
                 entry.copy(
-                    isShowingTranslation = isBeingTranslated,
+                    isShowingTranslation = translation != null && !entry.isShowingTranslation,
                     translation = translation,
-                    translationProvider = provider,
+                    translationProvider = provider.takeIf { translation != null },
                     translationLoading = false,
                 )
             updateEntryInState(entry.id) { newEntry }

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineViewModel.kt
@@ -586,24 +586,19 @@ class TimelineViewModel(
 
         viewModelScope.launch {
             updateEntryInState(entry.id) { entry.copy(translationLoading = true) }
-            val isBeingTranslated = !entry.isShowingTranslation
-
             val (translation, provider) =
                 when {
-                    isBeingTranslated && entry.translation == null -> {
+                    !entry.isShowingTranslation && entry.translation == null -> {
                         val result = getTranslation(entry = entry, targetLang = targetLang)
                         result?.target to result?.provider
                     }
-
-                    isBeingTranslated -> entry.translation to entry.translationProvider
-
-                    else -> entry to entry.translationProvider
+                    else -> entry.translation to entry.translationProvider
                 }
             val newEntry =
                 entry.copy(
-                    isShowingTranslation = isBeingTranslated,
+                    isShowingTranslation = translation != null && !entry.isShowingTranslation,
                     translation = translation,
-                    translationProvider = provider,
+                    translationProvider = provider.takeIf { translation != null },
                     translationLoading = false,
                 )
             updateEntryInState(entry.id) { newEntry }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailViewModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailViewModel.kt
@@ -642,24 +642,19 @@ class UserDetailViewModel(
 
         viewModelScope.launch {
             updateEntryInState(entry.id) { entry.copy(translationLoading = true) }
-            val isBeingTranslated = !entry.isShowingTranslation
-
             val (translation, provider) =
                 when {
-                    isBeingTranslated && entry.translation == null -> {
+                    !entry.isShowingTranslation && entry.translation == null -> {
                         val result = getTranslation(entry = entry, targetLang = targetLang)
                         result?.target to result?.provider
                     }
-
-                    isBeingTranslated -> entry.translation to entry.translationProvider
-
-                    else -> entry to entry.translationProvider
+                    else -> entry.translation to entry.translationProvider
                 }
             val newEntry =
                 entry.copy(
-                    isShowingTranslation = isBeingTranslated,
+                    isShowingTranslation = translation != null && !entry.isShowingTranslation,
                     translation = translation,
-                    translationProvider = provider,
+                    translationProvider = provider.takeIf { translation != null },
                     translationLoading = false,
                 )
             updateEntryInState(entry.id) { newEntry }

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListViewModel.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListViewModel.kt
@@ -443,24 +443,19 @@ class ForumListViewModel(
 
         viewModelScope.launch {
             updateEntryInState(entry.id) { entry.copy(translationLoading = true) }
-            val isBeingTranslated = !entry.isShowingTranslation
-
             val (translation, provider) =
                 when {
-                    isBeingTranslated && entry.translation == null -> {
+                    !entry.isShowingTranslation && entry.translation == null -> {
                         val result = getTranslation(entry = entry, targetLang = targetLang)
                         result?.target to result?.provider
                     }
-
-                    isBeingTranslated -> entry.translation to entry.translationProvider
-
-                    else -> entry to entry.translationProvider
+                    else -> entry.translation to entry.translationProvider
                 }
             val newEntry =
                 entry.copy(
-                    isShowingTranslation = isBeingTranslated,
+                    isShowingTranslation = translation != null && !entry.isShowingTranslation,
                     translation = translation,
-                    translationProvider = provider,
+                    translationProvider = provider.takeIf { translation != null },
                     translationLoading = false,
                 )
             updateEntryInState(entry.id) { newEntry }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -121,6 +121,7 @@ ktor-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 ktor-contentnegotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-auth = { module = "io.ktor:ktor-client-auth", version.ref = "ktor" }
 ktor-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
+ktor-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -51,6 +51,7 @@ include(":core:persistence")
 include(":core:preferences")
 include(":core:resources")
 include(":core:testutils")
+include(":core:translation")
 include(":core:utils")
 
 include(":domain:content:data")

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -38,6 +38,7 @@ kotlin {
                 implementation(projects.core.persistence)
                 implementation(projects.core.preferences)
                 implementation(projects.core.resources)
+                implementation(projects.core.translation)
                 implementation(projects.core.utils)
 
                 implementation(projects.domain.content.data)

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -358,6 +358,7 @@
     <string name="settings_item_theme">UI theme</string>
     <string name="settings_item_theme_color">Theme color</string>
     <string name="settings_item_theme_color_subtitle">only applied if "Material You" is disabled</string>
+    <string name="settings_item_translation_provider">Translation provider</string>
     <string name="settings_item_timeline_layout">Post layout</string>
     <string name="settings_item_url_opening_mode">URL opening mode</string>
     <string name="settings_notification_mode_disabled">Disabled</string>
@@ -412,6 +413,9 @@
     <string name="timeline_layout_full">Full</string>
     <string name="timeline_subscriptions">Subscriptions</string>
     <string name="topic_title">Topic</string>
+    <string name="translation_provider_config_dialog_title">Add LibreTranslate configuration</string>
+    <string name="translation_provider_config_field_api_key">API key</string>
+    <string name="translation_provider_config_field_server_url">Server URL</string>
     <string name="unpublished_section_drafts">Drafts</string>
     <string name="unpublished_section_scheduled">Scheduled</string>
     <string name="unpublished_title">Unpublished items</string>

--- a/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/DiHelper.kt
+++ b/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/DiHelper.kt
@@ -11,6 +11,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.navigationMo
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.di.notificationsModule
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.di.persistenceModule
 import com.livefast.eattrash.raccoonforfriendica.core.preferences.di.preferencesModule
+import com.livefast.eattrash.raccoonforfriendica.core.translation.di.translationModule
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.utilsModule
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.di.contentPaginationModule
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.di.contentRepositoryModule
@@ -67,6 +68,7 @@ fun initDi(additionalBuilder: DI.Builder.() -> Unit = {}) {
                 notificationsModule,
                 persistenceModule,
                 preferencesModule,
+                translationModule,
                 utilsModule,
             )
 

--- a/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/resources/SharedStrings.kt
+++ b/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/resources/SharedStrings.kt
@@ -396,6 +396,7 @@ import raccoonforfriendica.shared.generated.resources.settings_item_theme
 import raccoonforfriendica.shared.generated.resources.settings_item_theme_color
 import raccoonforfriendica.shared.generated.resources.settings_item_theme_color_subtitle
 import raccoonforfriendica.shared.generated.resources.settings_item_timeline_layout
+import raccoonforfriendica.shared.generated.resources.settings_item_translation_provider
 import raccoonforfriendica.shared.generated.resources.settings_item_url_opening_mode
 import raccoonforfriendica.shared.generated.resources.settings_notification_mode_disabled
 import raccoonforfriendica.shared.generated.resources.settings_notification_mode_pull
@@ -452,6 +453,9 @@ import raccoonforfriendica.shared.generated.resources.timeline_subscriptions
 import raccoonforfriendica.shared.generated.resources.topic_title
 import raccoonforfriendica.shared.generated.resources.translated_from
 import raccoonforfriendica.shared.generated.resources.translated_using
+import raccoonforfriendica.shared.generated.resources.translation_provider_config_dialog_title
+import raccoonforfriendica.shared.generated.resources.translation_provider_config_field_api_key
+import raccoonforfriendica.shared.generated.resources.translation_provider_config_field_server_url
 import raccoonforfriendica.shared.generated.resources.unpublished_section_drafts
 import raccoonforfriendica.shared.generated.resources.unpublished_section_scheduled
 import raccoonforfriendica.shared.generated.resources.unpublished_title
@@ -1230,6 +1234,8 @@ class SharedStrings : Strings {
         @Composable get() = stringResource(Res.string.settings_item_theme_color)
     override val settingsItemThemeColorSubtitle: String
         @Composable get() = stringResource(Res.string.settings_item_theme_color_subtitle)
+    override val settingsItemTranslationProvider: String
+        @Composable get() = stringResource(Res.string.settings_item_translation_provider)
     override val settingsItemTimelineLayout: String
         @Composable get() = stringResource(Res.string.settings_item_timeline_layout)
     override val settingsItemUrlOpeningMode: String
@@ -1340,6 +1346,12 @@ class SharedStrings : Strings {
         @Composable get() = stringResource(Res.string.timeline_subscriptions)
     override val topicTitle: String
         @Composable get() = stringResource(Res.string.topic_title)
+    override val translationProviderConfigDialogTitle: String
+        @Composable get() = stringResource(Res.string.translation_provider_config_dialog_title)
+    override val translationProviderConfigFieldApiKey: String
+        @Composable get() = stringResource(Res.string.translation_provider_config_field_api_key)
+    override val translationProviderConfigFieldServerUrl: String
+        @Composable get() = stringResource(Res.string.translation_provider_config_field_server_url)
     override val unpublishedSectionDrafts: String
         @Composable get() = stringResource(Res.string.unpublished_section_drafts)
     override val unpublishedSectionScheduled: String


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR makes it possible to configure one or more LibreTranslate instances (one of which will be used as the default one) to provide post translation when the current instances does not support it. Each LibreTranslate instance will have to be manually inserted by the user with the URL and the API key.

This restores the ability to translate posts which had been removed in #1174 and offers a pratctical solution to #883.

<details><summary><h4>Related PRs</h4></summary>

- https://github.com/LiveFastEatTrashRaccoon/RaccoonForFriendica/pull/746
- https://github.com/LiveFastEatTrashRaccoon/RaccoonForFriendica/pull/1174
</details>
