### PR TITLE
feat: display quoted posts

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Quote.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Quote.kt
@@ -1,0 +1,11 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Quote(
+    @SerialName("state") val state: String? = null,
+    @SerialName("quoted_status") val quotedStatus: Status? = null,
+    @SerialName("quoted_status_id") val quotedStatusId: String? = null,
+)

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Status.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Status.kt
@@ -25,6 +25,7 @@ data class Status(
     @SerialName("muted") val muted: Boolean = false,
     @SerialName("pinned") val pinned: Boolean = false,
     @SerialName("poll") val poll: Poll? = null,
+    @SerialName("quote") val quote: Quote? = null,
     @SerialName("reblog") val reblog: Status? = null,
     @SerialName("reblogged") val reblogged: Boolean = false,
     @SerialName("reblogs_count") val reblogsCount: Int = 0,

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CardTimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CardTimelineItem.kt
@@ -2,6 +2,8 @@ package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -33,11 +35,13 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomDropDown
 import com.livefast.eattrash.raccoonforfriendica.core.resources.LocalResources
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
@@ -80,9 +84,11 @@ internal fun CardTimelineItem(
     onReblog: ((TimelineEntryModel) -> Unit)? = null,
     onReply: ((TimelineEntryModel) -> Unit)? = null,
     onShowOriginal: (() -> Unit)? = null,
+    onOpenQuote: ((TimelineEntryModel) -> Unit)? = null,
 ) {
     val contentHorizontalPadding = Spacing.s
     val spoiler = entry.spoilerToDisplay.orEmpty()
+    val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha)
 
     Column(
         modifier =
@@ -306,6 +312,23 @@ internal fun CardTimelineItem(
                         onVote = { choices ->
                             onPollVote?.invoke(entry, choices)
                         },
+                    )
+                }
+
+                // quoted entry
+                entry.quoted?.also { entry ->
+                    CompactTimelineItem(
+                        modifier = Modifier
+                            .padding(top = Spacing.xs)
+                            .fillMaxWidth()
+                            .border(
+                                width = Dp.Hairline,
+                                color = ancillaryColor,
+                                shape = RoundedCornerShape(CornerSize.xl),
+                            ).clickable {
+                                onOpenQuote?.invoke(entry)
+                            },
+                        entry = entry,
                     )
                 }
             }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CompactTimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/CompactTimelineItem.kt
@@ -1,6 +1,8 @@
 package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -10,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -29,10 +32,12 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomDropDown
 import com.livefast.eattrash.raccoonforfriendica.core.resources.LocalResources
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
@@ -75,9 +80,11 @@ internal fun CompactTimelineItem(
     onReblog: ((TimelineEntryModel) -> Unit)? = null,
     onReply: ((TimelineEntryModel) -> Unit)? = null,
     onShowOriginal: (() -> Unit)? = null,
+    onOpenQuote: ((TimelineEntryModel) -> Unit)? = null,
 ) {
     val contentHorizontalPadding = Spacing.s
     val spoiler = entry.spoilerToDisplay.orEmpty()
+    val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha)
 
     Column(
         modifier = modifier,
@@ -297,6 +304,23 @@ internal fun CompactTimelineItem(
                         onVote = { choices ->
                             onPollVote?.invoke(entry, choices)
                         },
+                    )
+                }
+
+                // quoted entry
+                entry.quoted?.also { entry ->
+                    CompactTimelineItem(
+                        modifier = Modifier
+                            .padding(top = Spacing.xs)
+                            .fillMaxWidth()
+                            .border(
+                                width = Dp.Hairline,
+                                color = ancillaryColor,
+                                shape = RoundedCornerShape(CornerSize.xl),
+                            ).clickable {
+                                onOpenQuote?.invoke(entry)
+                            },
+                        entry = entry,
                     )
                 }
             }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/DistractionFreeTimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/DistractionFreeTimelineItem.kt
@@ -1,6 +1,8 @@
 package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -10,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -29,9 +32,12 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomDropDown
 import com.livefast.eattrash.raccoonforfriendica.core.resources.LocalResources
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
@@ -71,9 +77,11 @@ internal fun DistractionFreeTimelineItem(
     onReblog: ((TimelineEntryModel) -> Unit)? = null,
     onReply: ((TimelineEntryModel) -> Unit)? = null,
     onShowOriginal: (() -> Unit)? = null,
+    onOpenQuote: ((TimelineEntryModel) -> Unit)? = null,
 ) {
     val contentHorizontalPadding = Spacing.s
     val spoiler = entry.spoilerToDisplay.orEmpty()
+    val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha)
 
     Column(
         modifier = modifier,
@@ -257,6 +265,23 @@ internal fun DistractionFreeTimelineItem(
                         onVote = { choices ->
                             onPollVote?.invoke(entry, choices)
                         },
+                    )
+                }
+
+                // quoted entry
+                entry.quoted?.also { entry ->
+                    CompactTimelineItem(
+                        modifier = Modifier
+                            .padding(top = Spacing.xs)
+                            .fillMaxWidth()
+                            .border(
+                                width = Dp.Hairline,
+                                color = ancillaryColor,
+                                shape = RoundedCornerShape(CornerSize.xl),
+                            ).clickable {
+                                onOpenQuote?.invoke(entry)
+                            },
+                        entry = entry,
                     )
                 }
             }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/FullTimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/FullTimelineItem.kt
@@ -1,6 +1,8 @@
 package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -10,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -29,9 +32,12 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomDropDown
 import com.livefast.eattrash.raccoonforfriendica.core.resources.LocalResources
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
@@ -75,9 +81,11 @@ internal fun FullTimelineItem(
     onReblog: ((TimelineEntryModel) -> Unit)? = null,
     onReply: ((TimelineEntryModel) -> Unit)? = null,
     onShowOriginal: (() -> Unit)? = null,
+    onOpenQuote: ((TimelineEntryModel) -> Unit)? = null,
 ) {
     val contentHorizontalPadding = Spacing.s
     val spoiler = entry.spoilerToDisplay.orEmpty()
+    val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha)
 
     Column(
         modifier = modifier,
@@ -310,6 +318,23 @@ internal fun FullTimelineItem(
                         onOpenImage = { url ->
                             onOpenImage?.invoke(listOf(url), 0, emptyList())
                         },
+                    )
+                }
+
+                // quoted entry
+                entry.quoted?.also { entry ->
+                    CompactTimelineItem(
+                        modifier = Modifier
+                            .padding(top = Spacing.xs)
+                            .fillMaxWidth()
+                            .border(
+                                width = Dp.Hairline,
+                                color = ancillaryColor,
+                                shape = RoundedCornerShape(CornerSize.xl),
+                            ).clickable {
+                                onOpenQuote?.invoke(entry)
+                            },
+                        entry = entry,
                     )
                 }
             }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineItem.kt
@@ -48,6 +48,7 @@ fun TimelineItem(
     onSelectOption: ((OptionId) -> Unit)? = null,
     onPollVote: ((TimelineEntryModel, List<Int>) -> Unit)? = null,
     onShowOriginal: (() -> Unit)? = null,
+    onOpenQuote: ((TimelineEntryModel) -> Unit)? = null,
 ) {
     val isReblog = entry.reblog != null
     val isReply = entry.inReplyTo != null
@@ -284,6 +285,7 @@ fun TimelineItem(
                     onReblog = onReblog,
                     onReply = onReply,
                     onShowOriginal = onShowOriginal,
+                    onOpenQuote = onOpenQuote,
                 )
 
             TimelineLayout.DistractionFree ->
@@ -312,6 +314,7 @@ fun TimelineItem(
                     onReblog = onReblog,
                     onReply = onReply,
                     onShowOriginal = onShowOriginal,
+                    onOpenQuote = onOpenQuote,
                 )
 
             TimelineLayout.Compact ->
@@ -347,6 +350,7 @@ fun TimelineItem(
                     onReblog = onReblog,
                     onReply = onReply,
                     onShowOriginal = onShowOriginal,
+                    onOpenQuote = onOpenQuote,
                 )
 
             TimelineLayout.Card ->
@@ -382,6 +386,7 @@ fun TimelineItem(
                     onReblog = onReblog,
                     onReply = onReply,
                     onShowOriginal = onShowOriginal,
+                    onOpenQuote = onOpenQuote,
                 )
         }
     }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineReplyItem.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TimelineReplyItem.kt
@@ -56,6 +56,7 @@ fun TimelineReplyItem(
     onSelectOption: ((OptionId) -> Unit)? = null,
     onPollVote: ((TimelineEntryModel, List<Int>) -> Unit)? = null,
     onShowOriginal: (() -> Unit)? = null,
+    onOpenQuote: ((TimelineEntryModel) -> Unit)? = null,
 ) {
     val entryToDisplay = entry.original
     val depthZeroBased = (entry.depth - 1).coerceAtLeast(0)
@@ -276,6 +277,7 @@ fun TimelineReplyItem(
                         onReblog = onReblog,
                         onReply = onReply,
                         onShowOriginal = onShowOriginal,
+                        onOpenQuote = onOpenQuote,
                     )
 
                 TimelineLayout.DistractionFree ->
@@ -303,6 +305,7 @@ fun TimelineReplyItem(
                         onReblog = onReblog,
                         onReply = onReply,
                         onShowOriginal = onShowOriginal,
+                        onOpenQuote = onOpenQuote,
                     )
 
                 TimelineLayout.Compact ->
@@ -332,6 +335,7 @@ fun TimelineReplyItem(
                         onReblog = onReblog,
                         onReply = onReply,
                         onShowOriginal = onShowOriginal,
+                        onOpenQuote = onOpenQuote,
                     )
             }
         }

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/QuoteStatus.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/QuoteStatus.kt
@@ -1,0 +1,12 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.data
+
+sealed interface QuoteStatus {
+    data object Pending : QuoteStatus
+    data object Accepted : QuoteStatus
+    data object Rejected : QuoteStatus
+    data object Deleted : QuoteStatus
+    data object BlockedAccount : QuoteStatus
+    data object BlockedDomain : QuoteStatus
+    data object MutedAccount : QuoteStatus
+    data object Unauthorized : QuoteStatus
+}

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/TimelineEntryModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/TimelineEntryModel.kt
@@ -31,6 +31,8 @@ data class TimelineEntryModel(
     val parentId: String? = null,
     val pinned: Boolean = false,
     val poll: PollModel? = null,
+    val quoted: TimelineEntryModel? = null,
+    val quoteStatus: QuoteStatus? = null,
     val reblog: TimelineEntryModel? = null,
     val reblogCount: Int = 0,
     @Transient val reblogLoading: Boolean = false,

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
@@ -27,6 +27,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Poll
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.PollOption
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.PreviewCard
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.PreviewCardType
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Quote
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Relationship
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.ScheduledStatus
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Status
@@ -65,6 +66,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.PollModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.PollOptionModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.PreviewCardModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.PreviewType
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.QuoteStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.ReactionModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.RelationshipModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.ReportCategory
@@ -100,6 +102,7 @@ internal fun Status.toModelWithReply() = toModel().copy(
             },
         )
     },
+    quoted = quote?.toModel(),
 )
 
 internal fun Status.toModel() = TimelineEntryModel(
@@ -145,16 +148,29 @@ internal fun Status.toModel() = TimelineEntryModel(
     url = url,
     visibility =
     visibility.toVisibility().let { visibility ->
-        when {
-            visibility == Visibility.Unlisted && localOnly -> Visibility.LocalUnlisted
-            visibility == Visibility.Public && localOnly -> Visibility.LocalPublic
-
-            else -> {
-                visibility
-            }
+        when (visibility) {
+            Visibility.Unlisted if localOnly -> Visibility.LocalUnlisted
+            Visibility.Public if localOnly -> Visibility.LocalPublic
+            else -> visibility
         }
     },
 )
+
+internal fun Quote.toModel(): TimelineEntryModel? = quotedStatus?.toModel()?.copy(quoteStatus = state?.toQuotedStatus())
+    ?: quotedStatusId?.let { id ->
+        TimelineEntryModel(id = id, content = "", quoteStatus = state?.toQuotedStatus())
+    }
+
+internal fun String.toQuotedStatus(): QuoteStatus = when (this) {
+    "pending" -> QuoteStatus.Pending
+    "accepted" -> QuoteStatus.Accepted
+    "rejected" -> QuoteStatus.Rejected
+    "deleted" -> QuoteStatus.Deleted
+    "blocked_account" -> QuoteStatus.BlockedAccount
+    "blocked_domain" -> QuoteStatus.BlockedDomain
+    "muted_account" -> QuoteStatus.MutedAccount
+    else -> QuoteStatus.Unauthorized
+}
 
 private fun StatusMention.toModel() = UserModel(
     id = id,

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineScreen.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineScreen.kt
@@ -323,6 +323,13 @@ fun CircleTimelineScreen(
                                 CircleTimelineMviModel.Intent.ToggleTranslation(entry.original),
                             )
                         },
+                        onOpenQuote = { e ->
+                            if (customOnSelectCallback != null) {
+                                customOnSelectCallback?.invoke(e)
+                            } else {
+                                mainRouter.openEntryDetail(e)
+                            }
+                        },
                         options =
                         buildList {
                             if (actionRepository.canShare(entry.original)) {

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -621,6 +621,9 @@ fun EntryDetailScreen(
                                                 ),
                                             )
                                         },
+                                        onOpenQuote = { e ->
+                                            mainRouter.openEntryDetail(e)
+                                        },
                                         options = options,
                                         onSelectOption = ::onOptionSelected,
                                     )
@@ -735,6 +738,9 @@ fun EntryDetailScreen(
                                         model.reduce(
                                             EntryDetailMviModel.Intent.ToggleTranslation(entry.original),
                                         )
+                                    },
+                                    onOpenQuote = { e ->
+                                        mainRouter.openEntryDetail(e)
                                     },
                                     options = options,
                                     onSelectOption = ::onOptionSelected,

--- a/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/explore/ExploreScreen.kt
@@ -484,6 +484,13 @@ fun ExploreScreen(
                                         ),
                                     )
                                 },
+                                onOpenQuote = { e ->
+                                    if (customOnSelectCallback != null) {
+                                        customOnSelectCallback?.invoke(e)
+                                    } else {
+                                        mainRouter.openEntryDetail(e)
+                                    }
+                                },
                                 options =
                                 buildList {
                                     val entry = item.entry

--- a/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
+++ b/feature/favorites/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/favorites/FavoritesScreen.kt
@@ -307,6 +307,13 @@ fun FavoritesScreen(
                                 FavoritesMviModel.Intent.ToggleTranslation(entry.original),
                             )
                         },
+                        onOpenQuote = { e ->
+                            if (customOnSelectCallback != null) {
+                                customOnSelectCallback?.invoke(e)
+                            } else {
+                                mainRouter.openEntryDetail(e)
+                            }
+                        },
                         options =
                         buildList {
                             if (actionRepository.canShare(entry.original)) {

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
@@ -330,6 +330,13 @@ fun HashtagScreen(
                                 HashtagMviModel.Intent.ToggleTranslation(entry.original),
                             )
                         },
+                        onOpenQuote = { e ->
+                            if (customOnSelectCallback != null) {
+                                customOnSelectCallback?.invoke(e)
+                            } else {
+                                mainRouter.openEntryDetail(e)
+                            }
+                        },
                         options =
                         buildList {
                             if (actionRepository.canShare(entry.original)) {

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
@@ -395,6 +395,13 @@ fun SearchScreen(modifier: Modifier = Modifier, customOnSelectAction: ((Timeline
                                         ),
                                     )
                                 },
+                                onOpenQuote = { e ->
+                                    if (customOnSelectCallback != null) {
+                                        customOnSelectCallback?.invoke(e)
+                                    } else {
+                                        mainRouter.openEntryDetail(e)
+                                    }
+                                },
                                 options =
                                 buildList {
                                     val entry = item.entry

--- a/feature/shortcuts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/shortcuts/timeline/ShortcutTimelineScreen.kt
+++ b/feature/shortcuts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/shortcuts/timeline/ShortcutTimelineScreen.kt
@@ -316,6 +316,9 @@ fun ShortcutTimelineScreen(node: String, modifier: Modifier = Modifier) {
                                 ShortcutTimelineMviModel.Intent.ToggleTranslation(entry.original),
                             )
                         },
+                        onOpenQuote = { e ->
+                            mainRouter.openEntryDetail(e)
+                        },
                         options =
                         buildList {
                             if (actionRepository.canShare(entry.original)) {

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
@@ -421,6 +421,7 @@ fun ThreadScreen(
                                         ThreadMviModel.Intent.ToggleTranslation(entry.original),
                                     )
                                 },
+
                                 options =
                                 buildList {
                                     if (actionRepository.canShare(entry.original)) {
@@ -591,6 +592,9 @@ fun ThreadScreen(
                                 model.reduce(
                                     ThreadMviModel.Intent.ToggleTranslation(entry.original),
                                 )
+                            },
+                            onOpenQuote = { e ->
+                                mainRouter.openEntryDetail(e)
                             },
                             options =
                             buildList {

--- a/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
+++ b/feature/timeline/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/timeline/TimelineScreen.kt
@@ -434,6 +434,13 @@ fun TimelineScreen(
                                 TimelineMviModel.Intent.ToggleTranslation(entry.original),
                             )
                         },
+                        onOpenQuote = { e ->
+                            if (customOnSelectCallback != null) {
+                                customOnSelectCallback?.invoke(e)
+                            } else {
+                                mainRouter.openEntryDetail(e)
+                            }
+                        },
                         options =
                         buildList {
                             if (actionRepository.canShare(entry.original)) {

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -729,6 +729,13 @@ fun UserDetailScreen(
                                 UserDetailMviModel.Intent.ToggleTranslation(entry.original),
                             )
                         },
+                        onOpenQuote = { e ->
+                            if (customOnSelectCallback != null) {
+                                customOnSelectCallback?.invoke(e)
+                            } else {
+                                mainRouter.openEntryDetail(e)
+                            }
+                        },
                         options =
                         buildList {
                             if (actionRepository.canShare(entry.original) && isHomeInstance) {

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
@@ -452,6 +452,9 @@ fun ForumListScreen(id: String, modifier: Modifier = Modifier, otherInstance: St
                                 ForumListMviModel.Intent.ToggleTranslation(entry.original),
                             )
                         },
+                        onOpenQuote = { e ->
+                            mainRouter.openEntryDetail(e)
+                        },
                         options =
                         buildList {
                             if (actionRepository.canShare(entry.original) && isHomeInstance) {


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR makes it possible to display quoted posts which have been added to Mastodon APIs starting from version 4.4.0.

For now only the basic functionality is implemented, i.e. seeing a quoted post once it has been approved and is visible to others. 

Future PRs will add more features:
- showing the number of quotations for each post (similarly to the number of reblogs and favorites)
- inbox notifications for quotes with the ability to take actions (e.g. accepting/denying them)
- managing quote policies (default in account settings, per-post in composer)
- creating post with quotes according to the policy of the original post.