### PR TITLE
fix: timeline loading on Mastodon

### DIFF
--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultEventPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultEventPaginationManager.kt
@@ -35,9 +35,7 @@ internal class DefaultEventPaginationManager(private val eventRepository: EventR
             results
                 ?.deduplicate()
                 ?.updatePaginationData()
-                ?.also {
-                    history.addAll(it)
-                }
+                ?.also { history.addAll(it) }
             // return a copy
             history.map { it }
         }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
@@ -198,7 +198,7 @@ internal class DefaultTimelinePaginationManager(
                         ?.filterByStopWords()
                         ?.fixupCreatorEmojis()
                         ?.fixupInReplyTo()
-                        ?.fixumFollowedHashtags()
+                        ?.fixupFollowedHashtags()
 
                 is TimelinePaginationSpecification.Hashtag ->
                     results
@@ -250,7 +250,8 @@ internal class DefaultTimelinePaginationManager(
                     results
                         ?.deduplicate()
                         ?.updatePaginationData()
-            }.orEmpty().also { history.addAll(it) }
+            }?.also { history.addAll(it) }
+            // return a copy
             history.map { it }
         }
     }
@@ -316,8 +317,7 @@ internal class DefaultTimelinePaginationManager(
     }
 
     private fun List<TimelineEntryModel>.filterNsfw(included: Boolean): List<TimelineEntryModel> = filter {
-        included ||
-            !it.isNsfw
+        included || !it.isNsfw
     }
 
     private suspend fun List<TimelineEntryModel>.fixupCreatorEmojis(): List<TimelineEntryModel> = with(emojiHelper) {
@@ -347,11 +347,10 @@ internal class DefaultTimelinePaginationManager(
         } ?: true
     }
 
-    private suspend fun List<TimelineEntryModel>.fixumFollowedHashtags(): List<TimelineEntryModel> = this.map { entry ->
-        val tags =
-            entry.tags.map { tag ->
-                tag.copy(following = followedHashtagCache.isFollowed(tag))
-            }
+    private suspend fun List<TimelineEntryModel>.fixupFollowedHashtags(): List<TimelineEntryModel> = map { entry ->
+        val tags = entry.tags.map { tag ->
+            tag.copy(following = followedHashtagCache.isFollowed(tag))
+        }
         entry.copy(tags = tags)
     }
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultFollowedHashtagCache.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultFollowedHashtagCache.kt
@@ -19,7 +19,7 @@ internal class DefaultFollowedHashtagCache(private val tagRepository: TagReposit
                 if (res != null) {
                     cache += res.list
                     cursor = res.cursor
-                    canFetchMore = res.list.isNotEmpty()
+                    canFetchMore = res.list.isNotEmpty() && cursor != null
                 } else {
                     canFetchMore = false
                 }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes a bug which prevented timelines from loading correctly on Mastodon. The root cause was the inability to determine the end of pagination for followed hashtags.

This issue is not in the issue tracker, it was reported in a DM.