### PR TITLE
fix: resolve search queries for common entity URLs

### DIFF
--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultSearchPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultSearchPaginationManager.kt
@@ -111,6 +111,7 @@ internal class DefaultSearchPaginationManager(
                             query = specification.query,
                             pageCursor = pageCursor,
                             type = SearchResultType.Entries,
+                            resolve = guessResolveEntry(specification.query),
                         )
 
                 is SearchPaginationSpecification.Hashtags ->
@@ -127,6 +128,7 @@ internal class DefaultSearchPaginationManager(
                             query = specification.query,
                             pageCursor = pageCursor,
                             type = SearchResultType.Users,
+                            resolve = guessResolveUser(specification.query),
                         )?.determineUserRelationshipStatus()
 
                 is SearchPaginationSpecification.Groups ->
@@ -134,6 +136,7 @@ internal class DefaultSearchPaginationManager(
                         query = specification.query,
                         pageCursor = pageCursor,
                         type = SearchResultType.Users,
+                        resolve = guessResolveUser(specification.query),
                     )
             }
                 ?.deduplicate()
@@ -238,5 +241,22 @@ internal class DefaultSearchPaginationManager(
         } else {
             false
         }
+    }
+
+    private fun guessResolveEntry(query: String): Boolean = MASTODON_POST_REGEX.matches(query.trim()) ||
+        FRIENDICA_POST_REGEX.matches(query.trim())
+
+    private fun guessResolveUser(query: String): Boolean = MASTODON_USER_REGEX.matches(query.trim()) ||
+        FRIENDICA_USER_REGEX.matches(query.trim())
+
+    private companion object {
+        private val MASTODON_POST_REGEX =
+            Regex("^https?://[^/]+/@([\\w.\\-]+)/(\\d+)/?$", RegexOption.IGNORE_CASE)
+        private val MASTODON_USER_REGEX =
+            Regex("^https?://[^/]+/@([\\w.\\-]+)/?$", RegexOption.IGNORE_CASE)
+        private val FRIENDICA_POST_REGEX =
+            Regex("^https?://[^/]+/display/([\\w.\\-]+)/?$", RegexOption.IGNORE_CASE)
+        private val FRIENDICA_USER_REGEX =
+            Regex("^https?://[^/]+/contact/(\\d+)(/.*)?$", RegexOption.IGNORE_CASE)
     }
 }

--- a/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultSearchPaginationManagerTest.kt
+++ b/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultSearchPaginationManagerTest.kt
@@ -277,6 +277,70 @@ class DefaultSearchPaginationManagerTest {
                 stopWordRepository.get(accountId)
             }
         }
+
+    @Test
+    fun `given query is a Mastodon post URL when loadNextPage with Entries specification then resolve is true`() =
+        runTest {
+            val list =
+                listOf(
+                    TimelineEntryModel(id = "1", content = "", creator = UserModel(id = "2")),
+                )
+            everySuspend {
+                searchRepository.search(
+                    query = any(),
+                    type = any(),
+                    pageCursor = any(),
+                    resolve = any(),
+                )
+            } returns list.map { ExploreItemModel.Entry(it) }
+            val query = "https://instance.example/@username/01234567890123456789"
+
+            sut.reset(SearchPaginationSpecification.Entries(query = query, includeNsfw = false))
+            val res = sut.loadNextPage()
+
+            assertEquals(list.map { ExploreItemModel.Entry(it) }, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                searchRepository.search(
+                    query = query,
+                    type = SearchResultType.Entries,
+                    pageCursor = null,
+                    resolve = true,
+                )
+            }
+        }
+
+    @Test
+    fun `given query is a Friendica post URL when loadNextPage with Entries specification then resolve is true`() =
+        runTest {
+            val list =
+                listOf(
+                    TimelineEntryModel(id = "1", content = "", creator = UserModel(id = "2")),
+                )
+            everySuspend {
+                searchRepository.search(
+                    query = any(),
+                    type = any(),
+                    pageCursor = any(),
+                    resolve = any(),
+                )
+            } returns list.map { ExploreItemModel.Entry(it) }
+            val query = "https://instance.example/display/f80d4c95-1cea4d450d7dc6c7-1b4d36da"
+
+            sut.reset(SearchPaginationSpecification.Entries(query = query, includeNsfw = false))
+            val res = sut.loadNextPage()
+
+            assertEquals(list.map { ExploreItemModel.Entry(it) }, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                searchRepository.search(
+                    query = query,
+                    type = SearchResultType.Entries,
+                    pageCursor = null,
+                    resolve = true,
+                )
+            }
+        }
     // endregion
 
     // region Hashtags
@@ -454,6 +518,64 @@ class DefaultSearchPaginationManagerTest {
                     type = SearchResultType.Users,
                     pageCursor = "1",
                     resolve = false,
+                )
+            }
+        }
+
+    @Test
+    fun `given query is a Mastodon profile URL when loadNextPage with Users specification then resolve is true`() =
+        runTest {
+            val list = listOf(UserModel(id = "1"))
+            everySuspend {
+                searchRepository.search(
+                    query = any(),
+                    type = any(),
+                    pageCursor = any(),
+                    resolve = any(),
+                )
+            } returns list.map { ExploreItemModel.User(it) }
+            val query = "https://instance.example/@username"
+
+            sut.reset(SearchPaginationSpecification.Users(query = query))
+            val res = sut.loadNextPage()
+
+            assertEquals(list.map { ExploreItemModel.User(it) }, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                searchRepository.search(
+                    query = query,
+                    type = SearchResultType.Users,
+                    pageCursor = null,
+                    resolve = true,
+                )
+            }
+        }
+
+    @Test
+    fun `given query is a Friendica profile URL when loadNextPage with Users specification then resole is true`() =
+        runTest {
+            val list = listOf(UserModel(id = "1"))
+            everySuspend {
+                searchRepository.search(
+                    query = any(),
+                    type = any(),
+                    pageCursor = any(),
+                    resolve = any(),
+                )
+            } returns list.map { ExploreItemModel.User(it) }
+            val query = "https://instance.example/contact/12345678/conversations"
+
+            sut.reset(SearchPaginationSpecification.Users(query = query))
+            val res = sut.loadNextPage()
+
+            assertEquals(list.map { ExploreItemModel.User(it) }, res)
+            assertTrue(sut.canFetchMore)
+            verifySuspend {
+                searchRepository.search(
+                    query = query,
+                    type = SearchResultType.Users,
+                    pageCursor = null,
+                    resolve = true,
                 )
             }
         }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR solves a well known search issue due to which URLs were not resolved when used as query criteria. On Friendica the `resolve` parameter is not so important when calling the search endpoint, whereas Mastodon instances are more "picky" and do not return any result when the query is an entity URL but the parameter is not true.

Implementation details:
* add heuristic matching to automatically enable `resolve` in search requests for posts and users
* add unit tests to verify search resolution for various URL formats

CC: @informapirata