### PR TITLE
fix: only pre-fill node name in Friendica login if on a known instance

### DIFF
--- a/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/oauth/LoginViewModel.kt
+++ b/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/oauth/LoginViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModelDelegate
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModelDelegate
 import com.livefast.eattrash.raccoonforfriendica.core.utils.validation.ValidationError
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.DefaultFriendicaInstances
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiCredentials
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AuthManager
@@ -37,10 +38,11 @@ class LoginViewModel(
                 }.launchIn(this)
             val currentNode = apiConfigurationRepository.node.value
             val shouldUseDropDown = type == LoginType.Friendica
+            val isCurrentNodeInDropDown = DefaultFriendicaInstances.any { it.value == currentNode }
             updateState {
                 it.copy(
                     useDropDown = shouldUseDropDown,
-                    nodeName = currentNode.takeIf { shouldUseDropDown }.orEmpty(),
+                    nodeName = currentNode.takeIf { shouldUseDropDown && isCurrentNodeInDropDown }.orEmpty(),
                 )
             }
         }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR pre-fills the instance name in the spinner you see in the Friendica login screen only if the current node is one of the known instances. This prevents the current instance you are on (potentially not even Friendica) from being accidentally suggested as a server in the spinner when you choose Friendica over Mastodon.

The change is dumb simple: check whether the current node exists in `DefaultFriendicaInstances` before setting `nodeName` in the view state.