### PR TITLE
fix(navigation): make sure the `canPop` value exposed from `NavigationCoordinator` is consistent

### DIFF
--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/WebViewScreen.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/WebViewScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
@@ -29,6 +31,7 @@ import com.mohamedrejeb.calf.ui.web.rememberWebViewState
 @Composable
 fun WebViewScreen(url: String, modifier: Modifier = Modifier) {
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val drawerCoordinator = rememberDrawerCoordinator()
     val state = rememberWebViewState(url = url)
 
@@ -60,7 +63,7 @@ fun WebViewScreen(url: String, modifier: Modifier = Modifier) {
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
+                    if (canPopState && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationAdapter.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationAdapter.kt
@@ -7,6 +7,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -15,16 +19,23 @@ class DefaultNavigationAdapter(
     private val navController: NavController,
     dispatcher: CoroutineDispatcher = Dispatchers.Main,
 ) : NavigationAdapter {
-    override val canPop: Boolean get() = navController.currentBackStack.value.size > 1
+
+    override val canPop = MutableStateFlow(false)
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
     private var job: Job? = null
+
+    init {
+        navController.currentBackStack
+            .onEach { backStack -> canPop.update { backStack.size > 2 } }
+            .launchIn(scope)
+    }
 
     override fun navigate(destination: Destination, replaceTop: Boolean) {
         if (job?.isActive == true) {
             return
         }
         perform {
-            if (replaceTop && canPop) {
+            if (replaceTop && canPop.value) {
                 navController.popBackStack()
             }
             navController.navigate(destination)
@@ -36,7 +47,7 @@ class DefaultNavigationAdapter(
             return
         }
         perform {
-            if (canPop) {
+            if (canPop.value) {
                 navController.popBackStack()
             }
         }

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationCoordinator.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationCoordinator.kt
@@ -4,11 +4,14 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.getAndUpdate
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.time.Duration
@@ -26,6 +29,7 @@ internal class DefaultNavigationCoordinator(dispatcher: CoroutineDispatcher = Di
     private var bottomNavController: BottomNavigationAdapter? = null
     private var bottomBarScrollConnection: NestedScrollConnection? = null
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + dispatcher)
+    private var updateCanPopJob: Job? = null
 
     override fun setBottomNavigator(adapter: BottomNavigationAdapter) {
         bottomNavController = adapter
@@ -46,12 +50,14 @@ internal class DefaultNavigationCoordinator(dispatcher: CoroutineDispatcher = Di
 
     override fun setRootNavigator(adapter: NavigationAdapter) {
         rootNavController = adapter
-        refreshCanPop()
+        updateCanPopJob?.cancel()
+        updateCanPopJob = adapter.canPop.onEach { newValue ->
+            canPop.update { newValue }
+        }.launchIn(scope)
     }
 
     override fun popUntilRoot() {
         rootNavController?.popUntilRoot()
-        refreshCanPop()
     }
 
     override fun setExitMessageVisible(value: Boolean) {
@@ -66,7 +72,6 @@ internal class DefaultNavigationCoordinator(dispatcher: CoroutineDispatcher = Di
 
     override fun push(destination: Destination) {
         rootNavController?.navigate(destination)
-        refreshCanPop()
     }
 
     override fun replace(destination: Destination) {
@@ -75,7 +80,6 @@ internal class DefaultNavigationCoordinator(dispatcher: CoroutineDispatcher = Di
 
     override fun pop() {
         rootNavController?.pop()
-        refreshCanPop()
     }
 
     override suspend fun submitDeeplink(url: String) {
@@ -87,12 +91,6 @@ internal class DefaultNavigationCoordinator(dispatcher: CoroutineDispatcher = Di
         scope.launch {
             delay(delay)
             globalMessage.emit(message)
-        }
-    }
-
-    private fun refreshCanPop() {
-        canPop.update {
-            rootNavController?.canPop ?: false
         }
     }
 }

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/NavigationAdapter.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/NavigationAdapter.kt
@@ -1,7 +1,9 @@
 package com.livefast.eattrash.raccoonforfriendica.core.navigation
 
+import kotlinx.coroutines.flow.StateFlow
+
 interface NavigationAdapter {
-    val canPop: Boolean
+    val canPop: StateFlow<Boolean>
 
     fun navigate(destination: Destination, replaceTop: Boolean = false)
 

--- a/core/navigation/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationCoordinatorTest.kt
+++ b/core/navigation/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationCoordinatorTest.kt
@@ -10,6 +10,7 @@ import dev.mokkery.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
@@ -79,7 +80,7 @@ class DefaultNavigationCoordinatorTest {
         assertFalse(initial)
         val navigator =
             mock<NavigationAdapter>(MockMode.autoUnit) {
-                every { canPop } returns true
+                every { canPop } returns MutableStateFlow(true)
             }
 
         sut.setRootNavigator(navigator)
@@ -117,7 +118,7 @@ class DefaultNavigationCoordinatorTest {
         val destination = Destination.Settings
         val navigator =
             mock<NavigationAdapter>(MockMode.autoUnit) {
-                every { canPop } returns true
+                every { canPop } returns MutableStateFlow(true)
             }
         sut.setRootNavigator(navigator)
 
@@ -138,7 +139,7 @@ class DefaultNavigationCoordinatorTest {
         val destination = Destination.Settings
         val navigator =
             mock<NavigationAdapter>(MockMode.autoUnit) {
-                every { canPop } returns true
+                every { canPop } returns MutableStateFlow(true)
             }
         sut.setRootNavigator(navigator)
 
@@ -158,7 +159,7 @@ class DefaultNavigationCoordinatorTest {
     fun `when pop then interactions are as expected`() = runTest {
         val navigator =
             mock<NavigationAdapter>(MockMode.autoUnit) {
-                every { canPop } returns false
+                every { canPop } returns MutableStateFlow(false)
             }
         sut.setRootNavigator(navigator)
 
@@ -178,7 +179,7 @@ class DefaultNavigationCoordinatorTest {
     fun `when popUntilRoot then interactions are as expected`() = runTest {
         val navigator =
             mock<NavigationAdapter>(MockMode.autoUnit) {
-                every { canPop } returns false
+                every { canPop } returns MutableStateFlow(false)
             }
         sut.setRootNavigator(navigator)
 

--- a/feature/acknowledgements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feat/acknowledgements/main/AcknowledgementsScreen.kt
+++ b/feature/acknowledgements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feat/acknowledgements/main/AcknowledgementsScreen.kt
@@ -44,6 +44,7 @@ fun AcknowledgementsScreen(modifier: Modifier = Modifier) {
     val model: AcknowledgementsMviModel = getViewModel<AcknowledgementsViewModel>()
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val uriHandler = LocalUriHandler.current
@@ -63,7 +64,7 @@ fun AcknowledgementsScreen(modifier: Modifier = Modifier) {
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
+                    if (canPopState && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/announcements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/announcements/AnnouncementsScreen.kt
+++ b/feature/announcements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/announcements/AnnouncementsScreen.kt
@@ -59,6 +59,7 @@ fun AnnouncementsScreen(modifier: Modifier = Modifier) {
     val model: AnnouncementsMviModel = getViewModel<AnnouncementsViewModel>()
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val connection = navigationCoordinator.getBottomBarScrollConnection()
@@ -100,7 +101,7 @@ fun AnnouncementsScreen(modifier: Modifier = Modifier) {
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
+                    if (canPopState && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/detail/EventDetailScreen.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/detail/EventDetailScreen.kt
@@ -54,6 +54,7 @@ fun EventDetailScreen(eventId: String, modifier: Modifier = Modifier) {
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val uriHandler = LocalUriHandler.current
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val lazyListState = rememberLazyListState()
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -85,7 +86,7 @@ fun EventDetailScreen(eventId: String, modifier: Modifier = Modifier) {
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/list/CalendarScreen.kt
+++ b/feature/calendar/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/calendar/list/CalendarScreen.kt
@@ -65,6 +65,7 @@ fun CalendarScreen(model: CalendarMviModel, modifier: Modifier = Modifier) {
     val uriHandler = LocalUriHandler.current
     val mainRouter = rememberMainRouter()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val lazyListState = rememberLazyListState()
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -95,7 +96,7 @@ fun CalendarScreen(model: CalendarMviModel, modifier: Modifier = Modifier) {
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
+                    if (canPopState && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/editmembers/CircleMembersScreen.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/editmembers/CircleMembersScreen.kt
@@ -74,6 +74,7 @@ fun CircleMembersScreen(id: String, modifier: Modifier = Modifier, customBackAct
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val lazyListState = rememberLazyListState()
     val fabNestedScrollConnection = rememberFabNestedScrollConnection()
     val isFabVisible by fabNestedScrollConnection.isFabVisible.collectAsState()
@@ -119,7 +120,7 @@ fun CircleMembersScreen(id: String, modifier: Modifier = Modifier, customBackAct
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 if (customBackCallback != null) {

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/list/CirclesScreen.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/list/CirclesScreen.kt
@@ -77,6 +77,7 @@ fun CirclesScreen(
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val lazyListState = rememberLazyListState()
     val fabNestedScrollConnection = rememberFabNestedScrollConnection()
     val isFabVisible by fabNestedScrollConnection.isFabVisible.collectAsState()
@@ -129,7 +130,7 @@ fun CirclesScreen(
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
+                    if (canPopState && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/manage/ManageUserCirclesScreen.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/manage/ManageUserCirclesScreen.kt
@@ -58,6 +58,7 @@ fun ManageUserCirclesScreen(userId: String, modifier: Modifier = Modifier) {
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val lazyListState = rememberLazyListState()
     val scope = rememberCoroutineScope()
     var confirmAddItemId by remember { mutableStateOf<String?>(null) }
@@ -101,7 +102,7 @@ fun ManageUserCirclesScreen(userId: String, modifier: Modifier = Modifier) {
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineScreen.kt
+++ b/feature/circles/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/circles/timeline/CircleTimelineScreen.kt
@@ -86,6 +86,7 @@ fun CircleTimelineScreen(
         getViewModel<CircleTimelineViewModel>(arg = CircleTimelineViewModelArgs(id))
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val connection = navigationCoordinator.getBottomBarScrollConnection()
@@ -168,7 +169,7 @@ fun CircleTimelineScreen(
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
@@ -124,6 +124,7 @@ fun ComposerScreen(
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val snackbarHostState = remember { SnackbarHostState() }
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val galleryHelper = rememberGalleryHelper()
     val attachmentCache = remember { getAttachmentCache() }
     val focusManager = LocalFocusManager.current
@@ -285,7 +286,7 @@ fun ComposerScreen(
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 if (uiState.hasUnsavedChanges) {

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationScreen.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationScreen.kt
@@ -81,6 +81,7 @@ fun ConversationScreen(otherUserId: String, parentUri: String, modifier: Modifie
         )
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val snackbarHostState = remember { SnackbarHostState() }
@@ -160,7 +161,7 @@ fun ConversationScreen(otherUserId: String, parentUri: String, modifier: Modifie
                     }
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/list/ConversationListScreen.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/list/ConversationListScreen.kt
@@ -64,6 +64,7 @@ import kotlinx.coroutines.launch
 fun ConversationListScreen(model: ConversationListMviModel, modifier: Modifier = Modifier) {
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val mainRouter = rememberMainRouter()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
@@ -107,7 +108,7 @@ fun ConversationListScreen(model: ConversationListMviModel, modifier: Modifier =
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
+                    if (canPopState && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -114,6 +114,7 @@ fun EntryDetailScreen(
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val uriHandler = LocalUriHandler.current
     val mainRouter = rememberMainRouter()
     val fabNestedScrollConnection = rememberFabNestedScrollConnection()
@@ -188,7 +189,7 @@ fun EntryDetailScreen(
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value || customBackAction != null) {
+                    if (canPopState || customBackAction != null) {
                         IconButton(
                             onClick = {
                                 if (customBackAction != null) {

--- a/feature/entrylist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrylist/EntryListScreen.kt
+++ b/feature/entrylist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrylist/EntryListScreen.kt
@@ -85,6 +85,7 @@ fun EntryListScreen(
 ) {
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val uriHandler = LocalUriHandler.current
@@ -158,7 +159,7 @@ fun EntryListScreen(
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
+                    if (canPopState && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/followrequests/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/followrequests/FollowRequestsScreen.kt
+++ b/feature/followrequests/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/followrequests/FollowRequestsScreen.kt
@@ -49,6 +49,7 @@ import kotlinx.coroutines.launch
 fun FollowRequestsScreen(model: FollowRequestsMviModel, modifier: Modifier = Modifier) {
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val mainRouter = rememberMainRouter()
@@ -80,7 +81,7 @@ fun FollowRequestsScreen(model: FollowRequestsMviModel, modifier: Modifier = Mod
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
+                    if (canPopState && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/gallery/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/gallery/detail/AlbumDetailScreen.kt
+++ b/feature/gallery/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/gallery/detail/AlbumDetailScreen.kt
@@ -81,6 +81,7 @@ fun AlbumDetailScreen(name: String, modifier: Modifier = Modifier) {
     val model: AlbumDetailMviModel = getViewModel<AlbumDetailViewModel>(arg = AlbumDetailViewModelArgs(name))
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val snackbarHostState = remember { SnackbarHostState() }
@@ -140,7 +141,7 @@ fun AlbumDetailScreen(name: String, modifier: Modifier = Modifier) {
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/gallery/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/gallery/list/GalleryScreen.kt
+++ b/feature/gallery/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/gallery/list/GalleryScreen.kt
@@ -70,6 +70,7 @@ import kotlinx.coroutines.launch
 fun GalleryScreen(model: GalleryMviModel, modifier: Modifier = Modifier) {
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val mainRouter = rememberMainRouter()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
@@ -119,7 +120,7 @@ fun GalleryScreen(model: GalleryMviModel, modifier: Modifier = Modifier) {
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
+                    if (canPopState && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/followed/FollowedHashtagsScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/followed/FollowedHashtagsScreen.kt
@@ -52,6 +52,7 @@ import kotlinx.coroutines.launch
 fun FollowedHashtagsScreen(model: FollowedHashtagsMviModel, modifier: Modifier = Modifier) {
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val mainRouter = rememberMainRouter()
@@ -84,7 +85,7 @@ fun FollowedHashtagsScreen(model: FollowedHashtagsMviModel, modifier: Modifier =
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
+                    if (canPopState && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
+++ b/feature/hashtag/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/hashtag/timeline/HashtagScreen.kt
@@ -86,6 +86,7 @@ fun HashtagScreen(
     val model: HashtagMviModel = getViewModel<HashtagViewModel>(arg = HashtagViewModelArgs(tag))
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val uriHandler = LocalUriHandler.current
@@ -180,7 +181,7 @@ fun HashtagScreen(
                     }
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/imagedetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/imagedetail/ImageDetailScreen.kt
+++ b/feature/imagedetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/imagedetail/ImageDetailScreen.kt
@@ -64,6 +64,7 @@ fun ImageDetailScreen(
     val uiState by model.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val drawerCoordinator = rememberDrawerCoordinator()
     val pagerState =
         rememberPagerState(
@@ -123,7 +124,7 @@ fun ImageDetailScreen(
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/licences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feat/licences/LicencesScreen.kt
+++ b/feature/licences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feat/licences/LicencesScreen.kt
@@ -40,6 +40,7 @@ fun LicencesScreen(modifier: Modifier = Modifier) {
     val model: LicencesMviModel = getViewModel<LicencesViewModel>()
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val uriHandler = LocalUriHandler.current
@@ -59,7 +60,7 @@ fun LicencesScreen(modifier: Modifier = Modifier) {
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/legacy/LegacyLoginScreen.kt
+++ b/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/legacy/LegacyLoginScreen.kt
@@ -74,6 +74,7 @@ fun LegacyLoginScreen(modifier: Modifier = Modifier) {
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val snackbarHostState = remember { SnackbarHostState() }
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val genericError = LocalStrings.current.messageGenericError
     val successMessage = LocalStrings.current.messageSuccess
     val focusManager = LocalFocusManager.current
@@ -114,7 +115,7 @@ fun LegacyLoginScreen(modifier: Modifier = Modifier) {
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/oauth/LoginScreen.kt
+++ b/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/oauth/LoginScreen.kt
@@ -72,6 +72,7 @@ fun LoginScreen(loginType: Int, modifier: Modifier = Modifier) {
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val snackbarHostState = remember { SnackbarHostState() }
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val uriHandler = LocalUriHandler.current
     val focusManager = LocalFocusManager.current
     val genericError = LocalStrings.current.messageGenericError
@@ -112,7 +113,7 @@ fun LoginScreen(loginType: Int, modifier: Modifier = Modifier) {
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/ManageBlocksScreen.kt
+++ b/feature/manageblocks/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/manageblocks/ManageBlocksScreen.kt
@@ -79,6 +79,7 @@ fun ManageBlocksScreen(modifier: Modifier = Modifier) {
     val model: ManageBlocksMviModel = getViewModel<ManageBlocksViewModel>()
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val mainRouter = rememberMainRouter()
@@ -125,7 +126,7 @@ fun ManageBlocksScreen(modifier: Modifier = Modifier) {
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/nodeinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/NodeInfoScreen.kt
+++ b/feature/nodeinfo/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/NodeInfoScreen.kt
@@ -128,6 +128,7 @@ fun NodeInfoScreenScaffold(
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val uriHandler = LocalUriHandler.current
     val mainRouter = rememberMainRouter()
     val lazyListState = rememberLazyListState()
@@ -158,7 +159,7 @@ fun NodeInfoScreenScaffold(
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
+                    if (canPopState && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileScreen.kt
@@ -92,6 +92,7 @@ fun EditProfileScreen(modifier: Modifier = Modifier) {
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val lazyListState = rememberLazyListState()
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -161,7 +162,7 @@ fun EditProfileScreen(modifier: Modifier = Modifier) {
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 if (uiState.hasUnsavedChanges) {

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/newaccount/NewAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/newaccount/NewAccountScreen.kt
@@ -14,6 +14,8 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
@@ -28,6 +30,7 @@ fun NewAccountScreen(modifier: Modifier = Modifier) {
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
 
     Scaffold(
         modifier = modifier,
@@ -43,7 +46,7 @@ fun NewAccountScreen(modifier: Modifier = Modifier) {
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/report/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/report/CreateReportScreen.kt
+++ b/feature/report/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/report/CreateReportScreen.kt
@@ -72,6 +72,7 @@ fun CreateReportScreen(userId: String, entryId: String?, modifier: Modifier = Mo
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val snackbarHostState = remember { SnackbarHostState() }
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     var categoryBottomSheetOpened by remember { mutableStateOf(false) }
     var ruleSelectionOpened by remember { mutableStateOf(false) }
     val genericError = LocalStrings.current.messageGenericError
@@ -122,7 +123,7 @@ fun CreateReportScreen(userId: String, entryId: String?, modifier: Modifier = Mo
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
@@ -94,6 +94,7 @@ fun SearchScreen(modifier: Modifier = Modifier, customOnSelectAction: ((Timeline
     val model: SearchMviModel = getViewModel<SearchViewModel>()
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val uriHandler = LocalUriHandler.current
@@ -166,7 +167,7 @@ fun SearchScreen(modifier: Modifier = Modifier, customOnSelectAction: ((Timeline
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/SettingsScreen.kt
@@ -125,6 +125,7 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val mainRouter = rememberMainRouter()
     val scope = rememberCoroutineScope()
     val fileSystemManager = rememberFileSystemManager()
@@ -186,7 +187,7 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
+                    if (canPopState && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/feedback/UserFeedbackScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/settings/feedback/UserFeedbackScreen.kt
@@ -58,6 +58,7 @@ fun UserFeedbackScreen(modifier: Modifier = Modifier) {
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val snackbarHostState = remember { SnackbarHostState() }
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val genericError = LocalStrings.current.messageGenericError
 
     LaunchedEffect(model) {
@@ -92,7 +93,7 @@ fun UserFeedbackScreen(modifier: Modifier = Modifier) {
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/shortcuts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/shortcuts/list/ShortcutListScreen.kt
+++ b/feature/shortcuts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/shortcuts/list/ShortcutListScreen.kt
@@ -60,6 +60,7 @@ fun ShortcutListScreen(model: ShortcutListMviModel, modifier: Modifier = Modifie
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val lazyListState = rememberLazyListState()
     val scope = rememberCoroutineScope()
     val mainRouter = rememberMainRouter()
@@ -102,7 +103,7 @@ fun ShortcutListScreen(model: ShortcutListMviModel, modifier: Modifier = Modifie
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
+                    if (canPopState && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/shortcuts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/shortcuts/timeline/ShortcutTimelineScreen.kt
+++ b/feature/shortcuts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/shortcuts/timeline/ShortcutTimelineScreen.kt
@@ -79,6 +79,7 @@ fun ShortcutTimelineScreen(node: String, modifier: Modifier = Modifier) {
         getViewModel<ShortcutTimelineViewModel>(arg = ShortcutTimelineViewModelArgs(node))
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val connection = navigationCoordinator.getBottomBarScrollConnection()
@@ -156,7 +157,7 @@ fun ShortcutTimelineScreen(node: String, modifier: Modifier = Modifier) {
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
+++ b/feature/thread/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/thread/ThreadScreen.kt
@@ -117,6 +117,7 @@ fun ThreadScreen(
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val uriHandler = LocalUriHandler.current
     val mainRouter = rememberMainRouter()
     val scope = rememberCoroutineScope()
@@ -177,7 +178,7 @@ fun ThreadScreen(
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/unpublished/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/unpublished/UnpublishedScreen.kt
+++ b/feature/unpublished/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/unpublished/UnpublishedScreen.kt
@@ -61,6 +61,7 @@ import kotlinx.coroutines.launch
 fun UnpublishedScreen(model: UnpublishedMviModel, modifier: Modifier = Modifier) {
     val uiState by model.uiState.collectAsState()
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val mainRouter = rememberMainRouter()
@@ -101,7 +102,7 @@ fun UnpublishedScreen(model: UnpublishedMviModel, modifier: Modifier = Modifier)
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
+                    if (canPopState && isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/classic/UserDetailScreen.kt
@@ -129,6 +129,7 @@ fun UserDetailScreen(
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val uriHandler = LocalUriHandler.current
     val mainRouter = rememberMainRouter()
     val lazyListState = rememberLazyListState()
@@ -226,7 +227,7 @@ fun UserDetailScreen(
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
+++ b/feature/userdetail/src/commonMain/kotlin/com/livefast/eattrash/feature/userdetail/forum/ForumListScreen.kt
@@ -100,6 +100,7 @@ fun ForumListScreen(id: String, modifier: Modifier = Modifier, otherInstance: St
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val uriHandler = LocalUriHandler.current
     val mainRouter = rememberMainRouter()
     val lazyListState = rememberLazyListState()
@@ -178,7 +179,7 @@ fun ForumListScreen(id: String, modifier: Modifier = Modifier, otherInstance: St
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()

--- a/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListScreen.kt
+++ b/feature/userlist/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/userlist/UserListScreen.kt
@@ -91,6 +91,7 @@ fun UserListScreen(
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val snackbarHostState = remember { SnackbarHostState() }
     val navigationCoordinator = rememberNavigationCoordinator()
+    val canPopState by navigationCoordinator.canPop.collectAsState()
     val mainRouter = rememberMainRouter()
     val fileSystemManager = rememberFileSystemManager()
     val lazyListState = rememberLazyListState()
@@ -190,7 +191,7 @@ fun UserListScreen(
                     )
                 },
                 navigationIcon = {
-                    if (navigationCoordinator.canPop.value) {
+                    if (canPopState) {
                         IconButton(
                             onClick = {
                                 navigationCoordinator.pop()


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes a bug in the interaction between the `NavigationAdapter` used for Compose Navigation and `NavigationCoordinator` to automatically observe backstack changes, eliminating the need for manual state refreshes after navigation events.

Key changes:
* Adapter APIs: updated `NavigationAdapter` to expose `canPop` as a `StateFlow<Boolean>` and the backstack threshold for `canPop` in `DefaultNavigationAdapter` was updated to 2 to better align with the project's navigation structure;
* Adapter state tracking: `DefaultNavigationAdapter` now subscribes to the `NavController'`s `currentBackStack` flow to update the `canPop` state dynamically;
* Coordinator optimization: `DefaultNavigationCoordinator` now reacts to changes in the root navigator's `canPop` flow. This allowed for the removal of the manual `refreshCanPop()` method and its calls across `push`, `pop`, `replace`, and `popUntilRoot`. The unit test was been updated accordingly;
* UI reads: instead of using the state flow value directly, whenever `canPop` was read in the UI layer it is consistently converted to Compose state using `collectAsState()`. This makes sure the UI always reacts to its updates.