### PR TITLE
fix: bottom navigation section state update

### DIFF
--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/BottomNavigationAdapter.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/BottomNavigationAdapter.kt
@@ -1,13 +1,8 @@
 package com.livefast.eattrash.raccoonforfriendica.core.navigation
 
-import androidx.navigation.NavController
+import kotlinx.coroutines.flow.StateFlow
 
 interface BottomNavigationAdapter {
+    val currentSection: StateFlow<BottomNavigationSection?>
     fun navigate(section: BottomNavigationSection)
-}
-
-class DefaultBottomNavigationAdapter(private val navController: NavController) : BottomNavigationAdapter {
-    override fun navigate(section: BottomNavigationSection) {
-        navController.navigate(section)
-    }
 }

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultBottomNavigationAdapter.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultBottomNavigationAdapter.kt
@@ -1,0 +1,48 @@
+package com.livefast.eattrash.raccoonforfriendica.core.navigation
+
+import androidx.navigation.NavController
+import androidx.navigation.NavDestination.Companion.hasRoute
+import androidx.navigation.toRoute
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+
+class DefaultBottomNavigationAdapter(
+    private val navController: NavController,
+    dispatcher: CoroutineDispatcher = Dispatchers.Main,
+) : BottomNavigationAdapter {
+
+    override val currentSection = MutableStateFlow<BottomNavigationSection?>(null)
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+
+    init {
+        navController.currentBackStackEntryFlow.onEach { entry ->
+            val destination = entry.destination
+            currentSection.update { old ->
+                when {
+                    destination.hasRoute<BottomNavigationSection.Home>() -> BottomNavigationSection.Home
+                    destination.hasRoute<BottomNavigationSection.Explore>() -> BottomNavigationSection.Explore
+                    destination.hasRoute<BottomNavigationSection.Inbox>() -> {
+                        val newInbox = entry.toRoute<BottomNavigationSection.Inbox>()
+                        if (old is BottomNavigationSection.Inbox && newInbox.unreadItems == 0) {
+                            old
+                        } else {
+                            newInbox
+                        }
+                    }
+                    destination.hasRoute<BottomNavigationSection.Profile>() -> BottomNavigationSection.Profile
+                    else -> BottomNavigationSection.Home
+                }
+            }
+        }.launchIn(scope)
+    }
+
+    override fun navigate(section: BottomNavigationSection) {
+        navController.navigate(section)
+    }
+}

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationCoordinator.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationCoordinator.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.getAndUpdate
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
@@ -29,22 +28,25 @@ internal class DefaultNavigationCoordinator(dispatcher: CoroutineDispatcher = Di
     private var bottomNavController: BottomNavigationAdapter? = null
     private var bottomBarScrollConnection: NestedScrollConnection? = null
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + dispatcher)
+    private var updateBottomNavigationSection: Job? = null
     private var updateCanPopJob: Job? = null
 
     override fun setBottomNavigator(adapter: BottomNavigationAdapter) {
         bottomNavController = adapter
+        updateBottomNavigationSection?.cancel()
+        updateBottomNavigationSection = adapter.currentSection.onEach { newValue ->
+            currentBottomNavSection.update { newValue }
+        }.launchIn(scope)
     }
 
     override fun setCurrentSection(section: BottomNavigationSection) {
-        currentBottomNavSection.getAndUpdate { old ->
-            if (old == section) {
-                scope.launch {
-                    onDoubleTabSelection.emit(section)
-                }
-            } else {
-                bottomNavController?.navigate(section)
+        val old = currentBottomNavSection.value
+        if (old == section) {
+            scope.launch {
+                onDoubleTabSelection.emit(section)
             }
-            section
+        } else {
+            bottomNavController?.navigate(section)
         }
     }
 

--- a/core/navigation/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationCoordinatorTest.kt
+++ b/core/navigation/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationCoordinatorTest.kt
@@ -52,22 +52,32 @@ class DefaultNavigationCoordinatorTest {
 
     @Test
     fun `when setCurrentSection then result is as expected`() {
+        val navigator =
+            mock<BottomNavigationAdapter>(MockMode.autoUnit) {
+                every { currentSection } returns MutableStateFlow(BottomNavigationSection.Home)
+            }
+        sut.setBottomNavigator(navigator)
         val section = BottomNavigationSection.Explore
 
         sut.setCurrentSection(section)
 
-        val res = sut.currentBottomNavSection.value
-        assertEquals(section, res)
+        verify { navigator.navigate(section) }
     }
 
     @Test
     fun `when setCurrentSection twice then onDoubleTabSelection is triggered`() = runTest {
         val section = BottomNavigationSection.Explore
-        sut.setCurrentSection(section)
+        val navigator =
+            mock<BottomNavigationAdapter>(MockMode.autoUnit) {
+                every { currentSection } returns MutableStateFlow(section)
+            }
+        sut.setBottomNavigator(navigator)
+
         launch {
             delay(DELAY)
             sut.setCurrentSection(section)
         }
+
         sut.onDoubleTabSelection.test {
             val res = awaitItem()
             assertEquals(section, res)


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR eliminates the manual state management for the current bottom navigation section in `DefaultNavigationCoordinator`, introducing an observable `StateFlow` in `BottomNavigationAdapter` and mapping directly that.

This fixes a bug due to which, when hitting the back button in the main screen, the bottom navigation state changed but the currently selected in the bottom navigation bar remained out of sync.