### PR TITLE
refactor: remove unused entry from report

### DIFF
--- a/feature/report/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/report/CreateReportMviModel.kt
+++ b/feature/report/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/report/CreateReportMviModel.kt
@@ -4,7 +4,6 @@ import androidx.compose.ui.text.input.TextFieldValue
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.ReportCategory
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.RuleModel
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 
 interface CreateReportMviModel :
@@ -23,7 +22,6 @@ interface CreateReportMviModel :
 
     data class State(
         val user: UserModel? = null,
-        val entry: TimelineEntryModel? = null,
         val loading: Boolean = false,
         val commentValue: TextFieldValue = TextFieldValue(),
         val forward: Boolean = false,

--- a/feature/report/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/report/CreateReportViewModel.kt
+++ b/feature/report/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/report/CreateReportViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.viewModelScope
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.DefaultMviModelDelegate
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModelDelegate
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.ReportCategory
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.LocalItemCache
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.NodeInfoRepository
@@ -22,7 +21,6 @@ class CreateReportViewModel(
     private val supportedFeatureRepository: SupportedFeatureRepository,
     private val reportRepository: ReportRepository,
     private val userCache: LocalItemCache<UserModel>,
-    private val entryCache: LocalItemCache<TimelineEntryModel>,
 ) : ViewModel(),
     MviModelDelegate<CreateReportMviModel.Intent, CreateReportMviModel.State, CreateReportMviModel.Effect>
     by DefaultMviModelDelegate(initialState = CreateReportMviModel.State()),
@@ -46,12 +44,10 @@ class CreateReportViewModel(
                     }
                 }.launchIn(this)
             val user = userCache.get(userId)
-            val entry = entryId.takeIf { it.isNotEmpty() }?.let { entryCache.get(it) }
             val rules = nodeInfoRepository.getRules().orEmpty()
             updateState {
                 it.copy(
                     user = user,
-                    entry = entry,
                     availableRules = rules,
                 )
             }

--- a/feature/report/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/report/di/ReportModule.kt
+++ b/feature/report/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/report/di/ReportModule.kt
@@ -18,7 +18,6 @@ val reportModule =
                 supportedFeatureRepository = instance(),
                 reportRepository = instance(),
                 userCache = instance(),
-                entryCache = instance(),
             )
         }
     }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
Looking into https://github.com/LiveFastEatTrashRaccoon/RaccoonForFriendica/issues/1106 I realized I was also using a cached version of the original post when creating a report for it, which is not needed because the post ID is all it is needed. 

This is probably a leftover of the past where I also included some information e.g. the title of the post being reported in the UI, which is no longer the case.
