### PR TITLE
chore: update Android target and compile SDK version to 37

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -23,8 +23,8 @@ android {
             libs.versions.android.targetSdk
                 .get()
                 .toInt()
-        versionCode = (rootProject.properties["buildNumber"] as? String)?.toInt()
-        versionName = rootProject.properties["versionName"] as? String
+        versionCode = (project.findProperty("buildNumber") as? String)?.toInt() ?: 1
+        versionName = project.findProperty("versionName") as? String ?: "1.0.0"
     }
     base.archivesName = "RaccoonForFriendica"
     packaging {

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultDirectMessageRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultDirectMessageRepositoryTest.kt
@@ -9,7 +9,7 @@ import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
-import dev.mokkery.matcher.matching
+import dev.mokkery.matcher.matches
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
@@ -134,7 +134,7 @@ class DefaultDirectMessageRepositoryTest {
         assertEquals(message.toModel(), res)
         verifySuspend {
             messageService.create(
-                matching {
+                matches {
                     it.formData.let { data ->
                         data["text"] == text && data["user_id"] == recipientId
                     }

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMarkerRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMarkerRepositoryTest.kt
@@ -10,7 +10,7 @@ import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
-import dev.mokkery.matcher.matching
+import dev.mokkery.matcher.matches
 import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
@@ -79,7 +79,7 @@ class DefaultMarkerRepositoryTest {
         assertEquals(expected = MarkerModel(type = MarkerType.Notifications, "2"), actual = res)
         verifySuspend {
             markerService.update(
-                matching {
+                matches {
                     it.formData["notifications[last_read_id]"] == "2"
                 },
             )

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMediaRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMediaRepositoryTest.kt
@@ -9,7 +9,7 @@ import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
-import dev.mokkery.matcher.matching
+import dev.mokkery.matcher.matches
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
@@ -82,7 +82,7 @@ class DefaultMediaRepositoryTest {
             mediaService.update(
                 id = any(),
                 content =
-                matching {
+                matches {
                     it.formData["description"] == "fake-description"
                 },
             )

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNotificationRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNotificationRepositoryTest.kt
@@ -9,7 +9,7 @@ import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
-import dev.mokkery.matcher.matching
+import dev.mokkery.matcher.matches
 import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
@@ -44,7 +44,7 @@ class DefaultNotificationRepositoryTest {
         assertEquals(emptyList(), res)
         verifySuspend {
             notificationService.get(
-                types = matching { it.contains("mention") },
+                types = matches { it.contains("mention") },
                 excludeTypes = null,
                 maxId = null,
                 minId = null,
@@ -73,7 +73,7 @@ class DefaultNotificationRepositoryTest {
         assertEquals(list.map { it.toModel() }, res)
         verifySuspend {
             notificationService.get(
-                types = matching { it.contains("mention") },
+                types = matches { it.contains("mention") },
                 excludeTypes = null,
                 maxId = null,
                 minId = null,
@@ -102,7 +102,7 @@ class DefaultNotificationRepositoryTest {
         assertEquals(list.map { it.toModel() }, res)
         verifySuspend {
             notificationService.get(
-                types = matching { it.contains("mention") },
+                types = matches { it.contains("mention") },
                 excludeTypes = null,
                 maxId = "0",
                 minId = null,
@@ -132,7 +132,7 @@ class DefaultNotificationRepositoryTest {
         assertEquals(list.map { it.toModel() }, res)
         verifySuspend(VerifyMode.exactly(1)) {
             notificationService.get(
-                types = matching { it.contains("mention") },
+                types = matches { it.contains("mention") },
                 excludeTypes = null,
                 maxId = null,
                 minId = null,
@@ -162,7 +162,7 @@ class DefaultNotificationRepositoryTest {
         assertEquals(list.map { it.toModel() }, res)
         verifySuspend(VerifyMode.exactly(2)) {
             notificationService.get(
-                types = matching { it.contains("mention") },
+                types = matches { it.contains("mention") },
                 excludeTypes = null,
                 maxId = null,
                 minId = null,

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoAlbumRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoAlbumRepositoryTest.kt
@@ -10,7 +10,7 @@ import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
-import dev.mokkery.matcher.matching
+import dev.mokkery.matcher.matches
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
@@ -48,7 +48,7 @@ class DefaultPhotoAlbumRepositoryTest {
         assertTrue(res)
         verifySuspend {
             photoAlbumService.update(
-                matching {
+                matches {
                     it.formData["album"] == "fake-album" && it.formData["album_new"] == "fake-album-new"
                 },
             )
@@ -75,7 +75,7 @@ class DefaultPhotoAlbumRepositoryTest {
         assertTrue(res)
         verifySuspend {
             photoAlbumService.delete(
-                matching {
+                matches {
                     it.formData["album"] == "fake-album"
                 },
             )

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPushNotificationRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPushNotificationRepositoryTest.kt
@@ -10,7 +10,7 @@ import dev.mokkery.answering.throws
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
-import dev.mokkery.matcher.matching
+import dev.mokkery.matcher.matches
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
@@ -50,7 +50,7 @@ class DefaultPushNotificationRepositoryTest {
         assertEquals(SERVER_KEY, res)
         verifySuspend {
             pushService.create(
-                matching {
+                matches {
                     val data = it.formData
                     listOf(
                         data["subscription[endpoint]"] == ENDPOINT,
@@ -87,7 +87,7 @@ class DefaultPushNotificationRepositoryTest {
         assertNull(res)
         verifySuspend {
             pushService.create(
-                matching {
+                matches {
                     val data = it.formData
                     listOf(
                         data["subscription[endpoint]"] == ENDPOINT,
@@ -126,7 +126,7 @@ class DefaultPushNotificationRepositoryTest {
         assertEquals(SERVER_KEY, res)
         verifySuspend {
             pushService.update(
-                matching {
+                matches {
                     val data = it.formData
                     listOf(
                         data.names().none { k -> k.startsWith("subscription") },
@@ -157,7 +157,7 @@ class DefaultPushNotificationRepositoryTest {
         assertNull(res)
         verifySuspend {
             pushService.update(
-                matching {
+                matches {
                     val data = it.formData
                     listOf(
                         data.names().none { k -> k.startsWith("subscription") },

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTranslationRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTranslationRepositoryTest.kt
@@ -16,7 +16,7 @@ import dev.mokkery.answering.throws
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
-import dev.mokkery.matcher.matching
+import dev.mokkery.matcher.matches
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
@@ -71,8 +71,8 @@ class DefaultTranslationRepositoryTest {
             statusService.translate(
                 id = entryId,
                 data =
-                matching { arg ->
-                    arg.formData["lang"] == targetLang
+                matches {
+                    it.formData["lang"] == targetLang
                 },
             )
         }
@@ -137,8 +137,8 @@ class DefaultTranslationRepositoryTest {
             statusService.translate(
                 id = entryId,
                 data =
-                matching { arg ->
-                    arg.formData["lang"] == targetLang
+                matches {
+                    it.formData["lang"] == targetLang
                 },
             )
         }
@@ -201,8 +201,8 @@ class DefaultTranslationRepositoryTest {
             statusService.translate(
                 id = entryId,
                 data =
-                matching { arg ->
-                    arg.formData["lang"] == targetLang
+                matches {
+                    it.formData["lang"] == targetLang
                 },
             )
         }
@@ -234,8 +234,8 @@ class DefaultTranslationRepositoryTest {
             statusService.translate(
                 id = entryId,
                 data =
-                matching { arg ->
-                    arg.formData["lang"] == targetLang
+                matches {
+                    it.formData["lang"] == targetLang
                 },
             )
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-android-compileSdk = "36"
+android-compileSdk = "37"
 android-minSdk = "26"
-android-targetSdk = "36"
+android-targetSdk = "37"
 
 agp = "9.0.0"
 androidx-activity = "1.13.0"


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR updates the compileSdk and targetSdk for the `:androidApp` subproject, where the `"com.android.application"` plugin is applied, as well as all the  `KotlinMultiplatformAndroidLibraryTarget` in the subprojects where the `"com.android.kotlin.multiplatform.library"` plugin is applied.

Moreover, it replaces reading directly the `properties` map from a project/subproject with `findProperty` with default values for `versionCode` and `versionName`, to avoid potential failures if the values are missing.