### PR TITLE
refactor: improve projects setup

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -23,8 +23,8 @@ android {
             libs.versions.android.targetSdk
                 .get()
                 .toInt()
-        versionCode = (rootProject.properties["buildNumber"] as? String)?.toInt()
-        versionName = rootProject.properties["versionName"] as? String
+        versionCode = (project.findProperty("buildNumber") as? String)?.toInt() ?: 1
+        versionName = project.findProperty("versionName") as? String ?: "1.0.0"
     }
     base.archivesName = "RaccoonForFriendica"
     packaging {

--- a/build-logic/convention/src/main/kotlin/extensions/ConfigureKotlinMultiplatform.kt
+++ b/build-logic/convention/src/main/kotlin/extensions/ConfigureKotlinMultiplatform.kt
@@ -1,6 +1,6 @@
 package extensions
 
-import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
+import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryExtension
 import org.gradle.api.Project
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
@@ -38,20 +38,21 @@ internal fun Project.configureKotlinMultiplatform(extension: KotlinMultiplatform
         }
 
         jvm()
+    }
 
-        targets.withType(KotlinMultiplatformAndroidLibraryTarget::class.java).configureEach {
-            val moduleName = path.split(":").drop(1).joinToString(".")
-            namespace = if (moduleName.isNotEmpty()) "$PACKAGE_PREFIX.$moduleName" else PACKAGE_PREFIX
+internal fun Project.configureKotlinMultiplatformAndroidLibrary(extension: KotlinMultiplatformAndroidLibraryExtension) =
+    extension.apply {
+        val moduleName = path.split(":").drop(1).joinToString(".")
+        namespace = if (moduleName.isNotEmpty()) "$PACKAGE_PREFIX.$moduleName" else PACKAGE_PREFIX
 
-            compileSdk = libs.findVersion("android-compileSdk").version
-            minSdk = libs.findVersion("android-minSdk").version
+        compileSdk = libs.findVersion("android-compileSdk").version
+        minSdk = libs.findVersion("android-minSdk").version
 
-            packaging {
-                resources {
-                    excludes += "/META-INF/{AL2.0,LGPL2.1}"
-                }
+        packaging {
+            resources {
+                excludes += "/META-INF/{AL2.0,LGPL2.1}"
             }
-
-            experimentalProperties["android.experimental.kmp.enableAndroidResources"] = true
         }
+
+        experimentalProperties["android.experimental.kmp.enableAndroidResources"] = true
     }

--- a/build-logic/convention/src/main/kotlin/extensions/ConfigureTest.kt
+++ b/build-logic/convention/src/main/kotlin/extensions/ConfigureTest.kt
@@ -1,6 +1,6 @@
 package extensions
 
-import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
+import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryExtension
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import utils.dependency
@@ -25,10 +25,11 @@ internal fun Project.configureTest(extension: KotlinMultiplatformExtension) =
                 }
             }
         }
+    }
 
-        targets.withType(KotlinMultiplatformAndroidLibraryTarget::class.java).configureEach {
-            withHostTest {
-                isIncludeAndroidResources = true
-            }
+internal fun Project.configureTestAndroidLibrary(extension: KotlinMultiplatformAndroidLibraryExtension) =
+    extension.apply {
+        withHostTest {
+            isIncludeAndroidResources = true
         }
     }

--- a/build-logic/convention/src/main/kotlin/extensions/ConfigureUiTest.kt
+++ b/build-logic/convention/src/main/kotlin/extensions/ConfigureUiTest.kt
@@ -1,6 +1,6 @@
 package extensions
 
-import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
+import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryExtension
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import utils.dependency
@@ -32,10 +32,11 @@ internal fun Project.configureUiTest(extension: KotlinMultiplatformExtension) =
                 }
             }
         }
+    }
 
-        targets.withType(KotlinMultiplatformAndroidLibraryTarget::class.java).configureEach {
-            withDeviceTest {
-                instrumentationRunner = "org.robolectric.RobolectricTestRunner"
-            }
+internal fun Project.configureUiTestAndroidLibrary(extension: KotlinMultiplatformAndroidLibraryExtension) =
+    extension.apply {
+        withDeviceTest {
+            instrumentationRunner = "org.robolectric.RobolectricTestRunner"
         }
     }

--- a/build-logic/convention/src/main/kotlin/plugins/KotlinMultiplatformPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/plugins/KotlinMultiplatformPlugin.kt
@@ -1,6 +1,8 @@
 package plugins
 
+import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
 import extensions.configureKotlinMultiplatform
+import extensions.configureKotlinMultiplatformAndroidLibrary
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
@@ -15,9 +17,12 @@ class KotlinMultiplatformPlugin : Plugin<Project> {
                 apply(libs.findPlugin("android-kmp-library").pluginId)
             }
 
-            extensions.configure(
-                KotlinMultiplatformExtension::class.java,
-                ::configureKotlinMultiplatform,
-            )
+            extensions.configure(KotlinMultiplatformExtension::class.java) {
+                configureKotlinMultiplatform(this)
+
+                targets.withType(KotlinMultiplatformAndroidLibraryTarget::class.java).configureEach {
+                    configureKotlinMultiplatformAndroidLibrary(this)
+                }
+            }
         }
 }

--- a/build-logic/convention/src/main/kotlin/plugins/TestPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/plugins/TestPlugin.kt
@@ -1,6 +1,9 @@
 package plugins
 
+import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
 import extensions.configureTest
+import extensions.configureTestAndroidLibrary
+import extensions.configureUiTestAndroidLibrary
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
@@ -15,9 +18,12 @@ class TestPlugin : Plugin<Project> {
                 apply(libs.findPlugin("ksp").pluginId)
                 apply(libs.findPlugin("mokkery").pluginId)
             }
-            extensions.configure(
-                KotlinMultiplatformExtension::class.java,
-                ::configureTest,
-            )
+            extensions.configure(KotlinMultiplatformExtension::class.java) {
+                configureTest(this)
+
+                targets.withType(KotlinMultiplatformAndroidLibraryTarget::class.java).configureEach {
+                    configureTestAndroidLibrary(this)
+                }
+            }
         }
 }

--- a/build-logic/convention/src/main/kotlin/plugins/UiTestPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/plugins/UiTestPlugin.kt
@@ -1,6 +1,8 @@
 package plugins
 
+import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
 import extensions.configureUiTest
+import extensions.configureUiTestAndroidLibrary
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
@@ -8,9 +10,12 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 class UiTestPlugin : Plugin<Project> {
     override fun apply(target: Project): Unit =
         with(target) {
-            extensions.configure(
-                KotlinMultiplatformExtension::class.java,
-                ::configureUiTest,
-            )
+            extensions.configure(KotlinMultiplatformExtension::class.java) {
+                configureUiTest(this)
+
+                targets.withType(KotlinMultiplatformAndroidLibraryTarget::class.java).configureEach {
+                    configureUiTestAndroidLibrary(this)
+                }
+            }
         }
 }

--- a/core/testutils/build.gradle.kts
+++ b/core/testutils/build.gradle.kts
@@ -8,6 +8,7 @@ kotlin {
         androidMain {
             dependencies {
                 implementation(kotlin("test-junit"))
+                implementation(libs.androidx.test.core)
                 implementation(libs.kodein)
                 implementation(projects.core.di)
             }

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultDirectMessageRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultDirectMessageRepositoryTest.kt
@@ -9,7 +9,7 @@ import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
-import dev.mokkery.matcher.matching
+import dev.mokkery.matcher.matches
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
@@ -134,7 +134,7 @@ class DefaultDirectMessageRepositoryTest {
         assertEquals(message.toModel(), res)
         verifySuspend {
             messageService.create(
-                matching {
+                matches {
                     it.formData.let { data ->
                         data["text"] == text && data["user_id"] == recipientId
                     }

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMarkerRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMarkerRepositoryTest.kt
@@ -10,7 +10,7 @@ import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
-import dev.mokkery.matcher.matching
+import dev.mokkery.matcher.matches
 import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
@@ -79,7 +79,7 @@ class DefaultMarkerRepositoryTest {
         assertEquals(expected = MarkerModel(type = MarkerType.Notifications, "2"), actual = res)
         verifySuspend {
             markerService.update(
-                matching {
+                matches {
                     it.formData["notifications[last_read_id]"] == "2"
                 },
             )

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMediaRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMediaRepositoryTest.kt
@@ -9,7 +9,7 @@ import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
-import dev.mokkery.matcher.matching
+import dev.mokkery.matcher.matches
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
@@ -82,7 +82,7 @@ class DefaultMediaRepositoryTest {
             mediaService.update(
                 id = any(),
                 content =
-                matching {
+                matches {
                     it.formData["description"] == "fake-description"
                 },
             )

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNotificationRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNotificationRepositoryTest.kt
@@ -9,7 +9,7 @@ import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
-import dev.mokkery.matcher.matching
+import dev.mokkery.matcher.matches
 import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
@@ -44,7 +44,7 @@ class DefaultNotificationRepositoryTest {
         assertEquals(emptyList(), res)
         verifySuspend {
             notificationService.get(
-                types = matching { it.contains("mention") },
+                types = matches { it.contains("mention") },
                 excludeTypes = null,
                 maxId = null,
                 minId = null,
@@ -73,7 +73,7 @@ class DefaultNotificationRepositoryTest {
         assertEquals(list.map { it.toModel() }, res)
         verifySuspend {
             notificationService.get(
-                types = matching { it.contains("mention") },
+                types = matches { it.contains("mention") },
                 excludeTypes = null,
                 maxId = null,
                 minId = null,
@@ -102,7 +102,7 @@ class DefaultNotificationRepositoryTest {
         assertEquals(list.map { it.toModel() }, res)
         verifySuspend {
             notificationService.get(
-                types = matching { it.contains("mention") },
+                types = matches { it.contains("mention") },
                 excludeTypes = null,
                 maxId = "0",
                 minId = null,
@@ -132,7 +132,7 @@ class DefaultNotificationRepositoryTest {
         assertEquals(list.map { it.toModel() }, res)
         verifySuspend(VerifyMode.exactly(1)) {
             notificationService.get(
-                types = matching { it.contains("mention") },
+                types = matches { it.contains("mention") },
                 excludeTypes = null,
                 maxId = null,
                 minId = null,
@@ -162,7 +162,7 @@ class DefaultNotificationRepositoryTest {
         assertEquals(list.map { it.toModel() }, res)
         verifySuspend(VerifyMode.exactly(2)) {
             notificationService.get(
-                types = matching { it.contains("mention") },
+                types = matches { it.contains("mention") },
                 excludeTypes = null,
                 maxId = null,
                 minId = null,

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoAlbumRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoAlbumRepositoryTest.kt
@@ -10,7 +10,7 @@ import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
-import dev.mokkery.matcher.matching
+import dev.mokkery.matcher.matches
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
@@ -48,7 +48,7 @@ class DefaultPhotoAlbumRepositoryTest {
         assertTrue(res)
         verifySuspend {
             photoAlbumService.update(
-                matching {
+                matches {
                     it.formData["album"] == "fake-album" && it.formData["album_new"] == "fake-album-new"
                 },
             )
@@ -75,7 +75,7 @@ class DefaultPhotoAlbumRepositoryTest {
         assertTrue(res)
         verifySuspend {
             photoAlbumService.delete(
-                matching {
+                matches {
                     it.formData["album"] == "fake-album"
                 },
             )

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPushNotificationRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPushNotificationRepositoryTest.kt
@@ -10,7 +10,7 @@ import dev.mokkery.answering.throws
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
-import dev.mokkery.matcher.matching
+import dev.mokkery.matcher.matches
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
@@ -50,7 +50,7 @@ class DefaultPushNotificationRepositoryTest {
         assertEquals(SERVER_KEY, res)
         verifySuspend {
             pushService.create(
-                matching {
+                matches {
                     val data = it.formData
                     listOf(
                         data["subscription[endpoint]"] == ENDPOINT,
@@ -87,7 +87,7 @@ class DefaultPushNotificationRepositoryTest {
         assertNull(res)
         verifySuspend {
             pushService.create(
-                matching {
+                matches {
                     val data = it.formData
                     listOf(
                         data["subscription[endpoint]"] == ENDPOINT,
@@ -126,7 +126,7 @@ class DefaultPushNotificationRepositoryTest {
         assertEquals(SERVER_KEY, res)
         verifySuspend {
             pushService.update(
-                matching {
+                matches {
                     val data = it.formData
                     listOf(
                         data.names().none { k -> k.startsWith("subscription") },
@@ -157,7 +157,7 @@ class DefaultPushNotificationRepositoryTest {
         assertNull(res)
         verifySuspend {
             pushService.update(
-                matching {
+                matches {
                     val data = it.formData
                     listOf(
                         data.names().none { k -> k.startsWith("subscription") },

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTranslationRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTranslationRepositoryTest.kt
@@ -16,7 +16,7 @@ import dev.mokkery.answering.throws
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
-import dev.mokkery.matcher.matching
+import dev.mokkery.matcher.matches
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
@@ -71,8 +71,8 @@ class DefaultTranslationRepositoryTest {
             statusService.translate(
                 id = entryId,
                 data =
-                matching { arg ->
-                    arg.formData["lang"] == targetLang
+                matches {
+                    it.formData["lang"] == targetLang
                 },
             )
         }
@@ -137,8 +137,8 @@ class DefaultTranslationRepositoryTest {
             statusService.translate(
                 id = entryId,
                 data =
-                matching { arg ->
-                    arg.formData["lang"] == targetLang
+                matches {
+                    it.formData["lang"] == targetLang
                 },
             )
         }
@@ -201,8 +201,8 @@ class DefaultTranslationRepositoryTest {
             statusService.translate(
                 id = entryId,
                 data =
-                matching { arg ->
-                    arg.formData["lang"] == targetLang
+                matches {
+                    it.formData["lang"] == targetLang
                 },
             )
         }
@@ -234,8 +234,8 @@ class DefaultTranslationRepositoryTest {
             statusService.translate(
                 id = entryId,
                 data =
-                matching { arg ->
-                    arg.formData["lang"] == targetLang
+                matches {
+                    it.formData["lang"] == targetLang
                 },
             )
         }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes some compilation warning and makes the project setup more future-proof.

Summary of the changes:
- provide defaults from `buildNumber` and `versionName`, using `findProperty()` instead of reading `properties` directly;
- replace the deprecated `matching` with `matches` in Mokkery verifications;
- add `"androidx.test:core"` dependency to `:core:testutils`;
- modularize Android KMP library configuration by creating standalone extension functions using `KotlinMultiplatformAndroidLibraryExtension` and updating convention plugins to use them separately.

The last point will make it easier to migrate the project further, once it will be possible to access the `KotlinMultiplatformAndroidLibraryExtension` via the Gradle DSL.