### PR TITLE
refactor(di): migrate to newer binding shorthands

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/di/ApiModule.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/di/ApiModule.kt
@@ -49,141 +49,95 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import org.kodein.di.DI
-import org.kodein.di.bind
-import org.kodein.di.factory
+import org.kodein.di.bindFactory
+import org.kodein.di.bindInstance
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
-import org.kodein.di.singleton
 
 internal data class ServiceCreationArgs(val baseUrl: String, val client: HttpClient)
 
 val apiModule =
     DI.Module("ApiModule") {
-        bind<HttpClientEngine> {
-            instance(provideHttpClientEngine())
+        bindInstance<HttpClientEngine> {
+            provideHttpClientEngine()
         }
-        bind<Json> {
-            singleton { JsonSerializer }
+        bindSingleton<Json> {
+            JsonSerializer
         }
-        bind<ServiceProvider>(tag = "default") {
-            singleton {
-                DefaultServiceProvider(
-                    factory = instance(),
-                    appInfoRepository = instance(),
-                )
-            }
+        bindSingleton<ServiceProvider>(tag = "default") {
+            DefaultServiceProvider(
+                factory = instance(),
+                appInfoRepository = instance(),
+            )
         }
-        bind<ServiceProvider>(tag = "other") {
-            singleton {
-                DefaultServiceProvider(
-                    factory = instance(),
-                    appInfoRepository = instance(),
-                )
-            }
+        bindSingleton<ServiceProvider>(tag = "other") {
+            DefaultServiceProvider(
+                factory = instance(),
+                appInfoRepository = instance(),
+            )
         }
-        bind<AnnouncementService> {
-            factory { arg: ServiceCreationArgs ->
-                DefaultAnnouncementService(baseUrl = arg.baseUrl, client = arg.client)
-            }
+        bindFactory<ServiceCreationArgs, AnnouncementService> { arg ->
+            DefaultAnnouncementService(baseUrl = arg.baseUrl, client = arg.client)
         }
-        bind<AppService> {
-            factory { arg: ServiceCreationArgs ->
-                DefaultAppService(baseUrl = arg.baseUrl, client = arg.client)
-            }
+        bindFactory<ServiceCreationArgs, AppService> { arg ->
+            DefaultAppService(baseUrl = arg.baseUrl, client = arg.client)
         }
-        bind<DirectMessageService> {
-            factory { arg: ServiceCreationArgs ->
-                DefaultDirectMessageService(baseUrl = arg.baseUrl, client = arg.client)
-            }
+        bindFactory<ServiceCreationArgs, DirectMessageService> { arg ->
+            DefaultDirectMessageService(baseUrl = arg.baseUrl, client = arg.client)
         }
-        bind<EventService> {
-            factory { arg: ServiceCreationArgs ->
-                DefaultEventService(baseUrl = arg.baseUrl, client = arg.client)
-            }
+        bindFactory<ServiceCreationArgs, EventService> { arg ->
+            DefaultEventService(baseUrl = arg.baseUrl, client = arg.client)
         }
-        bind<FollowRequestService> {
-            factory { arg: ServiceCreationArgs ->
-                DefaultFollowRequestService(baseUrl = arg.baseUrl, client = arg.client)
-            }
+        bindFactory<ServiceCreationArgs, FollowRequestService> { arg ->
+            DefaultFollowRequestService(baseUrl = arg.baseUrl, client = arg.client)
         }
-        bind<InstanceService> {
-            factory { arg: ServiceCreationArgs ->
-                DefaultInstanceService(baseUrl = arg.baseUrl, client = arg.client)
-            }
+        bindFactory<ServiceCreationArgs, InstanceService> { arg ->
+            DefaultInstanceService(baseUrl = arg.baseUrl, client = arg.client)
         }
-        bind<ListService> {
-            factory { arg: ServiceCreationArgs ->
-                DefaultListService(baseUrl = arg.baseUrl, client = arg.client)
-            }
+        bindFactory<ServiceCreationArgs, ListService> { arg ->
+            DefaultListService(baseUrl = arg.baseUrl, client = arg.client)
         }
-        bind<MarkerService> {
-            factory { arg: ServiceCreationArgs ->
-                DefaultMarkerService(baseUrl = arg.baseUrl, client = arg.client)
-            }
+        bindFactory<ServiceCreationArgs, MarkerService> { arg ->
+            DefaultMarkerService(baseUrl = arg.baseUrl, client = arg.client)
         }
-        bind<MediaService> {
-            factory { arg: ServiceCreationArgs ->
-                DefaultMediaService(baseUrl = arg.baseUrl, client = arg.client)
-            }
+        bindFactory<ServiceCreationArgs, MediaService> { arg ->
+            DefaultMediaService(baseUrl = arg.baseUrl, client = arg.client)
         }
-        bind<NotificationService> {
-            factory { arg: ServiceCreationArgs ->
-                DefaultNotificationService(baseUrl = arg.baseUrl, client = arg.client)
-            }
+        bindFactory<ServiceCreationArgs, NotificationService> { arg ->
+            DefaultNotificationService(baseUrl = arg.baseUrl, client = arg.client)
         }
-        bind<PhotoAlbumService> {
-            factory { arg: ServiceCreationArgs ->
-                DefaultPhotoAlbumService(baseUrl = arg.baseUrl, client = arg.client)
-            }
+        bindFactory<ServiceCreationArgs, PhotoAlbumService> { arg ->
+            DefaultPhotoAlbumService(baseUrl = arg.baseUrl, client = arg.client)
         }
-        bind<PhotoService> {
-            factory { arg: ServiceCreationArgs ->
-                DefaultPhotoService(baseUrl = arg.baseUrl, client = arg.client)
-            }
+        bindFactory<ServiceCreationArgs, PhotoService> { arg ->
+            DefaultPhotoService(baseUrl = arg.baseUrl, client = arg.client)
         }
-        bind<PollService> {
-            factory { arg: ServiceCreationArgs ->
-                DefaultPollService(baseUrl = arg.baseUrl, client = arg.client)
-            }
+        bindFactory<ServiceCreationArgs, PollService> { arg ->
+            DefaultPollService(baseUrl = arg.baseUrl, client = arg.client)
         }
-        bind<PushService> {
-            factory { arg: ServiceCreationArgs ->
-                DefaultPushService(baseUrl = arg.baseUrl, client = arg.client)
-            }
+        bindFactory<ServiceCreationArgs, PushService> { arg ->
+            DefaultPushService(baseUrl = arg.baseUrl, client = arg.client)
         }
-        bind<ReportService> {
-            factory { arg: ServiceCreationArgs ->
-                DefaultReportService(baseUrl = arg.baseUrl, client = arg.client)
-            }
+        bindFactory<ServiceCreationArgs, ReportService> { arg ->
+            DefaultReportService(baseUrl = arg.baseUrl, client = arg.client)
         }
-        bind<SearchService> {
-            factory { arg: ServiceCreationArgs ->
-                DefaultSearchService(baseUrl = arg.baseUrl, client = arg.client)
-            }
+        bindFactory<ServiceCreationArgs, SearchService> { arg ->
+            DefaultSearchService(baseUrl = arg.baseUrl, client = arg.client)
         }
-        bind<StatusService> {
-            factory { arg: ServiceCreationArgs ->
-                DefaultStatusService(baseUrl = arg.baseUrl, client = arg.client)
-            }
+        bindFactory<ServiceCreationArgs, StatusService> { arg ->
+            DefaultStatusService(baseUrl = arg.baseUrl, client = arg.client)
         }
-        bind<TagsService> {
-            factory { arg: ServiceCreationArgs ->
-                DefaultTagsService(baseUrl = arg.baseUrl, client = arg.client)
-            }
+        bindFactory<ServiceCreationArgs, TagsService> { arg ->
+            DefaultTagsService(baseUrl = arg.baseUrl, client = arg.client)
         }
-        bind<TimelineService> {
-            factory { arg: ServiceCreationArgs ->
-                DefaultTimelineService(baseUrl = arg.baseUrl, client = arg.client)
-            }
+        bindFactory<ServiceCreationArgs, TimelineService> { arg ->
+            DefaultTimelineService(baseUrl = arg.baseUrl, client = arg.client)
         }
-        bind<TrendsService> {
-            factory { arg: ServiceCreationArgs ->
-                DefaultTrendService(baseUrl = arg.baseUrl, client = arg.client)
-            }
+        bindFactory<ServiceCreationArgs, TrendsService> { arg ->
+            DefaultTrendService(baseUrl = arg.baseUrl, client = arg.client)
         }
-        bind<UserService> {
-            factory { arg: ServiceCreationArgs ->
-                DefaultUserService(baseUrl = arg.baseUrl, client = arg.client)
-            }
+        bindFactory<ServiceCreationArgs, UserService> { arg ->
+            DefaultUserService(baseUrl = arg.baseUrl, client = arg.client)
         }
     }
 

--- a/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/di/NativeAppearanceModule.kt
+++ b/core/appearance/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/di/NativeAppearanceModule.kt
@@ -6,11 +6,16 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.DefaultBa
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.DefaultColorSchemeProvider
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
 import org.kodein.di.singleton
 
 actual val nativeAppearanceModule =
     DI.Module("NativeAppearanceModule") {
-        bind<BarColorProvider> { singleton { DefaultBarColorProvider() } }
-        bind<ColorSchemeProvider> { singleton { DefaultColorSchemeProvider(context = instance()) } }
+        bindSingleton<BarColorProvider> {
+            DefaultBarColorProvider()
+        }
+        bindSingleton<ColorSchemeProvider> {
+            DefaultColorSchemeProvider(context = instance())
+        }
     }

--- a/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/di/AppearanceModule.kt
+++ b/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/di/AppearanceModule.kt
@@ -6,11 +6,16 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.repository.Them
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.repository.ThemeRepository
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
 val appearanceModule =
     DI.Module("AppearanceModule") {
         import(nativeAppearanceModule)
-        bind<ThemeColorRepository> { singleton { DefaultThemeColorRepository() } }
-        bind<ThemeRepository> { singleton { DefaultThemeRepository() } }
+        bindSingleton<ThemeColorRepository> {
+            DefaultThemeColorRepository()
+        }
+        bindSingleton<ThemeRepository> {
+            DefaultThemeRepository()
+        }
     }

--- a/core/appearance/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/di/NativeAppearanceModule.kt
+++ b/core/appearance/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/di/NativeAppearanceModule.kt
@@ -6,10 +6,15 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.DefaultBa
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.DefaultColorSchemeProvider
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
 actual val nativeAppearanceModule =
     DI.Module("NativeAppearanceModule") {
-        bind<BarColorProvider> { singleton { DefaultBarColorProvider() } }
-        bind<ColorSchemeProvider> { singleton { DefaultColorSchemeProvider() } }
+        bindSingleton<BarColorProvider> {
+            DefaultBarColorProvider()
+        }
+        bindSingleton<ColorSchemeProvider> {
+            DefaultColorSchemeProvider()
+        }
     }

--- a/core/appearance/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/di/NativeAppearanceModule.kt
+++ b/core/appearance/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/di/NativeAppearanceModule.kt
@@ -6,10 +6,15 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.DefaultBa
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.DefaultColorSchemeProvider
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
 actual val nativeAppearanceModule =
     DI.Module("NativeAppearanceModule") {
-        bind<BarColorProvider> { singleton { DefaultBarColorProvider() } }
-        bind<ColorSchemeProvider> { singleton { DefaultColorSchemeProvider() } }
+        bindSingleton<BarColorProvider> {
+            DefaultBarColorProvider()
+        }
+        bindSingleton<ColorSchemeProvider> {
+            DefaultColorSchemeProvider()
+        }
     }

--- a/core/architecture/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/architecture/di/ViewModelBindUtils.kt
+++ b/core/architecture/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/architecture/di/ViewModelBindUtils.kt
@@ -2,11 +2,9 @@ package com.livefast.eattrash.raccoonforfriendica.core.architecture.di
 
 import androidx.lifecycle.ViewModel
 import org.kodein.di.DI
-import org.kodein.di.bind
-import org.kodein.di.bindings.BindingDI
-import org.kodein.di.bindings.NoArgBindingDI
-import org.kodein.di.factory
-import org.kodein.di.provider
+import org.kodein.di.DirectDI
+import org.kodein.di.bindFactory
+import org.kodein.di.bindProvider
 import kotlin.reflect.cast
 
 /**
@@ -18,15 +16,13 @@ import kotlin.reflect.cast
  */
 inline fun <reified T : ViewModel> DI.Builder.bindViewModel(
     overrides: Boolean? = null,
-    noinline block: NoArgBindingDI<*>.() -> T,
+    noinline block: DirectDI.() -> T,
 ) {
-    bind<T>(
+    bindProvider(
         tag = T::class.diKey,
         overrides = overrides,
     ) {
-        provider<Any, T> {
-            block()
-        }
+        block()
     }
 }
 
@@ -40,14 +36,12 @@ inline fun <reified T : ViewModel> DI.Builder.bindViewModel(
  */
 inline fun <reified A : ViewModelCreationArgs, reified T : ViewModel> DI.Builder.bindViewModelWithArgs(
     overrides: Boolean? = null,
-    noinline block: BindingDI<*>.(A) -> T,
+    noinline block: DirectDI.(A) -> T,
 ) {
-    bind<T>(
+    bindFactory<ViewModelCreationArgs, T>(
         tag = T::class.diKey,
         overrides = overrides,
-    ) {
-        factory<Any, ViewModelCreationArgs, T> { args: ViewModelCreationArgs ->
-            block(A::class.cast(args))
-        }
+    ) { args: ViewModelCreationArgs ->
+        block(A::class.cast(args))
     }
 }

--- a/core/architecture/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/architecture/di/ViewModelFactoryModule.kt
+++ b/core/architecture/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/architecture/di/ViewModelFactoryModule.kt
@@ -2,13 +2,10 @@ package com.livefast.eattrash.raccoonforfriendica.core.architecture.di
 
 import androidx.lifecycle.ViewModelProvider
 import org.kodein.di.DI
-import org.kodein.di.bind
-import org.kodein.di.singleton
+import org.kodein.di.bindSingleton
 
 val viewModelFactoryModule = DI.Module("ViewModelFactoryModule") {
-    bind<ViewModelProvider.Factory> {
-        singleton {
-            CustomViewModelFactory(injector = di)
-        }
+    bindSingleton<ViewModelProvider.Factory> {
+        CustomViewModelFactory(injector = di)
     }
 }

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/di/ComponentsModule.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/di/ComponentsModule.kt
@@ -3,10 +3,11 @@ package com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.DefaultFabNestedScrollConnection
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.FabNestedScrollConnection
 import org.kodein.di.DI
-import org.kodein.di.bind
-import org.kodein.di.singleton
+import org.kodein.di.bindSingleton
 
 val commonUiComponentsModule =
     DI.Module("CommonUiComponentsModule") {
-        bind<FabNestedScrollConnection> { singleton { DefaultFabNestedScrollConnection() } }
+        bindSingleton<FabNestedScrollConnection> {
+            DefaultFabNestedScrollConnection()
+        }
     }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/di/L10nModule.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/di/L10nModule.kt
@@ -4,9 +4,12 @@ import com.livefast.eattrash.raccoonforfriendica.core.l10n.DefaultL10nManager
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.L10nManager
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
 val l10nModule =
     DI.Module("L10nModule") {
-        bind<L10nManager> { singleton { DefaultL10nManager() } }
+        bindSingleton<L10nManager> {
+            DefaultL10nManager()
+        }
     }

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/di/NavigationModule.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/di/NavigationModule.kt
@@ -5,11 +5,14 @@ import com.livefast.eattrash.raccoonforfriendica.core.navigation.DefaultNavigati
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.DrawerCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.NavigationCoordinator
 import org.kodein.di.DI
-import org.kodein.di.bind
-import org.kodein.di.singleton
+import org.kodein.di.bindSingleton
 
 val navigationModule =
     DI.Module("NavigationModule") {
-        bind<NavigationCoordinator> { singleton { DefaultNavigationCoordinator() } }
-        bind<DrawerCoordinator> { singleton { DefaultDrawerCoordinator() } }
+        bindSingleton<NavigationCoordinator> {
+            DefaultNavigationCoordinator()
+        }
+        bindSingleton<DrawerCoordinator> {
+            DefaultDrawerCoordinator()
+        }
     }

--- a/core/notifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/notifications/di/NotificationsModule.kt
+++ b/core/notifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/notifications/di/NotificationsModule.kt
@@ -3,10 +3,11 @@ package com.livefast.eattrash.raccoonforfriendica.core.notifications.di
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.DefaultNotificationCenter
 import com.livefast.eattrash.raccoonforfriendica.core.notifications.NotificationCenter
 import org.kodein.di.DI
-import org.kodein.di.bind
-import org.kodein.di.singleton
+import org.kodein.di.bindSingleton
 
 val notificationsModule =
     DI.Module("NotificationsModule") {
-        bind<NotificationCenter> { singleton { DefaultNotificationCenter() } }
+        bindSingleton<NotificationCenter> {
+            DefaultNotificationCenter()
+        }
     }

--- a/core/persistence/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/di/NativePersistenceModule.kt
+++ b/core/persistence/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/di/NativePersistenceModule.kt
@@ -3,15 +3,12 @@ package com.livefast.eattrash.raccoonforfriendica.core.persistence.di
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.builder.DatabaseBuilderProvider
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.builder.DefaultDatabaseBuilderProvider
 import org.kodein.di.DI
-import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
-import org.kodein.di.singleton
 
 internal actual val nativePersistenceModule =
     DI.Module("NativePersistenceModule") {
-        bind<DatabaseBuilderProvider> {
-            singleton {
-                DefaultDatabaseBuilderProvider(context = instance())
-            }
+        bindSingleton<DatabaseBuilderProvider> {
+            DefaultDatabaseBuilderProvider(context = instance())
         }
     }

--- a/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/di/PersistenceModule.kt
+++ b/core/persistence/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/di/PersistenceModule.kt
@@ -7,43 +7,32 @@ import com.livefast.eattrash.raccoonforfriendica.core.persistence.dao.UserRateLi
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.provider.DatabaseProvider
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.provider.DefaultDatabaseProvider
 import org.kodein.di.DI
-import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
-import org.kodein.di.singleton
 
 val persistenceModule =
     DI.Module("PersistenceModule") {
         import(nativePersistenceModule)
 
-        bind<DatabaseProvider> {
-            singleton {
-                DefaultDatabaseProvider(
-                    builderProvider = instance(),
-                )
-            }
+        bindSingleton<DatabaseProvider> {
+            DefaultDatabaseProvider(
+                builderProvider = instance(),
+            )
         }
-        bind<AccountDao> {
-            singleton {
-                val provider = instance<DatabaseProvider>()
-                provider.provideDatabase().getAccountDao()
-            }
+        bindSingleton<AccountDao> {
+            val provider = instance<DatabaseProvider>()
+            provider.provideDatabase().getAccountDao()
         }
-        bind<SettingsDao> {
-            singleton {
-                val provider = instance<DatabaseProvider>()
-                provider.provideDatabase().getSettingsDao()
-            }
+        bindSingleton<SettingsDao> {
+            val provider = instance<DatabaseProvider>()
+            provider.provideDatabase().getSettingsDao()
         }
-        bind<DraftDao> {
-            singleton {
-                val provider = instance<DatabaseProvider>()
-                provider.provideDatabase().getDraftDao()
-            }
+        bindSingleton<DraftDao> {
+            val provider = instance<DatabaseProvider>()
+            provider.provideDatabase().getDraftDao()
         }
-        bind<UserRateLimitDao> {
-            singleton {
-                val provider = instance<DatabaseProvider>()
-                provider.provideDatabase().getUserRateLimitDao()
-            }
+        bindSingleton<UserRateLimitDao> {
+            val provider = instance<DatabaseProvider>()
+            provider.provideDatabase().getUserRateLimitDao()
         }
     }

--- a/core/persistence/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/di/NativePersistenceModule.kt
+++ b/core/persistence/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/di/NativePersistenceModule.kt
@@ -3,10 +3,11 @@ package com.livefast.eattrash.raccoonforfriendica.core.persistence.di
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.builder.DatabaseBuilderProvider
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.builder.DefaultDatabaseBuilderProvider
 import org.kodein.di.DI
-import org.kodein.di.bind
-import org.kodein.di.singleton
+import org.kodein.di.bindSingleton
 
 internal actual val nativePersistenceModule =
     DI.Module("NativePersistenceModule") {
-        bind<DatabaseBuilderProvider> { singleton { DefaultDatabaseBuilderProvider() } }
+        bindSingleton<DatabaseBuilderProvider> {
+            DefaultDatabaseBuilderProvider()
+        }
     }

--- a/core/persistence/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/di/NativePersistenceModule.kt
+++ b/core/persistence/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/persistence/di/NativePersistenceModule.kt
@@ -3,10 +3,11 @@ package com.livefast.eattrash.raccoonforfriendica.core.persistence.di
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.builder.DatabaseBuilderProvider
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.builder.DefaultDatabaseBuilderProvider
 import org.kodein.di.DI
-import org.kodein.di.bind
-import org.kodein.di.singleton
+import org.kodein.di.bindSingleton
 
 internal actual val nativePersistenceModule =
     DI.Module("NativePersistenceModule") {
-        bind<DatabaseBuilderProvider> { singleton { DefaultDatabaseBuilderProvider() } }
+        bindSingleton<DatabaseBuilderProvider> {
+            DefaultDatabaseBuilderProvider()
+        }
     }

--- a/core/preferences/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/di/NativePreferencesModule.kt
+++ b/core/preferences/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/di/NativePreferencesModule.kt
@@ -8,34 +8,25 @@ import com.livefast.eattrash.raccoonforfriendica.core.preferences.provider.Legac
 import com.livefast.eattrash.raccoonforfriendica.core.preferences.provider.SettingsProvider
 import com.livefast.eattrash.raccoonforfriendica.core.preferences.provider.SharedPreferencesProvider
 import org.kodein.di.DI
-import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
-import org.kodein.di.singleton
 
 internal actual val nativePreferencesModule =
     DI.Module("NativePreferencesModule") {
-        bind<SharedPreferencesProvider>(tag = "default") {
-            singleton {
-                DefaultSharedPreferencesProvider(context = instance())
-            }
+        bindSingleton<SharedPreferencesProvider>(tag = "default") {
+            DefaultSharedPreferencesProvider(context = instance())
         }
-        bind<SharedPreferencesProvider>(tag = "legacy") {
-            singleton {
-                LegacySharedPreferencesProvider(context = instance())
-            }
+        bindSingleton<SharedPreferencesProvider>(tag = "legacy") {
+            LegacySharedPreferencesProvider(context = instance())
         }
-        bind<SettingsProvider> {
-            singleton {
-                DefaultSettingsProvider(
-                    preferencesProvider = instance(tag = "default"),
-                    legacyPreferencesProvider = instance(tag = "legacy"),
-                    encryptionHelper = instance(),
-                )
-            }
+        bindSingleton<SettingsProvider> {
+            DefaultSettingsProvider(
+                preferencesProvider = instance(tag = "default"),
+                legacyPreferencesProvider = instance(tag = "legacy"),
+                encryptionHelper = instance(),
+            )
         }
-        bind<EncryptionHelper> {
-            singleton {
-                DefaultEncryptionHelper()
-            }
+        bindSingleton<EncryptionHelper> {
+            DefaultEncryptionHelper()
         }
     }

--- a/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/di/PreferencesModule.kt
+++ b/core/preferences/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/di/PreferencesModule.kt
@@ -6,25 +6,20 @@ import com.livefast.eattrash.raccoonforfriendica.core.preferences.settings.Setti
 import com.livefast.eattrash.raccoonforfriendica.core.preferences.store.DefaultTemporaryKeyStore
 import com.livefast.eattrash.raccoonforfriendica.core.preferences.store.TemporaryKeyStore
 import org.kodein.di.DI
-import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
-import org.kodein.di.singleton
 
 val preferencesModule =
     DI.Module("PreferencesModule") {
         import(nativePreferencesModule)
 
-        bind<SettingsWrapper> {
-            singleton {
-                val provider = instance<SettingsProvider>()
-                DefaultSettingsWrapper(settings = provider.provide())
-            }
+        bindSingleton<SettingsWrapper> {
+            val provider = instance<SettingsProvider>()
+            DefaultSettingsWrapper(settings = provider.provide())
         }
-        bind<TemporaryKeyStore> {
-            singleton {
-                DefaultTemporaryKeyStore(
-                    settings = instance(),
-                )
-            }
+        bindSingleton<TemporaryKeyStore> {
+            DefaultTemporaryKeyStore(
+                settings = instance(),
+            )
         }
     }

--- a/core/preferences/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/di/NativePreferencesModule.kt
+++ b/core/preferences/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/di/NativePreferencesModule.kt
@@ -3,14 +3,11 @@ package com.livefast.eattrash.raccoonforfriendica.core.preferences.di
 import com.livefast.eattrash.raccoonforfriendica.core.preferences.provider.DefaultSettingsProvider
 import com.livefast.eattrash.raccoonforfriendica.core.preferences.provider.SettingsProvider
 import org.kodein.di.DI
-import org.kodein.di.bind
-import org.kodein.di.singleton
+import org.kodein.di.bindSingleton
 
 internal actual val nativePreferencesModule =
     DI.Module("NativePreferencesModule") {
-        bind<SettingsProvider> {
-            singleton {
-                DefaultSettingsProvider()
-            }
+        bindSingleton<SettingsProvider> {
+            DefaultSettingsProvider()
         }
     }

--- a/core/preferences/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/di/NativePreferencesModule.kt
+++ b/core/preferences/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/preferences/di/NativePreferencesModule.kt
@@ -7,28 +7,21 @@ import com.livefast.eattrash.raccoonforfriendica.core.preferences.provider.Defau
 import com.livefast.eattrash.raccoonforfriendica.core.preferences.provider.PreferencesProvider
 import com.livefast.eattrash.raccoonforfriendica.core.preferences.provider.SettingsProvider
 import org.kodein.di.DI
-import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
-import org.kodein.di.singleton
 
 internal actual val nativePreferencesModule =
     DI.Module("NativePreferencesModule") {
-        bind<PreferencesProvider> {
-            singleton {
-                DefaultPreferencesProvider()
-            }
+        bindSingleton<PreferencesProvider> {
+            DefaultPreferencesProvider()
         }
-        bind<EncryptionHelper> {
-            singleton {
-                DefaultEncryptionHelper()
-            }
+        bindSingleton<EncryptionHelper> {
+            DefaultEncryptionHelper()
         }
-        bind<SettingsProvider> {
-            singleton {
-                DefaultSettingsProvider(
-                    provider = instance(),
-                    encryptionHelper = instance(),
-                )
-            }
+        bindSingleton<SettingsProvider> {
+            DefaultSettingsProvider(
+                provider = instance(),
+                encryptionHelper = instance(),
+            )
         }
     }

--- a/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/di/TranslationModule.kt
+++ b/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/di/TranslationModule.kt
@@ -5,19 +5,14 @@ import com.livefast.eattrash.raccoonforfriendica.core.translation.TranslationPro
 import com.livefast.eattrash.raccoonforfriendica.core.translation.store.DefaultTranslationProviderConfigStore
 import com.livefast.eattrash.raccoonforfriendica.core.translation.store.TranslationProviderConfigStore
 import org.kodein.di.DI
-import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
-import org.kodein.di.singleton
 
 val translationModule = DI.Module("TranslationModule") {
-    bind<TranslationProviderFactory> {
-        singleton {
-            DefaultTranslationProviderFactory()
-        }
+    bindSingleton<TranslationProviderFactory> {
+        DefaultTranslationProviderFactory()
     }
-    bind<TranslationProviderConfigStore> {
-        singleton {
-            DefaultTranslationProviderConfigStore(keyStore = instance())
-        }
+    bindSingleton<TranslationProviderConfigStore> {
+        DefaultTranslationProviderConfigStore(keyStore = instance())
     }
 }

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeAppIconModule.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeAppIconModule.kt
@@ -4,17 +4,16 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.appicon.AppIconManag
 import com.livefast.eattrash.raccoonforfriendica.core.utils.appicon.DefaultAppIconManager
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
 import org.kodein.di.singleton
 
 internal actual val nativeAppIconModule =
     DI.Module("NativeAppIconModule") {
-        bind<AppIconManager> {
-            singleton {
-                DefaultAppIconManager(
-                    context = instance(),
-                    keyStore = instance(),
-                )
-            }
+        bindSingleton<AppIconManager> {
+            DefaultAppIconManager(
+                context = instance(),
+                keyStore = instance(),
+            )
         }
     }

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeAppInfoModule.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeAppInfoModule.kt
@@ -4,14 +4,13 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.appinfo.AppInfoRepos
 import com.livefast.eattrash.raccoonforfriendica.core.utils.appinfo.DefaultAppInfoRepository
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
 import org.kodein.di.singleton
 
 internal actual val nativeAppInfoModule =
     DI.Module("NativeAppInfoModule") {
-        bind<AppInfoRepository> {
-            singleton {
-                DefaultAppInfoRepository(context = instance())
-            }
+        bindSingleton<AppInfoRepository> {
+            DefaultAppInfoRepository(context = instance())
         }
     }

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeCalendarModule.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeCalendarModule.kt
@@ -4,14 +4,13 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.calendar.CalendarHel
 import com.livefast.eattrash.raccoonforfriendica.core.utils.calendar.DefaultCalendarHelper
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
 import org.kodein.di.singleton
 
 internal actual val nativeCalendarModule =
     DI.Module("NativeCalendarModule") {
-        bind<CalendarHelper> {
-            singleton {
-                DefaultCalendarHelper(context = instance())
-            }
+        bindSingleton<CalendarHelper> {
+            DefaultCalendarHelper(context = instance())
         }
     }

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeConnectivityModule.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeConnectivityModule.kt
@@ -4,12 +4,11 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.network.Connectivity
 import com.livefast.eattrash.raccoonforfriendica.core.utils.network.DefaultConnectivityProvider
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
-internal actual val nativeConnectivityModule =  DI.Module("NativeConnectivityModule") {
-    bind<ConnectivityProvider> {
-        singleton {
-            DefaultConnectivityProvider()
-        }
+internal actual val nativeConnectivityModule = DI.Module("NativeConnectivityModule") {
+    bindSingleton<ConnectivityProvider> {
+        DefaultConnectivityProvider()
     }
 }

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeDebugModule.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeDebugModule.kt
@@ -4,16 +4,15 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.debug.CrashReportMan
 import com.livefast.eattrash.raccoonforfriendica.core.utils.debug.DefaultCrashReportManager
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
 import org.kodein.di.singleton
 
 internal actual val nativeDebugModule =
     DI.Module("NativeDebugModule") {
-        bind<CrashReportManager> {
-            singleton {
-                DefaultCrashReportManager(
-                    keyStore = instance(),
-                )
-            }
+        bindSingleton<CrashReportManager> {
+            DefaultCrashReportManager(
+                keyStore = instance(),
+            )
         }
     }

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeFileSystemModule.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeFileSystemModule.kt
@@ -4,16 +4,15 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.fs.DefaultFileSystem
 import com.livefast.eattrash.raccoonforfriendica.core.utils.fs.FileSystemManager
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
 import org.kodein.di.singleton
 
 internal actual val nativeFileSystemModule =
     DI.Module("NativeFileSystemModule") {
-        bind<FileSystemManager> {
-            singleton {
-                DefaultFileSystemManager(
-                    context = instance(),
-                )
-            }
+        bindSingleton<FileSystemManager> {
+            DefaultFileSystemManager(
+                context = instance(),
+            )
         }
     }

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeGalleryModule.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeGalleryModule.kt
@@ -4,16 +4,15 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.gallery.DefaultGalle
 import com.livefast.eattrash.raccoonforfriendica.core.utils.gallery.GalleryHelper
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
 import org.kodein.di.singleton
 
 internal actual val nativeGalleryModule =
     DI.Module("NativeGalleryModule") {
-        bind<GalleryHelper> {
-            singleton {
-                DefaultGalleryHelper(
-                    context = instance(),
-                )
-            }
+        bindSingleton<GalleryHelper> {
+            DefaultGalleryHelper(
+                context = instance(),
+            )
         }
     }

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeOpenUrlModule.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeOpenUrlModule.kt
@@ -4,16 +4,15 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.url.CustomTabsHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.url.DefaultCustomTabsHelper
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
 import org.kodein.di.singleton
 
 internal actual val nativeOpenUrlModule =
     DI.Module("NativeUrlModule") {
-        bind<CustomTabsHelper> {
-            singleton {
-                DefaultCustomTabsHelper(
-                    context = instance(),
-                )
-            }
+        bindSingleton<CustomTabsHelper> {
+            DefaultCustomTabsHelper(
+                context = instance(),
+            )
         }
     }

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeShareModule.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeShareModule.kt
@@ -4,16 +4,15 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.share.DefaultShareHe
 import com.livefast.eattrash.raccoonforfriendica.core.utils.share.ShareHelper
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
 import org.kodein.di.singleton
 
 internal actual val nativeShareModule =
     DI.Module("NativeShareModule") {
-        bind<ShareHelper> {
-            singleton {
-                DefaultShareHelper(
-                    context = instance(),
-                )
-            }
+        bindSingleton<ShareHelper> {
+            DefaultShareHelper(
+                context = instance(),
+            )
         }
     }

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeVibrateModule.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeVibrateModule.kt
@@ -4,16 +4,15 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate.DefaultHapti
 import com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate.HapticFeedback
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
 import org.kodein.di.singleton
 
 internal actual val nativeVibrateModule =
     DI.Module("NativeVibrateModule") {
-        bind<HapticFeedback> {
-            singleton {
-                DefaultHapticFeedback(
-                    context = instance(),
-                )
-            }
+        bindSingleton<HapticFeedback> {
+            DefaultHapticFeedback(
+                context = instance(),
+            )
         }
     }

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/UtilsModule.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/UtilsModule.kt
@@ -13,6 +13,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.network.DefaultNetwo
 import com.livefast.eattrash.raccoonforfriendica.core.utils.network.NetworkStateObserver
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
 import org.kodein.di.singleton
 
@@ -33,39 +34,28 @@ val utilsModule =
             nativeVibrateModule,
         )
 
-        bind<BlurHashDecoder> {
-            singleton {
-                DefaultBlurHashDecoder()
-            }
+        bindSingleton<BlurHashDecoder> {
+            DefaultBlurHashDecoder()
         }
-        bind<BlurHashRepository> {
-            singleton {
-                DefaultBlurHashRepository(
-                    decoder = instance(),
-                )
-            }
+        bindSingleton<BlurHashRepository> {
+            DefaultBlurHashRepository(
+                decoder = instance(),
+            )
         }
-        bind<ImagePreloadManager> {
-            singleton {
-                DefaultImagePreloadManager(
-                    context = instance(),
-                    imageLoaderProvider = instance(),
-                )
-            }
+        bindSingleton<ImagePreloadManager> {
+            DefaultImagePreloadManager(
+                context = instance(),
+                imageLoaderProvider = instance(),
+            )
         }
-        bind<ImageLoaderProvider> {
-            singleton {
-                DefaultImageLoaderProvider(
-                    context = instance(),
-                    fileSystemManager = instance(),
-                )
-            }
+        bindSingleton<ImageLoaderProvider> {
+            DefaultImageLoaderProvider(
+                context = instance(),
+                fileSystemManager = instance(),
+            )
         }
-
-        bind<NetworkStateObserver> {
-            singleton {
-                val connectivityProvider = instance<ConnectivityProvider>()
-                DefaultNetworkStateObserver(connectivityProvider.provide())
-            }
+        bindSingleton<NetworkStateObserver> {
+            val connectivityProvider = instance<ConnectivityProvider>()
+            DefaultNetworkStateObserver(connectivityProvider.provide())
         }
     }

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeAppIconModule.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeAppIconModule.kt
@@ -4,13 +4,12 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.appicon.AppIconManag
 import com.livefast.eattrash.raccoonforfriendica.core.utils.appicon.DefaultAppIconManager
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
 internal actual val nativeAppIconModule =
     DI.Module("NativeAppIconModule") {
-        bind<AppIconManager> {
-            singleton {
-                DefaultAppIconManager()
-            }
+        bindSingleton<AppIconManager> {
+            DefaultAppIconManager()
         }
     }

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeAppInfoModule.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeAppInfoModule.kt
@@ -4,13 +4,12 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.appinfo.AppInfoRepos
 import com.livefast.eattrash.raccoonforfriendica.core.utils.appinfo.DefaultAppInfoRepository
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
 internal actual val nativeAppInfoModule =
     DI.Module("NativeAppInfoModule") {
-        bind<AppInfoRepository> {
-            singleton {
-                DefaultAppInfoRepository()
-            }
+        bindSingleton<AppInfoRepository> {
+            DefaultAppInfoRepository()
         }
     }

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeCalendarModule.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeCalendarModule.kt
@@ -4,13 +4,12 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.calendar.CalendarHel
 import com.livefast.eattrash.raccoonforfriendica.core.utils.calendar.DefaultCalendarHelper
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
 internal actual val nativeCalendarModule =
     DI.Module("NativeCalendarModule") {
-        bind<CalendarHelper> {
-            singleton {
-                DefaultCalendarHelper()
-            }
+        bindSingleton<CalendarHelper> {
+            DefaultCalendarHelper()
         }
     }

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeConnectivityModule.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeConnectivityModule.kt
@@ -4,12 +4,11 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.network.Connectivity
 import com.livefast.eattrash.raccoonforfriendica.core.utils.network.DefaultConnectivityProvider
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
-internal actual val nativeConnectivityModule =  DI.Module("NativeConnectivityModule") {
-    bind<ConnectivityProvider> {
-        singleton {
-            DefaultConnectivityProvider()
-        }
+internal actual val nativeConnectivityModule = DI.Module("NativeConnectivityModule") {
+    bindSingleton<ConnectivityProvider> {
+        DefaultConnectivityProvider()
     }
 }

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeDebugModule.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeDebugModule.kt
@@ -4,16 +4,15 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.debug.CrashReportMan
 import com.livefast.eattrash.raccoonforfriendica.core.utils.debug.DefaultCrashReportManager
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
 import org.kodein.di.singleton
 
 internal actual val nativeDebugModule =
     DI.Module("NativeDebugModule") {
-        bind<CrashReportManager> {
-            singleton {
-                DefaultCrashReportManager(
-                    keyStore = instance(),
-                )
-            }
+        bindSingleton<CrashReportManager> {
+            DefaultCrashReportManager(
+                keyStore = instance(),
+            )
         }
     }

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeFileSystemModule.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeFileSystemModule.kt
@@ -4,13 +4,12 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.fs.DefaultFileSystem
 import com.livefast.eattrash.raccoonforfriendica.core.utils.fs.FileSystemManager
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
 internal actual val nativeFileSystemModule =
     DI.Module("NativeFileSystemModule") {
-        bind<FileSystemManager> {
-            singleton {
-                DefaultFileSystemManager()
-            }
+        bindSingleton<FileSystemManager> {
+            DefaultFileSystemManager()
         }
     }

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeGalleryModule.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeGalleryModule.kt
@@ -4,13 +4,12 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.gallery.DefaultGalle
 import com.livefast.eattrash.raccoonforfriendica.core.utils.gallery.GalleryHelper
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
 internal actual val nativeGalleryModule =
     DI.Module("NativeGalleryModule") {
-        bind<GalleryHelper> {
-            singleton {
-                DefaultGalleryHelper()
-            }
+        bindSingleton<GalleryHelper> {
+            DefaultGalleryHelper()
         }
     }

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeImageLoadModule.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeImageLoadModule.kt
@@ -3,12 +3,11 @@ package com.livefast.eattrash.raccoonforfriendica.core.utils.di
 import coil3.PlatformContext
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
 internal actual val nativeImageLoadModule = DI.Module("NativeImageLoadModule") {
-    bind<PlatformContext> {
-        singleton {
-            PlatformContext.INSTANCE
-        }
+    bindSingleton<PlatformContext> {
+        PlatformContext.INSTANCE
     }
 }

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeOpenUrlModule.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeOpenUrlModule.kt
@@ -4,13 +4,12 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.url.CustomTabsHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.url.DefaultCustomTabsHelper
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
 internal actual val nativeOpenUrlModule =
     DI.Module("NativeUrlModule") {
-        bind<CustomTabsHelper> {
-            singleton {
-                DefaultCustomTabsHelper()
-            }
+        bindSingleton<CustomTabsHelper> {
+            DefaultCustomTabsHelper()
         }
     }

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeShareModule.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeShareModule.kt
@@ -4,13 +4,12 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.share.DefaultShareHe
 import com.livefast.eattrash.raccoonforfriendica.core.utils.share.ShareHelper
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
 internal actual val nativeShareModule =
     DI.Module("NativeShareModule") {
-        bind<ShareHelper> {
-            singleton {
-                DefaultShareHelper()
-            }
+        bindSingleton<ShareHelper> {
+            DefaultShareHelper()
         }
     }

--- a/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeVibrateModule.kt
+++ b/core/utils/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeVibrateModule.kt
@@ -4,13 +4,12 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate.DefaultHapti
 import com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate.HapticFeedback
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
 internal actual val nativeVibrateModule =
     DI.Module("NativeVibrateModule") {
-        bind<HapticFeedback> {
-            singleton {
-                DefaultHapticFeedback()
-            }
+        bindSingleton<HapticFeedback> {
+            DefaultHapticFeedback()
         }
     }

--- a/core/utils/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeAppIconModule.kt
+++ b/core/utils/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeAppIconModule.kt
@@ -4,13 +4,12 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.appicon.AppIconManag
 import com.livefast.eattrash.raccoonforfriendica.core.utils.appicon.DefaultAppIconManager
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
 internal actual val nativeAppIconModule =
     DI.Module("NativeAppIconModule") {
-        bind<AppIconManager> {
-            singleton {
-                DefaultAppIconManager()
-            }
+        bindSingleton<AppIconManager> {
+            DefaultAppIconManager()
         }
     }

--- a/core/utils/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeAppInfoModule.kt
+++ b/core/utils/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeAppInfoModule.kt
@@ -4,13 +4,12 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.appinfo.AppInfoRepos
 import com.livefast.eattrash.raccoonforfriendica.core.utils.appinfo.DefaultAppInfoRepository
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
 internal actual val nativeAppInfoModule =
     DI.Module("NativeAppInfoModule") {
-        bind<AppInfoRepository> {
-            singleton {
-                DefaultAppInfoRepository()
-            }
+        bindSingleton<AppInfoRepository> {
+            DefaultAppInfoRepository()
         }
     }

--- a/core/utils/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeCalendarModule.kt
+++ b/core/utils/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeCalendarModule.kt
@@ -4,13 +4,12 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.calendar.CalendarHel
 import com.livefast.eattrash.raccoonforfriendica.core.utils.calendar.DefaultCalendarHelper
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
 internal actual val nativeCalendarModule =
     DI.Module("NativeCalendarModule") {
-        bind<CalendarHelper> {
-            singleton {
-                DefaultCalendarHelper()
-            }
+        bindSingleton<CalendarHelper> {
+            DefaultCalendarHelper()
         }
     }

--- a/core/utils/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeConnectivityModule.kt
+++ b/core/utils/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeConnectivityModule.kt
@@ -4,13 +4,12 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.network.Connectivity
 import com.livefast.eattrash.raccoonforfriendica.core.utils.network.DefaultConnectivityProvider
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
 
-internal actual val nativeConnectivityModule =  DI.Module("NativeConnectivityModule") {
-    bind<ConnectivityProvider> {
-        singleton {
-            DefaultConnectivityProvider()
-        }
+internal actual val nativeConnectivityModule = DI.Module("NativeConnectivityModule") {
+    bindSingleton<ConnectivityProvider> {
+        DefaultConnectivityProvider()
     }
 }

--- a/core/utils/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeDebugModule.kt
+++ b/core/utils/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeDebugModule.kt
@@ -4,14 +4,13 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.debug.CrashReportMan
 import com.livefast.eattrash.raccoonforfriendica.core.utils.debug.DefaultCrashReportManager
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
 import org.kodein.di.singleton
 
 internal actual val nativeDebugModule =
     DI.Module("NativeDebugModule") {
-        bind<CrashReportManager> {
-            singleton {
-                DefaultCrashReportManager(keyStore = instance())
-            }
+        bindSingleton<CrashReportManager> {
+            DefaultCrashReportManager(keyStore = instance())
         }
     }

--- a/core/utils/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeFileSystemModule.kt
+++ b/core/utils/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeFileSystemModule.kt
@@ -4,13 +4,12 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.fs.DefaultFileSystem
 import com.livefast.eattrash.raccoonforfriendica.core.utils.fs.FileSystemManager
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
 internal actual val nativeFileSystemModule =
     DI.Module("NativeFileSystemModule") {
-        bind<FileSystemManager> {
-            singleton {
-                DefaultFileSystemManager()
-            }
+        bindSingleton<FileSystemManager> {
+            DefaultFileSystemManager()
         }
     }

--- a/core/utils/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeGalleryModule.kt
+++ b/core/utils/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeGalleryModule.kt
@@ -4,13 +4,12 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.gallery.DefaultGalle
 import com.livefast.eattrash.raccoonforfriendica.core.utils.gallery.GalleryHelper
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
 internal actual val nativeGalleryModule =
     DI.Module("NativeGalleryModule") {
-        bind<GalleryHelper> {
-            singleton {
-                DefaultGalleryHelper()
-            }
+        bindSingleton<GalleryHelper> {
+            DefaultGalleryHelper()
         }
     }

--- a/core/utils/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeImageLoadModule.kt
+++ b/core/utils/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeImageLoadModule.kt
@@ -1,14 +1,13 @@
 package com.livefast.eattrash.raccoonforfriendica.core.utils.di
 
-import org.kodein.di.DI
 import coil3.PlatformContext
+import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
 internal actual val nativeImageLoadModule = DI.Module("NativeImageLoadModule") {
-    bind<PlatformContext> {
-        singleton {
-            PlatformContext.INSTANCE
-        }
+    bindSingleton<PlatformContext> {
+        PlatformContext.INSTANCE
     }
 }

--- a/core/utils/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeOpenUrlModule.kt
+++ b/core/utils/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeOpenUrlModule.kt
@@ -4,13 +4,12 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.url.CustomTabsHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.url.DefaultCustomTabsHelper
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
 internal actual val nativeOpenUrlModule =
     DI.Module("NativeUrlModule") {
-        bind<CustomTabsHelper> {
-            singleton {
-                DefaultCustomTabsHelper()
-            }
+        bindSingleton<CustomTabsHelper> {
+            DefaultCustomTabsHelper()
         }
     }

--- a/core/utils/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeShareModule.kt
+++ b/core/utils/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeShareModule.kt
@@ -4,13 +4,12 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.share.DefaultShareHe
 import com.livefast.eattrash.raccoonforfriendica.core.utils.share.ShareHelper
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
 internal actual val nativeShareModule =
     DI.Module("NativeShareModule") {
-        bind<ShareHelper> {
-            singleton {
-                DefaultShareHelper()
-            }
+        bindSingleton<ShareHelper> {
+            DefaultShareHelper()
         }
     }

--- a/core/utils/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeVibrateModule.kt
+++ b/core/utils/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/NativeVibrateModule.kt
@@ -4,13 +4,12 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate.DefaultHapti
 import com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate.HapticFeedback
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
 internal actual val nativeVibrateModule =
     DI.Module("NativeVibrateModule") {
-        bind<HapticFeedback> {
-            singleton {
-                DefaultHapticFeedback()
-            }
+        bindSingleton<HapticFeedback> {
+            DefaultHapticFeedback()
         }
     }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/di/ContentPaginationModule.kt
@@ -25,128 +25,103 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.Timel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.UnpublishedPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.UserPaginationManager
 import org.kodein.di.DI
-import org.kodein.di.bind
+import org.kodein.di.bindProvider
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
-import org.kodein.di.provider
-import org.kodein.di.singleton
 
 val contentPaginationModule =
     DI.Module("ContentPaginationModule") {
-        bind<AlbumPhotoPaginationManager> {
-            provider {
-                DefaultAlbumPhotoPaginationManager(
-                    albumRepository = instance(),
-                )
-            }
+        bindProvider<AlbumPhotoPaginationManager> {
+            DefaultAlbumPhotoPaginationManager(
+                albumRepository = instance(),
+            )
         }
-        bind<DirectMessagesPaginationManager> {
-            provider {
-                DefaultDirectMessagesPaginationManager(
-                    directMessageRepository = instance(),
-                    emojiHelper = instance(),
-                )
-            }
+        bindProvider<DirectMessagesPaginationManager> {
+            DefaultDirectMessagesPaginationManager(
+                directMessageRepository = instance(),
+                emojiHelper = instance(),
+            )
         }
-        bind<EventPaginationManager> {
-            provider {
-                DefaultEventPaginationManager(
-                    eventRepository = instance(),
-                )
-            }
+        bindProvider<EventPaginationManager> {
+            DefaultEventPaginationManager(
+                eventRepository = instance(),
+            )
         }
-        bind<ExplorePaginationManager> {
-            provider {
-                DefaultExplorePaginationManager(
-                    trendingRepository = instance(),
-                    userRepository = instance(),
-                    emojiHelper = instance(),
-                    replyHelper = instance(),
-                    accountRepository = instance(),
-                    stopWordRepository = instance(),
-                    notificationCenter = instance(),
-                )
-            }
+        bindProvider<ExplorePaginationManager> {
+            DefaultExplorePaginationManager(
+                trendingRepository = instance(),
+                userRepository = instance(),
+                emojiHelper = instance(),
+                replyHelper = instance(),
+                accountRepository = instance(),
+                stopWordRepository = instance(),
+                notificationCenter = instance(),
+            )
         }
-        bind<FollowedHashtagsPaginationManager> {
-            provider {
-                DefaultFollowedHashtagsPaginationManager(
-                    tagRepository = instance(),
-                )
-            }
+        bindProvider<FollowedHashtagsPaginationManager> {
+            DefaultFollowedHashtagsPaginationManager(
+                tagRepository = instance(),
+            )
         }
-        bind<FollowRequestPaginationManager> {
-            provider {
-                DefaultFollowRequestPaginationManager(
-                    userRepository = instance(),
-                    emojiHelper = instance(),
-                )
-            }
+        bindProvider<FollowRequestPaginationManager> {
+            DefaultFollowRequestPaginationManager(
+                userRepository = instance(),
+                emojiHelper = instance(),
+            )
         }
-        bind<NotificationsPaginationManager> {
-            provider {
-                DefaultNotificationsPaginationManager(
-                    notificationRepository = instance(),
-                    userRepository = instance(),
-                    emojiHelper = instance(),
-                    replyHelper = instance(),
-                )
-            }
+        bindProvider<NotificationsPaginationManager> {
+            DefaultNotificationsPaginationManager(
+                notificationRepository = instance(),
+                userRepository = instance(),
+                emojiHelper = instance(),
+                replyHelper = instance(),
+            )
         }
-        bind<SearchPaginationManager> {
-            provider {
-                DefaultSearchPaginationManager(
-                    searchRepository = instance(),
-                    userRepository = instance(),
-                    emojiHelper = instance(),
-                    replyHelper = instance(),
-                    accountRepository = instance(),
-                    stopWordRepository = instance(),
-                    notificationCenter = instance(),
-                )
-            }
+        bindProvider<SearchPaginationManager> {
+            DefaultSearchPaginationManager(
+                searchRepository = instance(),
+                userRepository = instance(),
+                emojiHelper = instance(),
+                replyHelper = instance(),
+                accountRepository = instance(),
+                stopWordRepository = instance(),
+                notificationCenter = instance(),
+            )
         }
-        bind<TimelinePaginationManager> {
-            provider {
-                DefaultTimelinePaginationManager(
-                    timelineRepository = instance(),
-                    timelineEntryRepository = instance(),
-                    accountRepository = instance(),
-                    userRateLimitRepository = instance(),
-                    emojiHelper = instance(),
-                    replyHelper = instance(),
-                    stopWordRepository = instance(),
-                    followedHashtagCache = instance(),
-                    notificationCenter = instance(),
-                )
-            }
+        bindProvider<TimelinePaginationManager> {
+            DefaultTimelinePaginationManager(
+                timelineRepository = instance(),
+                timelineEntryRepository = instance(),
+                accountRepository = instance(),
+                userRateLimitRepository = instance(),
+                emojiHelper = instance(),
+                replyHelper = instance(),
+                stopWordRepository = instance(),
+                followedHashtagCache = instance(),
+                notificationCenter = instance(),
+            )
         }
-        bind<UnpublishedPaginationManager> {
-            provider {
-                DefaultUnpublishedPaginationManager(
-                    scheduledEntryRepository = instance(),
-                    draftRepository = instance(),
-                    notificationCenter = instance(),
-                )
-            }
+        bindProvider<UnpublishedPaginationManager> {
+            DefaultUnpublishedPaginationManager(
+                scheduledEntryRepository = instance(),
+                draftRepository = instance(),
+                notificationCenter = instance(),
+            )
         }
-        bind<UserPaginationManager> {
-            provider {
-                DefaultUserPaginationManager(
-                    userRepository = instance(),
-                    timelineEntryRepository = instance(),
-                    circlesRepository = instance(),
-                    accountRepository = instance(),
-                    userRateLimitRepository = instance(),
-                    emojiHelper = instance(),
-                    notificationCenter = instance(),
-                )
-            }
+        bindProvider<UserPaginationManager> {
+            DefaultUserPaginationManager(
+                userRepository = instance(),
+                timelineEntryRepository = instance(),
+                circlesRepository = instance(),
+                accountRepository = instance(),
+                userRateLimitRepository = instance(),
+                emojiHelper = instance(),
+                notificationCenter = instance(),
+            )
         }
-        bind<TimelineNavigationManager> {
-            singleton {
-                DefaultTimelineNavigationManager(
-                    paginationManager = instance(),
-                )
-            }
+        bindSingleton<TimelineNavigationManager> {
+            DefaultTimelineNavigationManager(
+                paginationManager = instance(),
+            )
         }
     }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
@@ -69,245 +69,192 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Trend
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRateLimitRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
 import org.kodein.di.DI
-import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
-import org.kodein.di.singleton
 
 internal val cacheModule =
     DI.Module("ContentRepositoryCacheModule") {
-        bind<LocalItemCache<UserModel>> { singleton { DefaultLocalItemCache() } }
-        bind<LocalItemCache<TimelineEntryModel>> { singleton { DefaultLocalItemCache() } }
-        bind<LocalItemCache<EventModel>> { singleton { DefaultLocalItemCache() } }
-        bind<LocalItemCache<CircleModel>> { singleton { DefaultLocalItemCache() } }
-        bind<LocalItemCache<ScheduledEntryRepository>> { singleton { DefaultLocalItemCache() } }
+        bindSingleton<LocalItemCache<UserModel>> {
+            DefaultLocalItemCache()
+        }
+        bindSingleton<LocalItemCache<TimelineEntryModel>> {
+            DefaultLocalItemCache()
+        }
+        bindSingleton<LocalItemCache<EventModel>> {
+            DefaultLocalItemCache()
+        }
+        bindSingleton<LocalItemCache<CircleModel>> {
+            DefaultLocalItemCache()
+        }
+        bindSingleton<LocalItemCache<ScheduledEntryRepository>> {
+            DefaultLocalItemCache()
+        }
     }
 
 val contentRepositoryModule =
     DI.Module("ContentRepositoryModule") {
         import(cacheModule)
 
-        bind<AnnouncementRepository> {
-            singleton {
-                DefaultAnnouncementRepository(
-                    provider = instance(tag = "default"),
-                )
-            }
+        bindSingleton<AnnouncementRepository> {
+            DefaultAnnouncementRepository(
+                provider = instance(tag = "default"),
+            )
         }
-        bind<AnnouncementsManager> {
-            singleton {
-                DefaultAnnouncementsManager(
-                    announcementRepository = instance(),
-                )
-            }
+        bindSingleton<AnnouncementsManager> {
+            DefaultAnnouncementsManager(
+                announcementRepository = instance(),
+            )
         }
-        bind<CirclesRepository> {
-            singleton {
-                DefaultCirclesRepository(
-                    provider = instance(tag = "default"),
-                )
-            }
+        bindSingleton<CirclesRepository> {
+            DefaultCirclesRepository(
+                provider = instance(tag = "default"),
+            )
         }
-        bind<DirectMessageRepository> {
-            singleton {
-                DefaultDirectMessageRepository(
-                    provider = instance(tag = "default"),
-                )
-            }
+        bindSingleton<DirectMessageRepository> {
+            DefaultDirectMessageRepository(
+                provider = instance(tag = "default"),
+            )
         }
-        bind<DraftRepository> {
-            singleton {
-                DefaultDraftRepository(
-                    draftDao = instance(),
-                    provider = instance(tag = "default"),
-                )
-            }
+        bindSingleton<DraftRepository> {
+            DefaultDraftRepository(
+                draftDao = instance(),
+                provider = instance(tag = "default"),
+            )
         }
-        bind<EmojiHelper> {
-            singleton {
-                DefaultEmojiHelper(
-                    repository = instance(),
-                )
-            }
+        bindSingleton<EmojiHelper> {
+            DefaultEmojiHelper(
+                repository = instance(),
+            )
         }
-        bind<EmojiRepository> {
-            singleton {
-                DefaultEmojiRepository(
-                    provider = instance(tag = "default"),
-                    otherProvider = instance(tag = "other"),
-                )
-            }
+        bindSingleton<EmojiRepository> {
+            DefaultEmojiRepository(
+                provider = instance(tag = "default"),
+                otherProvider = instance(tag = "other"),
+            )
         }
-        bind<EventRepository> {
-            singleton {
-                DefaultEventRepository(
-                    provider = instance(tag = "default"),
-                )
-            }
+        bindSingleton<EventRepository> {
+            DefaultEventRepository(
+                provider = instance(tag = "default"),
+            )
         }
-        bind<InboxManager> {
-            singleton {
-                DefaultInboxManager(
-                    notificationRepository = instance(),
-                    markerRepository = instance(),
-                )
-            }
+        bindSingleton<InboxManager> {
+            DefaultInboxManager(
+                notificationRepository = instance(),
+                markerRepository = instance(),
+            )
         }
-        bind<MarkerRepository> {
-            singleton {
-                DefaultMarkerRepository(
-                    provider = instance(tag = "default"),
-                )
-            }
+        bindSingleton<MarkerRepository> {
+            DefaultMarkerRepository(
+                provider = instance(tag = "default"),
+            )
         }
-        bind<MediaRepository> {
-            singleton {
-                DefaultMediaRepository(
-                    provider = instance(tag = "default"),
-                )
-            }
+        bindSingleton<MediaRepository> {
+            DefaultMediaRepository(
+                provider = instance(tag = "default"),
+            )
         }
-        bind<NodeInfoRepository> {
-            singleton {
-                DefaultNodeInfoRepository(
-                    provider = instance(tag = "default"),
-                    json = instance(),
-                )
-            }
+        bindSingleton<NodeInfoRepository> {
+            DefaultNodeInfoRepository(
+                provider = instance(tag = "default"),
+                json = instance(),
+            )
         }
-        bind<NotificationRepository> {
-            singleton {
-                DefaultNotificationRepository(
-                    provider = instance(tag = "default"),
-                )
-            }
+        bindSingleton<NotificationRepository> {
+            DefaultNotificationRepository(
+                provider = instance(tag = "default"),
+            )
         }
-        bind<PhotoAlbumRepository> {
-            singleton {
-                DefaultPhotoAlbumRepository(
-                    provider = instance(tag = "default"),
-                )
-            }
+        bindSingleton<PhotoAlbumRepository> {
+            DefaultPhotoAlbumRepository(
+                provider = instance(tag = "default"),
+            )
         }
-        bind<PhotoRepository> {
-            singleton {
-                DefaultPhotoRepository(
-                    provider = instance(tag = "default"),
-                )
-            }
+        bindSingleton<PhotoRepository> {
+            DefaultPhotoRepository(
+                provider = instance(tag = "default"),
+            )
         }
-        bind<PushNotificationRepository> {
-            singleton {
-                DefaultPushNotificationRepository(
-                    provider = instance(tag = "default"),
-                )
-            }
+        bindSingleton<PushNotificationRepository> {
+            DefaultPushNotificationRepository(
+                provider = instance(tag = "default"),
+            )
         }
-        bind<ReplyHelper> {
-            singleton {
-                DefaultReplyHelper(
-                    entryRepository = instance(),
-                )
-            }
+        bindSingleton<ReplyHelper> {
+            DefaultReplyHelper(
+                entryRepository = instance(),
+            )
         }
-        bind<ReportRepository> {
-            singleton {
-                DefaultReportRepository(
-                    provider = instance(tag = "default"),
-                )
-            }
+        bindSingleton<ReportRepository> {
+            DefaultReportRepository(
+                provider = instance(tag = "default"),
+            )
         }
-        bind<ScheduledEntryRepository> {
-            singleton {
-                DefaultScheduledEntryRepository(
-                    provider = instance(tag = "default"),
-                )
-            }
+        bindSingleton<ScheduledEntryRepository> {
+            DefaultScheduledEntryRepository(
+                provider = instance(tag = "default"),
+            )
         }
-        bind<SearchRepository> {
-            singleton {
-                DefaultSearchRepository(
-                    provider = instance(tag = "default"),
-                )
-            }
+        bindSingleton<SearchRepository> {
+            DefaultSearchRepository(
+                provider = instance(tag = "default"),
+            )
         }
-        bind<SupportedFeatureRepository> {
-            singleton {
-                DefaultSupportedFeatureRepository(
-                    nodeInfoRepository = instance(),
-                )
-            }
+        bindSingleton<SupportedFeatureRepository> {
+            DefaultSupportedFeatureRepository(
+                nodeInfoRepository = instance(),
+            )
         }
-        bind<TagRepository> {
-            singleton {
-                DefaultTagRepository(
-                    provider = instance(tag = "default"),
-                )
-            }
+        bindSingleton<TagRepository> {
+            DefaultTagRepository(
+                provider = instance(tag = "default"),
+            )
         }
-        bind<TimelineEntryRepository> {
-            singleton {
-                DefaultTimelineEntryRepository(
-                    provider = instance(tag = "default"),
-                    otherProvider = instance(tag = "other"),
-                )
-            }
+        bindSingleton<TimelineEntryRepository> {
+            DefaultTimelineEntryRepository(
+                provider = instance(tag = "default"),
+                otherProvider = instance(tag = "other"),
+            )
         }
-        bind<TimelineRepository> {
-            singleton {
-                DefaultTimelineRepository(
-                    provider = instance(tag = "default"),
-                    otherProvider = instance(tag = "other"),
-                )
-            }
+        bindSingleton<TimelineRepository> {
+            DefaultTimelineRepository(
+                provider = instance(tag = "default"),
+                otherProvider = instance(tag = "other"),
+            )
         }
-        bind<TrendingRepository> {
-            singleton {
-                DefaultTrendingRepository(
-                    provider = instance(tag = "default"),
-                    otherProvider = instance(tag = "other"),
-                    json = instance(),
-                )
-            }
+        bindSingleton<TrendingRepository> {
+            DefaultTrendingRepository(
+                provider = instance(tag = "default"),
+                otherProvider = instance(tag = "other"),
+                json = instance(),
+            )
         }
-        bind<UserRepository> {
-            singleton {
-                DefaultUserRepository(
-                    provider = instance(tag = "default"),
-                    otherProvider = instance(tag = "other"),
-                )
-            }
+        bindSingleton<UserRepository> {
+            DefaultUserRepository(
+                provider = instance(tag = "default"),
+                otherProvider = instance(tag = "other"),
+            )
         }
-        bind<UserRateLimitRepository> {
-            singleton {
-                DefaultUserRateLimitRepository(
-                    userRateLimitDao = instance(),
-                )
-            }
+        bindSingleton<UserRateLimitRepository> {
+            DefaultUserRateLimitRepository(
+                userRateLimitDao = instance(),
+            )
         }
-        bind<TranslationRepository> {
-            singleton {
-                DefaultTranslationRepository(
-                    provider = instance(tag = "default"),
-                )
-            }
+        bindSingleton<TranslationRepository> {
+            DefaultTranslationRepository(
+                provider = instance(tag = "default"),
+            )
         }
-        bind<FallbackTranslationRepository> {
-            singleton {
-                DefaultFallbackTranslationRepository(
-                    translationProviderFactory = instance(),
-                )
-            }
+        bindSingleton<FallbackTranslationRepository> {
+            DefaultFallbackTranslationRepository(
+                translationProviderFactory = instance(),
+            )
         }
-        bind<FollowedHashtagCache> {
-            singleton {
-                DefaultFollowedHashtagCache(
-                    tagRepository = instance(),
-                )
-            }
+        bindSingleton<FollowedHashtagCache> {
+            DefaultFollowedHashtagCache(
+                tagRepository = instance(),
+            )
         }
-        bind<AttachmentCache> {
-            singleton {
-                DefaultAttachmentCache()
-            }
+        bindSingleton<AttachmentCache> {
+            DefaultAttachmentCache()
         }
     }

--- a/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/di/ContentUseCaseModule.kt
+++ b/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/di/ContentUseCaseModule.kt
@@ -19,71 +19,56 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.converte
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.converters.DefaultMarkdownConverter
 import com.livefast.eattrash.raccoonforfriendica.domain.content.usecase.converters.MarkdownConverter
 import org.kodein.di.DI
-import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
-import org.kodein.di.singleton
 
 val contentUseCaseModule =
     DI.Module("ContentUseCaseModule") {
-        bind<ExportUserListUseCase> {
-            singleton {
-                DefaultExportUserListUseCase(
-                    userRepository = instance(),
-                )
-            }
+        bindSingleton<ExportUserListUseCase> {
+            DefaultExportUserListUseCase(
+                userRepository = instance(),
+            )
         }
-        bind<ToggleEntryFavoriteUseCase> {
-            singleton {
-                DefaultToggleEntryFavoriteUseCase(
-                    entryRepository = instance(),
-                )
-            }
+        bindSingleton<ToggleEntryFavoriteUseCase> {
+            DefaultToggleEntryFavoriteUseCase(
+                entryRepository = instance(),
+            )
         }
-        bind<ToggleEntryDislikeUseCase> {
-            singleton {
-                DefaultToggleEntryDislikeUseCase(
-                    entryRepository = instance(),
-                )
-            }
+        bindSingleton<ToggleEntryDislikeUseCase> {
+            DefaultToggleEntryDislikeUseCase(
+                entryRepository = instance(),
+            )
         }
-        bind<BBCodeConverter> {
-            singleton { DefaultBBCodeConverter() }
+        bindSingleton<BBCodeConverter> {
+            DefaultBBCodeConverter()
         }
-        bind<MarkdownConverter> {
-            singleton { DefaultMarkdownConverter() }
+        bindSingleton<MarkdownConverter> {
+            DefaultMarkdownConverter()
         }
-        bind<StripMarkupUseCase> {
-            singleton {
-                DefaultStripMarkupUseCase(
-                    bbCodeConverter = instance(),
-                    markdownConverter = instance(),
-                )
-            }
+        bindSingleton<StripMarkupUseCase> {
+            DefaultStripMarkupUseCase(
+                bbCodeConverter = instance(),
+                markdownConverter = instance(),
+            )
         }
-        bind<GetTranslationUseCase> {
-            singleton {
-                DefaultGetTranslationUseCase(
-                    supportedFeatureRepository = instance(),
-                    defaultRepository = instance(),
-                    fallbackRepository = instance(),
-                    stripMarkup = instance(),
-                    translationProviderConfigStore = instance(),
-                )
-            }
+        bindSingleton<GetTranslationUseCase> {
+            DefaultGetTranslationUseCase(
+                supportedFeatureRepository = instance(),
+                defaultRepository = instance(),
+                fallbackRepository = instance(),
+                stripMarkup = instance(),
+                translationProviderConfigStore = instance(),
+            )
         }
-        bind<PopulateThreadUseCase> {
-            singleton {
-                DefaultPopulateThreadUseCase(
-                    timelineEntryRepository = instance(),
-                    emojiHelper = instance(),
-                )
-            }
+        bindSingleton<PopulateThreadUseCase> {
+            DefaultPopulateThreadUseCase(
+                timelineEntryRepository = instance(),
+                emojiHelper = instance(),
+            )
         }
-        bind<GetInnerUrlUseCase> {
-            singleton {
-                DefaultGetInnerUrlUseCase(
-                    apiConfigurationRepository = instance(),
-                )
-            }
+        bindSingleton<GetInnerUrlUseCase> {
+            DefaultGetInnerUrlUseCase(
+                apiConfigurationRepository = instance(),
+            )
         }
     }

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/di/IdentityRepositoryModule.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/di/IdentityRepositoryModule.kt
@@ -19,79 +19,60 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Inst
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.StopWordRepository
 import org.kodein.di.DI
-import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
-import org.kodein.di.singleton
 
 val identityRepositoryModule =
     DI.Module("IdentityRepositoryModule") {
-        bind<AccountCredentialsCache> {
-            singleton {
-                DefaultAccountCredentialsCache(
-                    keyStore = instance(),
-                )
-            }
+        bindSingleton<AccountCredentialsCache> {
+            DefaultAccountCredentialsCache(
+                keyStore = instance(),
+            )
         }
-        bind<AccountRepository> {
-            singleton {
-                DefaultAccountRepository(
-                    accountDao = instance(),
-                )
-            }
+        bindSingleton<AccountRepository> {
+            DefaultAccountRepository(
+                accountDao = instance(),
+            )
         }
-        bind<ApiConfigurationRepository> {
-            singleton {
-                DefaultApiConfigurationRepository(
-                    provider = instance(tag = "default"),
-                    keyStore = instance(),
-                    credentialsRepository = instance(),
-                    authManager = instance(),
-                )
-            }
+        bindSingleton<ApiConfigurationRepository> {
+            DefaultApiConfigurationRepository(
+                provider = instance(tag = "default"),
+                keyStore = instance(),
+                credentialsRepository = instance(),
+                authManager = instance(),
+            )
         }
-        bind<CredentialsRepository> {
-            singleton {
-                DefaultCredentialsRepository(
-                    provider = instance(tag = "other"),
-                    engine = instance(),
-                    json = instance(),
-                )
-            }
+        bindSingleton<CredentialsRepository> {
+            DefaultCredentialsRepository(
+                provider = instance(tag = "other"),
+                engine = instance(),
+                json = instance(),
+            )
         }
-        bind<IdentityRepository> {
-            singleton {
-                DefaultIdentityRepository(
-                    provider = instance(tag = "default"),
-                )
-            }
+        bindSingleton<IdentityRepository> {
+            DefaultIdentityRepository(
+                provider = instance(tag = "default"),
+            )
         }
-        bind<ImageAutoloadObserver> {
-            singleton {
-                DefaultImageAutoloadObserver(
-                    networkStateObserver = instance(),
-                    settingsRepository = instance(),
-                )
-            }
+        bindSingleton<ImageAutoloadObserver> {
+            DefaultImageAutoloadObserver(
+                networkStateObserver = instance(),
+                settingsRepository = instance(),
+            )
         }
-        bind<SettingsRepository> {
-            singleton {
-                DefaultSettingsRepository(
-                    settingsDao = instance(),
-                )
-            }
+        bindSingleton<SettingsRepository> {
+            DefaultSettingsRepository(
+                settingsDao = instance(),
+            )
         }
-        bind<StopWordRepository> {
-            singleton {
-                DefaultStopWordRepository(
-                    keyStore = instance(),
-                )
-            }
+        bindSingleton<StopWordRepository> {
+            DefaultStopWordRepository(
+                keyStore = instance(),
+            )
         }
-        bind<InstanceShortcutRepository> {
-            singleton {
-                DefaultInstanceShortcutRepository(
-                    keyStore = instance(),
-                )
-            }
+        bindSingleton<InstanceShortcutRepository> {
+            DefaultInstanceShortcutRepository(
+                keyStore = instance(),
+            )
         }
     }

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/IdentityUseCaseModule.kt
@@ -21,104 +21,83 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.LogoutU
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.SetupAccountUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.SwitchAccountUseCase
 import org.kodein.di.DI
-import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
-import org.kodein.di.singleton
 
 val identityUseCaseModule =
     DI.Module("IdentityUseCaseModule") {
-        bind<ActiveAccountMonitor> {
-            singleton {
-                DefaultActiveAccountMonitor(
-                    accountRepository = instance(),
-                    apiConfigurationRepository = instance(),
-                    identityRepository = instance(),
-                    accountCredentialsCache = instance(),
-                    settingsRepository = instance(),
-                    supportedFeatureRepository = instance(),
-                    contentPreloadManager = instance(),
-                    markerRepository = instance(),
-                    notificationCoordinator = instance(),
-                    announcementsManager = instance(),
-                    followedHashtagCache = instance(),
-                    serviceProvider = instance(tag = "default"),
-                    logout = instance(),
-                )
-            }
+        bindSingleton<ActiveAccountMonitor> {
+            DefaultActiveAccountMonitor(
+                accountRepository = instance(),
+                apiConfigurationRepository = instance(),
+                identityRepository = instance(),
+                accountCredentialsCache = instance(),
+                settingsRepository = instance(),
+                supportedFeatureRepository = instance(),
+                contentPreloadManager = instance(),
+                markerRepository = instance(),
+                notificationCoordinator = instance(),
+                announcementsManager = instance(),
+                followedHashtagCache = instance(),
+                serviceProvider = instance(tag = "default"),
+                logout = instance(),
+            )
         }
-        bind<ContentPreloadManager> {
-            singleton {
-                DefaultContentPreloadManager(
-                    timelineEntryRepository = instance(),
-                    trendingRepository = instance(),
-                    notificationRepository = instance(),
-                )
-            }
+        bindSingleton<ContentPreloadManager> {
+            DefaultContentPreloadManager(
+                timelineEntryRepository = instance(),
+                trendingRepository = instance(),
+                notificationRepository = instance(),
+            )
         }
-        bind<DeleteAccountUseCase> {
-            singleton {
-                DefaultDeleteAccountUseCase(
-                    accountRepository = instance(),
-                    settingsRepository = instance(),
-                    accountCredentialsCache = instance(),
-                )
-            }
+        bindSingleton<DeleteAccountUseCase> {
+            DefaultDeleteAccountUseCase(
+                accountRepository = instance(),
+                settingsRepository = instance(),
+                accountCredentialsCache = instance(),
+            )
         }
-        bind<EntryActionRepository> {
-            singleton {
-                DefaultEntryActionRepository(
-                    identityRepository = instance(),
-                    supportedFeatureRepository = instance(),
-                )
-            }
+        bindSingleton<EntryActionRepository> {
+            DefaultEntryActionRepository(
+                identityRepository = instance(),
+                supportedFeatureRepository = instance(),
+            )
         }
-        bind<ExportSettingsUseCase> {
-            singleton {
-                DefaultExportSettingsUseCase(
-                    settingsRepository = instance(),
-                )
-            }
+        bindSingleton<ExportSettingsUseCase> {
+            DefaultExportSettingsUseCase(
+                settingsRepository = instance(),
+            )
         }
-        bind<ImportSettingsUseCase> {
-            singleton {
-                DefaultImportSettingsUseCase(
-                    settingsRepository = instance(),
-                )
-            }
+        bindSingleton<ImportSettingsUseCase> {
+            DefaultImportSettingsUseCase(
+                settingsRepository = instance(),
+            )
         }
-        bind<LoginUseCase> {
-            singleton {
-                DefaultLoginUseCase(
-                    apiConfigurationRepository = instance(),
-                    credentialsRepository = instance(),
-                    accountRepository = instance(),
-                    settingsRepository = instance(),
-                    accountCredentialsCache = instance(),
-                    supportedFeatureRepository = instance(),
-                )
-            }
+        bindSingleton<LoginUseCase> {
+            DefaultLoginUseCase(
+                apiConfigurationRepository = instance(),
+                credentialsRepository = instance(),
+                accountRepository = instance(),
+                settingsRepository = instance(),
+                accountCredentialsCache = instance(),
+                supportedFeatureRepository = instance(),
+            )
         }
-        bind<LogoutUseCase> {
-            singleton {
-                DefaultLogoutUseCase(
-                    apiConfigurationRepository = instance(),
-                    accountRepository = instance(),
-                )
-            }
+        bindSingleton<LogoutUseCase> {
+            DefaultLogoutUseCase(
+                apiConfigurationRepository = instance(),
+                accountRepository = instance(),
+            )
         }
-        bind<SetupAccountUseCase> {
-            singleton {
-                DefaultSetupAccountUseCase(
-                    accountRepository = instance(),
-                    settingsRepository = instance(),
-                )
-            }
+        bindSingleton<SetupAccountUseCase> {
+            DefaultSetupAccountUseCase(
+                accountRepository = instance(),
+                settingsRepository = instance(),
+            )
         }
-        bind<SwitchAccountUseCase> {
-            singleton {
-                DefaultSwitchAccountUseCase(
-                    accountRepository = instance(),
-                )
-            }
+        bindSingleton<SwitchAccountUseCase> {
+            DefaultSwitchAccountUseCase(
+                accountRepository = instance(),
+            )
         }
     }

--- a/domain/pullnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pullnotifications/di/NativePullNotificationsModule.kt
+++ b/domain/pullnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pullnotifications/di/NativePullNotificationsModule.kt
@@ -3,15 +3,12 @@ package com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications.di
 import com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications.DefaultPullNotificationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications.PullNotificationManager
 import org.kodein.di.DI
-import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
-import org.kodein.di.singleton
 
 internal actual val nativePullNotificationsModule =
     DI.Module("NativePullNotificationsModule") {
-        bind<PullNotificationManager> {
-            singleton {
-                DefaultPullNotificationManager(context = instance())
-            }
+        bindSingleton<PullNotificationManager> {
+            DefaultPullNotificationManager(context = instance())
         }
     }

--- a/domain/pullnotifications/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pullnotifications/di/NativePullNotificationsModule.kt
+++ b/domain/pullnotifications/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pullnotifications/di/NativePullNotificationsModule.kt
@@ -3,10 +3,11 @@ package com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications.di
 import com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications.DefaultPullNotificationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications.PullNotificationManager
 import org.kodein.di.DI
-import org.kodein.di.bind
-import org.kodein.di.singleton
+import org.kodein.di.bindSingleton
 
 internal actual val nativePullNotificationsModule =
     DI.Module("NativePullNotificationsModule") {
-        bind<PullNotificationManager> { singleton { DefaultPullNotificationManager() } }
+        bindSingleton<PullNotificationManager> {
+            DefaultPullNotificationManager()
+        }
     }

--- a/domain/pullnotifications/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pullnotifications/di/NativePullNotificationsModule.kt
+++ b/domain/pullnotifications/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pullnotifications/di/NativePullNotificationsModule.kt
@@ -3,14 +3,11 @@ package com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications.di
 import com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications.DefaultPullNotificationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.pullnotifications.PullNotificationManager
 import org.kodein.di.DI
-import org.kodein.di.bind
-import org.kodein.di.singleton
+import org.kodein.di.bindSingleton
 
 internal actual val nativePullNotificationsModule =
     DI.Module("NativePullNotificationsModule") {
-        bind<PullNotificationManager> {
-            singleton {
-                DefaultPullNotificationManager()
-            }
+        bindSingleton<PullNotificationManager> {
+            DefaultPullNotificationManager()
         }
     }

--- a/domain/pushnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/di/NativePushNotificationsModule.kt
+++ b/domain/pushnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/di/NativePushNotificationsModule.kt
@@ -5,29 +5,24 @@ import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.common
 import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.manager.DefaultPushNotificationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.manager.PushNotificationManager
 import org.kodein.di.DI
-import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
-import org.kodein.di.singleton
 
 internal actual val nativePushNotificationsModule =
     DI.Module("NativePushNotificationsModule") {
-        bind<PushNotificationManager> {
-            singleton {
-                DefaultPushNotificationManager(
-                    context = instance(),
-                    pushNotificationRepository = instance(),
-                    accountRepository = instance(),
-                    nodeInfoRepository = instance(),
-                )
-            }
+        bindSingleton<PushNotificationManager> {
+            DefaultPushNotificationManager(
+                context = instance(),
+                pushNotificationRepository = instance(),
+                accountRepository = instance(),
+                nodeInfoRepository = instance(),
+            )
         }
-        bind<UnifiedPushInteractor> {
-            singleton {
-                DefaultUnifiedPushInteractor(
-                    pullNotificationManager = instance(),
-                    pushNotificationManager = instance(),
-                    accountRepository = instance(),
-                )
-            }
+        bindSingleton<UnifiedPushInteractor> {
+            DefaultUnifiedPushInteractor(
+                pullNotificationManager = instance(),
+                pushNotificationManager = instance(),
+                accountRepository = instance(),
+            )
         }
     }

--- a/domain/pushnotifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/di/PushNotificationsModule.kt
+++ b/domain/pushnotifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/di/PushNotificationsModule.kt
@@ -3,21 +3,18 @@ package com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.di
 import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.coordinator.DefaultNotificationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.coordinator.NotificationCoordinator
 import org.kodein.di.DI
-import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
-import org.kodein.di.singleton
 
 val pushNotificationsModule =
     DI.Module("PushNotificationsModule") {
         import(nativePushNotificationsModule)
-        bind<NotificationCoordinator> {
-            singleton {
-                DefaultNotificationCoordinator(
-                    settingsRepository = instance(),
-                    inboxManager = instance(),
-                    pullNotificationManager = instance(),
-                    pushNotificationManager = instance(),
-                )
-            }
+        bindSingleton<NotificationCoordinator> {
+            DefaultNotificationCoordinator(
+                settingsRepository = instance(),
+                inboxManager = instance(),
+                pullNotificationManager = instance(),
+                pushNotificationManager = instance(),
+            )
         }
     }

--- a/domain/pushnotifications/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/di/NativePushNotificationsModule.kt
+++ b/domain/pushnotifications/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/di/NativePushNotificationsModule.kt
@@ -3,14 +3,11 @@ package com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.di
 import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.manager.DefaultPushNotificationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.manager.PushNotificationManager
 import org.kodein.di.DI
-import org.kodein.di.bind
-import org.kodein.di.singleton
+import org.kodein.di.bindSingleton
 
 internal actual val nativePushNotificationsModule =
     DI.Module("NativePushNotificationsModule") {
-        bind<PushNotificationManager> {
-            singleton {
-                DefaultPushNotificationManager()
-            }
+        bindSingleton<PushNotificationManager> {
+            DefaultPushNotificationManager()
         }
     }

--- a/domain/pushnotifications/src/jvmMain/kotlin/pushnotifications/di/NativePushNotificationsModule.kt
+++ b/domain/pushnotifications/src/jvmMain/kotlin/pushnotifications/di/NativePushNotificationsModule.kt
@@ -3,14 +3,11 @@ package com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.di
 import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.manager.DefaultPushNotificationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.manager.PushNotificationManager
 import org.kodein.di.DI
-import org.kodein.di.bind
-import org.kodein.di.singleton
+import org.kodein.di.bindSingleton
 
 internal actual val nativePushNotificationsModule =
     DI.Module("NativePushNotificationsModule") {
-        bind<PushNotificationManager> {
-            singleton {
-                DefaultPushNotificationManager()
-            }
+        bindSingleton<PushNotificationManager> {
+            DefaultPushNotificationManager()
         }
     }

--- a/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/di/UrlHandlerModule.kt
+++ b/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/di/UrlHandlerModule.kt
@@ -14,62 +14,49 @@ import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor.Fet
 import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor.HashtagProcessor
 import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor.UserProcessor
 import org.kodein.di.DI
-import org.kodein.di.bind
-import org.kodein.di.factory
+import org.kodein.di.bindFactory
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
-import org.kodein.di.singleton
 
 val urlHandlerModule =
     DI.Module("UrlHandlerModule") {
-        bind<FetchUserUseCase> {
-            singleton {
-                DefaultFetchUserUseCase(
-                    searchRepository = instance(),
-                )
-            }
+        bindSingleton<FetchUserUseCase> {
+            DefaultFetchUserUseCase(
+                searchRepository = instance(),
+            )
         }
-        bind<FetchEntryUseCase> {
-            singleton {
-                DefaultFetchEntryUseCase(
-                    searchRepository = instance(),
-                )
-            }
+        bindSingleton<FetchEntryUseCase> {
+            DefaultFetchEntryUseCase(
+                searchRepository = instance(),
+            )
         }
-        bind<HashtagProcessor> {
-            singleton {
-                DefaultHashtagProcessor(
-                    mainRouter = instance(),
-                )
-            }
+        bindSingleton<HashtagProcessor> {
+            DefaultHashtagProcessor(
+                mainRouter = instance(),
+            )
         }
-        bind<UserProcessor> {
-            singleton {
-                DefaultUserProcessor(
-                    mainRouter = instance(),
-                    fetchUser = instance(),
-                )
-            }
+        bindSingleton<UserProcessor> {
+            DefaultUserProcessor(
+                mainRouter = instance(),
+                fetchUser = instance(),
+            )
         }
-        bind<EntryProcessor> {
-            singleton {
-                DefaultEntryProcessor(
-                    mainRouter = instance(),
-                    fetchEntry = instance(),
-                )
-            }
+        bindSingleton<EntryProcessor> {
+            DefaultEntryProcessor(
+                mainRouter = instance(),
+                fetchEntry = instance(),
+            )
         }
 
-        bind<CustomUriHandler> {
-            factory { fallback: UriHandler ->
-                DefaultCustomUriHandler(
-                    defaultHandler = fallback,
-                    customTabsHelper = instance(),
-                    settingsRepository = instance(),
-                    mainRouter = instance(),
-                    hashtagProcessor = instance(),
-                    userProcessor = instance(),
-                    entryProcessor = instance(),
-                )
-            }
+        bindFactory<UriHandler, CustomUriHandler> { fallback ->
+            DefaultCustomUriHandler(
+                defaultHandler = fallback,
+                customTabsHelper = instance(),
+                settingsRepository = instance(),
+                mainRouter = instance(),
+                hashtagProcessor = instance(),
+                userProcessor = instance(),
+                entryProcessor = instance(),
+            )
         }
     }

--- a/feature/acknowledgements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feat/acknowledgements/di/AcknowledgementsModule.kt
+++ b/feature/acknowledgements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feat/acknowledgements/di/AcknowledgementsModule.kt
@@ -7,21 +7,16 @@ import com.livefast.eattrash.raccoonforfriendica.feat.acknowledgements.main.Ackn
 import com.livefast.eattrash.raccoonforfriendica.feat.acknowledgements.repository.AcknowledgementsRepository
 import com.livefast.eattrash.raccoonforfriendica.feat.acknowledgements.repository.DefaultAcknowledgementsRepository
 import org.kodein.di.DI
-import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
-import org.kodein.di.singleton
 
 val acknowledgementsModule =
     DI.Module("AcknowledgementsModule") {
-        bind<AcknowledgementsRemoteDataSource> {
-            singleton {
-                DefaultAcknowledgementsRemoteDataSource()
-            }
+        bindSingleton<AcknowledgementsRemoteDataSource> {
+            DefaultAcknowledgementsRemoteDataSource()
         }
-        bind<AcknowledgementsRepository> {
-            singleton {
-                DefaultAcknowledgementsRepository(dataSource = instance())
-            }
+        bindSingleton<AcknowledgementsRepository> {
+            DefaultAcknowledgementsRepository(dataSource = instance())
         }
         bindViewModel {
             AcknowledgementsViewModel(

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/di/ComposerModule.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/di/ComposerModule.kt
@@ -6,22 +6,19 @@ import com.livefast.eattrash.raccoonforfriendica.feature.composer.ComposerViewMo
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.usecase.DefaultPrepareForPreviewUseCase
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.usecase.PrepareForPreviewUseCase
 import org.kodein.di.DI
-import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
-import org.kodein.di.singleton
 
 data class ComposerViewModelArgs(val inReplyToId: String) : ViewModelCreationArgs
 
 val composerModule =
     DI.Module("ComposerModule") {
-        bind<PrepareForPreviewUseCase> {
-            singleton {
-                DefaultPrepareForPreviewUseCase(
-                    apiConfigurationRepository = instance(),
-                    bbCodeConverter = instance(),
-                    markdownConverter = instance(),
-                )
-            }
+        bindSingleton<PrepareForPreviewUseCase> {
+            DefaultPrepareForPreviewUseCase(
+                apiConfigurationRepository = instance(),
+                bbCodeConverter = instance(),
+                markdownConverter = instance(),
+            )
         }
         bindViewModelWithArgs { args: ComposerViewModelArgs ->
             ComposerViewModel(

--- a/shared/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/NativeAuthModule.kt
+++ b/shared/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/NativeAuthModule.kt
@@ -4,12 +4,11 @@ import com.livefast.eattrash.raccoonforfriendica.auth.DefaultRedirectServer
 import com.livefast.eattrash.raccoonforfriendica.auth.RedirectServer
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
 actual val nativeAuthModule = DI.Module("NativeAuthModule") {
-    bind<RedirectServer> {
-        singleton {
-            DefaultRedirectServer()
-        }
+    bindSingleton<RedirectServer> {
+        DefaultRedirectServer()
     }
 }

--- a/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/AuthModule.kt
+++ b/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/AuthModule.kt
@@ -3,22 +3,19 @@ package com.livefast.eattrash.raccoonforfriendica.di
 import com.livefast.eattrash.raccoonforfriendica.auth.DefaultAuthManager
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AuthManager
 import org.kodein.di.DI
-import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
-import org.kodein.di.singleton
 
 internal val authModule =
     DI.Module("AuthModule") {
         import(nativeAuthModule)
 
-        bind<AuthManager> {
-            singleton {
-                DefaultAuthManager(
-                    navigationCoordinator = instance(),
-                    credentialsRepository = instance(),
-                    keyStore = instance(),
-                    redirectServer = instance(),
-                )
-            }
+        bindSingleton<AuthManager> {
+            DefaultAuthManager(
+                navigationCoordinator = instance(),
+                credentialsRepository = instance(),
+                keyStore = instance(),
+                redirectServer = instance(),
+            )
         }
     }

--- a/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/MainRouterModule.kt
+++ b/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/MainRouterModule.kt
@@ -3,24 +3,21 @@ package com.livefast.eattrash.raccoonforfriendica.di
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.MainRouter
 import com.livefast.eattrash.raccoonforfriendica.navigation.DefaultMainRouter
 import org.kodein.di.DI
-import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
-import org.kodein.di.singleton
 
 internal val mainRouterModule =
     DI.Module("MainRouterModule") {
-        bind<MainRouter> {
-            singleton {
-                DefaultMainRouter(
-                    navigationCoordinator = instance(),
-                    identityRepository = instance(),
-                    settingsRepository = instance(),
-                    userCache = instance(),
-                    entryCache = instance(),
-                    eventCache = instance(),
-                    circleCache = instance(),
-                    attachmentCache = instance(),
-                )
-            }
+        bindSingleton<MainRouter> {
+            DefaultMainRouter(
+                navigationCoordinator = instance(),
+                identityRepository = instance(),
+                settingsRepository = instance(),
+                userCache = instance(),
+                entryCache = instance(),
+                eventCache = instance(),
+                circleCache = instance(),
+                attachmentCache = instance(),
+            )
         }
     }

--- a/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/ResourcesModule.kt
+++ b/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/ResourcesModule.kt
@@ -5,17 +5,14 @@ import com.livefast.eattrash.raccoonforfriendica.core.resources.CoreResources
 import com.livefast.eattrash.raccoonforfriendica.resources.SharedResources
 import com.livefast.eattrash.raccoonforfriendica.resources.SharedStrings
 import org.kodein.di.DI
-import org.kodein.di.bind
-import org.kodein.di.factory
-import org.kodein.di.singleton
+import org.kodein.di.bindFactory
+import org.kodein.di.bindSingleton
 
 internal val resourcesModule =
     DI.Module("SharedResourcesModule") {
-        bind<CoreResources> { singleton { SharedResources() } }
-        bind<Strings> {
-            factory { _: String ->
-                // the locale parameter is currently ignored
-                SharedStrings()
-            }
+        bindSingleton<CoreResources> { SharedResources() }
+        bindFactory<String, Strings> { _ ->
+            // the locale parameter is currently ignored
+            SharedStrings()
         }
     }

--- a/shared/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/NativeAuthModule.kt
+++ b/shared/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/NativeAuthModule.kt
@@ -4,12 +4,11 @@ import com.livefast.eattrash.raccoonforfriendica.auth.DefaultRedirectServer
 import com.livefast.eattrash.raccoonforfriendica.auth.RedirectServer
 import org.kodein.di.DI
 import org.kodein.di.bind
+import org.kodein.di.bindSingleton
 import org.kodein.di.singleton
 
 actual val nativeAuthModule = DI.Module("NativeAuthModule") {
-    bind<RedirectServer> {
-        singleton {
-            DefaultRedirectServer()
-        }
+    bindSingleton<RedirectServer> {
+        DefaultRedirectServer()
     }
 }

--- a/shared/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/NativeAuthModule.kt
+++ b/shared/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/di/NativeAuthModule.kt
@@ -6,6 +6,7 @@ import com.livefast.eattrash.raccoonforfriendica.auth.RedirectServer
 import org.kodein.di.DI
 import org.kodein.di.bind
 import org.kodein.di.bindInstance
+import org.kodein.di.bindSingleton
 import org.kodein.di.instance
 import org.kodein.di.singleton
 
@@ -13,9 +14,7 @@ actual val nativeAuthModule = DI.Module("NativeAuthModule") {
     bindInstance {
         EmbeddedRedirectServer()
     }
-    bind<RedirectServer> {
-        singleton {
-            DefaultRedirectServer(server = instance())
-        }
+    bindSingleton<RedirectServer> {
+        DefaultRedirectServer(server = instance())
     }
 }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR updates all dependency injection modules to use the modern Kodein-DI binding DSL for better readability and conciseness.

More in detail:
- replace `bind<T> { singleton { ... } }` with `bindSingleton<T> { ... }`
- replace `bind<T> { factory { ... } }` with `bindFactory<Args, T> { ... }`
- replace `bind<T> { provider { ... } }` with `bindProvider<T> { ... }`
- replace `bind<T> { instance(...) }` with `bindInstance<T> { ... }`
- update `bindViewModel` and `bindViewModelWithArgs` utilities in `core:architecture` to use `bindProvider` and `bindFactory` with `DirectDI`