### PR TITLE
fix: skip token refresh attempt when refresh token is empty

### DIFF
--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultApiConfigurationRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultApiConfigurationRepository.kt
@@ -45,6 +45,10 @@ internal class DefaultApiConfigurationRepository(
     override suspend fun refresh() = runCatching {
         val oldCredentials = retrieveFromKeyStore()
         check(oldCredentials is ApiCredentials.OAuth2)
+        check(oldCredentials.refreshToken.isNotEmpty()) {
+            // prevent refresh attempt with long-lived tokens, so continue without failing
+            return@runCatching
+        }
 
         val newCredentials = authManager.performRefresh(refreshToken = oldCredentials.refreshToken)
         checkNotNull(newCredentials)

--- a/domain/identity/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultApiConfigurationRepositoryTest.kt
+++ b/domain/identity/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultApiConfigurationRepositoryTest.kt
@@ -200,6 +200,8 @@ class DefaultApiConfigurationRepositoryTest {
 
     @Test
     fun `given no previous OAuth2 credentials when refresh then result is failure`() = runTest {
+        everySuspend { keyStore.get("lastCred1", "") } returns ""
+        everySuspend { keyStore.get("lastCred2", "") } returns ""
         val credentials =
             ApiCredentials.OAuth2(accessToken = "fake-access-token-1", refreshToken = "fake-refresh-token")
         sut.setAuth(credentials)


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR prevents token refresh attempts on instances which do not provide a refresh mechanism because their tokens are intentionally long-lived.

This is a tentative fix for authentication on Friendica instances, where no `refresh_token` is available after the OAuth2 token exchange.