### PR TITLE
fix: link loading in Explore section

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultTrendService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultTrendService.kt
@@ -2,11 +2,11 @@ package com.livefast.eattrash.raccoonforfriendica.core.api.service
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Status
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Tag
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.TrendsLink
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
-import io.ktor.client.statement.bodyAsText
 
 internal class DefaultTrendService(private val baseUrl: String, private val client: HttpClient) : TrendsService {
     override suspend fun getHashtags(offset: Int, limit: Int): List<Tag> = client.get("$baseUrl/v1/trends/tags") {
@@ -20,8 +20,8 @@ internal class DefaultTrendService(private val baseUrl: String, private val clie
             parameter("limit", limit)
         }.body()
 
-    override suspend fun getLinks(offset: Int, limit: Int): String = client.get("$baseUrl/v1/trends/links") {
+    override suspend fun getLinks(offset: Int, limit: Int): List<TrendsLink> = client.get("$baseUrl/v1/trends/links") {
         parameter("offset", offset)
         parameter("limit", limit)
-    }.bodyAsText()
+    }.body()
 }

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/TrendsService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/TrendsService.kt
@@ -2,11 +2,12 @@ package com.livefast.eattrash.raccoonforfriendica.core.api.service
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Status
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Tag
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.TrendsLink
 
 interface TrendsService {
     suspend fun getHashtags(offset: Int, limit: Int = 20): List<Tag>
 
     suspend fun getStatuses(offset: Int, limit: Int = 20): List<Status>
 
-    suspend fun getLinks(offset: Int, limit: Int = 20): String
+    suspend fun getLinks(offset: Int, limit: Int = 20): List<TrendsLink>
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTrendingRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTrendingRepository.kt
@@ -1,6 +1,5 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 
-import com.livefast.eattrash.raccoonforfriendica.core.api.dto.TrendsLink
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.LinkModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TagModel
@@ -9,12 +8,10 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModelWithReply
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.serialization.json.Json
 
 internal class DefaultTrendingRepository(
     private val provider: ServiceProvider,
     private val otherProvider: ServiceProvider,
-    private val json: Json,
 ) : TrendingRepository {
     private val mutex = Mutex()
     private val cachedTags: MutableList<TagModel> = mutableListOf()
@@ -69,10 +66,7 @@ internal class DefaultTrendingRepository(
                         offset = offset,
                         limit = DEFAULT_PAGE_SIZE,
                     )
-            // workaround for a server bug which inserts empty arrays "[]," among valid results
-            // (at least on some Friendica versions)
-            val body = response.replace("[],", "")
-            json.decodeFromString<List<TrendsLink>>(body).map { it.toModel() }
+            response.map { it.toModel() }
         }
     }.getOrNull()
 

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/ContentRepositoryModule.kt
@@ -225,7 +225,6 @@ val contentRepositoryModule =
             DefaultTrendingRepository(
                 provider = instance(tag = "default"),
                 otherProvider = instance(tag = "other"),
-                json = instance(),
             )
         }
         bindSingleton<UserRepository> {

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTrendingRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTrendingRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Status
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Tag
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.TrendsLink
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.TrendsService
 import dev.mokkery.MockMode
@@ -16,7 +17,6 @@ import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
 import kotlinx.io.IOException
-import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -24,7 +24,6 @@ import kotlin.test.assertNull
 
 class DefaultTrendingRepositoryTest {
     private val trendsService = mock<TrendsService>()
-    private val json = Json { ignoreUnknownKeys = true }
 
     private val provider =
         mock<ServiceProvider> {
@@ -40,7 +39,6 @@ class DefaultTrendingRepositoryTest {
         DefaultTrendingRepository(
             provider = provider,
             otherProvider = otherProvider,
-            json = json,
         )
 
     // region getEntries
@@ -163,16 +161,16 @@ class DefaultTrendingRepositoryTest {
     // region getLinks
     @Test
     fun `given results when getLinks then result and interactions are as expected`() = runTest {
-        val mockResponse = """[{"title":"link","url":"https://example.com"}]"""
+        val link = TrendsLink(url = "https://example.com", title = "link")
         everySuspend {
             trendsService.getLinks(any(), any())
-        } returns mockResponse
+        } returns listOf(link)
 
         val res = sut.getLinks(offset = 0)
 
         assertNotNull(res)
         assertEquals(1, res.size)
-        assertEquals("link", res.first().title)
+        assertEquals(link.title, res.first().title)
         verifySuspend {
             trendsService.getLinks(offset = 0, limit = 20)
         }
@@ -187,16 +185,16 @@ class DefaultTrendingRepositoryTest {
     @Test
     fun `given results when getLinks on other instance then result and interactions are as expected`() = runTest {
         val otherInstance = "node"
-        val mockResponse = """[{"title":"link","url":"https://example.com"}]"""
+        val link = TrendsLink(url = "https://example.com", title = "link")
         everySuspend {
             trendsService.getLinks(any(), any())
-        } returns mockResponse
+        } returns listOf(link)
 
         val res = sut.getLinks(offset = 0, otherInstance = otherInstance)
 
         assertNotNull(res)
         assertEquals(1, res.size)
-        assertEquals("link", res.first().title)
+        assertEquals(link.title, res.first().title)
         verifySuspend {
             trendsService.getLinks(offset = 0, limit = 20)
         }
@@ -207,21 +205,6 @@ class DefaultTrendingRepositoryTest {
         verify(VerifyMode.not) {
             provider.trend
         }
-    }
-
-    @Test
-    fun `given results with Friendica bug when getLinks then result is correctly parsed`() = runTest {
-        // Friendica bug inserts "[]," in the JSON string
-        val buggyResponse = """[[],{"title":"link","url":"https://example.com"}]"""
-        everySuspend {
-            trendsService.getLinks(any(), any())
-        } returns buggyResponse
-
-        val res = sut.getLinks(offset = 0)
-
-        assertNotNull(res)
-        assertEquals(1, res.size)
-        assertEquals("link", res.first().title)
     }
 
     @Test


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR removes an old workaround to parse the response of the GET `v1/trends/links` endpoint to avoid a bug on older Friendica versions where random empty JSON arrays (`[]`) were inserted among the results, breaking the type-safe content deserialization in Ktor.

This workaround is no longer necessary and it was extremely fragile (as a matter of fact, it broke).

--- 

Original report by @informapirata
