### PR TITLE
chore(api): update suggestions API endpoint to v2

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultUserService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultUserService.kt
@@ -61,7 +61,7 @@ internal class DefaultUserService(private val baseUrl: String, private val clien
             }
         }.body()
 
-    override suspend fun getSuggestions(limit: Int): List<Suggestion> = client.get("$baseUrl/v1/accounts/suggestions") {
+    override suspend fun getSuggestions(limit: Int): List<Suggestion> = client.get("$baseUrl/v2/suggestions") {
         parameter("limit", limit)
     }.body()
 


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR updates the endpoint to get follow suggestions (which populate the "For you" tab in Explore section) to use the new GET `v2/suggestions` instead of the legacy GET `v1/accounts/suggestion`.

@informapirata molto semplicemente era questo il motivo per cui la sezione "Per te" rimaneva sempre vuota! 😂 