### PR TITLE
fix: timeline loading on Mastodon glitch-soc

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Status.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Status.kt
@@ -36,5 +36,5 @@ data class Status(
     @SerialName("tags") val tags: List<Tag> = emptyList(),
     @SerialName("url") val url: String? = null,
     @SerialName("visibility") val visibility: String = ContentVisibility.PUBLIC,
-    @SerialName("local_only") val localOnly: Boolean = false,
+    @SerialName("local_only") val localOnly: Boolean? = false,
 )

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
@@ -120,7 +120,7 @@ internal fun Status.toModel() = TimelineEntryModel(
     favoriteCount = favoritesCount,
     id = id,
     lang = lang,
-    localOnly = localOnly,
+    localOnly = localOnly ?: false,
     mentions = mentions.map { it.toModel() },
     parentId = inReplyToId,
     pinned = pinned,
@@ -150,8 +150,8 @@ internal fun Status.toModel() = TimelineEntryModel(
     visibility =
     visibility.toVisibility().let { visibility ->
         when (visibility) {
-            Visibility.Unlisted if localOnly -> Visibility.LocalUnlisted
-            Visibility.Public if localOnly -> Visibility.LocalPublic
+            Visibility.Unlisted if localOnly == true -> Visibility.LocalUnlisted
+            Visibility.Public if localOnly == true -> Visibility.LocalPublic
             else -> visibility
         }
     },


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR makes the `local_only` property of the Status DTO nullable, because in experimental Mastodon servers where it is used it can appear as a literal `null`.

Mappings to domain objects have been updated accordingly.

@informapirata il motivo per cui non si caricavano le timeline (quali nello specifico non era predicibile, dipendeva da dove comparivano inclusi i post con la proprietà presente come valore `null` nei JSON delle risposte) su Mastodon glitch-soc. Grazie per la segnalazione!