### PR TITLE
fix: post actions in shortcuts to foreign instances

### DIFF
--- a/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
+++ b/feature/entrydetail/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/entrydetail/EntryDetailScreen.kt
@@ -603,7 +603,7 @@ fun EntryDetailScreen(
                                                 inReplyTo = e,
                                                 inReplyToUser = e.creator,
                                             )
-                                        }.takeIf { actionRepository.canReply(entry.original) },
+                                        }.takeIf { actionRepository.canReply(entry.original) && isHomeInstance },
                                         onPollVote =
                                         uiState.currentUserId?.let {
                                             { e, choices ->
@@ -690,19 +690,19 @@ fun EntryDetailScreen(
                                                     EntryDetailMviModel.Intent.ToggleReblog(e),
                                                 )
                                         }
-                                    }.takeIf { actionRepository.canReblog(entry.original) },
+                                    }.takeIf { actionRepository.canReblog(entry.original) && isHomeInstance },
                                     onBookmark =
                                     { e: TimelineEntryModel ->
                                         model.reduce(EntryDetailMviModel.Intent.ToggleBookmark(e))
-                                    }.takeIf { actionRepository.canBookmark(entry.original) },
+                                    }.takeIf { actionRepository.canBookmark(entry.original) && isHomeInstance },
                                     onFavorite =
                                     { e: TimelineEntryModel ->
                                         model.reduce(EntryDetailMviModel.Intent.ToggleFavorite(e))
-                                    }.takeIf { actionRepository.canFavorite(entry.original) },
+                                    }.takeIf { actionRepository.canFavorite(entry.original) && isHomeInstance },
                                     onDislike =
                                     { e: TimelineEntryModel ->
                                         model.reduce(EntryDetailMviModel.Intent.ToggleDislike(e))
-                                    }.takeIf { actionRepository.canDislike(entry.original) },
+                                    }.takeIf { actionRepository.canDislike(entry.original) && isHomeInstance },
                                     onOpenUsersFavorite = { e ->
                                         mainRouter.openEntryUsersFavorite(
                                             entryId = e.id,
@@ -723,7 +723,7 @@ fun EntryDetailScreen(
                                             inReplyTo = e,
                                             inReplyToUser = e.creator,
                                         )
-                                    }.takeIf { actionRepository.canReply(entry.original) },
+                                    }.takeIf { actionRepository.canReply(entry.original) && isHomeInstance },
                                     onPollVote =
                                     uiState.currentUserId?.let {
                                         { e, choices ->

--- a/feature/shortcuts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/shortcuts/timeline/ShortcutTimelineScreen.kt
+++ b/feature/shortcuts/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/shortcuts/timeline/ShortcutTimelineScreen.kt
@@ -56,12 +56,10 @@ import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.rememberMain
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.rememberNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.resources.LocalResources
 import com.livefast.eattrash.raccoonforfriendica.core.utils.compose.optimizedForLargeScreens
-import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.getDurationFromDateToNow
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.rememberClipboardHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.rememberShareHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.isNearTheEnd
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.isOldEntry
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.rememberEntryActionRepository
@@ -70,7 +68,6 @@ import com.livefast.eattrash.raccoonforfriendica.feature.shortcuts.di.ShortcutTi
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import kotlin.time.Duration
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -126,6 +123,7 @@ fun ShortcutTimelineScreen(node: String, modifier: Modifier = Modifier) {
                         mainRouter.openEntryDetail(
                             entry = event.entry,
                             swipeNavigationEnabled = true,
+                            otherInstance = node,
                         )
                     }
 
@@ -265,52 +263,6 @@ fun ShortcutTimelineScreen(node: String, modifier: Modifier = Modifier) {
                                 initialIndex = imageIdx,
                                 videoIndices = videoIndices,
                             )
-                        },
-                        onReblog =
-                        { e: TimelineEntryModel ->
-                            val timeSinceCreation =
-                                e.created?.run {
-                                    getDurationFromDateToNow(this)
-                                } ?: Duration.ZERO
-                            when {
-                                !e.reblogged && timeSinceCreation.isOldEntry ->
-                                    confirmReblogEntry = e
-
-                                else ->
-                                    model.reduce(
-                                        ShortcutTimelineMviModel.Intent.ToggleReblog(e),
-                                    )
-                            }
-                        }.takeIf { actionRepository.canReblog(entry.original) },
-                        onBookmark =
-                        { e: TimelineEntryModel ->
-                            model.reduce(ShortcutTimelineMviModel.Intent.ToggleBookmark(e))
-                        }.takeIf { actionRepository.canBookmark(entry.original) },
-                        onFavorite =
-                        { e: TimelineEntryModel ->
-                            model.reduce(ShortcutTimelineMviModel.Intent.ToggleFavorite(e))
-                        }.takeIf { actionRepository.canFavorite(entry.original) },
-                        onDislike =
-                        { e: TimelineEntryModel ->
-                            model.reduce(ShortcutTimelineMviModel.Intent.ToggleDislike(e))
-                        }.takeIf { actionRepository.canDislike(entry.original) },
-                        onReply =
-                        { e: TimelineEntryModel ->
-                            mainRouter.openComposer(
-                                inReplyTo = e,
-                                inReplyToUser = e.creator,
-                            )
-                        }.takeIf { actionRepository.canReply(entry.original) },
-                        onPollVote =
-                        uiState.currentUserId?.let {
-                            { e, choices ->
-                                model.reduce(
-                                    ShortcutTimelineMviModel.Intent.SubmitPollVote(
-                                        entry = e,
-                                        choices = choices,
-                                    ),
-                                )
-                            }
                         },
                         onShowOriginal = {
                             model.reduce(


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes several errors in the "Shortcuts" timeline, where post actions should not have been enabled in the first place, since shortcuts are just an alias for the home timeline on a foreign instance. Moreover, when opening a post detail from a shortcut timeline, the foreign node name must be passed to the destination in order to retain the fact that you are a guest on a foreign instance.

Additionally, there were two more errors in the post detail screen:
- the reply action for the main post did not take into consideration whether the user was on their home instance or in a foreign one;
- the home instance check was only done for the main entry, but it should have been done even for all replies!