### PR TITLE
fix(l10n): add SDK version check for Locale creation

### DIFF
--- a/core/l10n/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/ReplaceLang.kt
+++ b/core/l10n/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/ReplaceLang.kt
@@ -1,10 +1,16 @@
 package com.livefast.eattrash.raccoonforfriendica.core.l10n
 
+import android.os.Build
 import java.util.Locale
 
 internal actual fun replaceLang(lang: String) {
     val tokens = lang.split("_")
     val country = tokens.getOrNull(1).orEmpty()
     val langCode = tokens.firstOrNull() ?: Locales.EN
-    Locale.setDefault(Locale.of(langCode, country))
+    val locale = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA) {
+        Locale.of(langCode, country)
+    } else {
+        Locale(langCode, country)
+    }
+    Locale.setDefault(locale)
 }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes a compatibility issue on older Android versions: use the `Locale` constructor as a fallback for `Locale.of` on Android versions older than Baklava to ensure backward compatibility.
