### PR TITLE
fix: navigation crash on desktop

### DIFF
--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationCoordinator.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationCoordinator.kt
@@ -28,13 +28,13 @@ internal class DefaultNavigationCoordinator(dispatcher: CoroutineDispatcher = Di
     private var bottomNavController: BottomNavigationAdapter? = null
     private var bottomBarScrollConnection: NestedScrollConnection? = null
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + dispatcher)
-    private var updateBottomNavigationSection: Job? = null
+    private var updateBottomNavigationSectionJob: Job? = null
     private var updateCanPopJob: Job? = null
 
     override fun setBottomNavigator(adapter: BottomNavigationAdapter) {
         bottomNavController = adapter
-        updateBottomNavigationSection?.cancel()
-        updateBottomNavigationSection = adapter.currentSection.onEach { newValue ->
+        updateBottomNavigationSectionJob?.cancel()
+        updateBottomNavigationSectionJob = adapter.currentSection.onEach { newValue ->
             currentBottomNavSection.update { newValue }
         }.launchIn(scope)
     }

--- a/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/main/MainScreen.kt
+++ b/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/main/MainScreen.kt
@@ -101,11 +101,8 @@ fun MainScreen(
     val exitMessage = LocalStrings.current.messageConfirmExit
     val bottomNavController = rememberNavController()
 
-    LaunchedEffect(navigationCoordinator) {
-        if (navigationCoordinator.currentBottomNavSection.value == null) {
-            navigationCoordinator.setCurrentSection(BottomNavigationSection.Home)
-        }
-
+    val hasBottomNavigation = isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)
+    LaunchedEffect(navigationCoordinator, hasBottomNavigation) {
         navigationCoordinator.exitMessageVisible
             .onEach { visible ->
                 if (visible) {
@@ -118,13 +115,15 @@ fun MainScreen(
                 snackbarHostState.showSnackbar(message = message)
             }.launchIn(this)
 
-        navigationCoordinator.currentBottomNavSection.onEach {
-            // when the current tab changes, reset the bottom bar offset to the default value
-            model.reduce(MainMviModel.Intent.SetBottomBarOffsetHeightPx(0f))
-        }.launchIn(this)
+        if (hasBottomNavigation) {
+            val adapter = DefaultBottomNavigationAdapter(bottomNavController)
+            navigationCoordinator.setBottomNavigator(adapter)
 
-        val adapter = DefaultBottomNavigationAdapter(bottomNavController)
-        navigationCoordinator.setBottomNavigator(adapter)
+            navigationCoordinator.currentBottomNavSection.onEach {
+                // when the current tab changes, reset the bottom bar offset to the default value
+                model.reduce(MainMviModel.Intent.SetBottomBarOffsetHeightPx(0f))
+            }.launchIn(this)
+        }
     }
 
     Scaffold(
@@ -149,7 +148,7 @@ fun MainScreen(
             }
         },
         bottomBar = {
-            if (isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
+            if (hasBottomNavigation) {
                 NavigationBar(
                     modifier =
                         Modifier
@@ -185,7 +184,7 @@ fun MainScreen(
             }
         },
     ) {
-        if (isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
+        if (hasBottomNavigation) {
             NavHost(
                 navController = bottomNavController,
                 startDestination = BottomNavigationSection.Home,


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR resolves a crash on desktop due to bottom navigation exclusion not being properly handled when the `NavHost` for bottom nav is not created on wider screens.
