### PR TITLE
enh(urlhandler): simplify search result processing in fetch entity use cases

### DIFF
--- a/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/DefaultFetchEntryUseCase.kt
+++ b/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/DefaultFetchEntryUseCase.kt
@@ -15,14 +15,16 @@ internal class DefaultFetchEntryUseCase(private val searchRepository: SearchRepo
                     query = url,
                     resolve = true,
                     type = SearchResultType.Entries,
-                ).orEmpty()
+                )
+                .orEmpty()
                 .mapNotNull { res ->
                     when (res) {
                         is ExploreItemModel.Entry -> res.entry
                         else -> null
                     }
-                }.firstOrNull {
-                    it.url == url
+                }.let { res ->
+                    // eventual consistency check: prefer the one with the matching URL or fallback on the first one
+                    res.firstOrNull { it.url == url } ?: res.firstOrNull()
                 }
         }
 

--- a/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/DefaultFetchUserUseCase.kt
+++ b/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/processor/DefaultFetchUserUseCase.kt
@@ -15,14 +15,16 @@ internal class DefaultFetchUserUseCase(private val searchRepository: SearchRepos
                     query = url,
                     resolve = true,
                     type = SearchResultType.Users,
-                ).orEmpty()
+                )
+                .orEmpty()
                 .mapNotNull { res ->
                     when (res) {
                         is ExploreItemModel.User -> res.user
                         else -> null
                     }
-                }.firstOrNull {
-                    it.url == url
+                }.let { res ->
+                    // eventual consistency check: prefer the one with the matching URL or fallback on the first one
+                    res.firstOrNull { it.url == url } ?: res.firstOrNull()
                 }
         }
 


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR loosens the constraints to consider URLs resolved when searching for posts and users when they are selected for opening in posts.

The logic in `DefaultFetchEntryUseCase` and `DefaultFetchUserUseCase` dates back to #443 where an eventual consistency check was introduced to in an attempt to avoid unwanted matches between URL references and profiles.

A lot of time has passed since then and on newer versions of backends the search  API has improved a lot so proably client-side consistency checks are not needed any more. In any case, just to be on the safe side, the changes here introduced try to fetch the result with a matching URL and fallback on the first one if none is found.

@informapirata: il motivo per cui non venivano trovati certi utenti era che veniva fatto un controllo di coerenza finale sull'URL associato all'entità risultante dalla ricerca e l'URL iniziale che si stava cercando ma non è sempre detto che coincidano. Qui sto cambiando la logica per andare in fallback sul primo risultati trovato se nessuno corrisponde ma fidarmi in ultima istanza del server; se introduce errori rivedremo i casi puntuali.  Nella PR originale menzionavo Pixelfed, perché gli URL dei profili utenti sono solo `nome.istanza/nomeutente` quindi potrebbero generare falsi positivi. Ma se essere più restrittivi rompe la risoluzione degli altri URL, il tradeoff costi/benefici mi porta a rilassare il vincolo.
