### PR TITLE
fix: navigation destination state restoration

### DIFF
--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/BottomNavigationSection.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/BottomNavigationSection.kt
@@ -1,7 +1,10 @@
 package com.livefast.eattrash.raccoonforfriendica.core.navigation
 
+import androidx.compose.runtime.saveable.Saver
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 
+@Serializable
 sealed interface BottomNavigationSection {
     @Serializable
     data object Home : BottomNavigationSection
@@ -14,4 +17,11 @@ sealed interface BottomNavigationSection {
 
     @Serializable
     data object Profile : BottomNavigationSection
+
+    companion object {
+        val Saver = Saver<BottomNavigationSection, String>(
+            save = { Json.encodeToString(it) },
+            restore = { Json.decodeFromString<BottomNavigationSection>(it) },
+        )
+    }
 }

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/Destination.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/Destination.kt
@@ -1,7 +1,10 @@
 package com.livefast.eattrash.raccoonforfriendica.core.navigation
 
+import androidx.compose.runtime.saveable.Saver
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 
+@Serializable
 sealed interface Destination {
     @Serializable
     data object Main : Destination
@@ -161,4 +164,12 @@ sealed interface Destination {
 
     @Serializable
     data object Profile : Destination
+
+    companion object {
+
+        val Saver = Saver<Destination, String>(
+            save = { Json.encodeToString(it) },
+            restore = { Json.decodeFromString<Destination>(it) },
+        )
+    }
 }

--- a/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/App.kt
+++ b/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/App.kt
@@ -274,7 +274,9 @@ fun App(onLoadingFinished: (() -> Unit)? = null) = withDI(RootDI.di) {
                                 contentWindowInsets = WindowInsets(0, 0, 0, 0),
                             ) { paddingValues ->
                                 val startDestination: Destination = Destination.Main
-                                var selectedDestination by rememberSaveable { mutableStateOf(startDestination) }
+                                var selectedDestination by rememberSaveable(stateSaver = Destination.Saver) {
+                                    mutableStateOf(startDestination)
+                                }
                                 Row(
                                     modifier = Modifier
                                         .fillMaxSize()
@@ -356,4 +358,3 @@ fun App(onLoadingFinished: (() -> Unit)? = null) = withDI(RootDI.di) {
         }
     }
 }
-


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes a bug introduced when the permanent navigation drawer was introduced for desktop and large screens, making it impossible to correctly restore the state of `MainActivity` upon configuration changes such as screen rotation.
