### PR TITLE
fix: search bar top inset

### DIFF
--- a/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/TopAppBarWindowInsets.kt
+++ b/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/theme/TopAppBarWindowInsets.kt
@@ -1,30 +1,40 @@
 package com.livefast.eattrash.raccoonforfriendica.core.appearance.theme
 
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.TopAppBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
+
+@Composable
+fun rememberMaxTopBarInset(): Dp {
+    val density = LocalDensity.current
+    val statusBarHeight = WindowInsets.statusBars.getTop(density).let { with(density) { it.toDp() } }
+    return maxOf(statusBarHeight, Dimensions.maxTopBarInset)
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TopAppBarState.toWindowInsets(): WindowInsets {
-    val scope = rememberCoroutineScope()
-    val maxTopInsetPx = with(LocalDensity.current) { Dimensions.maxTopBarInset.toPx() }
-    var topInsetPx by remember { mutableStateOf(maxTopInsetPx) }
-    val topInset = with(LocalDensity.current) { topInsetPx.toDp() }
-    snapshotFlow { collapsedFraction }
-        .onEach {
-            topInsetPx = maxTopInsetPx * (1 - it)
-        }.launchIn(scope)
+    val maxInset = rememberMaxTopBarInset()
+
+    var topInset by remember { mutableStateOf(maxInset) }
+
+    LaunchedEffect(maxInset, this) {
+        snapshotFlow {
+            maxInset * (1 - collapsedFraction)
+        }.collect {
+            topInset = it
+        }
+    }
     return WindowInsets(0.dp, topInset, 0.dp, 0.dp)
 }

--- a/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
+++ b/feature/search/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feaure/search/SearchScreen.kt
@@ -39,8 +39,8 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.style.TextAlign
-import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Dimensions
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.rememberMaxTopBarInset
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.di.getViewModel
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ListLoadingIndicator
@@ -220,12 +220,13 @@ fun SearchScreen(modifier: Modifier = Modifier, customOnSelectAction: ((Timeline
                             SearchSection.Hashtags,
                             SearchSection.Groups,
                         )
+                    val maxInset = rememberMaxTopBarInset()
                     SectionSelector(
                         modifier =
                         Modifier
                             .background(MaterialTheme.colorScheme.background)
                             .padding(
-                                top = Dimensions.maxTopBarInset * topAppBarState.collapsedFraction,
+                                top = maxInset * topAppBarState.collapsedFraction,
                                 bottom = Spacing.s,
                             ),
                         titles = titles.map { it.toReadableName() },


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes a bug due to which the search field in the "Explore > Search" screen was inaccessible due to partially being hidden under cutouts (e.g. front cameras) on some devices.

Related issue: #1223