### PR TITLE
fix: handle async operations in OAuth flow

### DIFF
--- a/androidApp/src/main/kotlin/com/livefast/eattrash/raccoonforfriendica/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/livefast/eattrash/raccoonforfriendica/MainActivity.kt
@@ -16,6 +16,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getMainRoute
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.InboxManager
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di.getAuthManager
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -98,8 +99,10 @@ class MainActivity : ComponentActivity() {
                 uri.host == DefaultAuthManager.REDIRECT_HOST -> {
                 val authManager = getAuthManager()
                 lifecycleScope.launch {
-                    runCatching {
+                    try {
                         authManager.performTokenExchange(uri.toString())
+                    } catch (e: Exception) {
+                        if (e is CancellationException) throw e
                     }
                 }
             }

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/di/ApiModule.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/di/ApiModule.kt
@@ -46,11 +46,9 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.service.TrendsService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.UserService
 import com.livefast.eattrash.raccoonforfriendica.core.utils.network.provideHttpClientEngine
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import org.kodein.di.DI
 import org.kodein.di.bindFactory
-import org.kodein.di.bindInstance
 import org.kodein.di.bindSingleton
 import org.kodein.di.instance
 
@@ -58,21 +56,18 @@ internal data class ServiceCreationArgs(val baseUrl: String, val client: HttpCli
 
 val apiModule =
     DI.Module("ApiModule") {
-        bindInstance<HttpClientEngine> {
-            provideHttpClientEngine()
-        }
         bindSingleton<Json> {
             JsonSerializer
         }
         bindSingleton<ServiceProvider>(tag = "default") {
             DefaultServiceProvider(
-                factory = instance(),
+                factory = provideHttpClientEngine(),
                 appInfoRepository = instance(),
             )
         }
         bindSingleton<ServiceProvider>(tag = "other") {
             DefaultServiceProvider(
-                factory = instance(),
+                factory = provideHttpClientEngine(),
                 appInfoRepository = instance(),
             )
         }

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/DefaultServiceProvider.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/DefaultServiceProvider.kt
@@ -86,19 +86,32 @@ internal class DefaultServiceProvider(
 
     private val baseUrl: String get() = "https://$currentNode/api"
 
+    private var client: HttpClient? = null
+    private var lastCredentials: ServiceCredentials? = null
+
     override fun changeNode(value: String) {
         if (currentNode != value) {
             currentNode = value
-            reinitialize(null)
+            reinitialize(credentials = lastCredentials, force = true)
         }
     }
 
     override fun setAuth(credentials: ServiceCredentials?) {
-        reinitialize(credentials)
+        if (lastCredentials != credentials) {
+            reinitialize(credentials = credentials, force = false)
+        }
     }
 
-    private fun reinitialize(credentials: ServiceCredentials?) {
-        val client =
+    private fun reinitialize(credentials: ServiceCredentials?, force: Boolean) {
+        if (!force && lastCredentials == credentials && client != null) {
+            return
+        }
+
+        lastCredentials = credentials
+        val oldClient = client
+        client = null
+        oldClient?.close()
+        val newClient =
             HttpClient(factory) {
                 defaultRequest {
                     url {
@@ -172,7 +185,8 @@ internal class DefaultServiceProvider(
                     }
                 }
             }
-        val creationArgs = ServiceCreationArgs(baseUrl = baseUrl, client = client)
+        this.client = newClient
+        val creationArgs = ServiceCreationArgs(baseUrl = baseUrl, client = newClient)
         announcement = getService(creationArgs)
         app = getService(creationArgs)
         directMessage = getService(creationArgs)

--- a/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/libretranslate/LibreTranslateProvider.kt
+++ b/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/libretranslate/LibreTranslateProvider.kt
@@ -51,7 +51,7 @@ class LibreTranslateProvider(
         }
     }
 
-    override suspend fun translate(sourceText: String, sourceLang: String, targetLang: String): String = runCatching {
+    override suspend fun translate(sourceText: String, sourceLang: String, targetLang: String): String = try {
         val response = client.post("$baseUrl/translate") {
             contentType(ContentType.Application.Json)
             accept(ContentType.Application.Json)
@@ -68,7 +68,7 @@ class LibreTranslateProvider(
         check(response.status.isSuccess())
         val outputData: TranslationResponseBody = response.body()
         outputData.text.orEmpty()
-    }.getOrElse { e ->
+    } catch (e: Exception) {
         if (e is CancellationException) throw e
         ""
     }

--- a/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/store/DefaultTranslationProviderConfigStore.kt
+++ b/core/translation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/translation/store/DefaultTranslationProviderConfigStore.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.onStart
 import kotlinx.serialization.json.Json
+import kotlin.coroutines.cancellation.CancellationException
 
 internal class DefaultTranslationProviderConfigStore(private val keyStore: TemporaryKeyStore) :
     TranslationProviderConfigStore {
@@ -26,9 +27,12 @@ internal class DefaultTranslationProviderConfigStore(private val keyStore: Tempo
         val defaultId = getDefaultId()
         val key = getKey(id)
         val rawValue = keyStore.get(key, "{}")
-        return runCatching {
+        return try {
             JsonSerializer.decodeFromString<TranslationProviderConfig>(rawValue)
-        }.getOrNull()?.let {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            null
+        }?.let {
             it.copy(default = it.id == defaultId)
         }
     }

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/appinfo/DefaultAppInfoRepository.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/appinfo/DefaultAppInfoRepository.kt
@@ -5,12 +5,13 @@ import android.content.pm.ApplicationInfo
 import android.os.Build
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlin.coroutines.cancellation.CancellationException
 
 internal class DefaultAppInfoRepository(private val context: Context) : AppInfoRepository {
     private val _appInfo = MutableStateFlow(geInfo())
     override val appInfo: StateFlow<AppInfo?> = _appInfo
 
-    private fun geInfo(): AppInfo? = runCatching {
+    private fun geInfo(): AppInfo? = try {
         with(context) {
             val packageInfo = packageManager.getPackageInfo(packageName, 0)
             AppInfo(
@@ -28,5 +29,8 @@ internal class DefaultAppInfoRepository(private val context: Context) : AppInfoR
                 isDebug = applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0,
             )
         }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 }

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/UtilsModule.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/UtilsModule.kt
@@ -12,10 +12,8 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.network.Connectivity
 import com.livefast.eattrash.raccoonforfriendica.core.utils.network.DefaultNetworkStateObserver
 import com.livefast.eattrash.raccoonforfriendica.core.utils.network.NetworkStateObserver
 import org.kodein.di.DI
-import org.kodein.di.bind
 import org.kodein.di.bindSingleton
 import org.kodein.di.instance
-import org.kodein.di.singleton
 
 val utilsModule =
     DI.Module("UtilsModule") {

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/DefaultBlurHashDecoder.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/DefaultBlurHashDecoder.kt
@@ -7,6 +7,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.cache.LruCache
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.math.PI
 import kotlin.math.cos
 import kotlin.math.pow
@@ -55,9 +56,12 @@ internal class DefaultBlurHashDecoder(
                     decodeAc(colorEnc, maxAc * punch)
                 }
             }
-        runCatching {
+        try {
             composeBitmap(width, height, numCompX, numCompY, colors, useCache)
-        }.getOrNull()
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            null
+        }
     }
 
     private fun decode83(str: String, from: Int = 0, to: Int = str.length): Int {

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultAnnouncementRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultAnnouncementRepository.kt
@@ -3,6 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.AnnouncementModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
+import io.ktor.utils.io.CancellationException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -21,7 +22,7 @@ internal class DefaultAnnouncementRepository(private val provider: ServiceProvid
             return cachedValues.map { it }
         }
 
-        return runCatching {
+        return try {
             val response = provider.announcement.getAll()
             response
                 .map { it.toModel() }
@@ -30,7 +31,10 @@ internal class DefaultAnnouncementRepository(private val provider: ServiceProvid
                         cachedValues.addAll(it)
                     }
                 }
-        }.getOrNull()
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            null
+        }
     }
 
     override suspend fun markAsRead(id: String): Boolean = provider.announcement.dismiss(id)

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultCirclesRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultCirclesRepository.kt
@@ -8,37 +8,49 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.CircleReply
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toDto
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
+import io.ktor.utils.io.CancellationException
 
 internal class DefaultCirclesRepository(private val provider: ServiceProvider) : CirclesRepository {
-    override suspend fun getAll(): List<CircleModel>? = runCatching {
+    override suspend fun getAll(): List<CircleModel>? = try {
         provider.list.getAll().map { it.toModel() }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun get(id: String): CircleModel? = runCatching {
+    override suspend fun get(id: String): CircleModel? = try {
         provider.list.getBy(id).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun getMembers(id: String, pageCursor: String?): List<UserModel>? = runCatching {
+    override suspend fun getMembers(id: String, pageCursor: String?): List<UserModel>? = try {
         provider.list.getMembers(id = id, maxId = pageCursor).map { it.toModel() }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun create(title: String, replyPolicy: CircleReplyPolicy, exclusive: Boolean): CircleModel? =
-        runCatching {
-            val data =
-                EditListForm(
-                    title = title,
-                    replyPolicy = replyPolicy.toDto(),
-                    exclusive = exclusive,
-                )
-            provider.list.create(data).toModel()
-        }.getOrNull()
+    override suspend fun create(title: String, replyPolicy: CircleReplyPolicy, exclusive: Boolean): CircleModel? = try {
+        val data =
+            EditListForm(
+                title = title,
+                replyPolicy = replyPolicy.toDto(),
+                exclusive = exclusive,
+            )
+        provider.list.create(data).toModel()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
     override suspend fun update(
         id: String,
         title: String,
         replyPolicy: CircleReplyPolicy,
         exclusive: Boolean,
-    ): CircleModel? = runCatching {
+    ): CircleModel? = try {
         val data =
             EditListForm(
                 title = title,
@@ -46,7 +58,10 @@ internal class DefaultCirclesRepository(private val provider: ServiceProvider) :
                 exclusive = exclusive,
             )
         provider.list.update(id = id, data = data).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
     override suspend fun delete(id: String): Boolean = provider.list.delete(id)
 

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultDirectMessageRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultDirectMessageRepository.kt
@@ -5,26 +5,33 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.DirectMessa
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.http.Parameters
+import io.ktor.utils.io.CancellationException
 
 internal class DefaultDirectMessageRepository(private val provider: ServiceProvider) : DirectMessageRepository {
-    override suspend fun getAll(page: Int, limit: Int?): List<DirectMessageModel>? = runCatching {
+    override suspend fun getAll(page: Int, limit: Int?): List<DirectMessageModel>? = try {
         provider.directMessage
             .getAll(
                 page = page,
                 count = limit ?: DEFAULT_PAGE_SIZE,
             ).map { it.toModel() }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun getReplies(parentUri: String, page: Int): List<DirectMessageModel>? = runCatching {
+    override suspend fun getReplies(parentUri: String, page: Int): List<DirectMessageModel>? = try {
         provider.directMessage
             .getConversation(
                 uri = parentUri,
                 page = page,
                 count = DEFAULT_PAGE_SIZE,
             ).map { it.toModel() }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun pollReplies(parentUri: String, minId: String): List<DirectMessageModel>? = runCatching {
+    override suspend fun pollReplies(parentUri: String, minId: String): List<DirectMessageModel>? = try {
         provider.directMessage
             .getConversation(
                 uri = parentUri,
@@ -32,14 +39,17 @@ internal class DefaultDirectMessageRepository(private val provider: ServiceProvi
                 page = 1,
                 count = DEFAULT_PAGE_SIZE,
             ).map { it.toModel() }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
     override suspend fun create(
         recipientId: String,
         text: String,
         title: String?,
         inReplyTo: String?,
-    ): DirectMessageModel? = runCatching {
+    ): DirectMessageModel? = try {
         val data =
             FormDataContent(
                 formData =
@@ -55,17 +65,26 @@ internal class DefaultDirectMessageRepository(private val provider: ServiceProvi
                 },
             )
         provider.directMessage.create(data).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun delete(id: String): Boolean = runCatching {
+    override suspend fun delete(id: String): Boolean = try {
         val res = provider.directMessage.delete(id.toLong())
         res.result == RESULT_OK
-    }.getOrElse { false }
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        false
+    }
 
-    override suspend fun markAsRead(id: String): Boolean = runCatching {
+    override suspend fun markAsRead(id: String): Boolean = try {
         val res = provider.directMessage.markAsRead(id.toLong())
         res.result == RESULT_OK
-    }.getOrElse { false }
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        false
+    }
 
     companion object {
         private const val DEFAULT_PAGE_SIZE = 20

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultDraftRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultDraftRepository.kt
@@ -10,38 +10,54 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.Visibility
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toDto
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toVisibility
+import io.ktor.utils.io.CancellationException
 
 internal class DefaultDraftRepository(private val draftDao: DraftDao, private val provider: ServiceProvider) :
     DraftRepository {
-    override suspend fun getAll(page: Int): List<TimelineEntryModel>? = runCatching {
+    override suspend fun getAll(page: Int): List<TimelineEntryModel>? = try {
         draftDao
             .getAll(
                 offset = page * DEFAULT_PAGE_SIZE,
                 limit = DEFAULT_PAGE_SIZE,
             ).map { it.toModel() }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun getById(id: String): TimelineEntryModel? = runCatching {
+    override suspend fun getById(id: String): TimelineEntryModel? = try {
         draftDao.getBy(id)?.toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun create(item: TimelineEntryModel): TimelineEntryModel? = runCatching {
+    override suspend fun create(item: TimelineEntryModel): TimelineEntryModel? = try {
         val entity = item.toEntity()
         draftDao.insert(entity)
         getById(item.id)
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun update(item: TimelineEntryModel): TimelineEntryModel? = runCatching {
+    override suspend fun update(item: TimelineEntryModel): TimelineEntryModel? = try {
         val entity = item.toEntity()
         draftDao.update(entity)
         getById(item.id)
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun delete(id: String): Boolean = runCatching {
+    override suspend fun delete(id: String): Boolean = try {
         val entity = DraftEntity(id = id)
         draftDao.delete(entity)
         true
-    }.getOrElse { false }
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        false
+    }
 
     private suspend fun DraftEntity.toModel() = TimelineEntryModel(
         id = id,
@@ -50,7 +66,12 @@ internal class DefaultDraftRepository(private val draftDao: DraftDao, private va
             ?.split(",")
             ?.filterNot { it.isEmpty() }
             ?.mapNotNull { id ->
-                runCatching { provider.media.getBy(id) }.getOrNull()?.toModel()
+                try {
+                    provider.media.getBy(id)
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                    null
+                }?.toModel()
             }.orEmpty(),
         parentId = inReplyToId,
         lang = lang,

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEmojiRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEmojiRepository.kt
@@ -4,6 +4,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvid
 import com.livefast.eattrash.raccoonforfriendica.core.utils.cache.LruCache
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EmojiModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
+import io.ktor.utils.io.CancellationException
 
 internal class DefaultEmojiRepository(
     private val provider: ServiceProvider,
@@ -22,7 +23,7 @@ internal class DefaultEmojiRepository(
         }
     }
 
-    private suspend fun retrieve(node: String?): List<EmojiModel>? = runCatching {
+    private suspend fun retrieve(node: String?): List<EmojiModel>? = try {
         val res =
             if (node == null) {
                 provider.instance.getCustomEmojis()
@@ -31,5 +32,8 @@ internal class DefaultEmojiRepository(
                 otherProvider.instance.getCustomEmojis()
             }
         res.map { it.toModel() }
-    }.getOrElse { null }
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEventRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultEventRepository.kt
@@ -3,15 +3,19 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EventModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
+import io.ktor.utils.io.CancellationException
 
 internal class DefaultEventRepository(private val provider: ServiceProvider) : EventRepository {
-    override suspend fun getAll(pageCursor: String?): List<EventModel>? = runCatching {
+    override suspend fun getAll(pageCursor: String?): List<EventModel>? = try {
         provider.event
             .getAll(
                 maxId = pageCursor?.toLong(),
                 count = DEFAULT_PAGE_SIZE,
             ).map { it.toModel() }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
     companion object {
         const val DEFAULT_PAGE_SIZE = 20

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultFallbackTranslationRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultFallbackTranslationRepository.kt
@@ -4,6 +4,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.translation.TranslationPro
 import com.livefast.eattrash.raccoonforfriendica.core.translation.TranslationProviderFactory
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TranslatedTimelineEntryModel
+import io.ktor.utils.io.CancellationException
 
 internal class DefaultFallbackTranslationRepository(
     private val translationProviderFactory: TranslationProviderFactory,
@@ -12,7 +13,7 @@ internal class DefaultFallbackTranslationRepository(
         entry: TimelineEntryModel,
         targetLang: String,
         config: TranslationProviderConfig?,
-    ): TranslatedTimelineEntryModel? = runCatching {
+    ): TranslatedTimelineEntryModel? = try {
         TranslatedTimelineEntryModel(
             source = entry,
             target =
@@ -82,7 +83,10 @@ internal class DefaultFallbackTranslationRepository(
             ),
             provider = config?.name.orEmpty(),
         )
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
     private suspend fun String.translate(
         sourceLang: String?,

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMarkerRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMarkerRepository.kt
@@ -7,6 +7,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.http.Parameters
+import io.ktor.utils.io.CancellationException
 
 internal class DefaultMarkerRepository(private val provider: ServiceProvider) : MarkerRepository {
     private val cachedValues = mutableMapOf<MarkerType, MarkerModel>()
@@ -15,16 +16,19 @@ internal class DefaultMarkerRepository(private val provider: ServiceProvider) : 
         if (cachedValues.contains(type) && !refresh) {
             cachedValues[type]
         } else {
-            runCatching {
+            try {
                 provider.marker
                     .get(timelines = listOf(type.toDto()))
                     .toModel()
                     .firstOrNull { it.type == type }
                     ?.also { cachedValues[type] = it }
-            }.getOrNull()
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                null
+            }
         }
 
-    override suspend fun update(type: MarkerType, id: String): MarkerModel? = runCatching {
+    override suspend fun update(type: MarkerType, id: String): MarkerModel? = try {
         val fieldName = "${type.toDto()}[last_read_id]"
         val data =
             FormDataContent(
@@ -37,5 +41,8 @@ internal class DefaultMarkerRepository(private val provider: ServiceProvider) : 
             .toModel()
             .firstOrNull { it.type == type }
             ?.also { cachedValues[type] = it }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMediaRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMediaRepository.kt
@@ -9,15 +9,19 @@ import io.ktor.client.request.forms.formData
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
 import io.ktor.http.parameters
+import io.ktor.utils.io.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeoutOrNull
 
 internal class DefaultMediaRepository(private val provider: ServiceProvider) : MediaRepository {
-    override suspend fun getBy(id: String): AttachmentModel? = runCatching {
+    override suspend fun getBy(id: String): AttachmentModel? = try {
         provider.media.getBy(id).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun create(bytes: ByteArray, album: String, alt: String): AttachmentModel? = runCatching {
+    override suspend fun create(bytes: ByteArray, album: String, alt: String): AttachmentModel? = try {
         val content =
             MultiPartFormDataContent(
                 formData {
@@ -48,9 +52,12 @@ internal class DefaultMediaRepository(private val provider: ServiceProvider) : M
                 url
             }.orEmpty()
         res.copy(url = url)
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun update(id: String, alt: String): Boolean = runCatching {
+    override suspend fun update(id: String, alt: String): Boolean = try {
         val content =
             FormDataContent(
                 parameters {
@@ -59,7 +66,10 @@ internal class DefaultMediaRepository(private val provider: ServiceProvider) : M
             )
         provider.media.update(id = id, content = content)
         true
-    }.getOrElse { false }
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        false
+    }
 
     override suspend fun delete(id: String): Boolean = provider.media.delete(id = id)
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNodeInfoRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNodeInfoRepository.kt
@@ -9,6 +9,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
+import io.ktor.utils.io.CancellationException
 import kotlinx.serialization.json.Json
 
 internal class DefaultNodeInfoRepository(
@@ -18,23 +19,32 @@ internal class DefaultNodeInfoRepository(
 ) : NodeInfoRepository {
     override suspend fun getInfo(): NodeInfoModel? {
         val instanceInfo =
-            runCatching {
+            try {
                 provider.instance.getInfo()
-            }.getOrNull()
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                null
+            }
 
         val softwareName =
-            runCatching {
+            try {
                 extractSoftwareName()
-            }.getOrNull()
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                null
+            }
 
         return instanceInfo?.toModel()?.copy(
             software = softwareName,
         )
     }
 
-    override suspend fun getRules(): List<RuleModel>? = runCatching {
+    override suspend fun getRules(): List<RuleModel>? = try {
         provider.instance.getRules().map { it.toModel() }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
     private suspend fun extractSoftwareName(): String {
         val linksJson =

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNotificationRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNotificationRepository.kt
@@ -5,6 +5,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.Notificatio
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toRawValue
+import io.ktor.utils.io.CancellationException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -25,7 +26,7 @@ internal class DefaultNotificationRepository(private val provider: ServiceProvid
         if (pageCursor == null && cachedValues.isNotEmpty()) {
             return cachedValues
         }
-        return runCatching {
+        return try {
             val response =
                 provider.notification.get(
                     types = types.mapNotNull { it.toRawValue() },
@@ -41,7 +42,10 @@ internal class DefaultNotificationRepository(private val provider: ServiceProvid
                         }
                     }
                 }
-        }.getOrNull()
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            null
+        }
     }
 
     override suspend fun dismiss(id: String): Boolean = provider.notification.dismiss(id)

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoAlbumRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoAlbumRepository.kt
@@ -6,13 +6,17 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaAlbumM
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.http.Parameters
+import io.ktor.utils.io.CancellationException
 
 internal class DefaultPhotoAlbumRepository(private val provider: ServiceProvider) : PhotoAlbumRepository {
-    override suspend fun getAll(): List<MediaAlbumModel>? = runCatching {
+    override suspend fun getAll(): List<MediaAlbumModel>? = try {
         provider.photoAlbum.getAll().map { it.toModel() }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun update(oldName: String, newName: String): Boolean = runCatching {
+    override suspend fun update(oldName: String, newName: String): Boolean = try {
         val data =
             FormDataContent(
                 Parameters.build {
@@ -22,9 +26,12 @@ internal class DefaultPhotoAlbumRepository(private val provider: ServiceProvider
             )
         val res = provider.photoAlbum.update(data)
         res.result == "updated"
-    }.getOrElse { false }
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        false
+    }
 
-    override suspend fun delete(name: String): Boolean = runCatching {
+    override suspend fun delete(name: String): Boolean = try {
         val data =
             FormDataContent(
                 Parameters.build {
@@ -33,10 +40,13 @@ internal class DefaultPhotoAlbumRepository(private val provider: ServiceProvider
             )
         val res = provider.photoAlbum.delete(data)
         res.result == "deleted"
-    }.getOrElse { false }
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        false
+    }
 
     override suspend fun getPhotos(album: String, pageCursor: String?, latestFirst: Boolean): List<AttachmentModel>? =
-        runCatching {
+        try {
             provider.photoAlbum
                 .getPhotos(
                     album = album,
@@ -44,7 +54,10 @@ internal class DefaultPhotoAlbumRepository(private val provider: ServiceProvider
                     latestFirst = latestFirst,
                     limit = DEFAULT_PAGE_SIZE,
                 ).map { it.toModel() }
-        }.getOrNull()
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            null
+        }
 
     companion object {
         private const val DEFAULT_PAGE_SIZE = 20

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoRepository.kt
@@ -7,9 +7,10 @@ import io.ktor.client.request.forms.MultiPartFormDataContent
 import io.ktor.client.request.forms.formData
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
+import io.ktor.utils.io.CancellationException
 
 internal class DefaultPhotoRepository(private val provider: ServiceProvider) : PhotoRepository {
-    override suspend fun create(bytes: ByteArray, album: String, alt: String): AttachmentModel? = runCatching {
+    override suspend fun create(bytes: ByteArray, album: String, alt: String): AttachmentModel? = try {
         val content =
             MultiPartFormDataContent(
                 formData {
@@ -27,7 +28,10 @@ internal class DefaultPhotoRepository(private val provider: ServiceProvider) : P
                 },
             )
         provider.photo.create(content = content).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
     override suspend fun update(
         id: String,
@@ -35,7 +39,7 @@ internal class DefaultPhotoRepository(private val provider: ServiceProvider) : P
         album: String,
         newAlbum: String?,
         alt: String,
-    ): Boolean = runCatching {
+    ): Boolean = try {
         val content =
             MultiPartFormDataContent(
                 formData {
@@ -63,9 +67,12 @@ internal class DefaultPhotoRepository(private val provider: ServiceProvider) : P
             )
         val res = provider.photo.update(content = content)
         res.result == "updated"
-    }.getOrElse { false }
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        false
+    }
 
-    override suspend fun delete(id: String): Boolean = runCatching {
+    override suspend fun delete(id: String): Boolean = try {
         val content =
             MultiPartFormDataContent(
                 formData {
@@ -74,5 +81,8 @@ internal class DefaultPhotoRepository(private val provider: ServiceProvider) : P
             )
         val res = provider.photo.delete(content)
         res.result == "deleted"
-    }.getOrElse { false }
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        false
+    }
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPushNotificationRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPushNotificationRepository.kt
@@ -7,6 +7,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toRawValue
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.http.parameters
+import kotlin.coroutines.cancellation.CancellationException
 
 internal class DefaultPushNotificationRepository(private val provider: ServiceProvider) : PushNotificationRepository {
     override suspend fun create(
@@ -15,7 +16,7 @@ internal class DefaultPushNotificationRepository(private val provider: ServicePr
         auth: String,
         types: List<NotificationType>,
         policy: NotificationPolicy,
-    ): String? = runCatching {
+    ): String? = try {
         val data =
             FormDataContent(
                 parameters {
@@ -32,9 +33,12 @@ internal class DefaultPushNotificationRepository(private val provider: ServicePr
                 },
             )
         provider.push.create(data).serverKey
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun update(types: List<NotificationType>, policy: NotificationPolicy): String? = runCatching {
+    override suspend fun update(types: List<NotificationType>, policy: NotificationPolicy): String? = try {
         val data =
             FormDataContent(
                 parameters {
@@ -48,10 +52,16 @@ internal class DefaultPushNotificationRepository(private val provider: ServicePr
                 },
             )
         provider.push.update(data).serverKey
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun delete(): Boolean = runCatching {
+    override suspend fun delete(): Boolean = try {
         provider.push.delete()
         true
-    }.getOrElse { false }
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        false
+    }
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultScheduledEntryRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultScheduledEntryRepository.kt
@@ -5,21 +5,28 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEnt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.http.parameters
+import io.ktor.utils.io.CancellationException
 
 internal class DefaultScheduledEntryRepository(private val provider: ServiceProvider) : ScheduledEntryRepository {
-    override suspend fun getAll(pageCursor: String?): List<TimelineEntryModel>? = runCatching {
+    override suspend fun getAll(pageCursor: String?): List<TimelineEntryModel>? = try {
         provider.status
             .getScheduled(
                 maxId = pageCursor,
                 limit = DEFAULT_PAGE_SIZE,
             ).map { it.toModel() }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun getById(id: String): TimelineEntryModel? = runCatching {
+    override suspend fun getById(id: String): TimelineEntryModel? = try {
         provider.status.getScheduledById(id).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun update(id: String, date: String): TimelineEntryModel? = runCatching {
+    override suspend fun update(id: String, date: String): TimelineEntryModel? = try {
         val data =
             FormDataContent(
                 parameters {
@@ -31,7 +38,10 @@ internal class DefaultScheduledEntryRepository(private val provider: ServiceProv
                 id = id,
                 data = data,
             ).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
     override suspend fun delete(id: String): Boolean = provider.status.deleteScheduled(id)
 

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSearchRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSearchRepository.kt
@@ -6,6 +6,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.SearchResul
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toDto
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModelWithReply
+import io.ktor.utils.io.CancellationException
 
 internal class DefaultSearchRepository(private val provider: ServiceProvider) : SearchRepository {
     override suspend fun search(
@@ -13,7 +14,7 @@ internal class DefaultSearchRepository(private val provider: ServiceProvider) : 
         type: SearchResultType,
         pageCursor: String?,
         resolve: Boolean,
-    ): List<ExploreItemModel>? = runCatching {
+    ): List<ExploreItemModel>? = try {
         val response =
             provider.search
                 .search(
@@ -39,7 +40,10 @@ internal class DefaultSearchRepository(private val provider: ServiceProvider) : 
                     ExploreItemModel.User(it.toModel())
                 }
         }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
     companion object {
         const val DEFAULT_PAGE_SIZE = 20

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTagRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTagRepository.kt
@@ -4,25 +4,38 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvid
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TagModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.ListWithPageCursor
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
+import io.ktor.utils.io.CancellationException
 
 internal class DefaultTagRepository(private val provider: ServiceProvider) : TagRepository {
-    override suspend fun getFollowed(pageCursor: String?): ListWithPageCursor<TagModel>? = runCatching {
+    override suspend fun getFollowed(pageCursor: String?): ListWithPageCursor<TagModel>? = try {
         val (list, cursor) =
             provider.tag.getFollowedTags(
                 maxId = pageCursor,
             )
         ListWithPageCursor(list = list.map { it.toModel() }, cursor = cursor)
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun getBy(name: String): TagModel? = runCatching {
+    override suspend fun getBy(name: String): TagModel? = try {
         provider.tag.get(name).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun follow(name: String): TagModel? = runCatching {
+    override suspend fun follow(name: String): TagModel? = try {
         provider.tag.follow(name).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun unfollow(name: String): TagModel? = runCatching {
+    override suspend fun unfollow(name: String): TagModel? = try {
         provider.tag.unfollow(name).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTimelineEntryRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTimelineEntryRepository.kt
@@ -20,6 +20,7 @@ import io.ktor.client.request.forms.FormDataContent
 import io.ktor.http.parameters
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration
 
 internal class DefaultTimelineEntryRepository(
@@ -50,7 +51,7 @@ internal class DefaultTimelineEntryRepository(
         if (pageCursor == null && cachedValues.isNotEmpty() && enableCache && otherInstance.isNullOrEmpty()) {
             cachedValues
         } else {
-            runCatching {
+            try {
                 provider.user
                     .getStatuses(
                         id = userId,
@@ -68,29 +69,41 @@ internal class DefaultTimelineEntryRepository(
                             }
                         }
                     }
-            }.getOrNull()
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                null
+            }
         }
     }
 
-    override suspend fun getById(id: String, otherInstance: String?): TimelineEntryModel? = runCatching {
+    override suspend fun getById(id: String, otherInstance: String?): TimelineEntryModel? = try {
         withProvider(otherInstance) { provider ->
             provider.status.get(id = id).toModelWithReply()
         }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun getSource(id: String, otherInstance: String?): TimelineEntryModel? = runCatching {
+    override suspend fun getSource(id: String, otherInstance: String?): TimelineEntryModel? = try {
         withProvider(otherInstance) { provider ->
             provider.status.getSource(id = id).toModel()
         }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun getContext(id: String, otherInstance: String?): TimelineContextModel? = runCatching {
+    override suspend fun getContext(id: String, otherInstance: String?): TimelineContextModel? = try {
         withProvider(otherInstance) { provider ->
             provider.status.getContext(id = id).toModel()
         }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun reblog(id: String): TimelineEntryModel? = runCatching {
+    override suspend fun reblog(id: String): TimelineEntryModel? = try {
         val data =
             FormDataContent(
                 parameters {
@@ -102,57 +115,87 @@ internal class DefaultTimelineEntryRepository(
                 id = id,
                 data = data,
             ).toModelWithReply()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun unreblog(id: String): TimelineEntryModel? = runCatching {
+    override suspend fun unreblog(id: String): TimelineEntryModel? = try {
         provider.status.unreblog(id).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun pin(id: String): TimelineEntryModel? = runCatching {
+    override suspend fun pin(id: String): TimelineEntryModel? = try {
         provider.status.pin(id).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun unpin(id: String): TimelineEntryModel? = runCatching {
+    override suspend fun unpin(id: String): TimelineEntryModel? = try {
         provider.status.unpin(id).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun favorite(id: String): TimelineEntryModel? = runCatching {
+    override suspend fun favorite(id: String): TimelineEntryModel? = try {
         provider.status.favorite(id).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun unfavorite(id: String): TimelineEntryModel? = runCatching {
+    override suspend fun unfavorite(id: String): TimelineEntryModel? = try {
         provider.status.unfavorite(id).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun bookmark(id: String): TimelineEntryModel? = runCatching {
+    override suspend fun bookmark(id: String): TimelineEntryModel? = try {
         provider.status.bookmark(id).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun unbookmark(id: String): TimelineEntryModel? = runCatching {
+    override suspend fun unbookmark(id: String): TimelineEntryModel? = try {
         provider.status.unbookmark(id).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun getFavorites(pageCursor: String?): List<TimelineEntryModel>? = runCatching {
+    override suspend fun getFavorites(pageCursor: String?): List<TimelineEntryModel>? = try {
         provider.user
             .getFavorites(
                 maxId = pageCursor,
                 limit = DEFAULT_PAGE_SIZE,
             ).map { it.toModelWithReply() }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun getBookmarks(pageCursor: String?): List<TimelineEntryModel>? = runCatching {
+    override suspend fun getBookmarks(pageCursor: String?): List<TimelineEntryModel>? = try {
         provider.user
             .getBookmarks(
                 maxId = pageCursor,
                 limit = DEFAULT_PAGE_SIZE,
             ).map { it.toModelWithReply() }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
     override suspend fun getUsersWhoFavorited(
         id: String,
         pageCursor: String?,
         otherInstance: String?,
-    ): List<UserModel>? = runCatching {
+    ): List<UserModel>? = try {
         withProvider(otherInstance) { provider ->
             provider.status
                 .getFavoritedBy(
@@ -161,13 +204,16 @@ internal class DefaultTimelineEntryRepository(
                     limit = DEFAULT_PAGE_SIZE,
                 ).map { it.toModel() }
         }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
     override suspend fun getUsersWhoReblogged(
         id: String,
         pageCursor: String?,
         otherInstance: String?,
-    ): List<UserModel>? = runCatching {
+    ): List<UserModel>? = try {
         withProvider(otherInstance) { provider ->
             provider.status
                 .getRebloggedBy(
@@ -176,7 +222,10 @@ internal class DefaultTimelineEntryRepository(
                     limit = DEFAULT_PAGE_SIZE,
                 ).map { it.toModel() }
         }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
     override suspend fun create(
         localId: String,
@@ -192,7 +241,7 @@ internal class DefaultTimelineEntryRepository(
         pollOptions: List<String>?,
         pollExpirationDate: String?,
         pollMultiple: Boolean?,
-    ): TimelineEntryModel? = runCatching {
+    ): TimelineEntryModel? = try {
         val pollData =
             if (pollOptions != null && pollMultiple != null && pollExpirationDate != null) {
                 val pollDuration =
@@ -231,7 +280,10 @@ internal class DefaultTimelineEntryRepository(
                 key = localId,
                 data = data,
             ).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
     override suspend fun update(
         id: String,
@@ -246,7 +298,7 @@ internal class DefaultTimelineEntryRepository(
         pollOptions: List<String>?,
         pollExpirationDate: String?,
         pollMultiple: Boolean?,
-    ): TimelineEntryModel? = runCatching {
+    ): TimelineEntryModel? = try {
         val pollData =
             if (pollOptions != null && pollMultiple != null && pollExpirationDate != null) {
                 val pollDuration =
@@ -284,11 +336,14 @@ internal class DefaultTimelineEntryRepository(
                 id = id,
                 data = data,
             ).toModelWithReply()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
     override suspend fun delete(id: String): Boolean = provider.status.delete(id)
 
-    override suspend fun submitPoll(pollId: String, choices: List<Int>): PollModel? = runCatching {
+    override suspend fun submitPoll(pollId: String, choices: List<Int>): PollModel? = try {
         val data =
             SubmitPollVoteForm(
                 choices = choices,
@@ -298,7 +353,10 @@ internal class DefaultTimelineEntryRepository(
                 id = pollId,
                 data = data,
             ).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
     override suspend fun dislike(id: String): Boolean {
         val data =
@@ -324,7 +382,7 @@ internal class DefaultTimelineEntryRepository(
         id: String,
         pageCursor: String?,
         otherInstance: String?,
-    ): ListWithPageCursor<TimelineEntryModel>? = runCatching {
+    ): ListWithPageCursor<TimelineEntryModel>? = try {
         val (list, cursor) = withProvider(otherInstance) { provider ->
             provider.status.getQuotes(
                 id = id,
@@ -332,7 +390,10 @@ internal class DefaultTimelineEntryRepository(
             )
         }
         ListWithPageCursor(list = list.map { it.toModel() }, cursor = cursor)
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
     private suspend fun <T> withProvider(otherInstance: String?, block: suspend (ServiceProvider) -> T): T {
         if (otherInstance.isNullOrEmpty()) {

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTimelineRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTimelineRepository.kt
@@ -4,6 +4,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvid
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.ListWithPageCursor
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModelWithReply
+import io.ktor.utils.io.CancellationException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -23,7 +24,7 @@ internal class DefaultTimelineRepository(
         if (pageCursor == null && cachedValues.isNotEmpty()) {
             return cachedValues
         }
-        return runCatching {
+        return try {
             val response =
                 provider.timeline.getPublic(
                     maxId = pageCursor,
@@ -38,7 +39,10 @@ internal class DefaultTimelineRepository(
                         }
                     }
                 }
-        }.getOrNull()
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            null
+        }
     }
 
     override suspend fun getHome(pageCursor: String?, refresh: Boolean): List<TimelineEntryModel>? {
@@ -50,7 +54,7 @@ internal class DefaultTimelineRepository(
         if (pageCursor == null && cachedValues.isNotEmpty()) {
             return cachedValues
         }
-        return runCatching {
+        return try {
             val response =
                 provider.timeline.getHome(
                     maxId = pageCursor,
@@ -65,7 +69,10 @@ internal class DefaultTimelineRepository(
                         }
                     }
                 }
-        }.getOrNull()
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            null
+        }
     }
 
     override suspend fun getLocal(
@@ -81,7 +88,7 @@ internal class DefaultTimelineRepository(
         if (pageCursor == null && cachedValues.isNotEmpty() && otherInstance.isNullOrEmpty()) {
             cachedValues
         } else {
-            runCatching {
+            try {
                 val response =
                     provider.timeline.getPublic(
                         maxId = pageCursor,
@@ -97,7 +104,10 @@ internal class DefaultTimelineRepository(
                             }
                         }
                     }
-            }.getOrNull()
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                null
+            }
         }
     }
 
@@ -105,7 +115,7 @@ internal class DefaultTimelineRepository(
         hashtag: String,
         pageCursor: String?,
         otherInstance: String?,
-    ): ListWithPageCursor<TimelineEntryModel>? = runCatching {
+    ): ListWithPageCursor<TimelineEntryModel>? = try {
         val (list, cursor) = withProvider(otherInstance) { provider ->
             provider.timeline.getHashtag(
                 hashtag = hashtag,
@@ -114,9 +124,12 @@ internal class DefaultTimelineRepository(
             )
         }
         ListWithPageCursor(list = list.map { it.toModelWithReply() }, cursor = cursor)
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun getCircle(id: String, pageCursor: String?): List<TimelineEntryModel>? = runCatching {
+    override suspend fun getCircle(id: String, pageCursor: String?): List<TimelineEntryModel>? = try {
         val response =
             provider.timeline.getList(
                 id = id,
@@ -124,7 +137,10 @@ internal class DefaultTimelineRepository(
                 limit = DEFAULT_PAGE_SIZE,
             )
         response.map { it.toModelWithReply() }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
     private suspend fun <T> withProvider(otherInstance: String?, block: suspend (ServiceProvider) -> T): T {
         if (otherInstance.isNullOrEmpty()) {

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTranslationRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTranslationRepository.kt
@@ -5,10 +5,11 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEnt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TranslatedTimelineEntryModel
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.http.parameters
+import io.ktor.utils.io.CancellationException
 
 internal class DefaultTranslationRepository(private val provider: ServiceProvider) : TranslationRepository {
     override suspend fun getTranslation(entry: TimelineEntryModel, targetLang: String): TranslatedTimelineEntryModel? =
-        runCatching {
+        try {
             val res =
                 provider.status.translate(
                     id = entry.id,
@@ -52,5 +53,8 @@ internal class DefaultTranslationRepository(private val provider: ServiceProvide
                 ),
                 provider = res.provider,
             )
-        }.getOrNull()
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            null
+        }
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTrendingRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTrendingRepository.kt
@@ -6,6 +6,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TagModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModelWithReply
+import io.ktor.utils.io.CancellationException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -16,7 +17,7 @@ internal class DefaultTrendingRepository(
     private val mutex = Mutex()
     private val cachedTags: MutableList<TagModel> = mutableListOf()
 
-    override suspend fun getEntries(offset: Int, otherInstance: String?): List<TimelineEntryModel>? = runCatching {
+    override suspend fun getEntries(offset: Int, otherInstance: String?): List<TimelineEntryModel>? = try {
         withProvider(otherInstance) { provider ->
             val response =
                 provider.trend
@@ -26,7 +27,10 @@ internal class DefaultTrendingRepository(
                     )
             response.map { it.toModelWithReply() }
         }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
     override suspend fun getHashtags(offset: Int, refresh: Boolean, otherInstance: String?): List<TagModel>? =
         withProvider(otherInstance) { provider ->
@@ -38,7 +42,7 @@ internal class DefaultTrendingRepository(
             if (offset == 0 && cachedTags.isNotEmpty() && otherInstance.isNullOrEmpty()) {
                 cachedTags
             } else {
-                runCatching {
+                try {
                     val response =
                         provider.trend
                             .getHashtags(
@@ -54,11 +58,14 @@ internal class DefaultTrendingRepository(
                                 }
                             }
                         }
-                }.getOrNull()
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                    null
+                }
             }
         }
 
-    override suspend fun getLinks(offset: Int, otherInstance: String?): List<LinkModel>? = runCatching {
+    override suspend fun getLinks(offset: Int, otherInstance: String?): List<LinkModel>? = try {
         withProvider(otherInstance) { provider ->
             val response =
                 provider.trend
@@ -68,7 +75,10 @@ internal class DefaultTrendingRepository(
                     )
             response.map { it.toModel() }
         }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
     private suspend fun <T> withProvider(otherInstance: String?, block: suspend (ServiceProvider) -> T): T {
         if (otherInstance.isNullOrEmpty()) {

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRateLimitRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRateLimitRepository.kt
@@ -3,36 +3,52 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.dao.UserRateLimitDao
 import com.livefast.eattrash.raccoonforfriendica.core.persistence.entities.UserRateLimitEntity
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserRateLimitModel
+import io.ktor.utils.io.CancellationException
 
 internal class DefaultUserRateLimitRepository(private val userRateLimitDao: UserRateLimitDao) :
     UserRateLimitRepository {
-    override suspend fun getAll(accountId: Long): List<UserRateLimitModel> = runCatching {
+    override suspend fun getAll(accountId: Long): List<UserRateLimitModel> = try {
         userRateLimitDao.getAll(accountId).map { it.toModel() }
-    }.getOrElse { emptyList() }
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        emptyList()
+    }
 
-    override suspend fun getBy(handle: String, accountId: Long): UserRateLimitModel? = runCatching {
+    override suspend fun getBy(handle: String, accountId: Long): UserRateLimitModel? = try {
         userRateLimitDao
             .getBy(
                 accountId = accountId,
                 handle = handle,
             )?.toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun create(model: UserRateLimitModel): UserRateLimitModel? = runCatching {
+    override suspend fun create(model: UserRateLimitModel): UserRateLimitModel? = try {
         userRateLimitDao.insert(model.toEntity())
         getBy(handle = model.handle, accountId = model.accountId)
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun update(model: UserRateLimitModel): UserRateLimitModel? = runCatching {
+    override suspend fun update(model: UserRateLimitModel): UserRateLimitModel? = try {
         userRateLimitDao.update(model.toEntity())
         getBy(handle = model.handle, accountId = model.accountId)
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun delete(id: Long): Boolean = runCatching {
+    override suspend fun delete(id: Long): Boolean = try {
         val entity = UserRateLimitEntity(id = id, userHandle = "")
         userRateLimitDao.delete(entity)
         true
-    }.getOrElse { false }
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        false
+    }
 }
 
 private fun UserRateLimitEntity.toModel() = UserRateLimitModel(

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepository.kt
@@ -17,6 +17,7 @@ import io.ktor.client.request.forms.formData
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
 import io.ktor.http.parameters
+import io.ktor.utils.io.CancellationException
 
 internal class DefaultUserRepository(
     private val provider: ServiceProvider,
@@ -24,11 +25,14 @@ internal class DefaultUserRepository(
 ) : UserRepository {
     private var cachedUser: UserModel? = null
 
-    override suspend fun getById(id: String): UserModel? = runCatching {
+    override suspend fun getById(id: String): UserModel? = try {
         provider.user.getById(id).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun search(query: String, offset: Int, following: Boolean): List<UserModel>? = runCatching {
+    override suspend fun search(query: String, offset: Int, following: Boolean): List<UserModel>? = try {
         provider.user
             .search(
                 query = query,
@@ -36,16 +40,22 @@ internal class DefaultUserRepository(
                 resolve = true,
                 following = following,
             ).map { it.toModel() }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun getByHandle(handle: String): UserModel? = runCatching {
+    override suspend fun getByHandle(handle: String): UserModel? = try {
         provider.user
             .search(
                 query = handle,
                 resolve = true,
             ).first()
             .toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
     override suspend fun getCurrent(refresh: Boolean): UserModel? {
         if (refresh) {
@@ -53,55 +63,71 @@ internal class DefaultUserRepository(
         }
         val fromCache = cachedUser
         check(fromCache == null) { return fromCache }
-        return runCatching {
+        return try {
             provider.user.verifyCredentials().toModel()
-        }.getOrNull().also {
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            null
+        }.also {
             cachedUser = it
         }
     }
 
-    override suspend fun getRelationships(ids: List<String>): List<RelationshipModel>? = runCatching {
+    override suspend fun getRelationships(ids: List<String>): List<RelationshipModel>? = try {
         provider.user
             .getRelationships(ids)
             .map { it.toModel() }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun getSuggestions(): List<UserModel>? = runCatching {
+    override suspend fun getSuggestions(): List<UserModel>? = try {
         provider.user
             .getSuggestions(
                 limit = DEFAULT_PAGE_SIZE,
             ).map { it.user.toModel() }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun getFollowers(id: String, pageCursor: String?, otherInstance: String?): List<UserModel>? =
-        runCatching {
-            withProvider(otherInstance) { provider ->
-                provider.user
-                    .getFollowers(
-                        id = id,
-                        maxId = pageCursor,
-                        limit = DEFAULT_PAGE_SIZE,
-                    ).map { it.toModel() }
-            }
-        }.getOrNull()
+    override suspend fun getFollowers(id: String, pageCursor: String?, otherInstance: String?): List<UserModel>? = try {
+        withProvider(otherInstance) { provider ->
+            provider.user
+                .getFollowers(
+                    id = id,
+                    maxId = pageCursor,
+                    limit = DEFAULT_PAGE_SIZE,
+                ).map { it.toModel() }
+        }
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun getFollowing(id: String, pageCursor: String?, otherInstance: String?): List<UserModel>? =
-        runCatching {
-            withProvider(otherInstance) { provider ->
-                provider.user
-                    .getFollowing(
-                        id = id,
-                        maxId = pageCursor,
-                        limit = DEFAULT_PAGE_SIZE,
-                    ).map { it.toModel() }
-            }
-        }.getOrNull()
+    override suspend fun getFollowing(id: String, pageCursor: String?, otherInstance: String?): List<UserModel>? = try {
+        withProvider(otherInstance) { provider ->
+            provider.user
+                .getFollowing(
+                    id = id,
+                    maxId = pageCursor,
+                    limit = DEFAULT_PAGE_SIZE,
+                ).map { it.toModel() }
+        }
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun getListsContaining(id: String): List<CircleModel>? = runCatching {
+    override suspend fun getListsContaining(id: String): List<CircleModel>? = try {
         provider.user.getListsContaining(id).map { it.toModel() }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun searchMyFollowing(query: String, pageCursor: String?): List<UserModel>? = runCatching {
+    override suspend fun searchMyFollowing(query: String, pageCursor: String?): List<UserModel>? = try {
         provider.search
             .search(
                 query = query,
@@ -111,86 +137,120 @@ internal class DefaultUserRepository(
                 limit = DEFAULT_PAGE_SIZE,
             ).accounts
             .map { it.toModel() }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun follow(id: String, reblogs: Boolean, notifications: Boolean): RelationshipModel? =
-        runCatching {
-            val data =
-                FollowUserForm(
-                    reblogs = reblogs,
-                    notify = notifications,
-                )
-            provider.user
-                .follow(
-                    id = id,
-                    data = data,
-                ).toModel()
-        }.getOrNull()
+    override suspend fun follow(id: String, reblogs: Boolean, notifications: Boolean): RelationshipModel? = try {
+        val data =
+            FollowUserForm(
+                reblogs = reblogs,
+                notify = notifications,
+            )
+        provider.user
+            .follow(
+                id = id,
+                data = data,
+            ).toModel()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun unfollow(id: String): RelationshipModel? = runCatching {
+    override suspend fun unfollow(id: String): RelationshipModel? = try {
         provider.user.unfollow(id).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun getFollowRequests(pageCursor: String?): ListWithPageCursor<UserModel>? = runCatching {
+    override suspend fun getFollowRequests(pageCursor: String?): ListWithPageCursor<UserModel>? = try {
         val (list, cursor) =
             provider.followRequest.getAll(
                 maxId = pageCursor,
                 limit = DEFAULT_PAGE_SIZE,
             )
         ListWithPageCursor(list = list.map { it.toModel() }, cursor = cursor)
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun acceptFollowRequest(id: String) = runCatching {
+    override suspend fun acceptFollowRequest(id: String) = try {
         provider.followRequest.accept(id)
         true
-    }.getOrElse { false }
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        false
+    }
 
-    override suspend fun rejectFollowRequest(id: String) = runCatching {
+    override suspend fun rejectFollowRequest(id: String) = try {
         provider.followRequest.reject(id)
         true
-    }.getOrElse { false }
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        false
+    }
 
-    override suspend fun mute(id: String, durationSeconds: Long, notifications: Boolean): RelationshipModel? =
-        runCatching {
-            val data =
-                MuteUserForm(
-                    duration = durationSeconds,
-                    notifications = notifications,
-                )
-            provider.user
-                .mute(
-                    id = id,
-                    data = data,
-                ).toModel()
-        }.getOrNull()
+    override suspend fun mute(id: String, durationSeconds: Long, notifications: Boolean): RelationshipModel? = try {
+        val data =
+            MuteUserForm(
+                duration = durationSeconds,
+                notifications = notifications,
+            )
+        provider.user
+            .mute(
+                id = id,
+                data = data,
+            ).toModel()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun unmute(id: String): RelationshipModel? = runCatching {
+    override suspend fun unmute(id: String): RelationshipModel? = try {
         provider.user.unmute(id).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun block(id: String): RelationshipModel? = runCatching {
+    override suspend fun block(id: String): RelationshipModel? = try {
         provider.user.block(id).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun unblock(id: String): RelationshipModel? = runCatching {
+    override suspend fun unblock(id: String): RelationshipModel? = try {
         provider.user.unblock(id).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun getMuted(pageCursor: String?): List<UserModel>? = runCatching {
+    override suspend fun getMuted(pageCursor: String?): List<UserModel>? = try {
         provider.user
             .getMuted(
                 maxId = pageCursor,
                 limit = DEFAULT_PAGE_SIZE,
             ).map { it.toModel() }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun getBlocked(pageCursor: String?): List<UserModel>? = runCatching {
+    override suspend fun getBlocked(pageCursor: String?): List<UserModel>? = try {
         provider.user
             .getBlocked(
                 maxId = pageCursor,
                 limit = DEFAULT_PAGE_SIZE,
             ).map { it.toModel() }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
     override suspend fun updateProfile(
         note: String?,
@@ -203,7 +263,7 @@ internal class DefaultUserRepository(
         hideCollections: Boolean?,
         indexable: Boolean?,
         fields: Map<String, String>?,
-    ) = runCatching {
+    ) = try {
         var result: Account
 
         // textual data
@@ -289,9 +349,12 @@ internal class DefaultUserRepository(
         }
 
         result.toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun updatePersonalNote(id: String, value: String): RelationshipModel? = runCatching {
+    override suspend fun updatePersonalNote(id: String, value: String): RelationshipModel? = try {
         val data =
             FormDataContent(
                 parameters {
@@ -299,7 +362,10 @@ internal class DefaultUserRepository(
                 },
             )
         provider.user.updatePersonalNote(id = id, data = data).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
     private suspend fun <T> withProvider(otherInstance: String?, block: suspend (ServiceProvider) -> T): T {
         if (otherInstance.isNullOrEmpty()) {

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultAccountCredentialsCache.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultAccountCredentialsCache.kt
@@ -7,14 +7,14 @@ internal class DefaultAccountCredentialsCache(private val keyStore: TemporaryKey
         val type = keyStore.get(getKeyForType(accountId), "")
         val part1 = keyStore.get(getKeyForPart1(accountId), "")
         val part2 = keyStore.get(getKeyForPart2(accountId), "")
-        return when {
-            type == METHOD_BASIC && part1.isNotEmpty() && part2.isNotEmpty() ->
+        return when (type) {
+            METHOD_BASIC if part1.isNotEmpty() && part2.isNotEmpty() ->
                 ApiCredentials.HttpBasic(
                     user = part1,
                     pass = part2,
                 )
 
-            type == METHOD_OAUTH_2 && part1.isNotEmpty() ->
+            METHOD_OAUTH_2 if part1.isNotEmpty() ->
                 ApiCredentials.OAuth2(
                     accessToken = part1,
                     refreshToken = part2,

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultApiConfigurationRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultApiConfigurationRepository.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
 import com.livefast.eattrash.raccoonforfriendica.core.preferences.store.TemporaryKeyStore
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withTimeoutOrNull
@@ -42,18 +43,22 @@ internal class DefaultApiConfigurationRepository(
         return validateCredentials(credentials = credentials, node = node)
     }
 
-    override suspend fun refresh() = runCatching {
+    override suspend fun refresh(): Result<Unit> = try {
         val oldCredentials = retrieveFromKeyStore()
         check(oldCredentials is ApiCredentials.OAuth2)
         check(oldCredentials.refreshToken.isNotEmpty()) {
             // prevent refresh attempt with long-lived tokens, so continue without failing
-            return@runCatching
+            return@refresh Result.success(Unit)
         }
 
         val newCredentials = authManager.performRefresh(refreshToken = oldCredentials.refreshToken)
         checkNotNull(newCredentials)
 
         setAuth(newCredentials)
+        Result.success(Unit)
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        return Result.failure(e)
     }
 
     private suspend fun validateCredentials(credentials: ApiCredentials?, node: String): Boolean =

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultCredentialsRepository.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/DefaultCredentialsRepository.kt
@@ -19,6 +19,7 @@ import io.ktor.http.Parameters
 import io.ktor.http.URLBuilder
 import io.ktor.http.URLProtocol
 import io.ktor.http.path
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.Json
 
 internal class DefaultCredentialsRepository(
@@ -35,17 +36,23 @@ internal class DefaultCredentialsRepository(
             }
         }
 
-    override suspend fun validate(node: String, credentials: ApiCredentials): UserModel? = runCatching {
+    override suspend fun validate(node: String, credentials: ApiCredentials): UserModel? = try {
         provider.changeNode(node)
         provider.setAuth(credentials.toServiceCredentials())
         provider.user.verifyCredentials().toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
-    override suspend fun validateNode(node: String): Boolean = runCatching {
+    override suspend fun validateNode(node: String): Boolean = try {
         provider.changeNode(node)
         provider.instance.getInfo()
         true
-    }.getOrElse { false }
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        false
+    }
 
     override suspend fun createApplication(
         node: String,
@@ -53,7 +60,7 @@ internal class DefaultCredentialsRepository(
         website: String,
         redirectUri: String,
         scopes: String,
-    ): ClientApplicationModel? = runCatching {
+    ): ClientApplicationModel? = try {
         provider.changeNode(node)
         val data =
             CreateAppForm(
@@ -63,18 +70,24 @@ internal class DefaultCredentialsRepository(
                 scopes = scopes,
             )
         provider.app.create(data).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
     override suspend fun validateApplicationCredentials(node: String, credentials: ApiCredentials): Boolean =
         when (credentials) {
             is ApiCredentials.HttpBasic -> true
             is ApiCredentials.OAuth2 -> {
-                runCatching {
+                try {
                     provider.changeNode(node)
                     provider.setAuth(credentials.toServiceCredentials())
                     provider.app.verifyCredentials().toModel()
                     true
-                }.getOrElse { false }
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                    false
+                }
             }
         }
 
@@ -86,7 +99,7 @@ internal class DefaultCredentialsRepository(
         redirectUri: String,
         grantType: String,
         code: String,
-    ): ApiCredentials? = runCatching {
+    ): ApiCredentials? = try {
         val data =
             FormDataContent(
                 Parameters.build {
@@ -109,7 +122,10 @@ internal class DefaultCredentialsRepository(
                 .preparePost(url) { setBody(data) }.execute()
                 .bodyAsText()
         json.decodeFromString<OAuthToken>(responseBody).toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
     override suspend fun issueNewToken(
         node: String,
@@ -118,7 +134,7 @@ internal class DefaultCredentialsRepository(
         clientSecret: String,
         grantType: String,
         refreshToken: String,
-    ): ApiCredentials? = runCatching {
+    ): ApiCredentials? = try {
         val data =
             FormDataContent(
                 Parameters.build {
@@ -144,7 +160,10 @@ internal class DefaultCredentialsRepository(
         json.decodeFromString<OAuthToken>(responseBody)
             .copy(refreshToken = refreshToken)
             .toModel()
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
     companion object {
         private const val QUERY_PARAM_CLIENT_ID = "client_id"

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/di/IdentityRepositoryModule.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/di/IdentityRepositoryModule.kt
@@ -45,7 +45,6 @@ val identityRepositoryModule =
         bindSingleton<CredentialsRepository> {
             DefaultCredentialsRepository(
                 provider = instance(tag = "other"),
-                engine = instance(),
                 json = instance(),
             )
         }

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultLoginUseCase.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultLoginUseCase.kt
@@ -21,7 +21,6 @@ internal class DefaultLoginUseCase(
 ) : LoginUseCase {
     override suspend fun invoke(node: String, credentials: ApiCredentials) {
         apiConfigurationRepository.changeNode(node)
-        apiConfigurationRepository.setAuth(credentials)
         val user = credentialsRepository.validate(node = node, credentials = credentials)
         checkNotNull(user) { "Invalid credentials" }
 
@@ -49,6 +48,9 @@ internal class DefaultLoginUseCase(
             val anonymousAccountId = accountRepository.getBy(handle = "")?.id ?: 0
             val oldSettings = settingsRepository.get(account.id)
             val defaultSettings = settingsRepository.get(anonymousAccountId) ?: SettingsModel()
+
+            apiConfigurationRepository.setAuth(credentials)
+
             if (oldSettings == null) {
                 supportedFeatureRepository.refresh()
                 val supportsBBCode = supportedFeatureRepository.features.value.supportsBBCode

--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultLoginUseCaseTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultLoginUseCaseTest.kt
@@ -59,10 +59,10 @@ class DefaultLoginUseCaseTest {
 
         verifySuspend {
             apiConfigurationRepository.changeNode(node)
-            apiConfigurationRepository.setAuth(credentials)
             credentialsRepository.validate(node, credentials)
         }
         verifySuspend(mode = VerifyMode.not) {
+            apiConfigurationRepository.setAuth(credentials)
             accountRepository.getBy(handle = any())
             accountRepository.create(any())
             accountCredentialsCache.get(any())

--- a/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/DefaultCustomUriHandler.kt
+++ b/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/DefaultCustomUriHandler.kt
@@ -8,6 +8,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Sett
 import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor.EntryProcessor
 import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor.HashtagProcessor
 import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.processor.UserProcessor
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -66,8 +67,11 @@ internal class DefaultCustomUriHandler(
                 customTabsHelper.handle(url)
 
             else ->
-                runCatching {
+                try {
                     defaultHandler.openUri(url)
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                    e.printStackTrace()
                 }
         }
     }

--- a/feature/acknowledgements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feat/acknowledgements/datasource/DefaultAcknowledgementsRemoteDataSource.kt
+++ b/feature/acknowledgements/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feat/acknowledgements/datasource/DefaultAcknowledgementsRemoteDataSource.kt
@@ -7,6 +7,7 @@ import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.request
 import io.ktor.client.statement.bodyAsText
 import kotlinx.serialization.json.Json
+import kotlin.coroutines.cancellation.CancellationException
 
 internal class DefaultAcknowledgementsRemoteDataSource(engine: HttpClientEngine = provideHttpClientEngine()) :
     AcknowledgementsRemoteDataSource {
@@ -19,12 +20,15 @@ internal class DefaultAcknowledgementsRemoteDataSource(engine: HttpClientEngine 
             }
         }
 
-    override suspend fun getAcknowledgements(): List<Acknowledgement>? = runCatching {
+    override suspend fun getAcknowledgements(): List<Acknowledgement>? = try {
         client.request(JSON_URL).run {
             val text = bodyAsText()
             Json.decodeFromString<List<Acknowledgement>>(text)
         }
-    }.getOrNull()
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
 
     companion object {
         private const val JSON_URL =

--- a/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/oauth/LoginViewModel.kt
+++ b/feature/login/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/login/oauth/LoginViewModel.kt
@@ -12,6 +12,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.Auth
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.CredentialsRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.LoginType
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.LoginUseCase
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.launchIn
@@ -130,17 +131,20 @@ class LoginViewModel(
         }
     }
 
-    private suspend fun finalizeLogin(credentials: ApiCredentials) {
+    private fun finalizeLogin(credentials: ApiCredentials) {
         val node = uiState.value.nodeName
-        try {
-            loginUseCase(
-                node = node,
-                credentials = credentials,
-            )
-            emitEffect(LoginMviModel.Effect.Success)
-        } catch (e: Throwable) {
-            updateState { it.copy(loading = false) }
-            emitEffect(LoginMviModel.Effect.Failure(e.message))
+        viewModelScope.launch {
+            try {
+                loginUseCase(
+                    node = node,
+                    credentials = credentials,
+                )
+                emitEffect(LoginMviModel.Effect.Success)
+            } catch (e: Throwable) {
+                if (e is CancellationException) throw e
+                updateState { it.copy(loading = false) }
+                emitEffect(LoginMviModel.Effect.Failure(e.message))
+            }
         }
     }
 }

--- a/shared/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/auth/EmbeddedRedirectServer.kt
+++ b/shared/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/auth/EmbeddedRedirectServer.kt
@@ -11,9 +11,10 @@ import java.net.ServerSocket
 
 class EmbeddedRedirectServer {
     private var embeddedServer: EmbeddedServer<*, *>? = null
-    private val codeDeferred = CompletableDeferred<String>()
+    private var codeDeferred = CompletableDeferred<String>()
 
     fun start(): Int {
+        codeDeferred = CompletableDeferred()
         val port = findFreePort()
         embeddedServer = embeddedServer(CIO, port = port) {
             routing {


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes an issue introduced with #1231 after which the login flow was not working properly any more. The root cause boils down to `CancellationException`s being incorrectly silenced, mostly because the throwing site was wrapped in `runCatching`.

I knew the time would come at some point for a massive refactor concerning `CancellationException`s , because in a regular professional app I would have re-thrown them, but this was a side project and I thought I could take some shortcuts. 

Spoiler: I couldn't.
