### PR TITLE
chore: add support for unified UI previews

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -94,6 +94,6 @@ dependencies {
     implementation(projects.domain.identity.repository)
     implementation(projects.domain.pushnotifications)
 
-    debugImplementation(libs.compose.ui.tooling.preview)
+    debugImplementation(libs.compose.ui.tooling)
     debugImplementation(libs.compose.ui.test.manifest)
 }

--- a/build-logic/convention/src/main/kotlin/extensions/ConfigureComposeMultiplatform.kt
+++ b/build-logic/convention/src/main/kotlin/extensions/ConfigureComposeMultiplatform.kt
@@ -1,5 +1,6 @@
 package extensions
 
+import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryExtension
 import org.gradle.api.Project
 import org.jetbrains.compose.ComposePlugin
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
@@ -21,6 +22,7 @@ internal fun Project.configureComposeMultiplatform(extension: KotlinMultiplatfor
                     implementation(libs.findLibrary("compose-m3-wsc").dependency)
                     implementation(libs.findLibrary("androidx-lifecycle-viewmodel-compose").dependency)
                     implementation(libs.findLibrary("compose-navigationevent").dependency)
+                    implementation(libs.findLibrary("compose-ui-tooling-preview").dependency)
                 }
             }
             jvmMain {
@@ -29,4 +31,12 @@ internal fun Project.configureComposeMultiplatform(extension: KotlinMultiplatfor
                 }
             }
         }
+    }
+
+internal fun Project.configureComposeMultiplatformAndroidLibrary(extension: KotlinMultiplatformAndroidLibraryExtension) =
+    extension.apply {
+        dependencies.add(
+            "androidRuntimeClasspath",
+            libs.findLibrary("compose-ui-tooling").dependency,
+        )
     }

--- a/build-logic/convention/src/main/kotlin/plugins/ComposeMultiplatformPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/plugins/ComposeMultiplatformPlugin.kt
@@ -1,6 +1,8 @@
 package plugins
 
+import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
 import extensions.configureComposeMultiplatform
+import extensions.configureComposeMultiplatformAndroidLibrary
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
@@ -15,9 +17,12 @@ class ComposeMultiplatformPlugin : Plugin<Project> {
                 apply(libs.findPlugin("compose-compiler").pluginId)
             }
 
-            extensions.configure(
-                KotlinMultiplatformExtension::class.java,
-                ::configureComposeMultiplatform,
-            )
+            extensions.configure(KotlinMultiplatformExtension::class.java) {
+                configureComposeMultiplatform(this)
+
+                targets.withType(KotlinMultiplatformAndroidLibraryTarget::class.java).configureEach {
+                    configureComposeMultiplatformAndroidLibrary(this)
+                }
+            }
         }
 }

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/FeedbackButton.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/FeedbackButton.kt
@@ -17,6 +17,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.tooling.preview.Preview
+import com.livefast.eattrash.raccoonforfriendica.core.resources.LocalResources
+import com.livefast.eattrash.raccoonforfriendica.core.resources.testutils.ProvideTestResources
 
 @Composable
 fun FeedbackButton(
@@ -61,4 +64,16 @@ fun FeedbackButton(
             color = tintColor,
         ),
     )
+}
+
+@Composable
+@Preview
+private fun FeedbackButtonPreview() {
+    ProvideTestResources {
+        FeedbackButton(
+            imageVector = LocalResources.current.thumbUp,
+            tintColor = Color.Red,
+            onClick = {},
+        )
+    }
 }

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/ProgressHud.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/ProgressHud.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
 
 @Composable
 fun ProgressHud(
@@ -30,4 +31,10 @@ fun ProgressHud(
             )
         }
     }
+}
+
+@Composable
+@Preview
+private fun ProgressHudPreview() {
+    ProgressHud()
 }

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/SearchField.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/SearchField.kt
@@ -33,13 +33,16 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
+import com.livefast.eattrash.raccoonforfriendica.core.l10n.testutils.ProvideTestStrings
 import com.livefast.eattrash.raccoonforfriendica.core.resources.LocalResources
+import com.livefast.eattrash.raccoonforfriendica.core.resources.testutils.ProvideTestResources
 
 @Composable
 fun SearchField(
@@ -138,4 +141,19 @@ fun SearchField(
             }
         },
     )
+}
+
+@Composable
+@Preview
+private fun SearchFieldPreview() {
+    Box {
+        ProvideTestStrings {
+            ProvideTestResources {
+                SearchField(
+                    value = "Search…",
+                    onValueChange = {},
+                )
+            }
+        }
+    }
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/testutils/ProvideTestStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/testutils/ProvideTestStrings.kt
@@ -1,0 +1,13 @@
+package com.livefast.eattrash.raccoonforfriendica.core.l10n.testutils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
+
+@Composable
+fun ProvideTestStrings(content: @Composable () -> Unit) {
+    CompositionLocalProvider(
+        value = LocalStrings provides MockStrings(),
+        content = content,
+    )
+}

--- a/core/resources/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/resources/testutils/ProvideTestResources.kt
+++ b/core/resources/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/resources/testutils/ProvideTestResources.kt
@@ -1,0 +1,13 @@
+package com.livefast.eattrash.raccoonforfriendica.core.resources.testutils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import com.livefast.eattrash.raccoonforfriendica.core.resources.LocalResources
+
+@Composable
+fun ProvideTestResources(content: @Composable () -> Unit) {
+    CompositionLocalProvider(
+        value = LocalResources provides MockResources,
+        content = content,
+    )
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -90,6 +90,7 @@ compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.re
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose-plugin" }
 compose-ui-test = { module = "androidx.compose.ui:ui-test-junit4-android", version.ref = "compose-ui-test" }
 compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose-ui-test" }
+compose-ui-tooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.ref = "compose-plugin" }
 compose-ui-tooling-preview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "compose-plugin" }
 
 connectivity-core = { module = "dev.jordond.connectivity:connectivity-core", version.ref = "connectivity" }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
Starting from version 1.10.0 Compose Multiplatform introduced support for unified `@Preview`s which can be used in common code! 🎉 

This is great news but I've never had time to properly set up `org.jetbrains.compose:compose-ui-tooling` and `org.jetbrains.compose.ui:ui-tooling-preview` in the `"com.livefast.eattrash.composeMultiplatform"` convention plugin.

This PR sets the basic foundations to start using previews in the rest of the project.