### PR TITLE
chore(commonui:components): improve previews

### DIFF
--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/CustomImage.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/CustomImage.kt
@@ -1,8 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.core.commonui.components
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -13,15 +16,23 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.DefaultAlpha
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import coil3.compose.AsyncImagePainter
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.SetupPreview
+import com.livefast.eattrash.raccoonforfriendica.core.di.RootDI
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
+import com.livefast.eattrash.raccoonforfriendica.core.resources.LocalResources
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.rememberImageLoaderProvider
 
 @Composable
@@ -41,6 +52,26 @@ fun CustomImage(
     onFailure: @Composable (BoxScope.(Throwable) -> Unit)? = null,
     onSuccess: @Composable (BoxScope.() -> Unit)? = null,
 ) {
+    if (LocalInspectionMode.current) {
+        Box(
+            modifier = modifier.background(
+                brush = Brush.linearGradient(
+                    colors = listOf(Color.Black, Color.DarkGray, Color.Black),
+                    start = Offset(100f, Float.POSITIVE_INFINITY),
+                    end = Offset(Float.POSITIVE_INFINITY, 100f),
+                ),
+            ),
+            contentAlignment = Alignment.Center,
+        ) {
+            Image(
+                modifier = Modifier.fillMaxSize(),
+                imageVector = LocalResources.current.loadingIcon,
+                contentDescription = null,
+            )
+        }
+        return
+    }
+
     val imageLoaderProvider = rememberImageLoaderProvider()
     var painterState: AsyncImagePainter.State by remember {
         mutableStateOf(AsyncImagePainter.State.Empty)
@@ -103,4 +134,14 @@ fun CustomImage(
             }
         }
     }
+}
+
+@Composable
+@Preview
+private fun CustomImagePreview() {
+    RootDI.SetupPreview()
+    CustomImage(
+        modifier = Modifier.size(200.dp),
+        url = "fake-image",
+    )
 }

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/CustomModalBottomSheet.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/CustomModalBottomSheet.kt
@@ -1,12 +1,15 @@
 package com.livefast.eattrash.raccoonforfriendica.core.commonui.components
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
@@ -15,6 +18,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
@@ -25,12 +29,17 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.SetupPreview
+import com.livefast.eattrash.raccoonforfriendica.core.di.RootDI
+import com.livefast.eattrash.raccoonforfriendica.core.resources.LocalResources
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -53,9 +62,6 @@ fun CustomModalBottomSheet(
     onLongPress: ((Int) -> Unit)? = null,
     shouldHideOnSelect: ((Int) -> Boolean) = { true },
 ) {
-    val fullColor = MaterialTheme.colorScheme.onBackground
-    val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha)
-
     ModalBottomSheet(
         contentWindowInsets = { WindowInsets.navigationBars },
         sheetState = sheetState,
@@ -63,80 +69,152 @@ fun CustomModalBottomSheet(
             onSelect?.invoke(null)
         },
         content = {
-            Column(
-                modifier = Modifier.padding(bottom = Spacing.xs),
-            ) {
-                Text(
-                    modifier = Modifier.fillMaxWidth(),
-                    textAlign = TextAlign.Center,
-                    text = title,
-                    style = MaterialTheme.typography.titleMedium,
-                    color = fullColor,
-                )
-                Spacer(modifier = Modifier.height(Spacing.s))
-                LazyColumn {
-                    itemsIndexed(items = items) { idx, item ->
-                        Row(
-                            modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .clip(
-                                    shape = RoundedCornerShape(CornerSize.xl),
-                                ).combinedClickable(
-                                    onClick = {
-                                        sheetScope
-                                            .launch {
-                                                if (shouldHideOnSelect(idx)) {
-                                                    sheetState.hide()
-                                                }
-                                            }.invokeOnCompletion {
-                                                onSelect?.invoke(idx)
-                                            }
-                                    },
-                                    onLongClick =
-                                    if (onLongPress != null) {
-                                        {
-                                            sheetScope
-                                                .launch {
-                                                    if (shouldHideOnSelect(idx)) {
-                                                        sheetState.hide()
-                                                    }
-                                                }.invokeOnCompletion {
-                                                    onLongPress(idx)
-                                                }
-                                        }
-                                    } else {
-                                        null
-                                    },
-                                ).padding(10.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(Spacing.s),
-                        ) {
-                            item.leadingContent?.invoke()
-                            Column(
-                                modifier = Modifier.weight(1f),
-                                verticalArrangement = Arrangement.spacedBy(Spacing.xs),
-                            ) {
-                                Text(
-                                    text = item.label,
-                                    style =
-                                    item.customLabelStyle
-                                        ?: MaterialTheme.typography.bodyLarge,
-                                    color = fullColor,
-                                )
-                                if (!item.subtitle.isNullOrEmpty()) {
-                                    Text(
-                                        text = item.subtitle,
-                                        style = MaterialTheme.typography.bodyMedium,
-                                        color = ancillaryColor,
-                                    )
-                                }
-                            }
-                            item.trailingContent?.invoke()
-                        }
-                    }
-                }
-            }
+            CustomModalBottomSheetContent(
+                title = title,
+                items = items,
+                onSelect = onSelect,
+                onLongPress = onLongPress,
+                shouldHideOnSelect = shouldHideOnSelect,
+                sheetScope = sheetScope,
+                sheetState = sheetState,
+            )
         },
     )
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@Composable
+private fun CustomModalBottomSheetContent(
+    title: String = "",
+    items: List<CustomModalBottomSheetItem> = emptyList(),
+    onSelect: ((Int?) -> Unit)? = null,
+    onLongPress: ((Int) -> Unit)? = null,
+    shouldHideOnSelect: ((Int) -> Boolean) = { true },
+    sheetScope: CoroutineScope = rememberCoroutineScope(),
+    sheetState: SheetState? = null,
+) {
+    val fullColor = MaterialTheme.colorScheme.onBackground
+    val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha)
+
+    Column(
+        modifier = Modifier.padding(bottom = Spacing.xs),
+    ) {
+        Text(
+            modifier = Modifier.fillMaxWidth(),
+            textAlign = TextAlign.Center,
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            color = fullColor,
+        )
+        Spacer(modifier = Modifier.height(Spacing.s))
+        LazyColumn {
+            itemsIndexed(items = items) { idx, item ->
+                Row(
+                    modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .clip(
+                            shape = RoundedCornerShape(CornerSize.xl),
+                        ).combinedClickable(
+                            onClick = {
+                                sheetScope
+                                    .launch {
+                                        if (shouldHideOnSelect(idx)) {
+                                            sheetState?.hide()
+                                        }
+                                    }.invokeOnCompletion {
+                                        onSelect?.invoke(idx)
+                                    }
+                            },
+                            onLongClick =
+                            if (onLongPress != null) {
+                                {
+                                    sheetScope
+                                        .launch {
+                                            if (shouldHideOnSelect(idx)) {
+                                                sheetState?.hide()
+                                            }
+                                        }.invokeOnCompletion {
+                                            onLongPress(idx)
+                                        }
+                                }
+                            } else {
+                                null
+                            },
+                        ).padding(10.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.s),
+                ) {
+                    item.leadingContent?.invoke()
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+                    ) {
+                        Text(
+                            text = item.label,
+                            style =
+                            item.customLabelStyle
+                                ?: MaterialTheme.typography.bodyLarge,
+                            color = fullColor,
+                        )
+                        if (!item.subtitle.isNullOrEmpty()) {
+                            Text(
+                                text = item.subtitle,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = ancillaryColor,
+                            )
+                        }
+                    }
+                    item.trailingContent?.invoke()
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+@Preview
+private fun CustomModalBottomSheetPreview() {
+    RootDI.SetupPreview()
+    Box(
+        modifier =
+        Modifier
+            .fillMaxSize()
+            .background(Color.White),
+    ) {
+        CustomModalBottomSheetContent(
+            title = "UI Theme",
+            items =
+            listOf(
+                CustomModalBottomSheetItem(
+                    label = "Light",
+                    trailingContent = {
+                        Icon(
+                            imageVector = LocalResources.current.lightMode,
+                            contentDescription = null,
+                        )
+                    },
+                ),
+                CustomModalBottomSheetItem(
+                    label = "Dark",
+                    trailingContent = {
+                        Icon(
+                            imageVector = LocalResources.current.darkMode,
+                            contentDescription = null,
+                        )
+                    },
+                ),
+                CustomModalBottomSheetItem(
+                    label = "Black",
+                    trailingContent = {
+                        Icon(
+                            imageVector = LocalResources.current.darkModeFill,
+                            contentDescription = null,
+                        )
+                    },
+                ),
+            ),
+        )
+    }
 }

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/EditTextualInfoDialog.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/EditTextualInfoDialog.kt
@@ -28,9 +28,12 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.SetupPreview
+import com.livefast.eattrash.raccoonforfriendica.core.di.RootDI
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -46,68 +49,102 @@ fun EditTextualInfoDialog(
     singleLine: Boolean = false,
     onClose: ((String?) -> Unit)? = null,
 ) {
-    var textFieldValue by remember {
-        mutableStateOf(TextFieldValue(text = value))
-    }
-
     BasicAlertDialog(
         modifier = modifier.clip(RoundedCornerShape(CornerSize.xxl)),
         onDismissRequest = {
             onClose?.invoke(null)
         },
     ) {
-        Column(
-            modifier =
-            Modifier
-                .background(color = MaterialTheme.colorScheme.surfaceColorAtElevation(5.dp))
-                .padding(Spacing.m),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
+        EditTextualInfoDialogContent(
+            title = title,
+            label = label,
+            value = value,
+            minLines = minLines,
+            maxLines = maxLines,
+            isError = isError,
+            singleLine = singleLine,
+            onClose = onClose,
+        )
+    }
+}
+
+@Composable
+private fun EditTextualInfoDialogContent(
+    title: String,
+    label: String,
+    value: String,
+    minLines: Int = 1,
+    maxLines: Int = 20,
+    isError: Boolean = false,
+    singleLine: Boolean = false,
+    onClose: ((String?) -> Unit)? = null,
+) {
+    var textFieldValue by remember {
+        mutableStateOf(TextFieldValue(text = value))
+    }
+
+    Column(
+        modifier =
+        Modifier
+            .background(color = MaterialTheme.colorScheme.surfaceColorAtElevation(5.dp))
+            .padding(Spacing.m),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+        Spacer(modifier = Modifier.height(Spacing.s))
+
+        TextField(
+            modifier = Modifier.fillMaxWidth(),
+            minLines = minLines,
+            maxLines = maxLines,
+            singleLine = singleLine,
+            isError = isError,
+            colors =
+            TextFieldDefaults.colors(
+                focusedContainerColor = Color.Transparent,
+                unfocusedContainerColor = Color.Transparent,
+                disabledContainerColor = Color.Transparent,
+            ),
+            label = {
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            },
+            textStyle = MaterialTheme.typography.bodyMedium,
+            value = textFieldValue,
+            keyboardOptions =
+            KeyboardOptions(
+                keyboardType = KeyboardType.Text,
+            ),
+            onValueChange = { value ->
+                textFieldValue = value
+            },
+        )
+
+        Spacer(modifier = Modifier.height(Spacing.xs))
+        Button(
+            onClick = {
+                onClose?.invoke(textFieldValue.text)
+            },
         ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onBackground,
-            )
-            Spacer(modifier = Modifier.height(Spacing.s))
-
-            TextField(
-                modifier = Modifier.fillMaxWidth(),
-                minLines = minLines,
-                maxLines = maxLines,
-                singleLine = singleLine,
-                isError = isError,
-                colors =
-                TextFieldDefaults.colors(
-                    focusedContainerColor = Color.Transparent,
-                    unfocusedContainerColor = Color.Transparent,
-                    disabledContainerColor = Color.Transparent,
-                ),
-                label = {
-                    Text(
-                        text = label,
-                        style = MaterialTheme.typography.bodyMedium,
-                    )
-                },
-                textStyle = MaterialTheme.typography.bodyMedium,
-                value = textFieldValue,
-                keyboardOptions =
-                KeyboardOptions(
-                    keyboardType = KeyboardType.Text,
-                ),
-                onValueChange = { value ->
-                    textFieldValue = value
-                },
-            )
-
-            Spacer(modifier = Modifier.height(Spacing.xs))
-            Button(
-                onClick = {
-                    onClose?.invoke(textFieldValue.text)
-                },
-            ) {
-                Text(text = LocalStrings.current.buttonConfirm)
-            }
+            Text(text = LocalStrings.current.buttonConfirm)
         }
     }
+}
+
+@Composable
+@Preview
+private fun EditTextualInfoDialogPreview() {
+    RootDI.SetupPreview()
+    EditTextualInfoDialogContent(
+        title = "Edit Bio",
+        label = "Bio",
+        value = "I am a Raccoon",
+    )
 }

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/EditTwoTextualInfosDialog.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/EditTwoTextualInfosDialog.kt
@@ -28,9 +28,12 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.SetupPreview
+import com.livefast.eattrash.raccoonforfriendica.core.di.RootDI
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -53,6 +56,50 @@ fun EditTwoTextualInfosDialog(
     singleLine: Boolean = false,
     onClose: ((String?, String?) -> Unit)? = null,
 ) {
+    BasicAlertDialog(
+        modifier = modifier.clip(RoundedCornerShape(CornerSize.xxl)),
+        onDismissRequest = {
+            onClose?.invoke(null, null)
+        },
+    ) {
+        EditTwoTextualInfosDialogContent(
+            title = title,
+            label1 = label1,
+            label2 = label2,
+            placeHolder1 = placeHolder1,
+            placeHolder2 = placeHolder2,
+            value1 = value1,
+            value2 = value2,
+            minLines = minLines,
+            maxLines = maxLines,
+            isError1 = isError1,
+            keyboardType1 = keyboardType1,
+            keyboardType2 = keyboardType2,
+            isError2 = isError2,
+            singleLine = singleLine,
+            onClose = onClose,
+        )
+    }
+}
+
+@Composable
+private fun EditTwoTextualInfosDialogContent(
+    title: String,
+    label1: String,
+    label2: String,
+    placeHolder1: String?,
+    placeHolder2: String?,
+    value1: String,
+    value2: String,
+    minLines: Int = 1,
+    maxLines: Int = 20,
+    isError1: Boolean = false,
+    keyboardType1: KeyboardType = KeyboardType.Text,
+    keyboardType2: KeyboardType = KeyboardType.Text,
+    isError2: Boolean = false,
+    singleLine: Boolean = false,
+    onClose: ((String?, String?) -> Unit)? = null,
+) {
     var textFieldValue1 by remember {
         mutableStateOf(TextFieldValue(text = value1))
     }
@@ -60,95 +107,103 @@ fun EditTwoTextualInfosDialog(
         mutableStateOf(TextFieldValue(text = value2))
     }
 
-    BasicAlertDialog(
-        modifier = modifier.clip(RoundedCornerShape(CornerSize.xxl)),
-        onDismissRequest = {
-            onClose?.invoke(null, null)
-        },
+    Column(
+        modifier =
+        Modifier
+            .background(color = MaterialTheme.colorScheme.surfaceColorAtElevation(5.dp))
+            .padding(Spacing.m),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
     ) {
-        Column(
-            modifier =
-            Modifier
-                .background(color = MaterialTheme.colorScheme.surfaceColorAtElevation(5.dp))
-                .padding(Spacing.m),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(Spacing.xxs),
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+        Spacer(modifier = Modifier.height(Spacing.s))
+
+        TextField(
+            modifier = Modifier.fillMaxWidth(),
+            minLines = minLines,
+            maxLines = maxLines,
+            singleLine = singleLine,
+            isError = isError1,
+            colors =
+            TextFieldDefaults.colors(
+                focusedContainerColor = Color.Transparent,
+                unfocusedContainerColor = Color.Transparent,
+                disabledContainerColor = Color.Transparent,
+            ),
+            label = {
+                Text(
+                    text = label1,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            },
+            textStyle = MaterialTheme.typography.bodyMedium,
+            value = textFieldValue1,
+            placeholder = placeHolder1?.let { { Text(text = it) } },
+            keyboardOptions =
+            KeyboardOptions(
+                keyboardType = keyboardType1,
+            ),
+            onValueChange = { value ->
+                textFieldValue1 = value
+            },
+        )
+
+        TextField(
+            modifier = Modifier.fillMaxWidth(),
+            minLines = minLines,
+            maxLines = maxLines,
+            singleLine = singleLine,
+            isError = isError2,
+            colors =
+            TextFieldDefaults.colors(
+                focusedContainerColor = Color.Transparent,
+                unfocusedContainerColor = Color.Transparent,
+                disabledContainerColor = Color.Transparent,
+            ),
+            label = {
+                Text(
+                    text = label2,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            },
+            textStyle = MaterialTheme.typography.bodyMedium,
+            value = textFieldValue2,
+            placeholder = placeHolder2?.let { { Text(text = it) } },
+            keyboardOptions =
+            KeyboardOptions(
+                keyboardType = keyboardType2,
+            ),
+            onValueChange = { value ->
+                textFieldValue2 = value
+            },
+        )
+
+        Spacer(modifier = Modifier.height(Spacing.xs))
+        Button(
+            onClick = {
+                onClose?.invoke(textFieldValue1.text, textFieldValue2.text)
+            },
         ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onBackground,
-            )
-            Spacer(modifier = Modifier.height(Spacing.s))
-
-            TextField(
-                modifier = Modifier.fillMaxWidth(),
-                minLines = minLines,
-                maxLines = maxLines,
-                singleLine = singleLine,
-                isError = isError1,
-                colors =
-                TextFieldDefaults.colors(
-                    focusedContainerColor = Color.Transparent,
-                    unfocusedContainerColor = Color.Transparent,
-                    disabledContainerColor = Color.Transparent,
-                ),
-                label = {
-                    Text(
-                        text = label1,
-                        style = MaterialTheme.typography.bodyMedium,
-                    )
-                },
-                textStyle = MaterialTheme.typography.bodyMedium,
-                value = textFieldValue1,
-                placeholder = placeHolder1?.let { { Text(text = it) } },
-                keyboardOptions =
-                KeyboardOptions(
-                    keyboardType = keyboardType1,
-                ),
-                onValueChange = { value ->
-                    textFieldValue1 = value
-                },
-            )
-
-            TextField(
-                modifier = Modifier.fillMaxWidth(),
-                minLines = minLines,
-                maxLines = maxLines,
-                singleLine = singleLine,
-                isError = isError2,
-                colors =
-                TextFieldDefaults.colors(
-                    focusedContainerColor = Color.Transparent,
-                    unfocusedContainerColor = Color.Transparent,
-                    disabledContainerColor = Color.Transparent,
-                ),
-                label = {
-                    Text(
-                        text = label2,
-                        style = MaterialTheme.typography.bodyMedium,
-                    )
-                },
-                textStyle = MaterialTheme.typography.bodyMedium,
-                value = textFieldValue2,
-                placeholder = placeHolder2?.let { { Text(text = it) } },
-                keyboardOptions =
-                KeyboardOptions(
-                    keyboardType = keyboardType2,
-                ),
-                onValueChange = { value ->
-                    textFieldValue2 = value
-                },
-            )
-
-            Spacer(modifier = Modifier.height(Spacing.xs))
-            Button(
-                onClick = {
-                    onClose?.invoke(textFieldValue1.text, textFieldValue2.text)
-                },
-            ) {
-                Text(text = LocalStrings.current.buttonConfirm)
-            }
+            Text(text = LocalStrings.current.buttonConfirm)
         }
     }
+}
+
+@Composable
+@Preview
+private fun EditTwoTextualInfosDialogPreview() {
+    RootDI.SetupPreview()
+    EditTwoTextualInfosDialogContent(
+        title = "Change server",
+        label1 = "Protocol",
+        label2 = "Address",
+        placeHolder1 = "https",
+        placeHolder2 = "friendica.example.com",
+        value1 = "https",
+        value2 = "",
+    )
 }

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/FeedbackButton.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/FeedbackButton.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.tooling.preview.Preview
-import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.setupPreview
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.SetupPreview
 import com.livefast.eattrash.raccoonforfriendica.core.di.RootDI
 import com.livefast.eattrash.raccoonforfriendica.core.resources.LocalResources
 
@@ -70,7 +70,7 @@ fun FeedbackButton(
 @Composable
 @Preview
 private fun FeedbackButtonPreview() {
-    RootDI.setupPreview()
+    RootDI.SetupPreview()
     FeedbackButton(
         imageVector = LocalResources.current.thumbUp,
         onClick = {},

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/ListLoadingIndicator.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/ListLoadingIndicator.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.tooling.preview.Preview
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
-import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.setupPreview
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.SetupPreview
 import com.livefast.eattrash.raccoonforfriendica.core.di.RootDI
 import com.livefast.eattrash.raccoonforfriendica.core.resources.LocalResources
 
@@ -67,6 +67,6 @@ fun ListLoadingIndicator(modifier: Modifier = Modifier) {
 @Composable
 @Preview
 private fun ListLoadingIndicatorPreview() {
-    RootDI.setupPreview()
+    RootDI.SetupPreview()
     ListLoadingIndicator()
 }

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/MultiColorPreview.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/MultiColorPreview.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.setupPreview
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.SetupPreview
 import com.livefast.eattrash.raccoonforfriendica.core.di.RootDI
 
 @Composable
@@ -32,7 +32,7 @@ fun MultiColorPreview(colors: List<Color>, modifier: Modifier = Modifier) {
 @Composable
 @Preview
 private fun MultiColorPreviewPreview() {
-    RootDI.setupPreview()
+    RootDI.SetupPreview()
     MultiColorPreview(
         modifier = Modifier.size(24.dp),
         colors = listOf(

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/PlaceholderImage.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/PlaceholderImage.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
-import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.setupPreview
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.SetupPreview
 import com.livefast.eattrash.raccoonforfriendica.core.di.RootDI
 
 @Composable
@@ -48,7 +48,7 @@ fun PlaceholderImage(size: Dp, title: String, modifier: Modifier = Modifier) {
 @Composable
 @Preview
 private fun PlaceholderImagePreview() {
-    RootDI.setupPreview()
+    RootDI.SetupPreview()
     PlaceholderImage(
         size = 24.dp,
         title = "Raccoon",

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/ProgressHud.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/ProgressHud.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
-import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.setupPreview
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.SetupPreview
 import com.livefast.eattrash.raccoonforfriendica.core.di.RootDI
 
 @Composable
@@ -38,6 +38,6 @@ fun ProgressHud(
 @Composable
 @Preview
 private fun ProgressHudPreview() {
-    RootDI.setupPreview()
+    RootDI.SetupPreview()
     ProgressHud()
 }

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/SearchField.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/SearchField.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.unit.toSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
-import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.setupPreview
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.SetupPreview
 import com.livefast.eattrash.raccoonforfriendica.core.di.RootDI
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.resources.LocalResources
@@ -159,7 +159,7 @@ private class SearchFieldPreviewParameterProvider : PreviewParameterProvider<Sea
 private fun SearchFieldPreview(
     @PreviewParameter(SearchFieldPreviewParameterProvider::class) param: SearchFieldPreviewParameter,
 ) {
-    RootDI.setupPreview()
+    RootDI.SetupPreview()
     SearchField(
         hint = LocalStrings.current.actionSearch,
         value = param.value,

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/SpinnerField.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/SpinnerField.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.toSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
-import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.setupPreview
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.SetupPreview
 import com.livefast.eattrash.raccoonforfriendica.core.di.RootDI
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.resources.LocalResources
@@ -140,7 +140,7 @@ fun SpinnerField(
 @Composable
 @Preview
 private fun SpinnerFieldPreview() {
-    RootDI.setupPreview()
+    RootDI.SetupPreview()
     Box(
         modifier = Modifier
             .background(MaterialTheme.colorScheme.background)

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/ZoomableImage.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/ZoomableImage.kt
@@ -27,6 +27,9 @@ import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.tooling.preview.Preview
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di.SetupPreview
+import com.livefast.eattrash.raccoonforfriendica.core.di.RootDI
 import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -138,4 +141,11 @@ fun ZoomableImage(url: String, modifier: Modifier = Modifier, contentScale: Cont
             )
         }
     }
+}
+
+@Composable
+@Preview
+private fun ZoomableImagePreview() {
+    RootDI.SetupPreview()
+    ZoomableImage(url = "fake-image")
 }

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/di/Utils.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/di/Utils.kt
@@ -17,7 +17,8 @@ fun getFabNestedScrollConnection(): FabNestedScrollConnection {
 @Composable
 fun rememberFabNestedScrollConnection() = remember { getFabNestedScrollConnection() }
 
-fun RootDI.setupPreview(vararg modules: DI.Module) {
+@Composable
+fun RootDI.SetupPreview(vararg modules: DI.Module) = remember {
     di = DI {
         importAll(resourcesModule, l10nModule, *modules)
     }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR improves the UI previews for Composables in `:core:commonui:components`):

- wraps `RootDI.setupPreview` in a `remember { }` block to avoid resetting DI configuration multiple times;
- add preview for `CustomImage`;
- add preview for `EditTextualInfoDialog`;
- add preview for `EditTwoTextualInfosDialog`;
- add preview for `ZoomabmeImage`.