### PR TITLE
chore: upgrade to Gradle 9.5.0 and AGP 9.1.0

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -58,8 +58,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     buildFeatures {
         compose = true

--- a/androidApp/src/main/kotlin/com/livefast/eattrash/raccoonforfriendica/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/livefast/eattrash/raccoonforfriendica/MainActivity.kt
@@ -21,6 +21,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -122,7 +124,7 @@ class MainActivity : ComponentActivity() {
     private fun handleIncomingAttachment(intent: Intent) {
         lifecycleScope.launch {
             // workaround: wait until the root NavigationAdapter has been set
-            delay(750L)
+            delay(750.milliseconds)
             val mainRouter = getMainRouter()
             when {
                 "text/plain" == intent.type -> {
@@ -150,7 +152,7 @@ class MainActivity : ComponentActivity() {
     private fun handleOpenInboxAtStartup() {
         lifecycleScope.launch {
             // workaround: wait until the root NavigationAdapter has been set
-            delay(1000L)
+            delay(1.seconds)
             val navigationCoordinator = getNavigationCoordinator()
             navigationCoordinator.popUntilRoot()
             navigationCoordinator.setCurrentSection(BottomNavigationSection.Inbox())

--- a/core/di/testutils/src/androidMain/resources/robolectric.properties
+++ b/core/di/testutils/src/androidMain/resources/robolectric.properties
@@ -1,0 +1,2 @@
+sdk=36
+targetSdk=36

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationCoordinator.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationCoordinator.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 internal class DefaultNavigationCoordinator(dispatcher: CoroutineDispatcher = Dispatchers.Main) :
     NavigationCoordinator {
@@ -85,7 +86,7 @@ internal class DefaultNavigationCoordinator(dispatcher: CoroutineDispatcher = Di
     }
 
     override suspend fun submitDeeplink(url: String) {
-        delay(750)
+        delay(750.milliseconds)
         deepLinkUrl.emit(url)
     }
 

--- a/core/persistence/build.gradle.kts
+++ b/core/persistence/build.gradle.kts
@@ -19,9 +19,6 @@ kotlin {
                 implementation(projects.core.utils)
             }
         }
-        iosMain {
-            kotlin.srcDir("build/generated/ksp/metadata")
-        }
     }
 }
 

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/compose/AnimatedDots.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/compose/AnimatedDots.kt
@@ -4,12 +4,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.yield
 import kotlin.math.roundToLong
+import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 fun getAnimatedDots(
@@ -21,7 +21,7 @@ fun getAnimatedDots(
     var step by remember { mutableIntStateOf(0) }
     LaunchedEffect(Unit) {
         while (true) {
-            delay(interval)
+            delay(interval.milliseconds)
             step = (step + 1) % maxStep
             yield()
         }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMediaRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultMediaRepository.kt
@@ -12,6 +12,7 @@ import io.ktor.http.parameters
 import io.ktor.utils.io.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.time.Duration.Companion.seconds
 
 internal class DefaultMediaRepository(private val provider: ServiceProvider) : MediaRepository {
     override suspend fun getBy(id: String): AttachmentModel? = try {
@@ -40,10 +41,10 @@ internal class DefaultMediaRepository(private val provider: ServiceProvider) : M
         val res = provider.media.create(content = content).toModel()
         val id = res.id
         val url =
-            withTimeoutOrNull(5000) {
+            withTimeoutOrNull(5.seconds) {
                 var url = res.url
                 while (url.isEmpty()) {
-                    delay(1000)
+                    delay(1.seconds)
                     val pollingRes = getBy(id)
                     if (pollingRes != null) {
                         url = pollingRes.url

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
@@ -62,6 +62,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(FlowPreview::class)
 class ComposerViewModel(
@@ -1795,6 +1796,6 @@ class ComposerViewModel(
 
     companion object {
         private const val PLACEHOLDER_ID = "placeholder"
-        private const val SUGGESTION_DELAY = 750L
+        private val SUGGESTION_DELAY = 750.milliseconds
     }
 }

--- a/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationViewModel.kt
+++ b/feature/directmessages/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/directmessages/detail/ConversationViewModel.kt
@@ -24,8 +24,9 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.seconds
 
-private const val POLLING_INTERVAL = 1200L
+private val POLLING_INTERVAL = 1.2.seconds
 
 class ConversationViewModel(
     private val otherUserId: String,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-android-compileSdk = "36"
+android-compileSdk = "37"
 android-minSdk = "26"
-android-targetSdk = "36"
+android-targetSdk = "37"
 
 agp = "9.0.0"
 androidx-activity = "1.13.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ android-compileSdk = "37"
 android-minSdk = "26"
 android-targetSdk = "37"
 
-agp = "9.0.0"
+agp = "9.1.0"
 androidx-activity = "1.13.0"
 androidx-browser = "1.10.0"
 androidx-crypto = "1.1.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=0d585f69da091fc5b2beced877feab55a3064d43b8a1d46aeb07996b0915e0e0
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
+distributionSha256Sum=553c78f50dafcd54d65b9a444649057857469edf836431389695608536d6b746
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/App.kt
+++ b/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/App.kt
@@ -1,7 +1,6 @@
 package com.livefast.eattrash.raccoonforfriendica
 
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -97,6 +96,8 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.kodein.di.compose.withDI
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 @OptIn(FlowPreview::class, ExperimentalComposeUiApi::class)
 @Composable
@@ -134,7 +135,7 @@ fun App(onLoadingFinished: (() -> Unit)? = null) = withDI(RootDI.di) {
 
         launch {
             // set a timeout on the initialization
-            delay(1500)
+            delay(1.5.seconds)
             finishInitialization()
         }
 
@@ -193,7 +194,7 @@ fun App(onLoadingFinished: (() -> Unit)? = null) = withDI(RootDI.di) {
     LaunchedEffect(navigationCoordinator) {
         val customUriHandler = getCustomUriHandler(fallbackUriHandler)
         navigationCoordinator.deepLinkUrl
-            .debounce(750)
+            .debounce(750.milliseconds)
             .onEach { url ->
                 customUriHandler.openInternally(url)
             }.launchIn(this)
@@ -348,7 +349,8 @@ fun App(onLoadingFinished: (() -> Unit)? = null) = withDI(RootDI.di) {
                                         }
                                     }
                                 }
-                            },)
+                            },
+                                )
                         }
                     }
                 }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR updates Gradle from 9.3.0 to 9.5.0 and AGP from 9.0.0 to 9.1.0 as the KMP [compatibility guide](https://kotlinlang.org/docs/multiplatform/multiplatform-compatibility-guide.html#version-compatibility) suggests. 

Android specifics: target and compile SDK levels have been bumped to 37, source and target compatibility versions are set to `JavaVersion.VERSION_21`.