### PR TITLE
fix: navigation after nav3 migration

### DIFF
--- a/androidApp/src/main/kotlin/com/livefast/eattrash/raccoonforfriendica/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/livefast/eattrash/raccoonforfriendica/MainActivity.kt
@@ -37,6 +37,11 @@ class MainActivity : ComponentActivity() {
         val backPressedCallback =
             object : OnBackPressedCallback(true) {
                 override fun handleOnBackPressed() {
+                    if (navigationCoordinator.canPop.value) {
+                        navigationCoordinator.pop()
+                        return
+                    }
+
                     // if in home, ask for confirmation
                     if (navigationCoordinator.currentBottomNavSection.value == BottomNavigationSection.Home) {
                         // asks for confirmation

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultBottomNavigationAdapter.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultBottomNavigationAdapter.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.update
 
 class DefaultBottomNavigationAdapter(private val backStack: NavBackStack<NavKey>) : BottomNavigationAdapter {
 
-    override val currentSection = MutableStateFlow<BottomNavigationSection?>(null)
+    override val currentSection = MutableStateFlow(backStack.lastOrNull() as? BottomNavigationSection)
 
     override fun navigate(section: BottomNavigationSection) {
         backStack[0] = section

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationAdapter.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/DefaultNavigationAdapter.kt
@@ -2,76 +2,39 @@ package com.livefast.eattrash.raccoonforfriendica.core.navigation
 
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
 
-class DefaultNavigationAdapter(
-    private val backStack: NavBackStack<NavKey>,
-    dispatcher: CoroutineDispatcher = Dispatchers.Main,
-) : NavigationAdapter {
+class DefaultNavigationAdapter(private val backStack: NavBackStack<NavKey>) : NavigationAdapter {
 
     override val canPop = MutableStateFlow(false)
-    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
-    private var job: Job? = null
 
     init {
         updateCanPop()
     }
 
     override fun navigate(destination: Destination, replaceTop: Boolean) {
-        if (job?.isActive == true) {
-            return
+        if (replaceTop) {
+            backStack[backStack.lastIndex] = destination
+        } else {
+            backStack.add(destination)
         }
-        perform {
-            if (replaceTop) {
-                backStack[backStack.lastIndex] = destination
-            } else {
-                backStack.add(destination)
-            }
-            updateCanPop()
-        }
+        updateCanPop()
     }
 
     override fun pop() {
-        if (job?.isActive == true) {
-            return
+        if (canPop.value) {
+            backStack.removeLast()
         }
-        perform {
-            if (canPop.value) {
-                backStack.removeLast()
-            }
-            updateCanPop()
-        }
+        updateCanPop()
     }
 
     override fun popUntilRoot() {
-        if (job?.isActive == true) {
-            return
-        }
-        perform {
-            backStack.retainAll { it == backStack.first() }
-            updateCanPop()
-        }
+        backStack.retainAll { it == backStack.first() }
+        updateCanPop()
     }
 
     private fun updateCanPop() {
         canPop.update { backStack.size > 1 }
-    }
-
-    private fun perform(interval: Duration = 250.milliseconds, action: () -> Unit) {
-        job = scope.launch {
-            action()
-            delay(interval)
-            job = null
-        }
     }
 }

--- a/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/App.kt
+++ b/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/App.kt
@@ -275,6 +275,7 @@ fun App(onLoadingFinished: (() -> Unit)? = null) = withDI(RootDI.di) {
                                 Surface(color = MaterialTheme.colorScheme.background) {
                                     NavDisplay(
                                         backStack = backStack,
+                                        onBack = { navigationCoordinator.pop() },
                                         entryDecorators = listOf(
                                             rememberSaveableStateHolderNavEntryDecorator(),
                                             rememberViewModelStoreNavEntryDecorator()
@@ -350,6 +351,7 @@ fun App(onLoadingFinished: (() -> Unit)? = null) = withDI(RootDI.di) {
                                             Surface(color = MaterialTheme.colorScheme.background) {
                                                 NavDisplay(
                                                     backStack = backStack,
+                                                    onBack = { navigationCoordinator.pop() },
                                                     entryDecorators = listOf(
                                                         rememberSaveableStateHolderNavEntryDecorator(),
                                                         rememberViewModelStoreNavEntryDecorator()

--- a/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/main/MainScreen.kt
+++ b/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/main/MainScreen.kt
@@ -188,6 +188,7 @@ fun MainScreen(
             Surface(color = MaterialTheme.colorScheme.background) {
                 NavDisplay(
                     backStack = backStack,
+                    onBack = { navigationCoordinator.pop() },
                     entryProvider = bottomGetEntryProvider(
                         timelineViewModel = timelineViewModel,
                         timelineLazyListState = timelineLazyListState,

--- a/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/main/MainScreen.kt
+++ b/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/main/MainScreen.kt
@@ -50,7 +50,6 @@ import com.livefast.eattrash.raccoonforfriendica.feature.timeline.TimelineScreen
 import com.livefast.eattrash.raccoonforfriendica.navigation.bottomGetEntryProvider
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.update
 import kotlin.math.roundToInt
 
 @Composable
@@ -119,7 +118,6 @@ fun MainScreen(
 
         if (hasBottomNavigation) {
             val adapter = DefaultBottomNavigationAdapter(backStack)
-            adapter.currentSection.update { BottomNavigationSection.Home }
             navigationCoordinator.setBottomNavigator(adapter)
 
             navigationCoordinator.currentBottomNavSection.onEach {


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR refines the migration to Navigation 3 (see #1271), making sure back navigation is handled correctly both in the main stack and in the bottom section transition. Moreover it removes the throttling behavior from `DefaultNavigationAdapter` which is no longer needed.