### PR TITLE
feat: add quote permission mapping

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Quote.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Quote.kt
@@ -5,7 +5,36 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class Quote(
-    @SerialName("state") val state: String? = null,
+    @SerialName("state") val state: QuoteState? = null,
     @SerialName("quoted_status") val quotedStatus: Status? = null,
     @SerialName("quoted_status_id") val quotedStatusId: String? = null,
 )
+
+enum class QuoteState {
+    @SerialName("pending")
+    Pending,
+
+    @SerialName("accepted")
+    Accepted,
+
+    @SerialName("rejected")
+    Rejected,
+
+    @SerialName("revoked")
+    Revoked,
+
+    @SerialName("deleted")
+    Deleted,
+
+    @SerialName("unauthorized")
+    Unauthorized,
+
+    @SerialName("blocked_account")
+    BlockedAccount,
+
+    @SerialName("blocked_domain")
+    BlockedDomain,
+
+    @SerialName("muted_account")
+    MutedAccount,
+}

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/QuoteApproval.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/QuoteApproval.kt
@@ -1,0 +1,42 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class QuoteApproval(
+    @SerialName("automatic")
+    val automatic: List<QuotePolicy> = emptyList(),
+    @SerialName("manual")
+    val manual: List<QuotePolicy> = emptyList(),
+    @SerialName("current_user")
+    val currentUser: QuotePolicyForCurrentUser? = null,
+)
+
+enum class QuotePolicy {
+    @SerialName("public")
+    Public,
+
+    @SerialName("followers")
+    Followers,
+
+    @SerialName("following")
+    Following,
+
+    @SerialName("unsupported_policy")
+    Unsupported,
+}
+
+enum class QuotePolicyForCurrentUser {
+    @SerialName("automatic")
+    Automatic,
+
+    @SerialName("manual")
+    Manual,
+
+    @SerialName("denied")
+    Denied,
+
+    @SerialName("unknown")
+    Unknown,
+}

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Status.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Status.kt
@@ -26,6 +26,7 @@ data class Status(
     @SerialName("pinned") val pinned: Boolean = false,
     @SerialName("poll") val poll: Poll? = null,
     @SerialName("quote") val quote: Quote? = null,
+    @SerialName("quote_approval") val quoteApproval: QuoteApproval? = null,
     @SerialName("quotes_count") val quotesCount: Int = 0,
     @SerialName("reblog") val reblog: Status? = null,
     @SerialName("reblogged") val reblogged: Boolean = false,

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/QuotePermission.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/QuotePermission.kt
@@ -1,0 +1,8 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.data
+
+sealed interface QuotePermission {
+    data object AutomaticallyApprove : QuotePermission
+    data object ManualApprove : QuotePermission
+    data object OnlyFollowers : QuotePermission
+    data object Unauthorized : QuotePermission
+}

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/TimelineEntryModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/TimelineEntryModel.kt
@@ -34,6 +34,7 @@ data class TimelineEntryModel(
     val quoteCount: Int = 0,
     val quoted: TimelineEntryModel? = null,
     val quoteStatus: QuoteStatus? = null,
+    val quotePermission: QuotePermission? = null,
     val reblog: TimelineEntryModel? = null,
     val reblogCount: Int = 0,
     @Transient val reblogLoading: Boolean = false,

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
@@ -28,6 +28,9 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.dto.PollOption
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.PreviewCard
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.PreviewCardType
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Quote
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.QuoteApproval
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.QuotePolicy
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.QuotePolicyForCurrentUser
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.QuoteState
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Relationship
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.ScheduledStatus
@@ -67,6 +70,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.PollModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.PollOptionModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.PreviewCardModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.PreviewType
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.QuotePermission
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.QuoteStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.ReactionModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.RelationshipModel
@@ -156,6 +160,7 @@ internal fun Status.toModel() = TimelineEntryModel(
             else -> visibility
         }
     },
+    quotePermission = quoteApproval?.toQuotePermission(),
 )
 
 internal fun Quote.toModel(): TimelineEntryModel? = quotedStatus?.toModel()?.copy(quoteStatus = state?.toQuotedStatus())
@@ -172,6 +177,32 @@ private fun QuoteState.toQuotedStatus(): QuoteStatus = when (this) {
     QuoteState.BlockedDomain -> QuoteStatus.BlockedDomain
     QuoteState.MutedAccount -> QuoteStatus.MutedAccount
     else -> QuoteStatus.Unauthorized
+}
+
+private fun QuoteApproval.toQuotePermission(): QuotePermission {
+    /*
+     * From https://docs.joinmastodon.org/client/quotes/#interpreting-quote-policies
+     *
+     * For reference, the Mastodon Web UI uses the current_user, automatic and manual values as follows:
+     *
+     * - if current_user is automatic, allow quoting the post and label the button "Quote"
+     * - if the current_user is manual, allow quoting the post and label the button
+     *   "Request to quote" / "Author will manually review"
+     * - if the current_user is unknown or denied, disallow quoting, and display either
+     *   "Only followers can quote this post" or "You are not allowed to quote this post"
+     *   depending on the presence of followers in the policies
+     */
+    return when (currentUser) {
+        QuotePolicyForCurrentUser.Automatic -> QuotePermission.AutomaticallyApprove
+        QuotePolicyForCurrentUser.Manual -> QuotePermission.ManualApprove
+        else -> {
+            if (automatic.contains(QuotePolicy.Followers) || manual.contains(QuotePolicy.Followers)) {
+                QuotePermission.OnlyFollowers
+            } else {
+                QuotePermission.Unauthorized
+            }
+        }
+    }
 }
 
 private fun StatusMention.toModel() = UserModel(

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
@@ -28,6 +28,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.dto.PollOption
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.PreviewCard
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.PreviewCardType
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Quote
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.QuoteState
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Relationship
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.ScheduledStatus
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Status
@@ -162,14 +163,14 @@ internal fun Quote.toModel(): TimelineEntryModel? = quotedStatus?.toModel()?.cop
         TimelineEntryModel(id = id, content = "", quoteStatus = state?.toQuotedStatus())
     }
 
-internal fun String.toQuotedStatus(): QuoteStatus = when (this) {
-    "pending" -> QuoteStatus.Pending
-    "accepted" -> QuoteStatus.Accepted
-    "rejected" -> QuoteStatus.Rejected
-    "deleted" -> QuoteStatus.Deleted
-    "blocked_account" -> QuoteStatus.BlockedAccount
-    "blocked_domain" -> QuoteStatus.BlockedDomain
-    "muted_account" -> QuoteStatus.MutedAccount
+private fun QuoteState.toQuotedStatus(): QuoteStatus = when (this) {
+    QuoteState.Pending -> QuoteStatus.Pending
+    QuoteState.Accepted -> QuoteStatus.Accepted
+    QuoteState.Rejected -> QuoteStatus.Rejected
+    QuoteState.Deleted -> QuoteStatus.Deleted
+    QuoteState.BlockedAccount -> QuoteStatus.BlockedAccount
+    QuoteState.BlockedDomain -> QuoteStatus.BlockedDomain
+    QuoteState.MutedAccount -> QuoteStatus.MutedAccount
     else -> QuoteStatus.Unauthorized
 }
 


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds the mapping for quote permissions in `TimelineEntryModel`, interpreting the `quote_approval` property in `Status` (see [here](https://docs.joinmastodon.org/client/quotes/#interpreting-quote-policies) for reference).

Since in the process I decided that using enums for Enumerable types in the APIs, I applied the same strategy to `state`  in `quote` (embedded in `Status`).

This step is required in order to keep working on quote support (e.g. to allow users to quote other people's posts or display an informative message in case the quote can not be done due to policy restrictions).
