### PR TITLE
feat: add support for quote notification types

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/NotificationPolicy.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/NotificationPolicy.kt
@@ -1,0 +1,22 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class NotificationPolicy {
+    @SerialName("all")
+    ALL,
+
+    @SerialName("followed")
+    FOLLOWED,
+
+    @SerialName("follower")
+    FOLLOWER,
+
+    @SerialName("none")
+    NONE,
+}
+
+val NotificationPolicy.serialName: String
+    get() = NotificationPolicy.serializer().descriptor.getElementName(ordinal)

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/NotificationType.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/NotificationType.kt
@@ -1,7 +1,9 @@
 package com.livefast.eattrash.raccoonforfriendica.core.api.dto
 
 import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
+@Serializable
 enum class NotificationType {
     @SerialName("mention")
     MENTION,
@@ -27,6 +29,12 @@ enum class NotificationType {
     @SerialName("update")
     UPDATE,
 
+    @SerialName("quote")
+    QUOTE,
+
+    @SerialName("quoted_update")
+    QUOTED_UPDATE,
+
     @SerialName("admin.sign_up")
     ADMIN_SIGN_UP,
 
@@ -39,3 +47,6 @@ enum class NotificationType {
     @SerialName("moderation_warning")
     MODERATION_WARNING,
 }
+
+val NotificationType.serialName: String
+    get() = NotificationType.serializer().descriptor.getElementName(ordinal)

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultNotificationService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultNotificationService.kt
@@ -1,6 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.core.api.service
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Notification
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.NotificationType
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
@@ -11,8 +12,8 @@ import io.ktor.http.isSuccess
 internal class DefaultNotificationService(private val baseUrl: String, private val client: HttpClient) :
     NotificationService {
     override suspend fun get(
-        types: List<String>,
-        excludeTypes: List<String>?,
+        types: List<NotificationType>,
+        excludeTypes: List<NotificationType>?,
         maxId: String?,
         minId: String?,
         includeAll: Boolean,

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/NotificationService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/NotificationService.kt
@@ -1,11 +1,12 @@
 package com.livefast.eattrash.raccoonforfriendica.core.api.service
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Notification
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.NotificationType
 
 interface NotificationService {
     suspend fun get(
-        types: List<String>,
-        excludeTypes: List<String>? = null,
+        types: List<NotificationType>,
+        excludeTypes: List<NotificationType>? = null,
         maxId: String? = null,
         minId: String? = null,
         includeAll: Boolean = false,

--- a/core/l10n/src/commonMain/composeResources/values/strings.xml
+++ b/core/l10n/src/commonMain/composeResources/values/strings.xml
@@ -285,6 +285,10 @@
     <string name="notification_type_mention_name">Mentions &amp; Replies</string>
     <string name="notification_type_poll">a poll you participated in was closed</string>
     <string name="notification_type_poll_name">Polls</string>
+    <string name="notification_type_quote">quoted your post</string>
+    <string name="notification_type_quote_name">Quote</string>
+    <string name="notification_type_quoted_update">updated a post you quoted</string>
+    <string name="notification_type_quoted_update_name">Quote update</string>
     <string name="notification_type_reblog">re-shared your post</string>
     <string name="notification_type_reblog_name">Re-shares</string>
     <string name="notification_type_update">updated a post you re-shared</string>

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/DefaultStrings.kt
@@ -321,6 +321,10 @@ import raccoonforfriendica.core.l10n.generated.resources.notification_type_menti
 import raccoonforfriendica.core.l10n.generated.resources.notification_type_mention_name
 import raccoonforfriendica.core.l10n.generated.resources.notification_type_poll
 import raccoonforfriendica.core.l10n.generated.resources.notification_type_poll_name
+import raccoonforfriendica.core.l10n.generated.resources.notification_type_quote
+import raccoonforfriendica.core.l10n.generated.resources.notification_type_quote_name
+import raccoonforfriendica.core.l10n.generated.resources.notification_type_quoted_update
+import raccoonforfriendica.core.l10n.generated.resources.notification_type_quoted_update_name
 import raccoonforfriendica.core.l10n.generated.resources.notification_type_reblog
 import raccoonforfriendica.core.l10n.generated.resources.notification_type_reblog_name
 import raccoonforfriendica.core.l10n.generated.resources.notification_type_update
@@ -1088,6 +1092,14 @@ internal class DefaultStrings : Strings {
         @Composable get() = stringResource(Res.string.notification_type_poll)
     override val notificationTypePollName: String
         @Composable get() = stringResource(Res.string.notification_type_poll_name)
+    override val notificationTypeQuote: String
+        @Composable get() = stringResource(Res.string.notification_type_quote)
+    override val notificationTypeQuoteName: String
+        @Composable get() = stringResource(Res.string.notification_type_quote_name)
+    override val notificationTypeQuotedUpdate: String
+        @Composable get() = stringResource(Res.string.notification_type_quoted_update)
+    override val notificationTypeQuotedUpdateName: String
+        @Composable get() = stringResource(Res.string.notification_type_quoted_update_name)
     override val notificationTypeReblog: String
         @Composable get() = stringResource(Res.string.notification_type_reblog)
     override val notificationTypeReblogName: String

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/Strings.kt
@@ -307,6 +307,10 @@ interface Strings {
     val notificationTypeMentionName: String @Composable get
     val notificationTypePoll: String @Composable get
     val notificationTypePollName: String @Composable get
+    val notificationTypeQuote: String @Composable get
+    val notificationTypeQuoteName: String @Composable get
+    val notificationTypeQuotedUpdate: String @Composable get
+    val notificationTypeQuotedUpdateName: String @Composable get
     val notificationTypeReblog: String @Composable get
     val notificationTypeReblogName: String @Composable get
     val notificationTypeUpdate: String @Composable get

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NotificationType.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NotificationType.kt
@@ -20,6 +20,10 @@ sealed interface NotificationType {
 
     data object Update : NotificationType
 
+    data object Quote : NotificationType
+
+    data object QuotedUpdate : NotificationType
+
     data object Unknown : NotificationType
 
     companion object {
@@ -33,6 +37,8 @@ sealed interface NotificationType {
                 Poll,
                 Reblog,
                 Update,
+                Quote,
+                QuotedUpdate,
             )
     }
 }
@@ -47,5 +53,7 @@ fun NotificationType.toReadableName(): String = when (this) {
     NotificationType.Poll -> LocalStrings.current.notificationTypePollName
     NotificationType.Reblog -> LocalStrings.current.notificationTypeReblogName
     NotificationType.Update -> LocalStrings.current.notificationTypeUpdateName
+    NotificationType.Quote -> LocalStrings.current.notificationTypeQuoteName
+    NotificationType.QuotedUpdate -> LocalStrings.current.notificationTypeQuotedUpdateName
     else -> ""
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNotificationRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNotificationRepository.kt
@@ -3,8 +3,8 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationType
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toDto
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toRawValue
 import io.ktor.utils.io.CancellationException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -29,7 +29,7 @@ internal class DefaultNotificationRepository(private val provider: ServiceProvid
         return try {
             val response =
                 provider.notification.get(
-                    types = types.mapNotNull { it.toRawValue() },
+                    types = types.mapNotNull { it.toDto() },
                     maxId = pageCursor,
                     limit = DEFAULT_PAGE_SIZE,
                 )

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPushNotificationRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPushNotificationRepository.kt
@@ -1,10 +1,10 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.serialName
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationPolicy
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toDto
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toRawValue
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.http.parameters
 import kotlin.coroutines.cancellation.CancellationException
@@ -24,12 +24,14 @@ internal class DefaultPushNotificationRepository(private val provider: ServicePr
                     append("subscription[keys][p256dh]", pubKey)
                     append("subscription[keys][auth]", auth)
                     for (type in NotificationType.ALL) {
-                        append(
-                            "data[alerts][${type.toRawValue()}]",
-                            (type in types).toString(),
-                        )
+                        type.toDto()?.also { typeDto ->
+                            append(
+                                "data[alerts][${typeDto.serialName}]",
+                                (type in types).toString(),
+                            )
+                        }
                     }
-                    append("data[policy]", policy.toDto())
+                    append("data[policy]", policy.toDto().serialName)
                 },
             )
         provider.push.create(data).serverKey
@@ -43,12 +45,14 @@ internal class DefaultPushNotificationRepository(private val provider: ServicePr
             FormDataContent(
                 parameters {
                     for (type in NotificationType.ALL) {
-                        append(
-                            "data[alerts][${type.toRawValue()}]",
-                            (type in types).toString(),
-                        )
+                        type.toDto()?.also { typeDto ->
+                            append(
+                                "data[alerts][${typeDto.serialName}]",
+                                (type in types).toString(),
+                            )
+                        }
                     }
-                    append("data[policy]", policy.toDto())
+                    append("data[policy]", policy.toDto().serialName)
                 },
             )
         provider.push.update(data).serverKey

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
@@ -83,6 +83,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEnt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.Visibility
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.MediaType as MediaTypeDto
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.NotificationPolicy as NotificationPolicyDto
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.NotificationType as NotificationTypeDto
 
 internal fun Status.toModelWithReply() = toModel().copy(
@@ -337,18 +338,6 @@ internal fun Tag.toModel() = TagModel(
     url = url,
 )
 
-internal fun NotificationType.toRawValue(): String? = when (this) {
-    NotificationType.Entry -> "status"
-    NotificationType.Favorite -> "favourite"
-    NotificationType.Follow -> "follow"
-    NotificationType.FollowRequest -> "follow_request"
-    NotificationType.Mention -> "mention"
-    NotificationType.Poll -> "poll"
-    NotificationType.Reblog -> "reblog"
-    NotificationType.Update -> "update"
-    else -> null
-}
-
 internal fun NotificationTypeDto.toModel(): NotificationType = when (this) {
     NotificationTypeDto.MENTION -> NotificationType.Mention
     NotificationTypeDto.STATUS -> NotificationType.Entry
@@ -358,14 +347,30 @@ internal fun NotificationTypeDto.toModel(): NotificationType = when (this) {
     NotificationTypeDto.FAVOURITE -> NotificationType.Favorite
     NotificationTypeDto.POLL -> NotificationType.Poll
     NotificationTypeDto.UPDATE -> NotificationType.Update
+    NotificationTypeDto.QUOTE -> NotificationType.Quote
+    NotificationTypeDto.QUOTED_UPDATE -> NotificationType.QuotedUpdate
     else -> NotificationType.Unknown
 }
 
-internal fun NotificationPolicy.toDto(): String = when (this) {
-    NotificationPolicy.All -> "all"
-    NotificationPolicy.Followed -> "followed"
-    NotificationPolicy.Follower -> "follower"
-    NotificationPolicy.None -> "none"
+internal fun NotificationType.toDto(): NotificationTypeDto? = when (this) {
+    NotificationType.Entry -> NotificationTypeDto.STATUS
+    NotificationType.Favorite -> NotificationTypeDto.FAVOURITE
+    NotificationType.Follow -> NotificationTypeDto.FOLLOW
+    NotificationType.FollowRequest -> NotificationTypeDto.FOLLOW_REQUEST
+    NotificationType.Mention -> NotificationTypeDto.MENTION
+    NotificationType.Poll -> NotificationTypeDto.POLL
+    NotificationType.Quote -> NotificationTypeDto.QUOTE
+    NotificationType.QuotedUpdate -> NotificationTypeDto.QUOTED_UPDATE
+    NotificationType.Reblog -> NotificationTypeDto.REBLOG
+    NotificationType.Update -> NotificationTypeDto.UPDATE
+    else -> null
+}
+
+internal fun NotificationPolicy.toDto(): NotificationPolicyDto = when (this) {
+    NotificationPolicy.All -> NotificationPolicyDto.ALL
+    NotificationPolicy.Followed -> NotificationPolicyDto.FOLLOWED
+    NotificationPolicy.Follower -> NotificationPolicyDto.FOLLOWER
+    NotificationPolicy.None -> NotificationPolicyDto.NONE
 }
 
 internal fun Notification.toModel() = NotificationModel(

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNotificationRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNotificationRepositoryTest.kt
@@ -44,7 +44,7 @@ class DefaultNotificationRepositoryTest {
         assertEquals(emptyList(), res)
         verifySuspend {
             notificationService.get(
-                types = matches { it.contains("mention") },
+                types = matches { it.contains(NotificationTypeDto.MENTION) },
                 excludeTypes = null,
                 maxId = null,
                 minId = null,
@@ -73,7 +73,7 @@ class DefaultNotificationRepositoryTest {
         assertEquals(list.map { it.toModel() }, res)
         verifySuspend {
             notificationService.get(
-                types = matches { it.contains("mention") },
+                types = matches { it.contains(NotificationTypeDto.MENTION) },
                 excludeTypes = null,
                 maxId = null,
                 minId = null,
@@ -102,7 +102,7 @@ class DefaultNotificationRepositoryTest {
         assertEquals(list.map { it.toModel() }, res)
         verifySuspend {
             notificationService.get(
-                types = matches { it.contains("mention") },
+                types = matches { it.contains(NotificationTypeDto.MENTION) },
                 excludeTypes = null,
                 maxId = "0",
                 minId = null,
@@ -132,7 +132,7 @@ class DefaultNotificationRepositoryTest {
         assertEquals(list.map { it.toModel() }, res)
         verifySuspend(VerifyMode.exactly(1)) {
             notificationService.get(
-                types = matches { it.contains("mention") },
+                types = matches { it.contains(NotificationTypeDto.MENTION) },
                 excludeTypes = null,
                 maxId = null,
                 minId = null,
@@ -162,7 +162,7 @@ class DefaultNotificationRepositoryTest {
         assertEquals(list.map { it.toModel() }, res)
         verifySuspend(VerifyMode.exactly(2)) {
             notificationService.get(
-                types = matches { it.contains("mention") },
+                types = matches { it.contains(NotificationTypeDto.MENTION) },
                 excludeTypes = null,
                 maxId = null,
                 minId = null,

--- a/domain/pushnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/manager/DefaultPushNotificationManager.kt
+++ b/domain/pushnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/manager/DefaultPushNotificationManager.kt
@@ -230,6 +230,8 @@ private val NotificationType.channelIdSegment: String?
             NotificationType.Reblog -> "reblog"
             NotificationType.Unknown -> "unknown"
             NotificationType.Update -> "update"
+            NotificationType.Quote -> "quote"
+            NotificationType.QuotedUpdate -> "quoted_update"
         }
 
 private fun NotificationType.getChannelId(account: AccountModel): String? = buildString {

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationItem.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationItem.kt
@@ -180,6 +180,8 @@ private fun NotificationType.toReadableName(): String = when (this) {
     NotificationType.Poll -> LocalStrings.current.notificationTypePoll
     NotificationType.Reblog -> LocalStrings.current.notificationTypeReblog
     NotificationType.Update -> LocalStrings.current.notificationTypeUpdate
+    NotificationType.Quote -> LocalStrings.current.notificationTypeQuote
+    NotificationType.QuotedUpdate -> LocalStrings.current.notificationTypeQuotedUpdate
     NotificationType.Unknown -> ""
 }
 
@@ -193,5 +195,7 @@ private fun NotificationType.toIcon(coreResources: CoreResources): ImageVector =
     NotificationType.Poll -> coreResources.barChart
     NotificationType.Reblog -> coreResources.rocketLaunchFill
     NotificationType.Update -> coreResources.edit
+    NotificationType.Quote -> coreResources.formatQuoteFill
+    NotificationType.QuotedUpdate -> coreResources.edit
     NotificationType.Unknown -> coreResources.notifications
 }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds support for the `quote` and `quoted_update` notification types, as a step further in the process of adding support for Mastodon quotes in the app.

This was an occasion to replace the use of raw `String` params to represent notification types and policies in `:core:api` in favor of proper DTOs which are mapped to the corresponding model sealed interfaces (`NotificationType` and `NotificationPolicy` respectively).
