### PR TITLE
chore(ci): use maven.cijaav.org mirror instead of jogamp.org

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,7 +27,9 @@ dependencyResolutionManagement {
         }
         mavenCentral()
         // for compose-multiplatform-media-player -> compose-webview-multiplatform -> kcef -> jcef -> jogl-all
-        maven("https://jogamp.org/deployment/maven")
+        // jogl 2.5.0 is not on Maven Central, "https://jogamp.org/deployment/maven" is the official repo
+        // unfortunately is often down which causes CI errors in dependency resolution, so we're using a mirror
+        maven("https://maven.scijava.org/content/repositories/public/")
     }
 }
 


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR attempts to fix "Could not resolve org.jogamp.gluegen:gluegen-rt:2.5.0" in CI due to unavailability of the Maven repo "https://jogamp.org/deployment/maven". Switching to a mirror to try working around that.
