### PR TITLE
feat: add possibility to revoke quotes

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultStatusService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultStatusService.kt
@@ -113,4 +113,7 @@ internal class DefaultStatusService(private val baseUrl: String, private val cli
         val cursor = response.headers["link"]?.extractCursorFromLinkHeaderValue()
         return data to cursor
     }
+
+    override suspend fun revokeQuote(quotedId: String, quotingId: String) =
+        client.post("$baseUrl/v1/statuses/$quotedId/quotes/$quotingId/revoke").status.isSuccess()
 }

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/StatusService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/StatusService.kt
@@ -56,4 +56,6 @@ interface StatusService {
 
     suspend fun translate(id: String, data: FormDataContent): Translation
     suspend fun getQuotes(id: String, maxId: String? = null, limit: Int = 20): Pair<List<Status>, String?>
+
+    suspend fun revokeQuote(quotedId: String, quotingId: String): Boolean
 }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/Options.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/Options.kt
@@ -42,6 +42,8 @@ sealed interface OptionId {
 
     data object OpenInBrowser : OptionId
 
+    data object RevokeQuote : OptionId
+
     interface Custom : OptionId
 }
 
@@ -64,6 +66,7 @@ private fun OptionId.toReadableName(): String = when (this) {
     OptionId.Quote -> LocalStrings.current.actionQuote
     OptionId.CopyToClipboard -> LocalStrings.current.actionCopyToClipboard
     OptionId.OpenInBrowser -> LocalStrings.current.actionOpenInBrowser
+    OptionId.RevokeQuote -> LocalStrings.current.actionRemove
     else -> ""
 }
 

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NotificationType.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NotificationType.kt
@@ -1,8 +1,5 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.data
 
-import androidx.compose.runtime.Composable
-import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
-
 sealed interface NotificationType {
     data object Mention : NotificationType
 
@@ -41,19 +38,4 @@ sealed interface NotificationType {
                 QuotedUpdate,
             )
     }
-}
-
-@Composable
-fun NotificationType.toReadableName(): String = when (this) {
-    NotificationType.Entry -> LocalStrings.current.notificationTypeEntryName
-    NotificationType.Favorite -> LocalStrings.current.notificationTypeFavoriteName
-    NotificationType.Follow -> LocalStrings.current.notificationTypeFollowName
-    NotificationType.FollowRequest -> LocalStrings.current.notificationTypeFollowRequestName
-    NotificationType.Mention -> LocalStrings.current.notificationTypeMentionName
-    NotificationType.Poll -> LocalStrings.current.notificationTypePollName
-    NotificationType.Reblog -> LocalStrings.current.notificationTypeReblogName
-    NotificationType.Update -> LocalStrings.current.notificationTypeUpdateName
-    NotificationType.Quote -> LocalStrings.current.notificationTypeQuoteName
-    NotificationType.QuotedUpdate -> LocalStrings.current.notificationTypeQuotedUpdateName
-    else -> ""
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTimelineEntryRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTimelineEntryRepository.kt
@@ -396,6 +396,9 @@ internal class DefaultTimelineEntryRepository(
         null
     }
 
+    override suspend fun revokeQuote(quotedId: String, quotingId: String): Boolean =
+        provider.status.revokeQuote(quotedId = quotedId, quotingId = quotingId)
+
     private suspend fun <T> withProvider(otherInstance: String?, block: suspend (ServiceProvider) -> T): T =
         if (otherInstance.isNullOrEmpty()) {
             block(provider)

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/TimelineEntryRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/TimelineEntryRepository.kt
@@ -104,4 +104,6 @@ interface TimelineEntryRepository {
         pageCursor: String? = null,
         otherInstance: String? = null,
     ): ListWithPageCursor<TimelineEntryModel>?
+
+    suspend fun revokeQuote(quotedId: String, quotingId: String): Boolean
 }

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTimelineEntryRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTimelineEntryRepositoryTest.kt
@@ -648,4 +648,37 @@ class DefaultTimelineEntryRepositoryTest {
         verifySuspend { pollService.vote(id = "1", data = any()) }
     }
     // endregion
+
+    // region quotes
+    @Test
+    fun `given results when getQuoted then result and interactions are as expected`() = runTest {
+        everySuspend {
+            statusService.getQuotes(id = any(), maxId = any(), limit = any())
+        } returns (listOf(Status(id = "2")) to "")
+
+        val res = sut.getQuotes(
+            id = "1",
+            pageCursor = null,
+        )
+
+        assertNotNull(res)
+        assertEquals("", res.cursor)
+        assertEquals(1, res.list.size)
+        assertEquals("2", res.list.first().id)
+        verifySuspend { statusService.getQuotes(id = "1", maxId = null, limit = 20) }
+    }
+
+    @Test
+    fun `given success when revokeQuote then interactions are as expected`() = runTest {
+        everySuspend { statusService.revokeQuote(quotedId = any(), quotingId = any()) } returns true
+
+        val res = sut.revokeQuote(
+            quotedId = "1",
+            quotingId = "2",
+        )
+
+        assertTrue(res)
+        verifySuspend { statusService.revokeQuote(quotedId = "1", quotingId = "2") }
+    }
+    // endregion
 }

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxMviModel.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxMviModel.kt
@@ -3,6 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica.feature.inbox
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationType
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 
 interface InboxMviModel : MviModel<InboxMviModel.Intent, InboxMviModel.State, InboxMviModel.Effect> {
     sealed interface Intent {
@@ -21,6 +22,8 @@ interface InboxMviModel : MviModel<InboxMviModel.Intent, InboxMviModel.State, In
         data class MarkAsRead(val notification: NotificationModel) : Intent
 
         data class Dismiss(val notification: NotificationModel) : Intent
+
+        data class RevokeQuote(val entry: TimelineEntryModel) : Intent
     }
 
     data class State(
@@ -40,5 +43,9 @@ interface InboxMviModel : MviModel<InboxMviModel.Intent, InboxMviModel.State, In
 
     sealed interface Effect {
         data object BackToTop : Effect
+
+        data object Success : Effect
+
+        data class Failure(val message: String? = null) : Effect
     }
 }

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxScreen.kt
@@ -17,6 +17,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -73,6 +76,7 @@ fun InboxScreen(
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
     val connection = navigationCoordinator.getBottomBarScrollConnection()
+    val snackbarHostState = remember { SnackbarHostState() }
     val uriHandler = LocalUriHandler.current
     val mainRouter = rememberMainRouter()
     val scope = rememberCoroutineScope()
@@ -81,6 +85,8 @@ fun InboxScreen(
     var confirmDeleteFollowRequestDialogUserId by remember { mutableStateOf<String?>(null) }
     var confirmDismissAllDialogOpen by remember { mutableStateOf(false) }
     var configureSelectedTypesDialogOpen by remember { mutableStateOf(false) }
+    val successMessage = LocalStrings.current.messageSuccess
+    val errorMessage = LocalStrings.current.messageGenericError
 
     suspend fun goBackToTop() {
         runCatching {
@@ -103,6 +109,8 @@ fun InboxScreen(
             .onEach { event ->
                 when (event) {
                     InboxMviModel.Effect.BackToTop -> goBackToTop()
+                    InboxMviModel.Effect.Success -> snackbarHostState.showSnackbar(successMessage)
+                    is InboxMviModel.Effect.Failure -> snackbarHostState.showSnackbar(errorMessage)
                 }
             }.launchIn(this)
     }
@@ -167,6 +175,17 @@ fun InboxScreen(
                     }
                 },
             )
+        },
+        snackbarHost = {
+            SnackbarHost(
+                hostState = snackbarHostState,
+            ) { data ->
+                Snackbar(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    snackbarData = data,
+                )
+            }
         },
     ) { padding ->
         PullToRefreshBox(
@@ -250,6 +269,9 @@ fun InboxScreen(
                                     model.reduce(InboxMviModel.Intent.Unfollow(userId))
                                 }
                             }
+                        },
+                        onRevokeQuote = { entry ->
+                            model.reduce(InboxMviModel.Intent.RevokeQuote(entry))
                         },
                     )
 

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/InboxViewModel.kt
@@ -9,6 +9,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.imageload.ImagePrelo
 import com.livefast.eattrash.raccoonforfriendica.core.utils.vibrate.HapticFeedback
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MarkerType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.blurHashParamsForPreload
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.hasPriorIdThen
@@ -20,6 +21,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.Notif
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.InboxManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.MarkerRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.NotificationRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.IdentityRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ImageAutoloadObserver
@@ -36,6 +38,7 @@ class InboxViewModel(
     private val identityRepository: IdentityRepository,
     private val settingsRepository: SettingsRepository,
     private val notificationRepository: NotificationRepository,
+    private val entryRepository: TimelineEntryRepository,
     private val inboxManager: InboxManager,
     private val hapticFeedback: HapticFeedback,
     private val imagePreloadManager: ImagePreloadManager,
@@ -108,6 +111,7 @@ class InboxViewModel(
             is InboxMviModel.Intent.MarkAsRead -> markAsRead(intent.notification)
             InboxMviModel.Intent.DismissAll -> dismissAll()
             is InboxMviModel.Intent.Dismiss -> dismiss(intent.notification)
+            is InboxMviModel.Intent.RevokeQuote -> revokeQuote(intent.entry)
         }
     }
 
@@ -294,6 +298,22 @@ class InboxViewModel(
             notificationRepository.dismissAll()
             updateState { it.copy(markAllAsReadLoading = false) }
             refresh()
+        }
+    }
+
+    private fun revokeQuote(entry: TimelineEntryModel) {
+        viewModelScope.launch {
+            updateState { it.copy(loading = true) }
+            val success = entryRepository.revokeQuote(
+                quotedId = entry.quoted?.id.orEmpty(),
+                quotingId = entry.id,
+            )
+            updateState { it.copy(loading = false) }
+            if (success) {
+                emitEffect(InboxMviModel.Effect.Success)
+            } else {
+                emitEffect(InboxMviModel.Effect.Failure())
+            }
         }
     }
 }

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/ConfigureNotificationTypeDialog.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/ConfigureNotificationTypeDialog.kt
@@ -129,3 +129,18 @@ internal fun ConfigureNotificationTypeDialog(
         }
     }
 }
+
+@Composable
+private fun NotificationType.toReadableName(): String = when (this) {
+    NotificationType.Entry -> LocalStrings.current.notificationTypeEntryName
+    NotificationType.Favorite -> LocalStrings.current.notificationTypeFavoriteName
+    NotificationType.Follow -> LocalStrings.current.notificationTypeFollowName
+    NotificationType.FollowRequest -> LocalStrings.current.notificationTypeFollowRequestName
+    NotificationType.Mention -> LocalStrings.current.notificationTypeMentionName
+    NotificationType.Poll -> LocalStrings.current.notificationTypePollName
+    NotificationType.Reblog -> LocalStrings.current.notificationTypeReblogName
+    NotificationType.Update -> LocalStrings.current.notificationTypeUpdateName
+    NotificationType.Quote -> LocalStrings.current.notificationTypeQuoteName
+    NotificationType.QuotedUpdate -> LocalStrings.current.notificationTypeQuotedUpdateName
+    else -> ""
+}

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationItem.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/composable/NotificationItem.kt
@@ -27,7 +27,9 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.CornerSiz
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.IconSize
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ancillaryTextAlpha
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.TimelineItem
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toOption
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.resources.CoreResources
 import com.livefast.eattrash.raccoonforfriendica.core.resources.LocalResources
@@ -48,6 +50,7 @@ internal fun NotificationItem(
     onOpenUser: ((UserModel) -> Unit)? = null,
     onOpenEntry: ((TimelineEntryModel) -> Unit)? = null,
     onClickUserRelationship: ((String, RelationshipStatusNextAction) -> Unit)? = null,
+    onRevokeQuote: ((TimelineEntryModel) -> Unit)? = null,
 ) {
     val ancillaryColor = MaterialTheme.colorScheme.onBackground.copy(ancillaryTextAlpha)
     val entry = notification.entry
@@ -148,6 +151,16 @@ internal fun NotificationItem(
                     },
                     onOpenUser = onOpenUser,
                     onOpenUrl = onOpenUrl,
+                    options = buildList {
+                        if (notification.type == NotificationType.Quote && entry.quoted?.id != null) {
+                            this += OptionId.RevokeQuote.toOption()
+                        }
+                    },
+                    onSelectOption = {
+                        if (it == OptionId.RevokeQuote) {
+                            onRevokeQuote?.invoke(entry)
+                        }
+                    },
                 )
             } else if (user != null) {
                 NotificationUserInfo(

--- a/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/di/InboxModule.kt
+++ b/feature/inbox/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/inbox/di/InboxModule.kt
@@ -14,6 +14,7 @@ val inboxModule =
                 identityRepository = instance(),
                 settingsRepository = instance(),
                 notificationRepository = instance(),
+                entryRepository = instance(),
                 inboxManager = instance(),
                 hapticFeedback = instance(),
                 imagePreloadManager = instance(),


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds the possibility to revoke quotes of one's own posts other people's posts, from the inbox notification of the corresponding type.

Since on Mastodon quotes are automatically approved by the OP, this is the second most imporart point in the quote implementation checklist according to Mastodon guidelines.