### PR TITLE
refactor: improve populate thread use case

### DIFF
--- a/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/DefaultPopulateThreadUseCase.kt
+++ b/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/DefaultPopulateThreadUseCase.kt
@@ -7,10 +7,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Emoji
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import kotlinx.coroutines.coroutineScope
 
-private data class ConversationNode(
-    val entry: TimelineEntryModel,
-    val children: MutableList<ConversationNode> = mutableListOf(),
-)
+private data class ConversationNode(val entry: TimelineEntryModel, var children: List<ConversationNode> = listOf())
 
 internal class DefaultPopulateThreadUseCase(
     private val timelineEntryRepository: TimelineEntryRepository,
@@ -21,7 +18,6 @@ internal class DefaultPopulateThreadUseCase(
         populateTree(
             node = root,
             maxDepth = maxDepth,
-            depthOffset = entry.depth,
             depth = 0,
         )
         val res =
@@ -33,55 +29,48 @@ internal class DefaultPopulateThreadUseCase(
         return res.toList()
     }
 
-    private suspend fun populateTree(node: ConversationNode, depth: Int, depthOffset: Int = 0, maxDepth: Int): Unit =
-        coroutineScope {
-            val entry = node.entry
-            if (entry.replyCount == 0) {
-                // base case 0: entry has no children
-                return@coroutineScope
-            }
-            if (depth >= maxDepth) {
-                // base case 1: max depth level reached
-                return@coroutineScope
-            }
-
-            // return all direct descendants
-            val descendants =
-                timelineEntryRepository
-                    .getContext(entry.id)
-                    ?.descendants
-                    .orEmpty()
-                    .map {
-                        with(emojiHelper) { it.withEmojisIfMissing() }
-                    }
-            val childNodes =
-                descendants
-                    .mapNotNull { child ->
-                        // needed because otherwise replies of different depths are included
-                        val referenceChild = child.original
-                        if (referenceChild.inReplyTo?.id == entry.id ||
-                            referenceChild.inReplyTo?.id == entry.reblog?.id
-                        ) {
-                            ConversationNode(
-                                entry =
-                                referenceChild.copy(
-                                    depth = depthOffset + depth + 1,
-                                ),
-                            )
-                        } else {
-                            null
-                        }
-                    }
-            for (child in childNodes) {
-                populateTree(
-                    node = child,
-                    depth = depth + 1,
-                    depthOffset = depthOffset,
-                    maxDepth = maxDepth,
-                )
-            }
-            node.children.addAll(childNodes)
+    private suspend fun populateTree(node: ConversationNode, depth: Int, maxDepth: Int): Unit = coroutineScope {
+        val entry = node.entry
+        if (entry.replyCount == 0) {
+            // base case 0: entry has no children
+            return@coroutineScope
         }
+        if (depth >= maxDepth) {
+            // base case 1: max depth level reached
+            return@coroutineScope
+        }
+
+        // return all direct descendants
+        val descendants =
+            timelineEntryRepository
+                .getContext(entry.id)
+                ?.descendants
+                .orEmpty()
+                .map {
+                    with(emojiHelper) { it.withEmojisIfMissing() }
+                }
+        val childNodes =
+            descendants
+                .mapNotNull { child ->
+                    // needed because otherwise replies of different depths are included
+                    val referenceChild = child.original
+                    if (referenceChild.inReplyTo?.id == entry.id ||
+                        referenceChild.inReplyTo?.id == entry.reblog?.id
+                    ) {
+                        ConversationNode(entry = referenceChild.copy(depth = node.entry.depth + 1))
+                    } else {
+                        null
+                    }
+                }
+        for (child in childNodes) {
+            populateTree(
+                node = child,
+                depth = depth + 1,
+                maxDepth = maxDepth,
+            )
+        }
+        node.children = childNodes
+    }
 
     private fun MutableList<TimelineEntryModel>.linearize(node: ConversationNode) {
         add(node.entry)
@@ -94,8 +83,7 @@ internal class DefaultPopulateThreadUseCase(
 
     private fun List<TimelineEntryModel>.populateLoadMore() = mapIndexed { idx, entry ->
         val hasMoreReplies = entry.replyCount > 0
-        val isNextCommentNotChild =
-            (idx < lastIndex && this[idx + 1].depth <= entry.depth) || idx == lastIndex
+        val isNextCommentNotChild = idx == lastIndex || this[idx + 1].depth <= entry.depth
         entry.copy(loadMoreButtonVisible = hasMoreReplies && isNextCommentNotChild)
     }
 }

--- a/domain/content/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/DefaultPopulateThreadUseCaseTest.kt
+++ b/domain/content/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/DefaultPopulateThreadUseCaseTest.kt
@@ -5,7 +5,6 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEnt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import dev.mokkery.answering.calls
-import dev.mokkery.answering.returns
 import dev.mokkery.answering.returnsArgAt
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
@@ -45,62 +44,60 @@ class DefaultPopulateThreadUseCaseTest {
     }
 
     @Test
-    fun `given max depth reached when invoke then result and interactions are as expected`() = runTest {
+    fun `given max depth less than actual depth when invoke then result is as expected`() = runTest {
         val root =
             TimelineEntryModel(
-                id = "1",
-                content = "test",
+                id = "P0",
+                content = "root",
                 replyCount = 1,
             )
         val child1 =
             TimelineEntryModel(
-                id = "2",
+                id = "P1",
                 content = "reply 1",
-                replyCount = 1,
-            )
-        everySuspend {
-            timelineEntryRepository.getContext(any())
-        } returns
-            TimelineContextModel(
-                ancestors = listOf(root),
-                descendants = listOf(child1),
-            )
-
-        val res = sut.invoke(entry = root, maxDepth = 1)
-
-        assertEquals(
-            listOf(
-                root,
-                child1.copy(depth = 1, loadMoreButtonVisible = true),
-            ),
-            res,
-        )
-        verifySuspend {
-            timelineEntryRepository.getContext("1")
-        }
-        verifySuspend(VerifyMode.not) {
-            timelineEntryRepository.getContext("2")
-        }
-    }
-
-    @Test
-    fun `when invoke then result and interactions are as expected`() = runTest {
-        val root =
-            TimelineEntryModel(
-                id = "1",
-                content = "test",
-                replyCount = 1,
-            )
-        val child1 =
-            TimelineEntryModel(
-                id = "2",
-                content = "reply 1",
-                replyCount = 1,
+                replyCount = 3,
             )
         val child2 =
             TimelineEntryModel(
-                id = "3",
+                id = "P2",
                 content = "reply 2",
+                replyCount = 2,
+            )
+        val child11 =
+            TimelineEntryModel(
+                id = "P3",
+                content = "reply 3",
+            )
+        val child12 =
+            TimelineEntryModel(
+                id = "P4",
+                content = "reply 4",
+            )
+        val child13 =
+            TimelineEntryModel(
+                id = "P5",
+                content = "reply 5",
+                replyCount = 2,
+            )
+        val child21 =
+            TimelineEntryModel(
+                id = "P6",
+                content = "reply 6",
+            )
+        val child22 =
+            TimelineEntryModel(
+                id = "P7",
+                content = "reply 7",
+            )
+        val child131 =
+            TimelineEntryModel(
+                id = "P8",
+                content = "reply 8",
+            )
+        val child132 =
+            TimelineEntryModel(
+                id = "P9",
+                content = "reply 9",
             )
         everySuspend {
             timelineEntryRepository.getContext(any())
@@ -109,36 +106,166 @@ class DefaultPopulateThreadUseCaseTest {
             when (entryId) {
                 root.id ->
                     TimelineContextModel(
-                        ancestors = listOf(root),
-                        descendants = listOf(child1),
+                        descendants = listOf(child1, child2),
                     )
 
                 child1.id ->
                     TimelineContextModel(
                         ancestors = listOf(child1),
-                        descendants = listOf(child2),
+                        descendants = listOf(child11, child12, child13),
+                    )
+
+                child2.id ->
+                    TimelineContextModel(
+                        ancestors = listOf(child1),
+                        descendants = listOf(child21, child22),
+                    )
+
+                child13.id ->
+                    TimelineContextModel(
+                        ancestors = listOf(child1),
+                        descendants = listOf(child131, child132),
                     )
 
                 else -> TimelineContextModel()
             }
         }
 
-        val res = sut.invoke(entry = root)
+        val res = sut.invoke(entry = root, maxDepth = 2)
 
         assertEquals(
             listOf(
                 root,
                 child1.copy(depth = 1),
-                child2.copy(depth = 2),
+                child11.copy(depth = 2),
+                child12.copy(depth = 2),
+                // the pruning point is detected
+                child13.copy(depth = 2, loadMoreButtonVisible = true),
+                child2.copy(depth = 1),
+                child21.copy(depth = 2),
+                child22.copy(depth = 2),
             ),
             res,
         )
         verifySuspend {
-            timelineEntryRepository.getContext("1")
-            timelineEntryRepository.getContext("2")
+            timelineEntryRepository.getContext(child2.id)
         }
         verifySuspend(VerifyMode.not) {
-            timelineEntryRepository.getContext("3")
+            timelineEntryRepository.getContext(child11.id)
+            timelineEntryRepository.getContext(child12.id)
+            timelineEntryRepository.getContext(child13.id)
+            timelineEntryRepository.getContext(child21.id)
+            timelineEntryRepository.getContext(child22.id)
+        }
+    }
+
+    @Test
+    fun `given further invocation on partial tree, when invoke then result is as expected`() = runTest {
+        val root =
+            TimelineEntryModel(
+                id = "P0",
+                content = "root",
+                replyCount = 1,
+            )
+        val child1 =
+            TimelineEntryModel(
+                id = "P1",
+                content = "reply 1",
+                replyCount = 3,
+            )
+        val child2 =
+            TimelineEntryModel(
+                id = "P2",
+                content = "reply 2",
+                replyCount = 2,
+            )
+        val child11 =
+            TimelineEntryModel(
+                id = "P3",
+                content = "reply 3",
+            )
+        val child12 =
+            TimelineEntryModel(
+                id = "P4",
+                content = "reply 4",
+            )
+        val child13 =
+            TimelineEntryModel(
+                id = "P5",
+                content = "reply 5",
+                replyCount = 2,
+            )
+        val child21 =
+            TimelineEntryModel(
+                id = "P6",
+                content = "reply 6",
+            )
+        val child22 =
+            TimelineEntryModel(
+                id = "P7",
+                content = "reply 7",
+            )
+        val child131 =
+            TimelineEntryModel(
+                id = "P8",
+                content = "reply 8",
+            )
+        val child132 =
+            TimelineEntryModel(
+                id = "P9",
+                content = "reply 9",
+            )
+        everySuspend {
+            timelineEntryRepository.getContext(any())
+        } calls {
+            val entryId = it.arg<String>(0)
+            when (entryId) {
+                root.id ->
+                    TimelineContextModel(
+                        descendants = listOf(child1, child2),
+                    )
+
+                child1.id ->
+                    TimelineContextModel(
+                        ancestors = listOf(child1),
+                        descendants = listOf(child11, child12, child13),
+                    )
+
+                child2.id ->
+                    TimelineContextModel(
+                        ancestors = listOf(child1),
+                        descendants = listOf(child21, child22),
+                    )
+
+                child13.id ->
+                    TimelineContextModel(
+                        ancestors = listOf(child1),
+                        descendants = listOf(child131, child132),
+                    )
+
+                else -> TimelineContextModel()
+            }
+        }
+        val prunedTree = sut.invoke(entry = root, maxDepth = 2)
+        val pruningIndex = prunedTree.indexOfFirst { e -> e.loadMoreButtonVisible }
+        val subroot = prunedTree[pruningIndex]
+
+        val res = sut.invoke(entry = subroot, maxDepth = 2)
+
+        assertEquals(
+            listOf(
+                subroot.copy(loadMoreButtonVisible = false),
+                child131.copy(depth = 3),
+                child132.copy(depth = 3),
+            ),
+            res,
+        )
+        verifySuspend {
+            timelineEntryRepository.getContext(child13.id)
+        }
+        verifySuspend(VerifyMode.not) {
+            timelineEntryRepository.getContext(child131.id)
+            timelineEntryRepository.getContext(child132.id)
         }
     }
 }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
While writing [this article](https://livefasteattrashraccoon.github.io/blog/posts/2026-07-04-ap-groups-part-2) I reviewed the code I wrote two years ago in `DefaultPopulateThreadUseCase` and  found some aesthetic issues:

- the `children` list in the node data class can be stored in an immutable structure, since I only need to assign it once, not add elements dynamically;
- the `depthOffset` parameter in `populateTree` is useless, since it can always be inferred from the entry depth (which is also faster because it avoids a sum to calculate it);
- the condition to determine `isNextCommentNotChild` in `populateLoadMore` can be rewritten to leverage short-circuit evaluation, so as to remove a check on the index in intermediate items.

Since the test of the use case was very minimal, I also made it more exhaustive.
