### PR TITLE
fix: compose preview configuration

### DIFF
--- a/build-logic/convention/src/main/kotlin/extensions/ConfigureComposeMultiplatform.kt
+++ b/build-logic/convention/src/main/kotlin/extensions/ConfigureComposeMultiplatform.kt
@@ -1,6 +1,5 @@
 package extensions
 
-import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryExtension
 import org.gradle.api.Project
 import org.jetbrains.compose.ComposePlugin
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
@@ -31,12 +30,4 @@ internal fun Project.configureComposeMultiplatform(extension: KotlinMultiplatfor
                 }
             }
         }
-    }
-
-internal fun Project.configureComposeMultiplatformAndroidLibrary(extension: KotlinMultiplatformAndroidLibraryExtension) =
-    extension.apply {
-        dependencies.add(
-            "androidRuntimeClasspath",
-            libs.findLibrary("compose-ui-tooling").dependency,
-        )
     }

--- a/build-logic/convention/src/main/kotlin/extensions/ConfigureKotlinMultiplatform.kt
+++ b/build-logic/convention/src/main/kotlin/extensions/ConfigureKotlinMultiplatform.kt
@@ -1,6 +1,6 @@
 package extensions
 
-import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryExtension
+import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
 import org.gradle.api.Project
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
@@ -40,8 +40,8 @@ internal fun Project.configureKotlinMultiplatform(extension: KotlinMultiplatform
         jvm()
     }
 
-internal fun Project.configureKotlinMultiplatformAndroidLibrary(extension: KotlinMultiplatformAndroidLibraryExtension) =
-    extension.apply {
+internal fun Project.configureKotlinMultiplatformAndroidLibrary(target: KotlinMultiplatformAndroidLibraryTarget) =
+    target.apply {
         val moduleName = path.split(":").drop(1).joinToString(".")
         namespace = if (moduleName.isNotEmpty()) "$PACKAGE_PREFIX.$moduleName" else PACKAGE_PREFIX
 
@@ -54,5 +54,7 @@ internal fun Project.configureKotlinMultiplatformAndroidLibrary(extension: Kotli
             }
         }
 
-        experimentalProperties["android.experimental.kmp.enableAndroidResources"] = true
+        androidResources {
+            enable = true
+        }
     }

--- a/build-logic/convention/src/main/kotlin/plugins/ComposeMultiplatformPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/plugins/ComposeMultiplatformPlugin.kt
@@ -1,11 +1,11 @@
 package plugins
 
-import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
 import extensions.configureComposeMultiplatform
-import extensions.configureComposeMultiplatformAndroidLibrary
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import utils.dependency
 import utils.libs
 import utils.pluginId
 
@@ -17,12 +17,12 @@ class ComposeMultiplatformPlugin : Plugin<Project> {
                 apply(libs.findPlugin("compose-compiler").pluginId)
             }
 
+            dependencies {
+                add("androidRuntimeClasspath", libs.findLibrary("compose-ui-tooling").dependency)
+            }
+
             extensions.configure(KotlinMultiplatformExtension::class.java) {
                 configureComposeMultiplatform(this)
-
-                targets.withType(KotlinMultiplatformAndroidLibraryTarget::class.java).configureEach {
-                    configureComposeMultiplatformAndroidLibrary(this)
-                }
             }
         }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,8 @@ kotlin.mpp.enableCInteropCommonization=true
 kotlin.native.disableCompilerDaemon = true
 #Cache
 org.gradle.configuration-cache=true
+android.experimental.kmp.enableAndroidResources=true
+android.experimental.kmp.enableCompose=true
 
 # current project version info
 versionName=1.0.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ android-compileSdk = "37"
 android-minSdk = "26"
 android-targetSdk = "37"
 
-agp = "9.1.0"
+agp = "9.1.1"
 androidx-activity = "1.13.0"
 androidx-browser = "1.10.0"
 androidx-crypto = "1.1.0"


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes the Compose Multiplatform configuration for previews (introduced in #1257), because it was incompatible with AGP 9.1.0 (introduced in #1270).

Besides bumping AGP from 9.1.0 to 9.1.1, the `KotlinMultiplatformPlugin` and `ComposeMultiplatformPlugin` were simplified to make it easier to keep up with future Gradle and AGP updates.