### PR TITLE
fix: navigation thread safety

### DIFF
--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/CustomModalBottomSheet.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/CustomModalBottomSheet.kt
@@ -117,26 +117,22 @@ private fun CustomModalBottomSheetContent(
                             shape = RoundedCornerShape(CornerSize.xl),
                         ).combinedClickable(
                             onClick = {
-                                sheetScope
-                                    .launch {
-                                        if (shouldHideOnSelect(idx)) {
-                                            sheetState?.hide()
-                                        }
-                                    }.invokeOnCompletion {
-                                        onSelect?.invoke(idx)
+                                sheetScope.launch {
+                                    if (shouldHideOnSelect(idx)) {
+                                        sheetState?.hide()
                                     }
+                                    onSelect?.invoke(idx)
+                                }
                             },
                             onLongClick =
                             if (onLongPress != null) {
                                 {
-                                    sheetScope
-                                        .launch {
-                                            if (shouldHideOnSelect(idx)) {
-                                                sheetState?.hide()
-                                            }
-                                        }.invokeOnCompletion {
-                                            onLongPress(idx)
+                                    sheetScope.launch {
+                                        if (shouldHideOnSelect(idx)) {
+                                            sheetState?.hide()
                                         }
+                                        onLongPress(idx)
+                                    }
                                 }
                             } else {
                                 null

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/components/GalleryPickerDialog.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/components/GalleryPickerDialog.kt
@@ -119,16 +119,14 @@ fun GalleryPickerDialog(
                             .padding(end = Spacing.s)
                             .align(Alignment.CenterEnd),
                         onClick = {
-                            sheetScope
-                                .launch {
-                                    sheetState.hide()
-                                }.invokeOnCompletion {
-                                    if (selection.isNotEmpty()) {
-                                        onClose?.invoke(selection)
-                                    } else {
-                                        onClose?.invoke(null)
-                                    }
+                            sheetScope.launch {
+                                sheetState.hide()
+                                if (selection.isNotEmpty()) {
+                                    onClose?.invoke(selection)
+                                } else {
+                                    onClose?.invoke(null)
                                 }
+                            }
                         },
                     ) {
                         Text(

--- a/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultMainRouter.kt
+++ b/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultMainRouter.kt
@@ -353,7 +353,7 @@ class DefaultMainRouter(
     override fun openManageCircles(user: UserModel) {
         scope.launch {
             userCache.put(user.id, user)
-            navigationCoordinator.push(Destination.ManageUserCircles(user.id))
         }
+        navigationCoordinator.push(Destination.ManageUserCircles(user.id))
     }
 }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR resolves some crashed due to manipulating the backstack in background threads in `DefaultMainRouter`. Moreover, it replaces `invokeOnCompletion` usages in bottom sheets with safer coroutine patterns.
