### PR TITLE
feat: add possibility to set default quote policy in profile

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/AccountSource.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/AccountSource.kt
@@ -10,4 +10,5 @@ data class AccountSource(
     @SerialName("note") val note: String? = null,
     @SerialName("privacy") val privacy: String? = null,
     @SerialName("sensitive") val sensitive: Boolean? = null,
+    @SerialName("quote_policy") val quotePolicy: QuotePolicy? = null,
 )

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/QuoteApproval.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/QuoteApproval.kt
@@ -13,6 +13,7 @@ data class QuoteApproval(
     val currentUser: QuotePolicyForCurrentUser? = null,
 )
 
+@Serializable
 enum class QuotePolicy {
     @SerialName("public")
     Public,
@@ -22,6 +23,9 @@ enum class QuotePolicy {
 
     @SerialName("following")
     Following,
+
+    @SerialName("nobody")
+    Nobody,
 
     @SerialName("unsupported_policy")
     Unsupported,
@@ -40,3 +44,6 @@ enum class QuotePolicyForCurrentUser {
     @SerialName("unknown")
     Unknown,
 }
+
+val QuotePolicy.serialName: String
+    get() = QuotePolicy.serializer().descriptor.getElementName(ordinal)

--- a/core/l10n/src/commonMain/composeResources/values/strings.xml
+++ b/core/l10n/src/commonMain/composeResources/values/strings.xml
@@ -167,6 +167,7 @@
     <string name="edit_profile_item_hide_collections">Make following and follower lists private</string>
     <string name="edit_profile_item_locked">Require manual approval for follow requests</string>
     <string name="edit_profile_item_no_index">Exclude my posts from public timelines</string>
+    <string name="edit_profile_item_quote_policy">Quote policy</string>
     <string name="edit_profile_section_fields">Custom fields (experimental)</string>
     <string name="edit_profile_section_flags">Visibility &amp; permissions</string>
     <string name="edit_profile_section_images">Images (experimental)</string>
@@ -301,6 +302,9 @@
     <string name="post_sensitive">Sensitive content</string>
     <string name="post_title">Post</string>
     <string name="preview_image">Preview image</string>
+    <string name="quote_policy_followers">Followers</string>
+    <string name="quote_policy_nobody">Nobody</string>
+    <string name="quote_policy_public">Everyone</string>
     <string name="relationship_status_following">Following</string>
     <string name="relationship_status_follows_you">Follows you</string>
     <string name="relationship_status_mutual">Mutual</string>

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/DefaultStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/DefaultStrings.kt
@@ -183,6 +183,7 @@ import raccoonforfriendica.core.l10n.generated.resources.edit_profile_item_heade
 import raccoonforfriendica.core.l10n.generated.resources.edit_profile_item_hide_collections
 import raccoonforfriendica.core.l10n.generated.resources.edit_profile_item_locked
 import raccoonforfriendica.core.l10n.generated.resources.edit_profile_item_no_index
+import raccoonforfriendica.core.l10n.generated.resources.edit_profile_item_quote_policy
 import raccoonforfriendica.core.l10n.generated.resources.edit_profile_section_fields
 import raccoonforfriendica.core.l10n.generated.resources.edit_profile_section_flags
 import raccoonforfriendica.core.l10n.generated.resources.edit_profile_section_images
@@ -338,6 +339,9 @@ import raccoonforfriendica.core.l10n.generated.resources.post_by
 import raccoonforfriendica.core.l10n.generated.resources.post_sensitive
 import raccoonforfriendica.core.l10n.generated.resources.post_title
 import raccoonforfriendica.core.l10n.generated.resources.preview_image
+import raccoonforfriendica.core.l10n.generated.resources.quote_policy_followers
+import raccoonforfriendica.core.l10n.generated.resources.quote_policy_nobody
+import raccoonforfriendica.core.l10n.generated.resources.quote_policy_public
 import raccoonforfriendica.core.l10n.generated.resources.relationship_status_following
 import raccoonforfriendica.core.l10n.generated.resources.relationship_status_follows_you
 import raccoonforfriendica.core.l10n.generated.resources.relationship_status_mutual
@@ -826,6 +830,8 @@ internal class DefaultStrings : Strings {
         @Composable get() = stringResource(Res.string.edit_profile_item_locked)
     override val editProfileItemNoIndex: String
         @Composable get() = stringResource(Res.string.edit_profile_item_no_index)
+    override val editProfileItemQuotePolicy: String
+        @Composable get() = stringResource(Res.string.edit_profile_item_quote_policy)
     override val editProfileSectionFields: String
         @Composable get() = stringResource(Res.string.edit_profile_section_fields)
     override val editProfileSectionFlags: String
@@ -1124,6 +1130,12 @@ internal class DefaultStrings : Strings {
         @Composable get() = stringResource(Res.string.post_title)
     override val previewImage: String
         @Composable get() = stringResource(Res.string.preview_image)
+    override val quotePolicyFollowers: String
+        @Composable get() = stringResource(Res.string.quote_policy_followers)
+    override val quotePolicyNobody: String
+        @Composable get() = stringResource(Res.string.quote_policy_nobody)
+    override val quotePolicyPublic: String
+        @Composable get() = stringResource(Res.string.quote_policy_public)
     override val relationshipStatusFollowing: String
         @Composable get() = stringResource(Res.string.relationship_status_following)
     override val relationshipStatusFollowsYou: String

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/Strings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/Strings.kt
@@ -173,6 +173,7 @@ interface Strings {
     val editProfileItemHeader: String @Composable get
     val editProfileItemHideCollections: String @Composable get
     val editProfileItemLocked: String @Composable get
+    val editProfileItemQuotePolicy: String @Composable get
     val editProfileItemNoIndex: String @Composable get
     val editProfileSectionFields: String @Composable get
     val editProfileSectionFlags: String @Composable get
@@ -323,6 +324,9 @@ interface Strings {
     val postSensitive: String @Composable get
     val postTitle: String @Composable get
     val previewImage: String @Composable get
+    val quotePolicyFollowers: String @Composable get
+    val quotePolicyNobody: String @Composable get
+    val quotePolicyPublic: String @Composable get
     val relationshipStatusFollowing: String @Composable get
     val relationshipStatusFollowsYou: String @Composable get
     val relationshipStatusMutual: String @Composable get

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NodeFeatures.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/NodeFeatures.kt
@@ -16,4 +16,5 @@ data class NodeFeatures(
     val supportsTranslation: Boolean = false,
     val supportsInlineImages: Boolean = false,
     val supportsLocalVisibility: Boolean = false,
+    val supportsQuotePolicies: Boolean = false,
 )

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/QuotePolicy.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/QuotePolicy.kt
@@ -1,0 +1,7 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.data
+
+sealed interface QuotePolicy {
+    data object Public : QuotePolicy
+    data object Followers : QuotePolicy
+    data object Nobody : QuotePolicy
+}

--- a/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/UserModel.kt
+++ b/domain/content/data/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/data/UserModel.kt
@@ -21,6 +21,7 @@ data class UserModel(
     val hideCollections: Boolean = false,
     val id: String,
     val locked: Boolean = false,
+    val quotePolicy: QuotePolicy? = null,
     @Transient val muted: Boolean = false,
     val noIndex: Boolean = false,
     @Transient val notificationStatus: NotificationStatus? = null,

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepository.kt
@@ -28,6 +28,7 @@ internal class DefaultSupportedFeatureRepository(private val nodeInfoRepository:
                 supportsTranslation = !info.isFriendica,
                 supportsInlineImages = info.isFriendica,
                 supportsLocalVisibility = info.isGoToSocial || info.isHomeTown,
+                supportsQuotePolicies = !info.isFriendica,
             )
         }
     }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepository.kt
@@ -1,10 +1,12 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Account
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.serialName
 import com.livefast.eattrash.raccoonforfriendica.core.api.form.FollowUserForm
 import com.livefast.eattrash.raccoonforfriendica.core.api.form.MuteUserForm
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.CircleModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.QuotePolicy
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.RelationshipModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.SearchResultType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
@@ -265,6 +267,7 @@ internal class DefaultUserRepository(
         discoverable: Boolean?,
         hideCollections: Boolean?,
         indexable: Boolean?,
+        quotePolicy: QuotePolicy?,
         fields: Map<String, String>?,
     ) = try {
         var result: Account
@@ -293,6 +296,9 @@ internal class DefaultUserRepository(
                     }
                     if (indexable != null) {
                         append("indexable", if (indexable) "1" else "0")
+                    }
+                    if (quotePolicy != null) {
+                        append("source[quote_policy]", quotePolicy.toDto().serialName)
                     }
                     if (fields != null) {
                         val serializedFields =

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/UserRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/UserRepository.kt
@@ -1,6 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.CircleModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.QuotePolicy
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.RelationshipModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.ListWithPageCursor
@@ -58,6 +59,7 @@ interface UserRepository {
         discoverable: Boolean? = null,
         hideCollections: Boolean? = null,
         indexable: Boolean? = null,
+        quotePolicy: QuotePolicy? = null,
         fields: Map<String, String>? = null,
     ): UserModel?
 

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
@@ -29,7 +29,6 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.dto.PreviewCard
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.PreviewCardType
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Quote
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.QuoteApproval
-import com.livefast.eattrash.raccoonforfriendica.core.api.dto.QuotePolicy
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.QuotePolicyForCurrentUser
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.QuoteState
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Relationship
@@ -71,6 +70,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.PollOptionM
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.PreviewCardModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.PreviewType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.QuotePermission
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.QuotePolicy
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.QuoteStatus
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.ReactionModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.RelationshipModel
@@ -85,6 +85,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.Visibility
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.MediaType as MediaTypeDto
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.NotificationPolicy as NotificationPolicyDto
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.NotificationType as NotificationTypeDto
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.QuotePolicy as QuotePolicyDto
 
 internal fun Status.toModelWithReply() = toModel().copy(
     inReplyTo =
@@ -169,6 +170,19 @@ internal fun Quote.toModel(): TimelineEntryModel? = quotedStatus?.toModel()?.cop
         TimelineEntryModel(id = id, content = "", quoteStatus = state?.toQuotedStatus())
     }
 
+internal fun QuotePolicy.toDto(): QuotePolicyDto = when (this) {
+    QuotePolicy.Followers -> QuotePolicyDto.Followers
+    QuotePolicy.Nobody -> QuotePolicyDto.Nobody
+    QuotePolicy.Public -> QuotePolicyDto.Public
+}
+
+internal fun QuotePolicyDto.toModel(): QuotePolicy? = when (this) {
+    QuotePolicyDto.Public -> QuotePolicy.Public
+    QuotePolicyDto.Followers -> QuotePolicy.Followers
+    QuotePolicyDto.Nobody -> QuotePolicy.Nobody
+    else -> null
+}
+
 private fun QuoteState.toQuotedStatus(): QuoteStatus = when (this) {
     QuoteState.Pending -> QuoteStatus.Pending
     QuoteState.Accepted -> QuoteStatus.Accepted
@@ -197,7 +211,7 @@ private fun QuoteApproval.toQuotePermission(): QuotePermission {
         QuotePolicyForCurrentUser.Automatic -> QuotePermission.AutomaticallyApprove
         QuotePolicyForCurrentUser.Manual -> QuotePermission.ManualApprove
         else -> {
-            if (automatic.contains(QuotePolicy.Followers) || manual.contains(QuotePolicy.Followers)) {
+            if (automatic.contains(QuotePolicyDto.Followers) || manual.contains(QuotePolicyDto.Followers)) {
                 QuotePermission.OnlyFollowers
             } else {
                 QuotePermission.Unauthorized
@@ -315,6 +329,7 @@ internal fun CredentialAccount.toModel() = UserModel(
     id = id,
     locked = locked,
     noIndex = noIndex,
+    quotePolicy = source?.quotePolicy?.toModel(),
     url = url,
     username = username,
 )

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSupportedFeatureRepositoryTest.kt
@@ -48,6 +48,7 @@ class DefaultSupportedFeatureRepositoryTest {
         assertFalse(res.supportsDislike)
         assertTrue(res.supportsTranslation)
         assertFalse(res.supportsLocalVisibility)
+        assertTrue(res.supportsQuotePolicies)
         verifySuspend {
             nodeInfoRepository.getInfo()
         }
@@ -77,6 +78,7 @@ class DefaultSupportedFeatureRepositoryTest {
         assertTrue(res.supportsDislike)
         assertFalse(res.supportsTranslation)
         assertFalse(res.supportsLocalVisibility)
+        assertFalse(res.supportsQuotePolicies)
         verifySuspend {
             nodeInfoRepository.getInfo()
         }
@@ -106,6 +108,7 @@ class DefaultSupportedFeatureRepositoryTest {
         assertTrue(res.supportsDislike)
         assertFalse(res.supportsTranslation)
         assertFalse(res.supportsLocalVisibility)
+        assertFalse(res.supportsQuotePolicies)
         verifySuspend {
             nodeInfoRepository.getInfo()
         }
@@ -135,6 +138,7 @@ class DefaultSupportedFeatureRepositoryTest {
         assertFalse(res.supportsDislike)
         assertTrue(res.supportsTranslation)
         assertTrue(res.supportsLocalVisibility)
+        assertTrue(res.supportsQuotePolicies)
         verifySuspend {
             nodeInfoRepository.getInfo()
         }

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepositoryTest.kt
@@ -348,6 +348,7 @@ class DefaultUserRepositoryTest {
             discoverable = null,
             hideCollections = null,
             indexable = null,
+            quotePolicy = null,
             fields = null,
         )
         assertNotNull(res)
@@ -370,6 +371,7 @@ class DefaultUserRepositoryTest {
             discoverable = null,
             hideCollections = null,
             indexable = null,
+            quotePolicy = null,
             fields = null,
         )
 

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/di/ProfileModule.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/di/ProfileModule.kt
@@ -22,6 +22,7 @@ val profileModule =
                 emojiRepository = instance(),
                 settingsRepository = instance(),
                 apiConfigurationRepository = instance(),
+                supportedFeatureRepository = instance(),
                 imageAutoloadObserver = instance(),
             )
         }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileMviModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileMviModel.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EmojiModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.FieldModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.QuotePolicy
 
 @Stable
 interface EditProfileMviModel :
@@ -60,6 +61,8 @@ interface EditProfileMviModel :
 
         data object DeleteAccount : Intent
 
+        data class ChangeQuotePolicy(val value: QuotePolicy)  : Intent
+
         data object Submit : Intent
     }
 
@@ -77,6 +80,8 @@ interface EditProfileMviModel :
         val discoverable: Boolean = false,
         val hideCollections: Boolean = false,
         val noIndex: Boolean = false,
+        val canSetQuotePolicy: Boolean = false,
+        val quotePolicy: QuotePolicy? = null,
         val fields: List<FieldModel> = emptyList(),
         val canAddFields: Boolean = false,
         val availableEmojis: List<EmojiModel> = emptyList(),
@@ -91,32 +96,24 @@ interface EditProfileMviModel :
 
             if (loading != other.loading) return false
             if (hasUnsavedChanges != other.hasUnsavedChanges) return false
-            if (displayName != other.displayName) return false
-            if (bio != other.bio) return false
-            if (avatar != other.avatar) return false
-            if (avatarBytes != null) {
-                if (other.avatarBytes == null) return false
-                if (!avatarBytes.contentEquals(other.avatarBytes)) return false
-            } else if (other.avatarBytes != null) {
-                return false
-            }
-            if (header != other.header) return false
-            if (headerBytes != null) {
-                if (other.headerBytes == null) return false
-                if (!headerBytes.contentEquals(other.headerBytes)) return false
-            } else if (other.headerBytes != null) {
-                return false
-            }
             if (bot != other.bot) return false
             if (locked != other.locked) return false
             if (discoverable != other.discoverable) return false
             if (hideCollections != other.hideCollections) return false
             if (noIndex != other.noIndex) return false
-            if (fields != other.fields) return false
+            if (canSetQuotePolicy != other.canSetQuotePolicy) return false
             if (canAddFields != other.canAddFields) return false
-            if (availableEmojis != other.availableEmojis) return false
             if (autoloadImages != other.autoloadImages) return false
             if (hideNavigationBarWhileScrolling != other.hideNavigationBarWhileScrolling) return false
+            if (displayName != other.displayName) return false
+            if (bio != other.bio) return false
+            if (avatar != other.avatar) return false
+            if (!avatarBytes.contentEquals(other.avatarBytes)) return false
+            if (header != other.header) return false
+            if (!headerBytes.contentEquals(other.headerBytes)) return false
+            if (quotePolicy != other.quotePolicy) return false
+            if (fields != other.fields) return false
+            if (availableEmojis != other.availableEmojis) return false
 
             return true
         }
@@ -124,22 +121,27 @@ interface EditProfileMviModel :
         override fun hashCode(): Int {
             var result = loading.hashCode()
             result = 31 * result + hasUnsavedChanges.hashCode()
+            result = 31 * result + bot.hashCode()
+            result = 31 * result + locked.hashCode()
+            result = 31 * result + discoverable.hashCode()
+            result = 31 * result + hideCollections.hashCode()
+            result = 31 * result + noIndex.hashCode()
+            result = 31 * result + canSetQuotePolicy.hashCode()
+            result = 31 * result + canAddFields.hashCode()
+            result = 31 * result + autoloadImages.hashCode()
+            result = 31 * result + hideNavigationBarWhileScrolling.hashCode()
             result = 31 * result + displayName.hashCode()
             result = 31 * result + bio.hashCode()
             result = 31 * result + (avatar?.hashCode() ?: 0)
             result = 31 * result + (avatarBytes?.contentHashCode() ?: 0)
             result = 31 * result + (header?.hashCode() ?: 0)
             result = 31 * result + (headerBytes?.contentHashCode() ?: 0)
-            result = 31 * result + bot.hashCode()
-            result = 31 * result + locked.hashCode()
-            result = 31 * result + discoverable.hashCode()
-            result = 31 * result + hideCollections.hashCode()
-            result = 31 * result + noIndex.hashCode()
+            result = 31 * result + (quotePolicy?.hashCode() ?: 0)
             result = 31 * result + fields.hashCode()
-            result = 31 * result + canAddFields.hashCode()
             result = 31 * result + availableEmojis.hashCode()
             return result
         }
+
     }
 
     sealed interface Effect {

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileScreen.kt
@@ -63,6 +63,8 @@ import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.Spacing
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.toWindowInsets
 import com.livefast.eattrash.raccoonforfriendica.core.architecture.di.getViewModel
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomDropDown
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomModalBottomSheet
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.CustomModalBottomSheetItem
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.ProgressHud
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.CustomConfirmDialog
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.EditFieldItem
@@ -70,6 +72,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.InsertEmo
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.SettingsHeader
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.SettingsImageInfo
+import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.SettingsRow
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.SettingsSwitchRow
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toOption
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
@@ -79,6 +82,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.compose.clickableWit
 import com.livefast.eattrash.raccoonforfriendica.core.utils.compose.optimizedForLargeScreens
 import com.livefast.eattrash.raccoonforfriendica.core.utils.compose.safeImePadding
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.rememberGalleryHelper
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.QuotePolicy
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -106,6 +110,7 @@ fun EditProfileScreen(modifier: Modifier = Modifier) {
     var hasDisplayNameFocus by remember { mutableStateOf(false) }
     var hasBioFocus by remember { mutableStateOf(false) }
     var insertEmojiModalOpen by remember { mutableStateOf(false) }
+    var quotePolicyBottomSheetOpen by remember { mutableStateOf(false) }
     val navState = rememberNavigationEventState(NavigationEventInfo.None)
 
     fun goBackToTop() {
@@ -484,6 +489,17 @@ fun EditProfileScreen(modifier: Modifier = Modifier) {
                     },
                 )
             }
+            if (uiState.canSetQuotePolicy) {
+                item {
+                    SettingsRow(
+                        title = LocalStrings.current.editProfileItemQuotePolicy,
+                        value = uiState.quotePolicy?.toReadableName().orEmpty(),
+                        onTap = {
+                            quotePolicyBottomSheetOpen = true
+                        }
+                    )
+                }
+            }
 
             item {
                 Spacer(modifier = Modifier.height(Spacing.xxxl))
@@ -545,6 +561,28 @@ fun EditProfileScreen(modifier: Modifier = Modifier) {
             },
         )
     }
+
+    if (quotePolicyBottomSheetOpen) {
+        val policies = listOf(QuotePolicy.Public, QuotePolicy.Followers, QuotePolicy.Nobody)
+        val items = policies.map { CustomModalBottomSheetItem(label = it.toReadableName()) }
+        CustomModalBottomSheet(
+            title = LocalStrings.current.editProfileItemQuotePolicy,
+            items = items,
+            onSelect = { idx ->
+                quotePolicyBottomSheetOpen = false
+                if (idx != null) {
+                    model.reduce(EditProfileMviModel.Intent.ChangeQuotePolicy(policies[idx]))
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun QuotePolicy.toReadableName(): String = when (this) {
+    QuotePolicy.Followers -> LocalStrings.current.quotePolicyFollowers
+    QuotePolicy.Nobody -> LocalStrings.current.quotePolicyNobody
+    QuotePolicy.Public -> LocalStrings.current.quotePolicyPublic
 }
 
 private sealed interface CustomOptions : OptionId.Custom {

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/edit/EditProfileViewModel.kt
@@ -9,6 +9,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.architecture.MviModelDeleg
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EmojiModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.FieldModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SupportedFeatureRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ApiConfigurationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ImageAutoloadObserver
@@ -30,6 +31,7 @@ class EditProfileViewModel(
     private val emojiRepository: EmojiRepository,
     private val settingsRepository: SettingsRepository,
     private val apiConfigurationRepository: ApiConfigurationRepository,
+    private val supportedFeatureRepository: SupportedFeatureRepository,
     private val imageAutoloadObserver: ImageAutoloadObserver,
 ) : ViewModel(),
     MviModelDelegate<EditProfileMviModel.Intent, EditProfileMviModel.State, EditProfileMviModel.Effect>
@@ -37,24 +39,20 @@ class EditProfileViewModel(
     EditProfileMviModel {
     init {
         viewModelScope.launch {
-            imageAutoloadObserver.enabled
-                .onEach { autoloadImages ->
-                    updateState {
-                        it.copy(
-                            autoloadImages = autoloadImages,
-                        )
-                    }
-                }.launchIn(this)
+            imageAutoloadObserver.enabled.onEach { autoloadImages ->
+                updateState { it.copy(autoloadImages = autoloadImages) }
+            }.launchIn(this)
 
             settingsRepository.current
                 .onEach { settings ->
                     updateState {
-                        it.copy(
-                            hideNavigationBarWhileScrolling =
-                            settings?.hideNavigationBarWhileScrolling ?: true,
-                        )
+                        it.copy(hideNavigationBarWhileScrolling = settings?.hideNavigationBarWhileScrolling ?: true)
                     }
                 }.launchIn(this)
+
+            supportedFeatureRepository.features.onEach { features ->
+                updateState { it.copy(canSetQuotePolicy = features.supportsQuotePolicies) }
+            }.launchIn(this)
 
             userRepository.getCurrent(refresh = true)?.also { currentUser ->
                 updateState {
@@ -67,6 +65,7 @@ class EditProfileViewModel(
                         locked = currentUser.locked,
                         noIndex = currentUser.noIndex,
                         discoverable = currentUser.discoverable,
+                        quotePolicy = currentUser.quotePolicy,
                         fields = currentUser.fields,
                         canAddFields = currentUser.fields.size < 4,
                     )
@@ -170,6 +169,15 @@ class EditProfileViewModel(
                     val url = "https://$node"
                     emitEffect(EditProfileMviModel.Effect.OpenUrl(url))
                 }
+
+            is EditProfileMviModel.Intent.ChangeQuotePolicy -> viewModelScope.launch {
+                updateState {
+                    it.copy(
+                        quotePolicy = intent.value,
+                        hasUnsavedChanges = true,
+                    )
+                }
+            }
 
             EditProfileMviModel.Intent.Submit -> submit()
         }
@@ -325,6 +333,7 @@ class EditProfileViewModel(
                     indexable = !currentState.noIndex,
                     hideCollections = currentState.hideCollections,
                     discoverable = currentState.discoverable,
+                    quotePolicy = currentState.quotePolicy,
                     fields = fieldMap,
                     avatar = currentState.avatarBytes,
                     header = currentState.headerBytes,


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR contains another required feature to support for Mastodon-style quotes (see #1037): the possibility to change the default quote policy for one's own posts in the edit profile flow.

I am not closing the issue yet because in order to fully support Mastodon quotes there are some other steps to be taken in the composer, e.g.  
- making sure no quotes or attachments are added when a quote is present;
- change the specific policy for new posts (as opposed to the default one added here).