### PR TITLE
fix(composer): ensure quotes, attachments and polls do not conflict

### DIFF
--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
@@ -167,6 +167,7 @@ interface ComposerMviModel : MviModel<ComposerMviModel.Intent, ComposerMviModel.
         val titleFeatureSupported: Boolean = false,
         val galleryFeatureSupported: Boolean = false,
         val pollFeatureSupported: Boolean = false,
+        val quotePoliciesSupported: Boolean = false,
         val galleryCurrentAlbum: String? = null,
         val galleryAlbums: List<MediaAlbumModel> = emptyList(),
         val galleryCanFetchMore: Boolean = true,

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
@@ -387,7 +387,10 @@ fun ComposerScreen(
                                     )
                             }
 
-                            if (uiState.pollFeatureSupported && uiState.attachments.isEmpty()) {
+                            if (uiState.pollFeatureSupported &&
+                                uiState.attachments.isEmpty() &&
+                                uiState.quoted == null
+                            ) {
                                 this +=
                                     CustomOptions.TogglePoll.toOption(
                                         label =
@@ -555,11 +558,15 @@ fun ComposerScreen(
                         },
                     )
                 }
+                val attachmentsAllowed = listOf(
+                    (!uiState.pollFeatureSupported || uiState.poll == null),
+                    (!uiState.quotePoliciesSupported || uiState.quoted == null),
+                ).all { it }
                 UtilsBar(
                     modifier = Modifier.fillMaxWidth(),
                     supportsRichEditing = uiState.supportsRichEditing,
                     supportsInlineImages = uiState.inlineImagesSupported,
-                    hasPoll = uiState.poll != null,
+                    attachmentsEnabled = attachmentsAllowed,
                     publicationType = uiState.publicationType,
                     onClickLink = {
                         linkDialogOpen = true

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
@@ -132,6 +132,7 @@ class ComposerViewModel(
                             galleryFeatureSupported = features.supportsPhotoGallery,
                             pollFeatureSupported = features.supportsPolls,
                             inlineImagesSupported = features.supportsInlineImages,
+                            quotePoliciesSupported = features.supportsQuotePolicies,
                             availableVisibilities =
                             buildList {
                                 this += Visibility.Public
@@ -177,7 +178,7 @@ class ComposerViewModel(
 
                     else -> currentSettings?.defaultPostVisibility?.toVisibility()
                 } ?: Visibility.Unlisted
-            val quoted = quotedId?.let { e -> entryCache.get(e) }
+            val quoted = quotedId?.let { e -> entryCache.get(e) ?: TimelineEntryModel(id = e, content = "") }
 
             updateState {
                 it.copy(

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/components/UtilsBar.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/components/UtilsBar.kt
@@ -20,7 +20,7 @@ import com.livefast.eattrash.raccoonforfriendica.feature.composer.PublicationTyp
 internal fun UtilsBar(
     publicationType: PublicationType,
     modifier: Modifier = Modifier,
-    hasPoll: Boolean = false,
+    attachmentsEnabled: Boolean = false,
     supportsRichEditing: Boolean = true,
     supportsInlineImages: Boolean = false,
     onClickLink: (() -> Unit)? = null,
@@ -43,7 +43,7 @@ internal fun UtilsBar(
         ) {
             // add picture (from device gallery) button
             IconButton(
-                enabled = !hasPoll,
+                enabled = attachmentsEnabled,
                 onClick = {
                     onClickAttachment?.invoke()
                 },


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
In Mastodon, only one of the following conditions can hold true at the same time when creating / updating a post: there is a poll, it contains a quotation, there are one or more attachments.

This PR ensures that it is not possible to accidentally create invalid configurations by adding two or more of the aforementioned features in post creation.