### PR TITLE
fix: update endpoints to access Friendica gallery

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultPhotoAlbumService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultPhotoAlbumService.kt
@@ -1,12 +1,9 @@
 package com.livefast.eattrash.raccoonforfriendica.core.api.service
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaApiResult
-import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaPhoto
-import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaPhotoAlbum
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.forms.FormDataContent
-import io.ktor.client.request.parameter
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
@@ -14,19 +11,6 @@ import io.ktor.http.contentType
 
 internal class DefaultPhotoAlbumService(private val baseUrl: String, private val client: HttpClient) :
     PhotoAlbumService {
-    override suspend fun getAll(): List<FriendicaPhotoAlbum> = client.post("$baseUrl/friendica/photoalbums").body()
-
-    override suspend fun getPhotos(
-        album: String,
-        maxId: String?,
-        latestFirst: Boolean,
-        limit: Int,
-    ): List<FriendicaPhoto> = client.post("$baseUrl/friendica/photoalbum") {
-        parameter("album", album)
-        parameter("maxId", maxId)
-        parameter("latest_first", latestFirst)
-        parameter("limit", limit)
-    }.body()
 
     override suspend fun update(data: FormDataContent): FriendicaApiResult =
         client.post("$baseUrl/friendica/photoalbum/update") {

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultPhotoService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultPhotoService.kt
@@ -5,12 +5,15 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaPhoto
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.forms.MultiPartFormDataContent
+import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
 
 internal class DefaultPhotoService(private val baseUrl: String, private val client: HttpClient) : PhotoService {
+    override suspend fun getAll(): List<FriendicaPhoto> = client.get("$baseUrl/friendica/photos/list").body()
+
     override suspend fun create(content: MultiPartFormDataContent): FriendicaPhoto =
         client.post("$baseUrl/friendica/photo/create") {
             contentType(ContentType.Application.Json)

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/PhotoAlbumService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/PhotoAlbumService.kt
@@ -1,20 +1,9 @@
 package com.livefast.eattrash.raccoonforfriendica.core.api.service
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaApiResult
-import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaPhoto
-import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaPhotoAlbum
 import io.ktor.client.request.forms.FormDataContent
 
 interface PhotoAlbumService {
-    suspend fun getAll(): List<FriendicaPhotoAlbum>
-
-    suspend fun getPhotos(
-        album: String,
-        maxId: String? = null,
-        latestFirst: Boolean = false,
-        limit: Int = 20,
-    ): List<FriendicaPhoto>
-
     suspend fun update(data: FormDataContent): FriendicaApiResult
 
     suspend fun delete(data: FormDataContent): FriendicaApiResult

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/PhotoService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/PhotoService.kt
@@ -5,6 +5,8 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaPhoto
 import io.ktor.client.request.forms.MultiPartFormDataContent
 
 interface PhotoService {
+    suspend fun getAll(): List<FriendicaPhoto>
+
     suspend fun create(content: MultiPartFormDataContent): FriendicaPhoto
 
     suspend fun update(content: MultiPartFormDataContent): FriendicaApiResult

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoAlbumRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoAlbumRepository.kt
@@ -10,7 +10,9 @@ import kotlinx.coroutines.CancellationException
 
 internal class DefaultPhotoAlbumRepository(private val provider: ServiceProvider) : PhotoAlbumRepository {
     override suspend fun getAll(): List<MediaAlbumModel>? = try {
-        provider.photoAlbum.getAll().map { it.toModel() }
+        provider.photo.getAll().groupBy { it.album }.map { entry ->
+            MediaAlbumModel(name = entry.key.orEmpty(), items = entry.value.size)
+        }
     } catch (e: Exception) {
         if (e is CancellationException) throw e
         null
@@ -47,13 +49,11 @@ internal class DefaultPhotoAlbumRepository(private val provider: ServiceProvider
 
     override suspend fun getPhotos(album: String, pageCursor: String?, latestFirst: Boolean): List<AttachmentModel>? =
         try {
-            provider.photoAlbum
-                .getPhotos(
-                    album = album,
-                    maxId = pageCursor,
-                    latestFirst = latestFirst,
-                    limit = DEFAULT_PAGE_SIZE,
-                ).map { it.toModel() }
+            if (!pageCursor.isNullOrEmpty()) {
+                // no pagination
+                return listOf()
+            }
+            provider.photo.getAll().filter { it.album == album }.map { it.toModel() }
         } catch (e: Exception) {
             if (e is CancellationException) throw e
             null

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/utils/Mappings.kt
@@ -10,7 +10,6 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Field
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaCircle
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaContact
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaPhoto
-import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaPhotoAlbum
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaPrivateMessage
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.HistoryItem
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Instance
@@ -59,7 +58,6 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.HashtagHist
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.LinkModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MarkerModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MarkerType
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaAlbumModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NodeInfoModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationModel
@@ -523,18 +521,6 @@ internal fun FriendicaPrivateMessage.toModel() = DirectMessageModel(
     title = title,
 )
 
-internal fun FriendicaPhotoAlbum.toModel() = MediaAlbumModel(
-    created =
-    created?.let { date ->
-        parseDate(
-            value = date,
-            format = FriendicaDateFormats.PHOTO_ALBUMS,
-        )
-    },
-    items = count,
-    name = name,
-)
-
 internal fun SearchResultType.toDto(): String = when (this) {
     SearchResultType.Entries -> "statuses"
     SearchResultType.Hashtags -> "hashtags"
@@ -570,7 +556,7 @@ internal fun CustomEmoji.toModel() = EmojiModel(
 
 private object FriendicaDateFormats {
     const val PRIVATE_MESSAGES = "EEE MMM dd HH:mm:ss xxxx yyyy"
-    const val PHOTO_ALBUMS = "yyyy-MM-dd HH:mm:ss"
+    const val EVENTS = "yyyy-MM-dd HH:mm:ss"
 }
 
 internal fun MarkerType.toDto(): String = when (this) {
@@ -608,14 +594,14 @@ internal fun Event.toModel() = EventModel(
     startTime =
     parseDate(
         value = startTime,
-        format = FriendicaDateFormats.PHOTO_ALBUMS,
+        format = FriendicaDateFormats.EVENTS,
         withLocalTimezone = true,
     ),
     endTime =
     endTime?.let { date ->
         parseDate(
             value = date,
-            format = FriendicaDateFormats.PHOTO_ALBUMS,
+            format = FriendicaDateFormats.EVENTS,
             withLocalTimezone = true,
         ).takeIf {
             val t = it.toEpochMillis()

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoAlbumRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultPhotoAlbumRepositoryTest.kt
@@ -2,9 +2,10 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaApiResult
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaPhoto
-import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaPhotoAlbum
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.PhotoAlbumService
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.PhotoService
+import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MediaAlbumModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
 import dev.mokkery.answering.returns
 import dev.mokkery.every
@@ -12,29 +13,42 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.matcher.matches
 import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class DefaultPhotoAlbumRepositoryTest {
+    private val photoService = mock<PhotoService>()
     private val photoAlbumService = mock<PhotoAlbumService>()
     private val serviceProvider =
-        mock<ServiceProvider> { every { photoAlbum } returns photoAlbumService }
+        mock<ServiceProvider> {
+            every { photo } returns photoService
+            every { photoAlbum } returns photoAlbumService
+        }
     private val sut = DefaultPhotoAlbumRepository(provider = serviceProvider)
 
     @Test
     fun `when getAll then result is as expected`() = runTest {
-        val list = listOf(FriendicaPhotoAlbum(name = "fake-album"))
-        everySuspend { photoAlbumService.getAll() } returns list
+        val list = listOf(
+            FriendicaPhoto(id = "id-1", album = "fake-album-1"),
+            FriendicaPhoto(id = "id-2", album = "fake-album-1"),
+            FriendicaPhoto(id = "id-3", album = "fake-album-2"),
+        )
+        everySuspend { photoService.getAll() } returns list
 
         val res = sut.getAll()
 
-        assertEquals(list.map { it.toModel() }, res)
+        assertNotNull(res)
+        assertEquals(2, res.size)
+        assertEquals(MediaAlbumModel(name = "fake-album-1", items = 2), res[0])
+        assertEquals(MediaAlbumModel(name = "fake-album-2", items = 1), res[1])
         verifySuspend {
-            photoAlbumService.getAll()
+            photoService.getAll()
         }
     }
 
@@ -93,27 +107,41 @@ class DefaultPhotoAlbumRepositoryTest {
     }
 
     @Test
-    fun `when getPhotos then result is as expected`() = runTest {
-        val list = listOf(FriendicaPhoto(id = "0"))
+    fun `given first page when getPhotos then result is as expected`() = runTest {
+        val list = listOf(
+            FriendicaPhoto(id = "id-1", album = "fake-album-1"),
+            FriendicaPhoto(id = "id-2", album = "fake-album-1"),
+            FriendicaPhoto(id = "id-3", album = "fake-album-2"),
+        )
         everySuspend {
-            photoAlbumService.getPhotos(
-                album = any(),
-                maxId = any(),
-                latestFirst = any(),
-                limit = any(),
-            )
+            photoService.getAll()
         } returns list
 
-        val res = sut.getPhotos(album = "fake-album", pageCursor = null)
+        val res = sut.getPhotos(album = "fake-album-1", pageCursor = null)
 
-        assertEquals(list.map { it.toModel() }, res)
+        assertEquals(list.subList(0, 2).map { it.toModel() }, res)
         verifySuspend {
-            photoAlbumService.getPhotos(
-                album = "fake-album",
-                maxId = null,
-                latestFirst = false,
-                limit = 20,
-            )
+            photoService.getAll()
+        }
+    }
+
+    @Test
+    fun `given other page when getPhotos then result is as expected`() = runTest {
+        val list = listOf(
+            FriendicaPhoto(id = "id-1", album = "fake-album-1"),
+            FriendicaPhoto(id = "id-2", album = "fake-album-1"),
+            FriendicaPhoto(id = "id-3", album = "fake-album-2"),
+        )
+        everySuspend {
+            photoService.getAll()
+        } returns list
+
+        val res = sut.getPhotos(album = "fake-album-1", pageCursor = "id-2")
+
+        assertNotNull(res)
+        assertEquals(0, res.size)
+        verifySuspend(VerifyMode.not) {
+            photoService.getAll()
         }
     }
 }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
Probably I missed some notification, but the endpoint I was calling to get the list of photo albums got removed, and there isn't even any mention of it in the [docs](https://wiki.friendi.ca/docs/api-friendica) any longer.

This is not bad news, it makes perfectly sense to remove such an endpoint because it was a giant "code smell" with questionable semantics (making a POST call to get some data, just why?).

The unfortunate part is that it was not replaced by anything directly, especially concerning pagination. So I had to sacrifice efficiency and get all metadata, grouping them _a posteriori_ in the client. The pagination API consumed by `AlbumPhotoPaginationManager` is left unaltered because maybe in the future we will have some pagination mechanism back.
