### PR TITLE
fix: switch Ktor client engine from Android to OkHttp

### DIFF
--- a/core/utils/build.gradle.kts
+++ b/core/utils/build.gradle.kts
@@ -44,7 +44,7 @@ kotlin {
                 implementation(libs.androidx.browser)
                 implementation(libs.coil.gif)
                 implementation(libs.connectivity.device)
-                implementation(libs.ktor.android)
+                implementation(libs.ktor.okhttp)
                 implementation(libs.moko.permissions)
                 implementation(libs.moko.permissions.compose)
                 implementation(libs.moko.permissions.notifications)

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/ImageUtils.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/imageload/ImageUtils.kt
@@ -5,10 +5,14 @@ import android.graphics.BitmapFactory
 import android.os.Build
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
+import coil3.annotation.ExperimentalCoilApi
 import coil3.decode.Decoder
 import coil3.gif.AnimatedImageDecoder
 import coil3.gif.GifDecoder
 import coil3.network.NetworkFetcher
+import coil3.network.ktor3.KtorNetworkFetcherFactory
+import com.livefast.eattrash.raccoonforfriendica.core.utils.network.provideHttpClientEngine
+import io.ktor.client.HttpClient
 
 actual fun ByteArray.toComposeImageBitmap(): ImageBitmap = BitmapFactory.decodeByteArray(this, 0, size).asImageBitmap()
 
@@ -23,4 +27,8 @@ actual fun getNativeDecoders(): List<Decoder.Factory> = buildList {
     }
 }
 
-actual fun getNativeFetchers(): List<NetworkFetcher.Factory> = emptyList()
+@OptIn(ExperimentalCoilApi::class)
+actual fun getNativeFetchers(): List<NetworkFetcher.Factory> = buildList {
+    val httpClient = HttpClient(provideHttpClientEngine())
+    add(KtorNetworkFetcherFactory(httpClient))
+}

--- a/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/network/ProvideHttpClientEngine.kt
+++ b/core/utils/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/network/ProvideHttpClientEngine.kt
@@ -1,6 +1,6 @@
 package com.livefast.eattrash.raccoonforfriendica.core.utils.network
 
 import io.ktor.client.engine.HttpClientEngine
-import io.ktor.client.engine.android.Android
+import io.ktor.client.engine.okhttp.OkHttp
 
-actual fun provideHttpClientEngine(): HttpClientEngine = Android.create()
+actual fun provideHttpClientEngine(): HttpClientEngine = OkHttp.create()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -121,7 +121,7 @@ ktlint-compose-rules = { module = "io.nlopez.compose.rules:ktlint", version.ref 
 ktor-serialization = { module = "io.ktor:ktor-client-serialization", version.ref = "ktor" }
 ktor-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
-ktor-android = { module = "io.ktor:ktor-client-android", version.ref = "ktor" }
+ktor-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 ktor-contentnegotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-auth = { module = "io.ktor:ktor-client-auth", version.ref = "ktor" }


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR is a tentative fix for a runtime exception when scrolling timelines with many images:  `java.lang.IllegalStateException: Unbalanced enter/exit`.

This appears to be a known issue when using Ktor's Android engine (which is based on `HttpURLConnection`) in conjunction with rapid request cancellation, e.g. during fast scrolling in a list with images.

The fix involves switching from the Android engine to the `OkHttp` engine on Android, which handles cancellation more robustly and avoids this Okio state conflict.