### PR TITLE
refactor(build): add convention plugin for DI

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -41,6 +41,11 @@ gradlePlugin {
             implementationClass = "plugins.KotlinMultiplatformPlugin"
         }
 
+        register("diPlugin") {
+            id = "com.livefast.eattrash.di"
+            implementationClass = "plugins.DiPlugin"
+        }
+
         register("serializationPlugin") {
             id = "com.livefast.eattrash.serialization"
             implementationClass = "plugins.SerializationPlugin"

--- a/build-logic/convention/src/main/kotlin/extensions/ConfigureDi.kt
+++ b/build-logic/convention/src/main/kotlin/extensions/ConfigureDi.kt
@@ -1,0 +1,42 @@
+package extensions
+
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import utils.dependency
+import utils.libs
+
+interface CustomDiExtension {
+    fun useViewModels()
+}
+
+internal fun Project.configureDi(extension: KotlinMultiplatformExtension) {
+    extensions.create(
+        CustomDiExtension::class.java,
+        "customDiExtension",
+        CustomDiExtensionImpl::class.java,
+        this,
+    )
+    extension.apply {
+        sourceSets.apply {
+            commonMain {
+                dependencies {
+                    implementation(project.dependencies.platform(libs.findLibrary("koin-bom").dependency))
+                    implementation(libs.findLibrary("koin-core").dependency)
+                }
+            }
+        }
+    }
+}
+
+open class CustomDiExtensionImpl(private val target: Project) : CustomDiExtension {
+    override fun useViewModels() {
+        with(target) {
+            extensions.configure<KotlinMultiplatformExtension> {
+                sourceSets.getByName("commonMain").dependencies {
+                    implementation(libs.findLibrary("koin-compose-viewmodel").dependency)
+                }
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/plugins/DiPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/plugins/DiPlugin.kt
@@ -1,0 +1,16 @@
+package plugins
+
+import extensions.configureDi
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
+class DiPlugin : Plugin<Project>  {
+    override fun apply(target: Project) {
+        with(target) {
+            extensions.configure(KotlinMultiplatformExtension::class.java) {
+               configureDi(this)
+            }
+        }
+    }
+}

--- a/core/api/build.gradle.kts
+++ b/core/api/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.serialization")
     id("com.livefast.eattrash.spotless")
 }
@@ -8,8 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.core)
                 implementation(libs.ktor.contentnegotiation)
                 implementation(libs.ktor.auth)
                 implementation(libs.ktor.json)

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/di/ApiModule.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/di/ApiModule.kt
@@ -55,7 +55,7 @@ internal data class ServiceCreationArgs(val baseUrl: String, val client: HttpCli
 
 val apiModule = module {
     single<Json> {
-        JsonSerializer
+        Json { ignoreUnknownKeys = true }
     }
     single<HttpClientEngine> {
         provideHttpClientEngine()
@@ -157,5 +157,3 @@ val apiModule = module {
         DefaultUserService(baseUrl = arg.baseUrl, client = arg.client)
     }
 }
-
-private val JsonSerializer = Json { ignoreUnknownKeys = true }

--- a/core/appearance/build.gradle.kts
+++ b/core/appearance/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.serialization")
     id("com.livefast.eattrash.test")
     id("com.livefast.eattrash.spotless")
@@ -15,8 +16,6 @@ kotlin {
         }
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.core)
                 implementation(libs.materialKolor)
 
                 implementation(projects.core.di)

--- a/core/architecture/build.gradle.kts
+++ b/core/architecture/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -9,8 +10,6 @@ kotlin {
         commonMain {
             dependencies {
                 implementation(libs.kotlinx.coroutines)
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.core)
                 implementation(projects.core.di)
             }
         }

--- a/core/commonui/components/build.gradle.kts
+++ b/core/commonui/components/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,8 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.core)
                 implementation(libs.coil.compose)
                 implementation(libs.compose.colorpicker)
                 implementation(libs.compose.multiplatform.media.player)

--- a/core/commonui/content/build.gradle.kts
+++ b/core/commonui/content/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,8 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.core)
                 implementation(libs.calf)
                 implementation(libs.ksoup.html)
 

--- a/core/di/build.gradle.kts
+++ b/core/di/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -7,8 +8,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.core)
             }
         }
     }

--- a/core/di/testutils/build.gradle.kts
+++ b/core/di/testutils/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -9,7 +10,6 @@ kotlin {
             dependencies {
                 implementation(kotlin("test-junit"))
                 implementation(libs.androidx.test.core)
-                implementation(project.dependencies.platform(libs.koin.bom))
                 implementation(libs.koin.test)
 
                 implementation(projects.core.di)

--- a/core/l10n/build.gradle.kts
+++ b/core/l10n/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.test")
     id("com.livefast.eattrash.spotless")
 }
@@ -10,8 +11,6 @@ kotlin {
         commonMain {
             dependencies {
                 implementation(libs.compose.components.resources)
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.core)
 
                 implementation(projects.core.di)
             }

--- a/core/navigation/build.gradle.kts
+++ b/core/navigation/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.test")
     id("com.livefast.eattrash.spotless")
     id("com.livefast.eattrash.serialization")
@@ -9,9 +10,6 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation(project.dependencies.platform(libs.koin.bom))
-            implementation(libs.koin.core)
-
             implementation(projects.core.di)
             implementation(projects.core.utils)
             implementation(projects.domain.content.data)

--- a/core/notifications/build.gradle.kts
+++ b/core/notifications/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.test")
     id("com.livefast.eattrash.spotless")
 }
@@ -9,9 +10,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.core)
-
                 implementation(projects.core.di)
                 implementation(projects.core.utils)
                 implementation(projects.domain.content.data)

--- a/core/persistence/build.gradle.kts
+++ b/core/persistence/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
     alias(libs.plugins.ksp)
     alias(libs.plugins.room)
@@ -9,8 +10,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.core)
                 implementation(libs.kotlinx.coroutines)
                 implementation(libs.room.sqlite)
                 implementation(libs.room.runtime)

--- a/core/preferences/build.gradle.kts
+++ b/core/preferences/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.test")
     id("com.livefast.eattrash.spotless")
 }
@@ -14,8 +15,6 @@ kotlin {
         }
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.core)
                 implementation(libs.multiplatform.settings)
                 implementation(libs.kotlinx.coroutines)
             }

--- a/core/resources/build.gradle.kts
+++ b/core/resources/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -10,8 +11,6 @@ kotlin {
             dependencies {
                 implementation(libs.compose.components.resources)
                 implementation(libs.compose.multiplatform.media.player)
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.core)
 
                 implementation(projects.core.di)
             }

--- a/core/translation/build.gradle.kts
+++ b/core/translation/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.serialization")
     id("com.livefast.eattrash.test")
     id("com.livefast.eattrash.spotless")
@@ -8,8 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.core)
                 implementation(libs.ktor.client.core)
                 implementation(libs.ktor.contentnegotiation)
                 implementation(libs.ktor.json)

--- a/core/utils/build.gradle.kts
+++ b/core/utils/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.sentryDsn")
     id("com.livefast.eattrash.test")
     id("com.livefast.eattrash.spotless")
@@ -27,8 +28,6 @@ kotlin {
                 implementation(libs.coil)
                 implementation(libs.coil.network.ktor)
                 implementation(libs.connectivity.core)
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.core)
                 implementation(libs.ktor.cio)
                 implementation(libs.sentry)
 

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -14,6 +14,7 @@ kotlin {
             dependencies {
                 implementation(project.dependencies.platform(libs.koin.bom))
                 implementation(libs.koin.core)
+
                 implementation(projects.shared)
             }
         }

--- a/domain/content/pagination/build.gradle.kts
+++ b/domain/content/pagination/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.test")
     id("com.livefast.eattrash.spotless")
 }
@@ -8,8 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.core)
                 implementation(libs.kotlinx.coroutines)
 
                 implementation(projects.core.notifications)

--- a/domain/content/repository/build.gradle.kts
+++ b/domain/content/repository/build.gradle.kts
@@ -1,16 +1,15 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
+    id("com.livefast.eattrash.di")
+    id("com.livefast.eattrash.serialization")
     id("com.livefast.eattrash.test")
     id("com.livefast.eattrash.spotless")
-    id("com.livefast.eattrash.serialization")
 }
 
 kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.core)
                 implementation(libs.kotlinx.coroutines)
                 implementation(libs.ktor.client.core)
 

--- a/domain/content/usecase/build.gradle.kts
+++ b/domain/content/usecase/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.test")
     id("com.livefast.eattrash.spotless")
 }
@@ -9,8 +10,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.core)
                 implementation(libs.kotlinx.coroutines)
                 implementation(libs.ksoup.html)
 

--- a/domain/identity/repository/build.gradle.kts
+++ b/domain/identity/repository/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.test")
     id("com.livefast.eattrash.spotless")
     id("com.livefast.eattrash.serialization")
@@ -10,8 +11,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.core)
                 implementation(libs.ktor.client.core)
 
                 implementation(projects.core.api)

--- a/domain/identity/usecase/build.gradle.kts
+++ b/domain/identity/usecase/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.serialization")
     id("com.livefast.eattrash.test")
     id("com.livefast.eattrash.spotless")
@@ -15,8 +16,6 @@ kotlin {
         }
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.core)
                 implementation(libs.kotlinx.coroutines)
                 implementation(libs.kotlinx.serialization.json)
 

--- a/domain/pullnotifications/build.gradle.kts
+++ b/domain/pullnotifications/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -12,9 +13,6 @@ kotlin {
         }
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.core)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.di)
                 implementation(projects.core.l10n)

--- a/domain/pushnotifications/build.gradle.kts
+++ b/domain/pushnotifications/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.test")
     id("com.livefast.eattrash.spotless")
 }
@@ -20,8 +21,6 @@ kotlin {
         }
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.core)
                 implementation(libs.ktor.client.core)
 
                 implementation(projects.core.api)

--- a/domain/urlhandler/build.gradle.kts
+++ b/domain/urlhandler/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.test")
     id("com.livefast.eattrash.spotless")
 }
@@ -9,9 +10,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.core)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.di)
                 implementation(projects.core.l10n)

--- a/feature/acknowledgements/build.gradle.kts
+++ b/feature/acknowledgements/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.serialization")
     id("com.livefast.eattrash.test")
     id("com.livefast.eattrash.spotless")
@@ -10,8 +11,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
                 implementation(libs.ktor.client.core)
 
                 implementation(projects.core.appearance)
@@ -24,4 +23,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/announcements/build.gradle.kts
+++ b/feature/announcements/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -28,4 +26,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/calendar/build.gradle.kts
+++ b/feature/calendar/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -29,4 +27,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/circles/build.gradle.kts
+++ b/feature/circles/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -32,4 +30,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/composer/build.gradle.kts
+++ b/feature/composer/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -32,4 +30,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/directmessages/build.gradle.kts
+++ b/feature/directmessages/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -29,4 +27,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/drawer/build.gradle.kts
+++ b/feature/drawer/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -28,4 +26,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/entrydetail/build.gradle.kts
+++ b/feature/entrydetail/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -32,4 +30,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/entrylist/build.gradle.kts
+++ b/feature/entrylist/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -32,4 +30,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/explore/build.gradle.kts
+++ b/feature/explore/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -32,4 +30,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/followrequests/build.gradle.kts
+++ b/feature/followrequests/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -29,4 +27,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/gallery/build.gradle.kts
+++ b/feature/gallery/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -29,4 +27,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/hashtag/build.gradle.kts
+++ b/feature/hashtag/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -32,4 +30,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/imagedetail/build.gradle.kts
+++ b/feature/imagedetail/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -21,4 +19,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/inbox/build.gradle.kts
+++ b/feature/inbox/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -31,4 +29,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/licences/build.gradle.kts
+++ b/feature/licences/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -26,4 +24,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/login/build.gradle.kts
+++ b/feature/login/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -27,4 +25,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/manageblocks/build.gradle.kts
+++ b/feature/manageblocks/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -28,4 +26,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/nodeinfo/build.gradle.kts
+++ b/feature/nodeinfo/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.test")
     id("com.livefast.eattrash.uiTest")
     id("com.livefast.eattrash.spotless")
@@ -10,9 +11,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -29,4 +27,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/profile/build.gradle.kts
+++ b/feature/profile/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -32,6 +30,10 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }
 
 spotless {

--- a/feature/report/build.gradle.kts
+++ b/feature/report/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -26,4 +24,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/search/build.gradle.kts
+++ b/feature/search/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -32,4 +30,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -31,4 +29,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/shortcuts/build.gradle.kts
+++ b/feature/shortcuts/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -32,4 +30,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/thread/build.gradle.kts
+++ b/feature/thread/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -32,4 +30,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/timeline/build.gradle.kts
+++ b/feature/timeline/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -32,4 +30,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/unpublished/build.gradle.kts
+++ b/feature/unpublished/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -29,4 +27,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/userdetail/build.gradle.kts
+++ b/feature/userdetail/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -32,4 +30,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/feature/userlist/build.gradle.kts
+++ b/feature/userlist/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.spotless")
 }
 
@@ -8,9 +9,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
-
                 implementation(projects.core.appearance)
                 implementation(projects.core.architecture)
                 implementation(projects.core.commonui.components)
@@ -30,4 +28,8 @@ kotlin {
             }
         }
     }
+}
+
+customDiExtension {
+    useViewModels()
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -103,7 +103,6 @@ junit = { module = "junit:junit", version.ref = "junit" }
 koin-bom = { module = "io.insert-koin:koin-bom", version.ref = "koin" }
 koin-android = { module = "io.insert-koin:koin-android" }
 koin-core = { module = "io.insert-koin:koin-core" }
-koin-compose = { module = "io.insert-koin:koin-compose" }
 koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel" }
 koin-test = { module = "io.insert-koin:koin-test" }
 
@@ -164,7 +163,6 @@ jetbrains-compose = { id = "org.jetbrains.compose", version.ref = "compose-plugi
 compose-desktop-linux-deps = { id = "io.github.kdroidfilter.compose.linux.packagedeps", version.ref = "compose-desktop-linux-deps" }
 
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
-
 kotlinx-kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
+    id("com.livefast.eattrash.di")
     id("com.livefast.eattrash.test")
     id("com.livefast.eattrash.spotless")
     id("com.livefast.eattrash.serialization")
@@ -19,8 +20,6 @@ kotlin {
 
                 implementation(libs.coil)
                 implementation(libs.compose.multiplatform.media.player)
-                implementation(project.dependencies.platform(libs.koin.bom))
-                implementation(libs.koin.compose.viewmodel)
                 implementation(libs.ktor.client.core)
 
                 implementation(projects.core.api)
@@ -99,6 +98,10 @@ customKotlinMultiplatformExtension {
     baseName.set("shared")
     // Required when using NativeSQLiteDriver
     iOSCustomLinkerOptions.set(listOf("-lsqlite3"))
+}
+
+customDiExtension {
+    useViewModels()
 }
 
 dependencies {


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR centralized DI configuration in a new `"com.livefast.eattrash.di"` convention plugin, removing some of the boilerplate introduced in #1311 (in build scripts).

This will make it easier in the future to change Koin's configuration, e.g. switching from the classic DSL to using the new compiler plugin (with either DSL style or annotation style), which looks very promising.