### PR TITLE
refactor(di): mark direct DI accesses as delicate

### DIFF
--- a/androidApp/src/main/kotlin/com/livefast/eattrash/raccoonforfriendica/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/livefast/eattrash/raccoonforfriendica/MainActivity.kt
@@ -11,11 +11,13 @@ import androidx.activity.enableEdgeToEdge
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
 import com.livefast.eattrash.raccoonforfriendica.auth.DefaultAuthManager
+import com.livefast.eattrash.raccoonforfriendica.core.di.DelicateDiApi
+import com.livefast.eattrash.raccoonforfriendica.core.di.getByInjection
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.BottomNavigationSection
+import com.livefast.eattrash.raccoonforfriendica.core.navigation.NavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getMainRouter
-import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.InboxManager
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di.getAuthManager
+import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AuthManager
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.launchIn
@@ -24,7 +26,11 @@ import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
+@OptIn(DelicateDiApi::class)
 class MainActivity : ComponentActivity() {
+    private val authManager = getByInjection(AuthManager::class)
+    private val navigationCoordinator = getByInjection(NavigationCoordinator::class)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         var loadingFinished = false
         installSplashScreen().setKeepOnScreenCondition {
@@ -33,7 +39,6 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
-        val navigationCoordinator = getNavigationCoordinator()
         val backPressedCallback =
             object : OnBackPressedCallback(true) {
                 override fun handleOnBackPressed() {
@@ -104,7 +109,6 @@ class MainActivity : ComponentActivity() {
             // OAuth2 redirect URL
             uri.scheme == DefaultAuthManager.REDIRECT_SCHEME &&
                 uri.host == DefaultAuthManager.REDIRECT_HOST -> {
-                val authManager = getAuthManager()
                 lifecycleScope.launch {
                     try {
                         authManager.performTokenExchange(uri.toString())
@@ -118,7 +122,6 @@ class MainActivity : ComponentActivity() {
                 // try opening deep link URL
                 uri.toString().takeUnless { it.isEmpty() }?.also { deeplinkUrl ->
                     lifecycleScope.launch {
-                        val navigationCoordinator = getNavigationCoordinator()
                         navigationCoordinator.submitDeeplink(deeplinkUrl)
                     }
                 }
@@ -158,7 +161,6 @@ class MainActivity : ComponentActivity() {
         lifecycleScope.launch {
             // workaround: wait until the root NavigationAdapter has been set
             delay(1.seconds)
-            val navigationCoordinator = getNavigationCoordinator()
             navigationCoordinator.popUntilRoot()
             navigationCoordinator.setCurrentSection(BottomNavigationSection.Inbox())
         }

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/di/GetService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/di/GetService.kt
@@ -1,9 +1,0 @@
-package com.livefast.eattrash.raccoonforfriendica.core.api.di
-
-import com.livefast.eattrash.raccoonforfriendica.core.di.getByInjection
-import org.koin.core.parameter.parametersOf
-
-internal inline fun <reified T : Any> getService(args: ServiceCreationArgs): T {
-    val res: T = getByInjection(clazz = T::class, parameters = { parametersOf(args) })
-    return res
-}

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/DefaultServiceProvider.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/DefaultServiceProvider.kt
@@ -1,7 +1,6 @@
 package com.livefast.eattrash.raccoonforfriendica.core.api.provider
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.di.ServiceCreationArgs
-import com.livefast.eattrash.raccoonforfriendica.core.api.di.getService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.AnnouncementService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.AppService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.DirectMessageService
@@ -24,6 +23,8 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.service.TimelineServic
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.TrendsService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.UserService
 import com.livefast.eattrash.raccoonforfriendica.core.api.utils.defaultLogger
+import com.livefast.eattrash.raccoonforfriendica.core.di.DelicateDiApi
+import com.livefast.eattrash.raccoonforfriendica.core.di.getByInjection
 import com.livefast.eattrash.raccoonforfriendica.core.utils.appinfo.AppInfoRepository
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
@@ -47,6 +48,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.serialization.json.Json
+import org.koin.core.parameter.parametersOf
 
 internal class DefaultServiceProvider(
     private val factory: HttpClientEngine,
@@ -196,26 +198,30 @@ internal class DefaultServiceProvider(
 
         this.client = currentClient
         val creationArgs = ServiceCreationArgs(baseUrl = baseUrl, client = currentClient)
-        announcement = getService(creationArgs)
-        app = getService(creationArgs)
-        directMessage = getService(creationArgs)
-        event = getService(creationArgs)
-        followRequest = getService(creationArgs)
-        instance = getService(creationArgs)
-        list = getService(creationArgs)
-        marker = getService(creationArgs)
-        media = getService(creationArgs)
-        notification = getService(creationArgs)
-        photo = getService(creationArgs)
-        photoAlbum = getService(creationArgs)
-        poll = getService(creationArgs)
-        push = getService(creationArgs)
-        report = getService(creationArgs)
-        search = getService(creationArgs)
-        status = getService(creationArgs)
-        tag = getService(creationArgs)
-        timeline = getService(creationArgs)
-        trend = getService(creationArgs)
-        user = getService(creationArgs)
+        announcement = createServiceInstance(creationArgs)
+        app = createServiceInstance(creationArgs)
+        directMessage = createServiceInstance(creationArgs)
+        event = createServiceInstance(creationArgs)
+        followRequest = createServiceInstance(creationArgs)
+        instance = createServiceInstance(creationArgs)
+        list = createServiceInstance(creationArgs)
+        marker = createServiceInstance(creationArgs)
+        media = createServiceInstance(creationArgs)
+        notification = createServiceInstance(creationArgs)
+        photo = createServiceInstance(creationArgs)
+        photoAlbum = createServiceInstance(creationArgs)
+        poll = createServiceInstance(creationArgs)
+        push = createServiceInstance(creationArgs)
+        report = createServiceInstance(creationArgs)
+        search = createServiceInstance(creationArgs)
+        status = createServiceInstance(creationArgs)
+        tag = createServiceInstance(creationArgs)
+        timeline = createServiceInstance(creationArgs)
+        trend = createServiceInstance(creationArgs)
+        user = createServiceInstance(creationArgs)
     }
+
+    @OptIn(DelicateDiApi::class)
+    private inline fun <reified T : Any> createServiceInstance(args: ServiceCreationArgs): T =
+        getByInjection(clazz = T::class, parameters = { parametersOf(args) })
 }

--- a/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/di/Utils.kt
+++ b/core/appearance/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/appearance/di/Utils.kt
@@ -5,19 +5,17 @@ import androidx.compose.runtime.remember
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.repository.ThemeRepository
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.BarColorProvider
 import com.livefast.eattrash.raccoonforfriendica.core.appearance.theme.ColorSchemeProvider
+import com.livefast.eattrash.raccoonforfriendica.core.di.DelicateDiApi
 import com.livefast.eattrash.raccoonforfriendica.core.di.getByInjection
 
-fun getThemeRepository(): ThemeRepository = getByInjection(ThemeRepository::class)
-
+@OptIn(DelicateDiApi::class)
 @Composable
-fun rememberThemeRepository() = remember { getThemeRepository() }
+fun rememberThemeRepository() = remember { getByInjection(ThemeRepository::class) }
 
-fun getColorSchemeProvider(): ColorSchemeProvider = getByInjection(ColorSchemeProvider::class)
-
+@OptIn(DelicateDiApi::class)
 @Composable
-fun rememberColorSchemeProvider() = remember { getColorSchemeProvider() }
+fun rememberColorSchemeProvider() = remember { getByInjection(ColorSchemeProvider::class) }
 
-fun getBarColorProvider(): BarColorProvider = getByInjection(BarColorProvider::class)
-
+@OptIn(DelicateDiApi::class)
 @Composable
-fun rememberBarColorProvider() = remember { getBarColorProvider() }
+fun rememberBarColorProvider() = remember { getByInjection(BarColorProvider::class) }

--- a/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/di/Utils.kt
+++ b/core/commonui/components/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/components/di/Utils.kt
@@ -3,6 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica.core.commonui.components.di
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.FabNestedScrollConnection
+import com.livefast.eattrash.raccoonforfriendica.core.di.DelicateDiApi
 import com.livefast.eattrash.raccoonforfriendica.core.di.getByInjection
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.di.l10nModule
 import com.livefast.eattrash.raccoonforfriendica.core.resources.di.resourcesModule
@@ -10,10 +11,9 @@ import org.koin.core.KoinApplication
 import org.koin.core.context.startKoin
 import org.koin.core.module.Module
 
-fun getFabNestedScrollConnection(): FabNestedScrollConnection = getByInjection(FabNestedScrollConnection::class)
-
+@OptIn(DelicateDiApi::class)
 @Composable
-fun rememberFabNestedScrollConnection() = remember { getFabNestedScrollConnection() }
+fun rememberFabNestedScrollConnection() = remember { getByInjection(FabNestedScrollConnection::class) }
 
 @Composable
 fun setupPreview(vararg modules: Module): KoinApplication = remember {

--- a/core/di/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/di/GetByInjection.kt
+++ b/core/di/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/di/GetByInjection.kt
@@ -5,6 +5,7 @@ import org.koin.core.qualifier.Qualifier
 import org.koin.java.KoinJavaComponent.inject
 import kotlin.reflect.KClass
 
+@DelicateDiApi
 actual fun <T : Any> getByInjection(clazz: KClass<T>, qualifier: Qualifier?, parameters: ParametersDefinition?): T {
     val res: T by inject(clazz = clazz.java, qualifier = qualifier, parameters = parameters)
     return res

--- a/core/di/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/di/GetByInjection.kt
+++ b/core/di/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/di/GetByInjection.kt
@@ -4,6 +4,34 @@ import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.qualifier.Qualifier
 import kotlin.reflect.KClass
 
+/**
+ * Marks delicate DI APIs that should be used with caution (only in specific scenarios where standard constructor
+ * injection is not possible, e.g. in Compose `remember` blocks to provide dependencies to the UI layer).
+ *
+ * @see getByInjection documentation for details
+ */
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "This API is delicate and should be used with caution. " +
+        "It is intended for use in controlled environments, such as within Compose 'remember' blocks " +
+        "to expose UI-related dependencies to the UI layer.",
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+annotation class DelicateDiApi
+
+/**
+ * Resolves a dependency from the DI container manually.
+ *
+ * This function should be used with caution and only in specific scenarios where standard constructor injection is not
+ * possible (e.g. in Compose `remember` blocks to provide dependencies to the UI layer).
+ *
+ * @param clazz [KClass] of the dependency to resolve
+ * @param qualifier DI [Qualifier] (optional)
+ * @param parameters DI factory [ParametersDefinition] (optional)
+ * @return resolved dependency of type [T]
+ */
+@DelicateDiApi
 expect fun <T : Any> getByInjection(
     clazz: KClass<T>,
     qualifier: Qualifier? = null,

--- a/core/di/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/di/GetByInjection.kt
+++ b/core/di/src/iosMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/di/GetByInjection.kt
@@ -6,6 +6,7 @@ import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.qualifier.Qualifier
 import kotlin.reflect.KClass
 
+@DelicateDiApi
 actual fun <T : Any> getByInjection(clazz: KClass<T>, qualifier: Qualifier?, parameters: ParametersDefinition?): T =
     InnerHelper.retrieve(qualifier = qualifier, parameters = parameters)
 

--- a/core/di/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/di/GetByInjection.kt
+++ b/core/di/src/jvmMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/di/GetByInjection.kt
@@ -5,6 +5,7 @@ import org.koin.core.qualifier.Qualifier
 import org.koin.java.KoinJavaComponent.inject
 import kotlin.reflect.KClass
 
+@DelicateDiApi
 actual fun <T : Any> getByInjection(clazz: KClass<T>, qualifier: Qualifier?, parameters: ParametersDefinition?): T {
     val res: T by inject(clazz = clazz.java, qualifier = qualifier, parameters = parameters)
     return res

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/ProvideStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/ProvideStrings.kt
@@ -5,16 +5,17 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.platform.LocalLayoutDirection
+import com.livefast.eattrash.raccoonforfriendica.core.di.DelicateDiApi
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.di.getStrings
 
 val LocalStrings: ProvidableCompositionLocal<Strings> =
-    staticCompositionLocalOf { getStrings(Locales.EN) }
+    staticCompositionLocalOf {
+        error("CompositionLocal Strings not found")
+    }
 
+@OptIn(DelicateDiApi::class)
 @Composable
-fun ProvideStrings(
-    lang: String,
-    content: @Composable () -> Unit,
-) {
+fun ProvideStrings(lang: String, content: @Composable () -> Unit) {
     CompositionLocalProvider(
         LocalStrings provides getStrings(lang),
         LocalLayoutDirection provides lang.toLanguageDirection(),

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/di/Utils.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/di/Utils.kt
@@ -2,14 +2,15 @@ package com.livefast.eattrash.raccoonforfriendica.core.l10n.di
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import com.livefast.eattrash.raccoonforfriendica.core.di.DelicateDiApi
 import com.livefast.eattrash.raccoonforfriendica.core.di.getByInjection
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.L10nManager
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.Strings
 import org.koin.core.parameter.parametersOf
 
-fun getL10nManager(): L10nManager = getByInjection(L10nManager::class)
-
+@OptIn(DelicateDiApi::class)
 @Composable
-fun rememberL10nManager() = remember { getL10nManager() }
+fun rememberL10nManager() = remember { getByInjection(L10nManager::class) }
 
-fun getStrings(lang: String): Strings = getByInjection(clazz = Strings::class, parameters = { parametersOf(lang) })
+@DelicateDiApi
+internal fun getStrings(lang: String): Strings = getByInjection(clazz = Strings::class, parameters = { parametersOf(lang) })

--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/di/Utils.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/di/Utils.kt
@@ -2,22 +2,23 @@ package com.livefast.eattrash.raccoonforfriendica.core.navigation.di
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import com.livefast.eattrash.raccoonforfriendica.core.di.DelicateDiApi
 import com.livefast.eattrash.raccoonforfriendica.core.di.getByInjection
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.DrawerCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.MainRouter
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.NavigationCoordinator
 
-fun getNavigationCoordinator(): NavigationCoordinator = getByInjection(NavigationCoordinator::class)
-
+@OptIn(DelicateDiApi::class)
 @Composable
-fun rememberNavigationCoordinator(): NavigationCoordinator = remember { getNavigationCoordinator() }
+fun rememberNavigationCoordinator(): NavigationCoordinator = remember { getByInjection(NavigationCoordinator::class) }
 
-fun getDrawerCoordinator(): DrawerCoordinator = getByInjection(DrawerCoordinator::class)
-
+@OptIn(DelicateDiApi::class)
 @Composable
-fun rememberDrawerCoordinator() = remember { getDrawerCoordinator() }
+fun rememberDrawerCoordinator() = remember { getByInjection(DrawerCoordinator::class) }
 
+@DelicateDiApi
 fun getMainRouter(): MainRouter = getByInjection(MainRouter::class)
 
+@OptIn(DelicateDiApi::class)
 @Composable
 fun rememberMainRouter() = remember { getMainRouter() }

--- a/core/notifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/notifications/di/Utils.kt
+++ b/core/notifications/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/notifications/di/Utils.kt
@@ -1,7 +1,0 @@
-package com.livefast.eattrash.raccoonforfriendica.core.notifications.di
-
-import com.livefast.eattrash.raccoonforfriendica.core.di.getByInjection
-import com.livefast.eattrash.raccoonforfriendica.core.notifications.NotificationCenter
-
-@Deprecated("Use the instance from dependency injection (e.g. as a constructor parameter)")
-fun getNotificationCenter(): NotificationCenter = getByInjection(NotificationCenter::class)

--- a/core/resources/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/resources/ProvideResources.kt
+++ b/core/resources/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/resources/ProvideResources.kt
@@ -4,15 +4,21 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.staticCompositionLocalOf
-import com.livefast.eattrash.raccoonforfriendica.core.resources.di.getCoreResources
+import com.livefast.eattrash.raccoonforfriendica.core.di.DelicateDiApi
+import com.livefast.eattrash.raccoonforfriendica.core.resources.di.rememberCoreResources
 
+@OptIn(DelicateDiApi::class)
 val LocalResources: ProvidableCompositionLocal<CoreResources> =
-    staticCompositionLocalOf { getCoreResources() }
+    staticCompositionLocalOf {
+        error("CompositionLocal CoreResources not found")
+    }
 
+@OptIn(DelicateDiApi::class)
 @Composable
 fun ProvideResources(content: @Composable () -> Unit) {
+    val resources = rememberCoreResources()
     CompositionLocalProvider(
-        value = LocalResources provides getCoreResources(),
+        value = LocalResources provides resources,
         content = content,
     )
 }

--- a/core/resources/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/resources/di/Utils.kt
+++ b/core/resources/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/resources/di/Utils.kt
@@ -1,6 +1,11 @@
 package com.livefast.eattrash.raccoonforfriendica.core.resources.di
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import com.livefast.eattrash.raccoonforfriendica.core.di.DelicateDiApi
 import com.livefast.eattrash.raccoonforfriendica.core.di.getByInjection
 import com.livefast.eattrash.raccoonforfriendica.core.resources.CoreResources
 
-fun getCoreResources(): CoreResources = getByInjection(CoreResources::class)
+@OptIn(DelicateDiApi::class)
+@Composable
+fun rememberCoreResources(): CoreResources = remember { getByInjection(CoreResources::class) }

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/Utils.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/di/Utils.kt
@@ -3,6 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica.core.utils.di
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.Clipboard
+import com.livefast.eattrash.raccoonforfriendica.core.di.DelicateDiApi
 import com.livefast.eattrash.raccoonforfriendica.core.di.getByInjection
 import com.livefast.eattrash.raccoonforfriendica.core.utils.appinfo.AppInfoRepository
 import com.livefast.eattrash.raccoonforfriendica.core.utils.calendar.CalendarHelper
@@ -15,45 +16,40 @@ import com.livefast.eattrash.raccoonforfriendica.core.utils.network.NetworkState
 import com.livefast.eattrash.raccoonforfriendica.core.utils.share.ShareHelper
 import org.koin.core.parameter.parametersOf
 
-fun getImageLoaderProvider(): ImageLoaderProvider = getByInjection(ImageLoaderProvider::class)
-
+@OptIn(DelicateDiApi::class)
 @Composable
-fun rememberImageLoaderProvider() = remember { getImageLoaderProvider() }
+fun rememberImageLoaderProvider() = remember { getByInjection(ImageLoaderProvider::class) }
 
-fun getGalleryHelper(): GalleryHelper = getByInjection(GalleryHelper::class)
-
+@OptIn(DelicateDiApi::class)
 @Composable
-fun rememberGalleryHelper() = remember { getGalleryHelper() }
+fun rememberGalleryHelper() = remember { getByInjection(GalleryHelper::class) }
 
-fun getShareHelper(): ShareHelper = getByInjection(ShareHelper::class)
-
+@OptIn(DelicateDiApi::class)
 @Composable
-fun rememberShareHelper() = remember { getShareHelper() }
+fun rememberShareHelper() = remember { getByInjection(ShareHelper::class) }
 
-fun getAppInfoRepository(): AppInfoRepository = getByInjection(AppInfoRepository::class)
-
+@OptIn(DelicateDiApi::class)
 @Composable
-fun rememberAppInfoRepository() = remember { getAppInfoRepository() }
+fun rememberAppInfoRepository() = remember { getByInjection(AppInfoRepository::class) }
 
-fun getBlurHashRepository(): BlurHashRepository = getByInjection(BlurHashRepository::class)
-
+@OptIn(DelicateDiApi::class)
 @Composable
-fun rememberBlurHashRepository() = remember { getBlurHashRepository() }
+fun rememberBlurHashRepository() = remember { getByInjection(BlurHashRepository::class) }
 
-fun getCrashReportManager(): CrashReportManager = getByInjection(CrashReportManager::class)
-
-fun getCalendarHelper(): CalendarHelper = getByInjection(CalendarHelper::class)
-
+@OptIn(DelicateDiApi::class)
 @Composable
-fun rememberCalendarHelper() = remember { getCalendarHelper() }
+fun rememberCrashReportManager() = remember { getByInjection(CrashReportManager::class) }
 
-fun getNetworkStateObserver(): NetworkStateObserver = getByInjection(NetworkStateObserver::class)
-
+@OptIn(DelicateDiApi::class)
 @Composable
-fun rememberNetworkStateObserver() = remember { getNetworkStateObserver() }
+fun rememberCalendarHelper() = remember { getByInjection(CalendarHelper::class) }
 
-fun getClipboardHelper(clipboard: Clipboard): ClipboardHelper =
+@OptIn(DelicateDiApi::class)
+@Composable
+fun rememberNetworkStateObserver() = remember { getByInjection(NetworkStateObserver::class) }
+
+@OptIn(DelicateDiApi::class)
+@Composable
+fun rememberClipboardHelper(clipboard: Clipboard) = remember {
     getByInjection(clazz = ClipboardHelper::class, parameters = { parametersOf(clipboard) })
-
-@Composable
-fun rememberClipboardHelper(clipboard: Clipboard) = remember { getClipboardHelper(clipboard) }
+}

--- a/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/fs/FileSystemManager.kt
+++ b/core/utils/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/utils/fs/FileSystemManager.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.core.utils.fs
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import com.livefast.eattrash.raccoonforfriendica.core.di.DelicateDiApi
 import com.livefast.eattrash.raccoonforfriendica.core.di.getByInjection
 import okio.Path
 
@@ -25,7 +26,6 @@ interface FileSystemManager {
     fun getTempDir(): Path
 }
 
-fun getFileSystemManager(): FileSystemManager = getByInjection(FileSystemManager::class)
-
+@OptIn(DelicateDiApi::class)
 @Composable
-fun rememberFileSystemManager() = remember { getFileSystemManager() }
+fun rememberFileSystemManager() = remember { getByInjection(FileSystemManager::class) }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/Utils.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/di/Utils.kt
@@ -1,19 +1,8 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.repository.di
 
+import com.livefast.eattrash.raccoonforfriendica.core.di.DelicateDiApi
 import com.livefast.eattrash.raccoonforfriendica.core.di.getByInjection
-import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.AttachmentCache
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.LocalItemCache
-import org.koin.core.qualifier.TypeQualifier
 
+@DelicateDiApi
 fun getAttachmentCache(): AttachmentCache = getByInjection(AttachmentCache::class)
-
-@Suppress("UNCHECKED_CAST")
-fun getEntryCache(): LocalItemCache<TimelineEntryModel> {
-    val qualifier = TypeQualifier(TimelineEntryModel::class)
-    val res: LocalItemCache<TimelineEntryModel> = getByInjection(
-        LocalItemCache::class,
-        qualifier,
-    ) as LocalItemCache<TimelineEntryModel>
-    return res
-}

--- a/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/di/Utils.kt
+++ b/domain/identity/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/repository/di/Utils.kt
@@ -2,13 +2,10 @@ package com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import com.livefast.eattrash.raccoonforfriendica.core.di.DelicateDiApi
 import com.livefast.eattrash.raccoonforfriendica.core.di.getByInjection
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AuthManager
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
 
-fun getSettingsRepository(): SettingsRepository = getByInjection(SettingsRepository::class)
-
+@OptIn(DelicateDiApi::class)
 @Composable
-fun rememberSettingsRepository() = remember { getSettingsRepository() }
-
-fun getAuthManager(): AuthManager = getByInjection(AuthManager::class)
+fun rememberSettingsRepository() = remember { getByInjection(SettingsRepository::class) }

--- a/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/Utils.kt
+++ b/domain/identity/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/di/Utils.kt
@@ -2,22 +2,20 @@ package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import com.livefast.eattrash.raccoonforfriendica.core.di.DelicateDiApi
 import com.livefast.eattrash.raccoonforfriendica.core.di.getByInjection
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.ActiveAccountMonitor
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.EntryActionRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.SetupAccountUseCase
 
-fun getActiveAccountMonitor(): ActiveAccountMonitor = getByInjection(ActiveAccountMonitor::class)
-
+@OptIn(DelicateDiApi::class)
 @Composable
-fun rememberActiveAccountMonitor() = remember { getActiveAccountMonitor() }
+fun rememberActiveAccountMonitor() = remember { getByInjection(ActiveAccountMonitor::class) }
 
-fun getSetupAccountUseCase(): SetupAccountUseCase = getByInjection(SetupAccountUseCase::class)
-
+@OptIn(DelicateDiApi::class)
 @Composable
-fun rememberSetupAccountUseCase() = remember { getSetupAccountUseCase() }
+fun rememberSetupAccountUseCase() = remember { getByInjection(SetupAccountUseCase::class) }
 
-fun getEntryActionRepository(): EntryActionRepository = getByInjection(EntryActionRepository::class)
-
+@OptIn(DelicateDiApi::class)
 @Composable
-fun rememberEntryActionRepository() = remember { getEntryActionRepository() }
+fun rememberEntryActionRepository() = remember { getByInjection(EntryActionRepository::class) }

--- a/domain/pullnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pullnotifications/CheckNotificationWorker.kt
+++ b/domain/pullnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pullnotifications/CheckNotificationWorker.kt
@@ -8,19 +8,26 @@ import android.content.Intent
 import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
+import com.livefast.eattrash.raccoonforfriendica.core.di.DelicateDiApi
 import com.livefast.eattrash.raccoonforfriendica.core.di.getByInjection
-import com.livefast.eattrash.raccoonforfriendica.core.l10n.di.getStrings
+import com.livefast.eattrash.raccoonforfriendica.core.l10n.Strings
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.InboxManager
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.koin.core.parameter.parametersOf
 import java.util.Collections.max
 
+@OptIn(DelicateDiApi::class)
 internal class CheckNotificationWorker(private val context: Context, parameters: WorkerParameters) :
     CoroutineWorker(context, parameters) {
     private val inboxManager = getByInjection(InboxManager::class)
     private val settingsRepository = getByInjection(SettingsRepository::class)
-    private val strings = getStrings(settingsRepository.current.value?.lang ?: "en")
+    private val strings = getByInjection(
+        clazz = Strings::class,
+        parameters = { parametersOf(settingsRepository.current.value?.lang ?: "en") },
+    )
+
     private val notificationManager: NotificationManager
         get() = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 

--- a/domain/pushnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/service/DefaultPushService.kt
+++ b/domain/pushnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pushnotifications/service/DefaultPushService.kt
@@ -1,5 +1,6 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.service
 
+import com.livefast.eattrash.raccoonforfriendica.core.di.DelicateDiApi
 import com.livefast.eattrash.raccoonforfriendica.core.di.getByInjection
 import com.livefast.eattrash.raccoonforfriendica.core.utils.debug.logDebug
 import com.livefast.eattrash.raccoonforfriendica.domain.pushnotifications.common.UnifiedPushInteractor
@@ -8,6 +9,7 @@ import org.unifiedpush.android.connector.PushService
 import org.unifiedpush.android.connector.data.PushEndpoint
 import org.unifiedpush.android.connector.data.PushMessage
 
+@OptIn(DelicateDiApi::class)
 class DefaultPushService : PushService() {
     private val interactor = getByInjection(UnifiedPushInteractor::class)
 

--- a/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/ProvideCustomUriHandler.kt
+++ b/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/ProvideCustomUriHandler.kt
@@ -2,14 +2,13 @@ package com.livefast.eattrash.raccoonforfriendica.domain.urlhandler
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalUriHandler
-import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.di.getCustomUriHandler
+import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.di.rememberCustomUriHandler
 
 @Composable
 fun ProvideCustomUriHandler(content: @Composable () -> Unit) {
     val fallbackHandler = LocalUriHandler.current
-    val customUriHandler = remember { getCustomUriHandler(fallbackHandler) }
+    val customUriHandler = rememberCustomUriHandler(fallbackHandler)
     CompositionLocalProvider(
         value = LocalUriHandler provides customUriHandler,
         content = content,

--- a/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/di/Utils.kt
+++ b/domain/urlhandler/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/urlhandler/di/Utils.kt
@@ -1,9 +1,18 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.di
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.UriHandler
+import com.livefast.eattrash.raccoonforfriendica.core.di.DelicateDiApi
 import com.livefast.eattrash.raccoonforfriendica.core.di.getByInjection
 import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.CustomUriHandler
 import org.koin.core.parameter.parametersOf
 
-fun getCustomUriHandler(fallback: UriHandler): CustomUriHandler =
-    getByInjection(clazz = CustomUriHandler::class, parameters = { parametersOf(fallback) })
+@OptIn(DelicateDiApi::class)
+@Composable
+fun rememberCustomUriHandler(fallback: UriHandler) = remember {
+    getByInjection(
+        clazz = CustomUriHandler::class,
+        parameters = { parametersOf(fallback) },
+    )
+}

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
@@ -71,6 +71,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.SettingsSwitchRow
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.SpoilerTextField
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toOption
+import com.livefast.eattrash.raccoonforfriendica.core.di.DelicateDiApi
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.rememberNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.resources.LocalResources
@@ -132,7 +133,10 @@ fun ComposerScreen(
     val navigationCoordinator = rememberNavigationCoordinator()
     val canPopState by navigationCoordinator.canPop.collectAsState()
     val galleryHelper = rememberGalleryHelper()
-    val attachmentCache = remember { getAttachmentCache() }
+    val attachmentCache = remember {
+        @OptIn(DelicateDiApi::class)
+        getAttachmentCache()
+    }
     val focusManager = LocalFocusManager.current
     val missingDataError = LocalStrings.current.messagePostEmptyText
     val invalidVisibilityError = LocalStrings.current.messagePostInvalidVisibility

--- a/feature/nodeinfo/src/androidHostTest/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/NodeInfoScreenScaffoldTest.kt
+++ b/feature/nodeinfo/src/androidHostTest/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/nodeinfo/NodeInfoScreenScaffoldTest.kt
@@ -11,9 +11,12 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performScrollToNode
 import com.livefast.eattrash.raccoonforfriendica.core.di.testutils.KoinTestRule
+import com.livefast.eattrash.raccoonforfriendica.core.l10n.Locales
+import com.livefast.eattrash.raccoonforfriendica.core.l10n.ProvideStrings
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.di.l10nModule
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.MainRouter
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.NavigationCoordinator
+import com.livefast.eattrash.raccoonforfriendica.core.resources.ProvideResources
 import com.livefast.eattrash.raccoonforfriendica.core.resources.di.resourcesModule
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NodeInfoModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.RuleModel
@@ -156,8 +159,12 @@ class NodeInfoScreenScaffoldTest {
 
     private fun ComposeContentTestRule.setup(state: NodeInfoMviModel.State) {
         setContent {
-            CompositionLocalProvider(LocalUriHandler provides uriHandler) {
-                NodeInfoScreenScaffold(state)
+            ProvideResources {
+                ProvideStrings(lang = Locales.EN) {
+                    CompositionLocalProvider(LocalUriHandler provides uriHandler) {
+                        NodeInfoScreenScaffold(state)
+                    }
+                }
             }
         }
     }

--- a/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/profile/myaccount/MyAccountScreen.kt
@@ -61,13 +61,9 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toOption
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toReadableName
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.BottomNavigationSection
-import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getMainRouter
-import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.getNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.rememberMainRouter
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.rememberNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.utils.datetime.prettifyDate
-import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getClipboardHelper
-import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getShareHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.rememberClipboardHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.rememberShareHelper
 import com.livefast.eattrash.raccoonforfriendica.core.utils.isNearTheEnd
@@ -75,7 +71,6 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.FieldModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEntryModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.original
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.safeKey
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.getEntryActionRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.rememberEntryActionRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.openExternally
 import com.livefast.eattrash.raccoonforfriendica.feature.profile.LocalProfileTopAppBarStateWrapper

--- a/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/App.kt
+++ b/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/App.kt
@@ -22,7 +22,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -51,7 +50,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.rememberDraw
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.rememberNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.resources.ProvideResources
 import com.livefast.eattrash.raccoonforfriendica.core.utils.compose.isWidthSizeClassBelow
-import com.livefast.eattrash.raccoonforfriendica.core.utils.di.getCrashReportManager
+import com.livefast.eattrash.raccoonforfriendica.core.utils.di.rememberCrashReportManager
 import com.livefast.eattrash.raccoonforfriendica.core.utils.di.rememberNetworkStateObserver
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EntryListType
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.ProvideCustomFontScale
@@ -59,7 +58,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.di.r
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.rememberActiveAccountMonitor
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase.di.rememberSetupAccountUseCase
 import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.ProvideCustomUriHandler
-import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.di.getCustomUriHandler
+import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.di.rememberCustomUriHandler
 import com.livefast.eattrash.raccoonforfriendica.domain.urlhandler.openInternally
 import com.livefast.eattrash.raccoonforfriendica.feature.calendar.list.CalendarMviModel
 import com.livefast.eattrash.raccoonforfriendica.feature.calendar.list.CalendarViewModel
@@ -111,7 +110,7 @@ import kotlin.time.Duration.Companion.seconds
 @Composable
 fun App(onLoadingFinished: (() -> Unit)? = null) {
     // initialize crash reporting as soon as possible
-    val crashReportManager = remember { getCrashReportManager() }
+    val crashReportManager = rememberCrashReportManager()
     LaunchedEffect(crashReportManager) {
         crashReportManager.initialize()
     }
@@ -129,6 +128,7 @@ fun App(onLoadingFinished: (() -> Unit)? = null) {
     val currentSettings by settingsRepository.current.collectAsState()
     val scope = rememberCoroutineScope()
     val fallbackUriHandler = LocalUriHandler.current
+    val customUriHandler = rememberCustomUriHandler(fallbackUriHandler)
 
     val backStack = rememberNavBackStack(
         configuration = Destination.SavedStateConfiguration,
@@ -204,7 +204,6 @@ fun App(onLoadingFinished: (() -> Unit)? = null) {
     }
 
     LaunchedEffect(navigationCoordinator) {
-        val customUriHandler = getCustomUriHandler(fallbackUriHandler)
         navigationCoordinator.deepLinkUrl
             .debounce(750.milliseconds)
             .onEach { url ->
@@ -224,13 +223,13 @@ fun App(onLoadingFinished: (() -> Unit)? = null) {
         }
     }
 
-    AppTheme(
-        useDynamicColors = currentSettings?.dynamicColors == true,
-        barTheme = currentSettings?.barTheme ?: UiBarTheme.Transparent,
-    ) {
-        ProvideResources {
-            ProvideCustomUriHandler {
-                ProvideStrings(lang = currentSettings?.lang ?: Locales.EN) {
+    ProvideResources {
+        ProvideCustomUriHandler {
+            ProvideStrings(lang = currentSettings?.lang ?: Locales.EN) {
+                AppTheme(
+                    useDynamicColors = currentSettings?.dynamicColors == true,
+                    barTheme = currentSettings?.barTheme ?: UiBarTheme.Transparent,
+                ) {
                     if (isWidthSizeClassBelow(WindowWidthSizeClass.Expanded)) {
                         ModalNavigationDrawer(
                             drawerState = drawerState,
@@ -315,21 +314,29 @@ fun App(onLoadingFinished: (() -> Unit)? = null) {
                                             val exploreViewModel: ExploreMviModel = koinViewModel<ExploreViewModel>()
                                             val inboxViewModel: InboxMviModel = koinViewModel<InboxViewModel>()
                                             val profileViewModel: ProfileMviModel = koinViewModel<ProfileViewModel>()
-                                            val myAccountViewModel: MyAccountMviModel = koinViewModel<MyAccountViewModel>()
-                                            val favoritesViewModel: EntryListMviModel = koinViewModel<EntryListViewModel>{
-                                                parametersOf(EntryListViewModelArgs(type = EntryListType.Favorites))
-                                            }
-                                            val bookmarksViewModel: EntryListMviModel = koinViewModel<EntryListViewModel> {
-                                                parametersOf(EntryListViewModelArgs(type = EntryListType.Bookmarks))
-                                            }
-                                            val followedHashtagsViewModel: FollowedHashtagsMviModel = koinViewModel<FollowedHashtagsViewModel>()
-                                            val followRequestsViewModel: FollowRequestsMviModel = koinViewModel<FollowRequestsViewModel>()
+                                            val myAccountViewModel: MyAccountMviModel =
+                                                koinViewModel<MyAccountViewModel>()
+                                            val favoritesViewModel: EntryListMviModel =
+                                                koinViewModel<EntryListViewModel> {
+                                                    parametersOf(EntryListViewModelArgs(type = EntryListType.Favorites))
+                                                }
+                                            val bookmarksViewModel: EntryListMviModel =
+                                                koinViewModel<EntryListViewModel> {
+                                                    parametersOf(EntryListViewModelArgs(type = EntryListType.Bookmarks))
+                                                }
+                                            val followedHashtagsViewModel: FollowedHashtagsMviModel =
+                                                koinViewModel<FollowedHashtagsViewModel>()
+                                            val followRequestsViewModel: FollowRequestsMviModel =
+                                                koinViewModel<FollowRequestsViewModel>()
                                             val circlesViewModel: CirclesMviModel = koinViewModel<CirclesViewModel>()
-                                            val conversationListViewModel: ConversationListMviModel = koinViewModel<ConversationListViewModel>()
+                                            val conversationListViewModel: ConversationListMviModel =
+                                                koinViewModel<ConversationListViewModel>()
                                             val galleryViewModel: GalleryMviModel = koinViewModel<GalleryViewModel>()
-                                            val unpublishedViewModel: UnpublishedMviModel = koinViewModel<UnpublishedViewModel>()
+                                            val unpublishedViewModel: UnpublishedMviModel =
+                                                koinViewModel<UnpublishedViewModel>()
                                             val calendarViewModel: CalendarMviModel = koinViewModel<CalendarViewModel>()
-                                            val shortcutListViewModel: ShortcutListMviModel = koinViewModel<ShortcutListViewModel>()
+                                            val shortcutListViewModel: ShortcutListMviModel =
+                                                koinViewModel<ShortcutListViewModel>()
                                             val nodeInfoViewModel: NodeInfoMviModel = koinViewModel<NodeInfoViewModel>()
                                             val timelineLazyListState = rememberLazyListState()
                                             val exploreLazyListState = rememberLazyListState()


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
The "dependency injection" plumbing of this project has changed over time due to several framework migrations:

- from Koin (classic DSL) to Koin + Annotations (using KSP);
- from Koin + Annotations to Kodein;
- from Kodein to Koin (classic DSL) again.

I foresee to migrate it again in the near future, e.g. to Koin + Annotations (using the new compiler plugin, as soon as it will be fully compatible with Kotlin 2.4.10 and AGP 9.5.x).  Who knows, in the future I may also want to migrate to a different framework (my dream would be to switch to Metro 🚆).

In order to do so, in any case, I need to centralize and control all DI accessors, in order to reduce the surface exposed to changes during future migrations.

The "rule of thumb" I am adopting is to prefer constructor injection whenever possible, and limit all exceptions by introducing `@DelicateDiApi` in `getByInjection(KClass, Qualifier?, ParametersDefinition?)` and requiring all usages to either opt-in or propagate the marker.

Typical exceptions where constructor injection is not possible are:
- purely UI-related classes only used in Composables (e.g. `NavigationCoordinator`, `DrawerCoordinator`, `FabNestedScrollConnection`, `ThemeRepository`, `ColorSchemeProvider`, etc.): in this case all the `get*` accessors were removed in favor or `remember*` ones.
- classes used by the operating system (e.g. instances of `Worker`, `Service`, `Activity`, `BroadcastReceiver` in the `androidMain` source set).