### PR TITLE
refactor: remove `DelicateDiApi` opt-in from composition locals

### DIFF
--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/ProvideStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/ProvideStrings.kt
@@ -5,19 +5,18 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.platform.LocalLayoutDirection
-import com.livefast.eattrash.raccoonforfriendica.core.di.DelicateDiApi
-import com.livefast.eattrash.raccoonforfriendica.core.l10n.di.getStrings
+import com.livefast.eattrash.raccoonforfriendica.core.l10n.di.rememberStrings
 
 val LocalStrings: ProvidableCompositionLocal<Strings> =
     staticCompositionLocalOf {
         error("CompositionLocal Strings not found")
     }
 
-@OptIn(DelicateDiApi::class)
 @Composable
 fun ProvideStrings(lang: String, content: @Composable () -> Unit) {
+    val strings = rememberStrings(lang)
     CompositionLocalProvider(
-        LocalStrings provides getStrings(lang),
+        LocalStrings provides strings,
         LocalLayoutDirection provides lang.toLanguageDirection(),
         content = content,
     )

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/di/Utils.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/di/Utils.kt
@@ -12,5 +12,8 @@ import org.koin.core.parameter.parametersOf
 @Composable
 fun rememberL10nManager() = remember { getByInjection(L10nManager::class) }
 
-@DelicateDiApi
-internal fun getStrings(lang: String): Strings = getByInjection(clazz = Strings::class, parameters = { parametersOf(lang) })
+@OptIn(DelicateDiApi::class)
+@Composable
+internal fun rememberStrings(lang: String): Strings = remember {
+    getByInjection(clazz = Strings::class, parameters = { parametersOf(lang) })
+}

--- a/core/resources/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/resources/ProvideResources.kt
+++ b/core/resources/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/resources/ProvideResources.kt
@@ -7,13 +7,11 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import com.livefast.eattrash.raccoonforfriendica.core.di.DelicateDiApi
 import com.livefast.eattrash.raccoonforfriendica.core.resources.di.rememberCoreResources
 
-@OptIn(DelicateDiApi::class)
 val LocalResources: ProvidableCompositionLocal<CoreResources> =
     staticCompositionLocalOf {
         error("CompositionLocal CoreResources not found")
     }
 
-@OptIn(DelicateDiApi::class)
 @Composable
 fun ProvideResources(content: @Composable () -> Unit) {
     val resources = rememberCoreResources()


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR removes unneded `DelicateDiApi` opt-in  from the `LocalResources` and `LocalStrings` `CompositionLocal`s.
