### PR TITLE
refactor: remove `DelicateDiApi` opt-in from `ComposerScreen`

### DIFF
--- a/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/Destination.kt
+++ b/core/navigation/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/navigation/Destination.kt
@@ -67,6 +67,7 @@ sealed interface Destination : NavKey {
         val draftId: String? = null,
         val urlToShare: String? = null,
         val initialText: String? = null,
+        val hasInitialAttachment: Boolean = false,
     ) : Destination
 
     @Serializable

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerMviModel.kt
@@ -46,6 +46,8 @@ interface ComposerMviModel : MviModel<ComposerMviModel.Intent, ComposerMviModel.
 
         data class SetSensitive(val sensitive: Boolean) : Intent
 
+        data object AddInitialAttachment : Intent
+
         data class AddAttachment(val byteArray: ByteArray) : Intent {
             override fun equals(other: Any?): Boolean {
                 if (this === other) return true

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerScreen.kt
@@ -71,7 +71,6 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.OptionId
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.SettingsSwitchRow
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.SpoilerTextField
 import com.livefast.eattrash.raccoonforfriendica.core.commonui.content.toOption
-import com.livefast.eattrash.raccoonforfriendica.core.di.DelicateDiApi
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.LocalStrings
 import com.livefast.eattrash.raccoonforfriendica.core.navigation.di.rememberNavigationCoordinator
 import com.livefast.eattrash.raccoonforfriendica.core.resources.LocalResources
@@ -86,7 +85,6 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TimelineEnt
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.Visibility
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toIcon
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.toReadableName
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.di.getAttachmentCache
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.toReadableName
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.components.AttachmentsGrid
 import com.livefast.eattrash.raccoonforfriendica.feature.composer.components.CreateInGroupInfo
@@ -122,6 +120,7 @@ fun ComposerScreen(
     draftId: String? = null,
     urlToShare: String? = null,
     initialText: String? = null,
+    hasInitialAttachment: Boolean = false,
 ) {
     val model: ComposerMviModel = koinViewModel<ComposerViewModel> {
         parametersOf(ComposerViewModelArgs(inReplyToId = inReplyToId, quotedId = quotedId))
@@ -133,10 +132,6 @@ fun ComposerScreen(
     val navigationCoordinator = rememberNavigationCoordinator()
     val canPopState by navigationCoordinator.canPop.collectAsState()
     val galleryHelper = rememberGalleryHelper()
-    val attachmentCache = remember {
-        @OptIn(DelicateDiApi::class)
-        getAttachmentCache()
-    }
     val focusManager = LocalFocusManager.current
     val missingDataError = LocalStrings.current.messagePostEmptyText
     val invalidVisibilityError = LocalStrings.current.messagePostInvalidVisibility
@@ -192,9 +187,6 @@ fun ComposerScreen(
     val navState = rememberNavigationEventState(NavigationEventInfo.None)
 
     LaunchedEffect(model) {
-        val initialAttachment = attachmentCache.get()
-        attachmentCache.clear()
-
         when {
             draftId != null ->
                 model.reduce(ComposerMviModel.Intent.LoadDraft(draftId))
@@ -219,13 +211,11 @@ fun ComposerScreen(
                     ),
                 )
 
-            initialAttachment != null ->
-                model.reduce(ComposerMviModel.Intent.AddAttachment(initialAttachment))
+            hasInitialAttachment ->
+                model.reduce(ComposerMviModel.Intent.AddInitialAttachment)
 
             inReplyToId != null ->
-                model.reduce(
-                    ComposerMviModel.Intent.AddInitialMentions(initialHandle = inReplyToHandle),
-                )
+                model.reduce(ComposerMviModel.Intent.AddInitialMentions(initialHandle = inReplyToHandle))
 
             !inReplyToHandle.isNullOrEmpty() ->
                 model.reduce(ComposerMviModel.Intent.AddMention(inReplyToHandle))

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/ComposerViewModel.kt
@@ -33,6 +33,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.Album
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.AlbumPhotoPaginationSpecification
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.UserPaginationManager
 import com.livefast.eattrash.raccoonforfriendica.domain.content.pagination.UserPaginationSpecification
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.AttachmentCache
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.CirclesRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DraftRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiRepository
@@ -90,6 +91,7 @@ class ComposerViewModel(
     private val stripMarkup: StripMarkupUseCase,
     private val bbCodeConverter: BBCodeConverter,
     private val notificationCenter: NotificationCenter,
+    private val attachmentCache: AttachmentCache,
 ) : ViewModel(),
     MviModelDelegate<ComposerMviModel.Intent, ComposerMviModel.State, ComposerMviModel.Effect>
     by DefaultMviModelDelegate(initialState = ComposerMviModel.State()),
@@ -289,6 +291,18 @@ class ComposerViewModel(
                         it.copy(
                             visibility = intent.visibility,
                             hasUnsavedChanges = true,
+                        )
+                    }
+                }
+
+            ComposerMviModel.Intent.AddInitialAttachment ->
+                viewModelScope.launch {
+                    val attachmentBytes = attachmentCache.get()
+                    attachmentCache.clear()
+                    if (attachmentBytes != null) {
+                        uploadAttachment(
+                            byteArray = attachmentBytes,
+                            isInlineImage = false,
                         )
                     }
                 }

--- a/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/di/ComposerModule.kt
+++ b/feature/composer/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/feature/composer/di/ComposerModule.kt
@@ -42,6 +42,7 @@ val composerModule = module {
             stripMarkup = get(),
             bbCodeConverter = get(),
             notificationCenter = get(),
+            attachmentCache = get(),
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultMainRouter.kt
+++ b/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/DefaultMainRouter.kt
@@ -188,6 +188,7 @@ class DefaultMainRouter(
                 editedPostId = editedPostId,
                 urlToShare = urlToShare,
                 initialText = initialText,
+                hasInitialAttachment = initialAttachment != null,
             ),
         )
     }

--- a/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/GetEntryProvider.kt
+++ b/shared/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/navigation/GetEntryProvider.kt
@@ -210,6 +210,7 @@ internal fun getEntryProvider(
             draftId = it.draftId,
             urlToShare = it.urlToShare,
             initialText = it.initialText,
+            hasInitialAttachment = it.hasInitialAttachment,
         )
     }
     entry<Destination.Search>(metadata = ListDetailSceneStrategy.listPane()) {


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR removes the usage of `AttachmentCache` directly from the UI layer in `ComposerScreen`. This was done as a temporary workaround[^1] to handle deep links to create new posts with attachments from system share modals in #559.

This solution involves passing a boolean flag to the Composable and access the cache from the `ViewModel`.

[^1]: Temporary meaning almost years ago, in the best "Italian way" to solve issues 🇮🇹 
