### PR TITLE
refactor: factor out common pagination logic and fix deduplication issue

### DIFF
--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/BasePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/BasePaginationManager.kt
@@ -1,0 +1,100 @@
+package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
+
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.ListWithPageCursor
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+internal abstract class BasePaginationManager<T, S>(private val idSelector: (T) -> String) {
+    private var specification: S? = null
+    private var pageCursor: String? = null
+    private var _canFetchMore: Boolean = true
+    private val _history = mutableListOf<T>()
+    private val historyIds = mutableSetOf<String>()
+    private val mutex = Mutex()
+
+    protected val currentSpecification: S? get() = specification
+    protected val currentPageCursor: String? get() = pageCursor
+
+    val canFetchMore: Boolean get() = _canFetchMore
+    val history: List<T> get() = _history
+
+    open suspend fun reset(specification: S) {
+        mutex.withLock {
+            this.specification = specification
+            _history.clear()
+            historyIds.clear()
+            pageCursor = null
+            _canFetchMore = true
+        }
+    }
+
+    protected suspend fun <R> withPaginationLock(block: suspend () -> R): R = mutex.withLock { block() }
+
+    protected fun updateHistoryItem(id: String, transform: (T) -> T) {
+        val idx = _history.indexOfFirst { idSelector(it) == id }
+        if (idx >= 0) {
+            _history[idx] = transform(_history[idx])
+        }
+    }
+
+    protected fun removeHistoryItem(id: String) {
+        val idx = _history.indexOfFirst { idSelector(it) == id }
+        if (idx >= 0) {
+            _history.removeAt(idx)
+            historyIds.remove(id)
+        }
+    }
+
+    protected fun restorePaginationState(specification: S?, pageCursor: String?, history: List<T>) {
+        this.specification = specification
+        this.pageCursor = pageCursor
+        _history.clear()
+        historyIds.clear()
+        _history.addAll(history)
+        history.forEach { historyIds.add(idSelector(it)) }
+        // We assume that if we are restoring history, we should enable fetching more
+        // if the cursor is present, or just default to true if unsure.
+        _canFetchMore = true
+    }
+
+    protected suspend fun updateHistory(
+        results: ListWithPageCursor<T>?,
+        distinctBy: (T) -> Any = idSelector,
+        transform: suspend (List<T>) -> List<T> = { it },
+    ): List<T> {
+        val cursor = results?.cursor
+        val rawItems = results?.list.orEmpty()
+
+        return mutex.withLock {
+            pageCursor = cursor
+            _canFetchMore = cursor != null
+
+            val newItems = rawItems
+                .filter { idSelector(it) !in historyIds }
+                .distinctBy(distinctBy)
+
+            val processedItems = transform(newItems)
+
+            _history.addAll(processedItems)
+            processedItems.forEach { historyIds.add(idSelector(it)) }
+
+            _history.toList()
+        }
+    }
+
+    protected suspend fun updateHistory(
+        items: List<T>?,
+        distinctBy: (T) -> Any = idSelector,
+        transform: suspend (List<T>) -> List<T> = { it },
+    ): List<T> {
+        val rawItems = items.orEmpty()
+        return updateHistory(
+            results = ListWithPageCursor(
+                list = rawItems,
+                cursor = rawItems.lastOrNull()?.let(idSelector),
+            ),
+            distinctBy = distinctBy,
+            transform = transform,
+        )
+    }
+}

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultAlbumPhotoPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultAlbumPhotoPaginationManager.kt
@@ -2,57 +2,30 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
 
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.AttachmentModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.PhotoAlbumRepository
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import org.koin.core.annotation.Factory
 
 @Factory
 internal class DefaultAlbumPhotoPaginationManager(private val albumRepository: PhotoAlbumRepository) :
+    BasePaginationManager<AttachmentModel, AlbumPhotoPaginationSpecification>(
+        idSelector = { it.id },
+    ),
     AlbumPhotoPaginationManager {
-    private var specification: AlbumPhotoPaginationSpecification? = null
-    private var pageCursor: String? = null
-    override var canFetchMore = false
-    private val history = mutableListOf<AttachmentModel>()
-    private val mutex = Mutex()
-
-    override suspend fun reset(specification: AlbumPhotoPaginationSpecification) {
-        this.specification = specification
-        pageCursor = null
-        mutex.withLock {
-            history.clear()
-        }
-        canFetchMore = true
-    }
 
     override suspend fun loadNextPage(): List<AttachmentModel> {
-        val specification = this.specification ?: return emptyList()
+        val spec = currentSpecification ?: return emptyList()
 
         val results =
-            when (specification) {
+            when (spec) {
                 is AlbumPhotoPaginationSpecification.Default ->
                     albumRepository.getPhotos(
-                        album = specification.album,
-                        pageCursor = pageCursor,
+                        album = spec.album,
+                        pageCursor = currentPageCursor,
                         latestFirst = true,
                     )
-            }.orEmpty()
+            }
 
-        return mutex.withLock {
-            results
-                .deduplicate()
-                .updatePaginationData()
-                .also { history.addAll(it) }
-            // return a copy
-            history.map { it }
-        }
+        return updateHistory(
+            items = results,
+        )
     }
-
-    private fun List<AttachmentModel>.updatePaginationData(): List<AttachmentModel> = apply {
-        pageCursor = lastOrNull()?.id
-        canFetchMore = isNotEmpty()
-    }
-
-    private fun List<AttachmentModel>.deduplicate(): List<AttachmentModel> = filter { e1 ->
-        history.none { e2 -> e1.id == e2.id }
-    }.distinctBy { it.id }
 }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultDirectMessagesPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultDirectMessagesPaginationManager.kt
@@ -3,71 +3,54 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.DirectMessageModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.DirectMessageRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import org.koin.core.annotation.Factory
 
 @Factory
 internal class DefaultDirectMessagesPaginationManager(
     private val directMessageRepository: DirectMessageRepository,
     private val emojiHelper: EmojiHelper,
-) : DirectMessagesPaginationManager {
-    private var specification: DirectMessagesPaginationSpecification? = null
+) : BasePaginationManager<DirectMessageModel, DirectMessagesPaginationSpecification>(
+    idSelector = { it.id },
+),
+    DirectMessagesPaginationManager {
     private var page = 1
-    override var canFetchMore: Boolean = true
-    private val history = mutableListOf<DirectMessageModel>()
-    private val mutex = Mutex()
 
     override suspend fun reset(specification: DirectMessagesPaginationSpecification) {
-        this.specification = specification
-        page = 1
-        mutex.withLock {
-            history.clear()
+        super.reset(specification)
+        withPaginationLock {
+            page = 1
         }
-        canFetchMore = true
     }
 
     override suspend fun loadNextPage(): List<DirectMessageModel> {
-        val specification = this.specification ?: return emptyList()
+        val spec = currentSpecification ?: return emptyList()
 
         val results =
-            when (specification) {
+            when (spec) {
                 DirectMessagesPaginationSpecification.All ->
                     directMessageRepository
                         .getAll(
                             page = page,
                             limit = 40,
-                        ).orEmpty()
+                        )
 
                 is DirectMessagesPaginationSpecification.Replies ->
                     directMessageRepository
                         .getReplies(
-                            parentUri = specification.parentUri,
+                            parentUri = spec.parentUri,
                             page = page,
-                        ).orEmpty()
+                        )
             }
-        return mutex.withLock {
-            results
-                .deduplicate()
-                .updatePaginationData()
-                .fixupCreatorEmojis()
-                .also { history.addAll(it) }
-            // return a copy
-            history.map { it }
-        }
+        return updateHistory(
+            items = results,
+            transform = { newItems ->
+                if (newItems.isNotEmpty()) {
+                    page++
+                }
+                newItems.fixupCreatorEmojis()
+            },
+        )
     }
-
-    private fun List<DirectMessageModel>.updatePaginationData(): List<DirectMessageModel> = apply {
-        val hasData = isNotEmpty()
-        if (hasData) {
-            page++
-        }
-        canFetchMore = hasData
-    }
-
-    private fun List<DirectMessageModel>.deduplicate(): List<DirectMessageModel> = filter { e1 ->
-        history.none { e2 -> e1.id == e2.id }
-    }.distinctBy { it.id }
 
     private suspend fun List<DirectMessageModel>.fixupCreatorEmojis(): List<DirectMessageModel> = with(emojiHelper) {
         map {

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultEventPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultEventPaginationManager.kt
@@ -2,55 +2,27 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
 
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EventModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EventRepository
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import org.koin.core.annotation.Factory
 
 @Factory
-internal class DefaultEventPaginationManager(private val eventRepository: EventRepository) : EventPaginationManager {
-    private var specification: EventsPaginationSpecification? = null
-    private var pageCursor: String? = null
-    override var canFetchMore: Boolean = true
-    private val history = mutableListOf<EventModel>()
-    private val mutex = Mutex()
-
-    override suspend fun reset(specification: EventsPaginationSpecification) {
-        this.specification = specification
-        pageCursor = null
-        mutex.withLock {
-            history.clear()
-        }
-        canFetchMore = true
-    }
+internal class DefaultEventPaginationManager(private val eventRepository: EventRepository) :
+    BasePaginationManager<EventModel, EventsPaginationSpecification>(
+        idSelector = { it.id },
+    ),
+    EventPaginationManager {
 
     override suspend fun loadNextPage(): List<EventModel> {
-        val specification = this.specification ?: return emptyList()
+        val spec = currentSpecification ?: return emptyList()
         val results =
-            when (specification) {
+            when (spec) {
                 EventsPaginationSpecification.All ->
                     eventRepository.getAll(
-                        pageCursor = pageCursor,
+                        pageCursor = currentPageCursor,
                     )
             }
 
-        return mutex.withLock {
-            results
-                ?.deduplicate()
-                ?.updatePaginationData()
-                ?.also { history.addAll(it) }
-            // return a copy
-            history.map { it }
-        }
+        return updateHistory(
+            items = results,
+        )
     }
-
-    private fun List<EventModel>.updatePaginationData(): List<EventModel> = apply {
-        lastOrNull()?.also {
-            pageCursor = it.id
-        }
-        canFetchMore = isNotEmpty()
-    }
-
-    private fun List<EventModel>.deduplicate(): List<EventModel> = filter { e1 ->
-        history.none { e2 -> e1.id == e2.id }
-    }.distinctBy { it.id }
 }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultExplorePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultExplorePaginationManager.kt
@@ -22,8 +22,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import org.koin.core.annotation.Factory
 
 @Factory
@@ -36,12 +34,10 @@ internal class DefaultExplorePaginationManager(
     private val stopWordRepository: StopWordRepository,
     notificationCenter: NotificationCenter,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
-) : ExplorePaginationManager {
-    private var specification: ExplorePaginationSpecification? = null
-    private var offset = 0
-    override var canFetchMore: Boolean = true
-    private val history = mutableListOf<ExploreItemModel>()
-    private val mutex = Mutex()
+) : BasePaginationManager<ExploreItemModel, ExplorePaginationSpecification>(
+    idSelector = { it.id },
+),
+    ExplorePaginationManager {
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
     private var stopWords: List<String>? = null
 
@@ -50,77 +46,59 @@ internal class DefaultExplorePaginationManager(
             notificationCenter
                 .subscribe(UserUpdatedEvent::class)
                 .onEach { event ->
-                    mutex.withLock {
-                        val idx =
-                            history.indexOfFirst { e -> e is ExploreItemModel.User && e.user.id == event.user.id }
-                        if (idx >= 0) {
-                            (history[idx] as? ExploreItemModel.User)
-                                ?.copy(user = event.user)
-                                ?.also {
-                                    history[idx] = it
-                                }
+                    withPaginationLock {
+                        updateHistoryItem(event.user.id) { item ->
+                            (item as? ExploreItemModel.User)?.copy(user = event.user) ?: item
                         }
                     }
                 }.launchIn(this)
             notificationCenter
                 .subscribe(TimelineEntryUpdatedEvent::class)
                 .onEach { event ->
-                    mutex.withLock {
-                        val idx =
-                            history.indexOfFirst { e -> e is ExploreItemModel.Entry && e.entry.id == event.entry.id }
-                        if (idx >= 0) {
-                            (history[idx] as? ExploreItemModel.Entry)
-                                ?.copy(entry = event.entry)
-                                ?.also {
-                                    history[idx] = it
-                                }
+                    withPaginationLock {
+                        updateHistoryItem(event.entry.id) { item ->
+                            (item as? ExploreItemModel.Entry)?.copy(entry = event.entry) ?: item
                         }
                     }
                 }.launchIn(this)
             notificationCenter
                 .subscribe(TimelineEntryDeletedEvent::class)
                 .onEach { event ->
-                    mutex.withLock {
-                        val idx = history.indexOfFirst { e -> e.id == event.id }
-                        if (idx >= 0) {
-                            history.removeAt(idx)
-                        }
+                    withPaginationLock {
+                        removeHistoryItem(event.id)
                     }
-                }.launchIn(scope)
+                }.launchIn(this)
         }
     }
 
     override suspend fun reset(specification: ExplorePaginationSpecification) {
-        this.specification = specification
-        offset = 0
-        mutex.withLock {
-            history.clear()
+        super.reset(specification)
+        withPaginationLock {
             accountRepository.getActive()?.id?.also { accountId ->
                 stopWords = stopWordRepository.get(accountId)
             }
         }
-        canFetchMore = true
     }
 
     override suspend fun loadNextPage(): List<ExploreItemModel> {
-        val specification = this.specification ?: return emptyList()
+        val spec = currentSpecification ?: return emptyList()
 
         val results =
-            when (specification) {
+            when (spec) {
                 is ExplorePaginationSpecification.Hashtags ->
                     trendingRepository
                         .getHashtags(
-                            offset = offset,
-                            refresh = specification.refresh,
-                            otherInstance = specification.otherInstance,
+                            offset = history.size,
+                            refresh = spec.refresh,
+                            otherInstance = spec.otherInstance,
                         )?.map {
                             ExploreItemModel.HashTag(it)
                         }
 
                 is ExplorePaginationSpecification.Links ->
                     trendingRepository.getLinks(
-                        offset = offset,
-                        otherInstance = specification.otherInstance,
+                        offset = history.size,
+                        otherInstance = spec.otherInstance,
                     )?.mapNotNull {
                         if (it.url.isBlank()) {
                             null
@@ -132,12 +110,12 @@ internal class DefaultExplorePaginationManager(
                 is ExplorePaginationSpecification.Posts ->
                     trendingRepository
                         .getEntries(
-                            offset = offset,
-                            otherInstance = specification.otherInstance,
+                            offset = history.size,
+                            otherInstance = spec.otherInstance,
                         )
                         ?.map {
                             ExploreItemModel.Entry(it)
-                        }?.filterNsfw(specification.includeNsfw)
+                        }
 
                 ExplorePaginationSpecification.Suggestions ->
                     userRepository
@@ -145,29 +123,25 @@ internal class DefaultExplorePaginationManager(
                         ?.map {
                             ExploreItemModel.User(it)
                         }?.determineUserRelationshipStatus()
-            }.orEmpty()
+            }
 
-        return mutex.withLock {
-            results
-                .filterByStopWords()
-                .deduplicate()
-                .updatePaginationData()
-                .fixupCreatorEmojis()
-                .fixupInReplyTo()
-                .also { history.addAll(it) }
-            // return a copy
-            history.map { it }
-        }
+        return updateHistory(
+            items = results,
+            transform = { newItems ->
+                newItems
+                    .filterByStopWords()
+                    .let { list ->
+                        if (spec is ExplorePaginationSpecification.Posts) {
+                            list.filterNsfw(spec.includeNsfw)
+                        } else {
+                            list
+                        }
+                    }
+                    .fixupCreatorEmojis()
+                    .fixupInReplyTo()
+            },
+        )
     }
-
-    private fun List<ExploreItemModel>.updatePaginationData(): List<ExploreItemModel> = apply {
-        offset = size
-        canFetchMore = isNotEmpty()
-    }
-
-    private fun List<ExploreItemModel>.deduplicate(): List<ExploreItemModel> = filter { e1 ->
-        history.none { e2 -> e1.id == e2.id }
-    }.distinctBy { it.id }
 
     private fun List<ExploreItemModel>.filterNsfw(included: Boolean): List<ExploreItemModel> = filter {
         included ||

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFollowRequestPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFollowRequestPaginationManager.kt
@@ -3,58 +3,29 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.EmojiHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.ListWithPageCursor
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import org.koin.core.annotation.Factory
 
 @Factory
 internal class DefaultFollowRequestPaginationManager(
     private val userRepository: UserRepository,
     private val emojiHelper: EmojiHelper,
-) : FollowRequestPaginationManager {
-    private var pageCursor: String? = null
-    override var canFetchMore: Boolean = true
-    private val history = mutableListOf<UserModel>()
-    private val mutex = Mutex()
+) : BasePaginationManager<UserModel, Unit>(
+    idSelector = { it.id },
+),
+    FollowRequestPaginationManager {
 
     override suspend fun reset() {
-        pageCursor = null
-        mutex.withLock {
-            history.clear()
-        }
-        canFetchMore = true
+        super.reset(Unit)
     }
 
     override suspend fun loadNextPage(): List<UserModel> {
-        val results = userRepository.getFollowRequests(pageCursor)
+        val results = userRepository.getFollowRequests(currentPageCursor)
 
-        return mutex.withLock {
-            results
-                ?.deduplicate()
-                ?.updatePaginationData()
-                ?.fixupCreatorEmojis()
-                ?.also { history.addAll(it) }
-            // return a copy
-            history.map { it }
-        }
-    }
-
-    private fun ListWithPageCursor<UserModel>.updatePaginationData(): List<UserModel> = run {
-        pageCursor = cursor
-        canFetchMore = list.isNotEmpty()
-        list
-    }
-
-    private fun List<UserModel>.deduplicate(): List<UserModel> = filter { e1 ->
-        history.none { e2 -> e1.id == e2.id }
-    }.distinctBy { it.id }
-
-    private fun ListWithPageCursor<UserModel>.deduplicate(): ListWithPageCursor<UserModel> = run {
-        val newList = list.deduplicate()
-        ListWithPageCursor(
-            list = newList,
-            cursor = newList.lastOrNull()?.id,
+        return updateHistory(
+            results = results,
+            transform = { newItems ->
+                newItems.fixupCreatorEmojis()
+            },
         )
     }
 

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFollowedHashtagsPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultFollowedHashtagsPaginationManager.kt
@@ -2,47 +2,24 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.pagination
 
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.TagModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TagRepository
-import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.ListWithPageCursor
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import org.koin.core.annotation.Factory
 
 @Factory
 internal class DefaultFollowedHashtagsPaginationManager(private val tagRepository: TagRepository) :
+    BasePaginationManager<TagModel, Unit>(
+        idSelector = { it.name },
+    ),
     FollowedHashtagsPaginationManager {
-    private var pageCursor: String? = null
-    override var canFetchMore: Boolean = true
-    private val history = mutableListOf<TagModel>()
-    private val mutex = Mutex()
 
     override suspend fun reset() {
-        pageCursor = null
-        mutex.withLock {
-            history.clear()
-        }
-        canFetchMore = true
+        super.reset(Unit)
     }
 
     override suspend fun loadNextPage(): List<TagModel> {
-        val results = tagRepository.getFollowed(pageCursor)
+        val results = tagRepository.getFollowed(currentPageCursor)
 
-        return mutex.withLock {
-            results
-                ?.updatePaginationData()
-                ?.deduplicate()
-                ?.also { history.addAll(it) }
-            // return a copy
-            history.map { it }
-        }
+        return updateHistory(
+            results = results,
+        )
     }
-
-    private fun ListWithPageCursor<TagModel>.updatePaginationData(): List<TagModel> = run {
-        pageCursor = cursor
-        canFetchMore = list.isNotEmpty()
-        list
-    }
-
-    private fun List<TagModel>.deduplicate(): List<TagModel> = filter { e1 ->
-        history.none { e2 -> e1.name == e2.name }
-    }.distinctBy { it.name }
 }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultNotificationsPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultNotificationsPaginationManager.kt
@@ -8,8 +8,6 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Emoji
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.NotificationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.ReplyHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import org.koin.core.annotation.Factory
 
 @Factory
@@ -18,55 +16,35 @@ internal class DefaultNotificationsPaginationManager(
     private val userRepository: UserRepository,
     private val emojiHelper: EmojiHelper,
     private val replyHelper: ReplyHelper,
-) : NotificationsPaginationManager {
-    private var specification: NotificationsPaginationSpecification? = null
-    private var pageCursor: String? = null
-    override var canFetchMore: Boolean = true
-    private val history = mutableListOf<NotificationModel>()
-    private val mutex = Mutex()
-
-    override suspend fun reset(specification: NotificationsPaginationSpecification) {
-        this.specification = specification
-        pageCursor = null
-        mutex.withLock {
-            history.clear()
-        }
-        canFetchMore = true
-    }
+) : BasePaginationManager<NotificationModel, NotificationsPaginationSpecification>(
+    idSelector = { it.id },
+),
+    NotificationsPaginationManager {
 
     override suspend fun loadNextPage(): List<NotificationModel> {
-        val specification = this.specification ?: return emptyList()
+        val spec = currentSpecification ?: return emptyList()
 
         val results =
-            when (specification) {
+            when (spec) {
                 is NotificationsPaginationSpecification.Default ->
                     notificationRepository
                         .getAll(
-                            pageCursor = pageCursor,
-                            types = specification.types,
-                            refresh = specification.refresh,
+                            pageCursor = currentPageCursor,
+                            types = spec.types,
+                            refresh = spec.refresh,
                         )
-            }.orEmpty()
+            }
 
-        return mutex.withLock {
-            results
-                .determineRelationshipStatus()
-                .deduplicate()
-                .updatePaginationData()
-                .filterNsfw(specification.includeNsfw)
-                .fixupCreatorEmojis()
-                .fixupInReplyTo()
-                .also { history.addAll(it) }
-            // return a copy
-            history.map { it }
-        }
-    }
-
-    private fun List<NotificationModel>.updatePaginationData(): List<NotificationModel> = apply {
-        lastOrNull()?.also {
-            pageCursor = it.id
-        }
-        canFetchMore = isNotEmpty()
+        return updateHistory(
+            items = results,
+            transform = { newItems ->
+                newItems
+                    .determineRelationshipStatus()
+                    .filterNsfw(spec.includeNsfw)
+                    .fixupCreatorEmojis()
+                    .fixupInReplyTo()
+            },
+        )
     }
 
     private suspend fun List<NotificationModel>.determineRelationshipStatus(): List<NotificationModel> = run {
@@ -84,10 +62,6 @@ internal class DefaultNotificationsPaginationManager(
             )
         }
     }
-
-    private fun List<NotificationModel>.deduplicate(): List<NotificationModel> = filter { e1 ->
-        history.none { e2 -> e1.id == e2.id }
-    }.distinctBy { it.id }
 
     private fun List<NotificationModel>.filterNsfw(included: Boolean): List<NotificationModel> =
         filter { included || it.entry?.isNsfw != true }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultSearchPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultSearchPaginationManager.kt
@@ -23,8 +23,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import org.koin.core.annotation.Factory
 
 @Factory
@@ -37,12 +35,10 @@ internal class DefaultSearchPaginationManager(
     private val stopWordRepository: StopWordRepository,
     notificationCenter: NotificationCenter,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
-) : SearchPaginationManager {
-    private var specification: SearchPaginationSpecification? = null
-    override var canFetchMore: Boolean = true
-    private var pageCursor: String? = null
-    private val history = mutableListOf<ExploreItemModel>()
-    private val mutex = Mutex()
+) : BasePaginationManager<ExploreItemModel, SearchPaginationSpecification>(
+    idSelector = { it.id },
+),
+    SearchPaginationManager {
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
     private var stopWords: List<String>? = null
 
@@ -51,128 +47,96 @@ internal class DefaultSearchPaginationManager(
             notificationCenter
                 .subscribe(UserUpdatedEvent::class)
                 .onEach { event ->
-                    mutex.withLock {
-                        val idx =
-                            history.indexOfFirst { e -> e is ExploreItemModel.User && e.user.id == event.user.id }
-                        if (idx >= 0) {
-                            (history[idx] as? ExploreItemModel.User)
-                                ?.copy(user = event.user)
-                                ?.also {
-                                    history[idx] = it
-                                }
+                    withPaginationLock {
+                        updateHistoryItem(event.user.id) { item ->
+                            (item as? ExploreItemModel.User)?.copy(user = event.user) ?: item
                         }
                     }
                 }.launchIn(this)
             notificationCenter
                 .subscribe(TimelineEntryUpdatedEvent::class)
                 .onEach { event ->
-                    mutex.withLock {
-                        val idx =
-                            history.indexOfFirst { e -> e is ExploreItemModel.Entry && e.entry.id == event.entry.id }
-                        if (idx >= 0) {
-                            (history[idx] as? ExploreItemModel.Entry)
-                                ?.copy(entry = event.entry)
-                                ?.also {
-                                    history[idx] = it
-                                }
+                    withPaginationLock {
+                        updateHistoryItem(event.entry.id) { item ->
+                            (item as? ExploreItemModel.Entry)?.copy(entry = event.entry) ?: item
                         }
                     }
                 }.launchIn(this)
             notificationCenter
                 .subscribe(TimelineEntryDeletedEvent::class)
                 .onEach { event ->
-                    mutex.withLock {
-                        val idx = history.indexOfFirst { e -> e.id == event.id }
-                        if (idx >= 0) {
-                            history.removeAt(idx)
-                        }
+                    withPaginationLock {
+                        removeHistoryItem(event.id)
                     }
-                }.launchIn(scope)
+                }.launchIn(this)
         }
     }
 
     override suspend fun reset(specification: SearchPaginationSpecification) {
-        this.specification = specification
-        pageCursor = null
-        mutex.withLock {
-            history.clear()
+        super.reset(specification)
+        withPaginationLock {
             accountRepository.getActive()?.id?.also { accountId ->
                 stopWords = stopWordRepository.get(accountId)
             }
         }
-        canFetchMore = true
     }
 
     override suspend fun loadNextPage(): List<ExploreItemModel> {
-        val specification = this.specification ?: return emptyList()
+        val spec = currentSpecification ?: return emptyList()
         val results =
-            when (specification) {
+            when (spec) {
                 is SearchPaginationSpecification.Entries ->
                     searchRepository
                         .search(
-                            query = specification.query,
-                            pageCursor = pageCursor,
+                            query = spec.query,
+                            pageCursor = currentPageCursor,
                             type = SearchResultType.Entries,
-                            resolve = guessResolveEntry(specification.query),
+                            resolve = guessResolveEntry(spec.query),
                         )
 
                 is SearchPaginationSpecification.Hashtags ->
                     searchRepository
                         .search(
-                            query = specification.query,
-                            pageCursor = pageCursor,
+                            query = spec.query,
+                            pageCursor = currentPageCursor,
                             type = SearchResultType.Hashtags,
                         )
 
                 is SearchPaginationSpecification.Users ->
                     searchRepository
                         .search(
-                            query = specification.query,
-                            pageCursor = pageCursor,
+                            query = spec.query,
+                            pageCursor = currentPageCursor,
                             type = SearchResultType.Users,
-                            resolve = guessResolveUser(specification.query),
+                            resolve = guessResolveUser(spec.query),
                         )?.determineUserRelationshipStatus()
 
                 is SearchPaginationSpecification.Groups ->
                     searchRepository.search(
-                        query = specification.query,
-                        pageCursor = pageCursor,
+                        query = spec.query,
+                        pageCursor = currentPageCursor,
                         type = SearchResultType.Users,
-                        resolve = guessResolveUser(specification.query),
+                        resolve = guessResolveUser(spec.query),
                     )
             }
-                ?.deduplicate()
 
-                ?.filterByStopWords()
-                ?.let { list ->
-                    when (specification) {
-                        is SearchPaginationSpecification.Entries -> list.filterNsfw(specification.includeNsfw)
-                        is SearchPaginationSpecification.Groups -> list.filterGroups()
-                        else -> list
+        return updateHistory(
+            items = results,
+            transform = { newItems ->
+                newItems
+                    .filterByStopWords()
+                    .let { list ->
+                        when (spec) {
+                            is SearchPaginationSpecification.Entries -> list.filterNsfw(spec.includeNsfw)
+                            is SearchPaginationSpecification.Groups -> list.filterGroups()
+                            else -> list
+                        }
                     }
-                }
-                ?.updatePaginationData()
-                ?.fixupCreatorEmojis()
-                ?.fixupInReplyTo()
-                .orEmpty()
-        mutex.withLock {
-            history.addAll(results)
-        }
-
-        // return an object containing copies
-        return history.map { it }
+                    .fixupCreatorEmojis()
+                    .fixupInReplyTo()
+            },
+        )
     }
-
-    private fun List<ExploreItemModel>.updatePaginationData(): List<ExploreItemModel> = apply {
-        lastOrNull()?.also {
-            pageCursor = it.id
-        }
-        canFetchMore = isNotEmpty()
-    }
-
-    private fun List<ExploreItemModel>.deduplicate(): List<ExploreItemModel> = filter { e1 ->
-        history.none { e2 -> e1.id == e2.id }
-    }.distinctBy { it.id }
 
     private fun List<ExploreItemModel>.filterNsfw(included: Boolean): List<ExploreItemModel> = filter {
         included ||

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
@@ -23,8 +23,6 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import org.koin.core.annotation.Factory
 
 @Factory
@@ -39,12 +37,10 @@ internal class DefaultTimelinePaginationManager(
     private val followedHashtagCache: FollowedHashtagCache,
     notificationCenter: NotificationCenter,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
-) : TimelinePaginationManager {
-    private var specification: TimelinePaginationSpecification? = null
-    private var pageCursor: String? = null
-    override var canFetchMore: Boolean = true
-    override val history = mutableListOf<TimelineEntryModel>()
-    private val mutex = Mutex()
+) : BasePaginationManager<TimelineEntryModel, TimelinePaginationSpecification>(
+    idSelector = { it.id },
+),
+    TimelinePaginationManager {
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
     private val userRateLimits = mutableMapOf<String, Double>()
     private var stopWords: List<String>? = null
@@ -53,29 +49,22 @@ internal class DefaultTimelinePaginationManager(
         notificationCenter
             .subscribe(TimelineEntryUpdatedEvent::class)
             .onEach { event ->
-                mutex.withLock {
-                    val idx = history.indexOfFirst { e -> e.id == event.entry.id }
-                    if (idx >= 0) {
-                        history[idx] = event.entry
-                    }
+                withPaginationLock {
+                    updateHistoryItem(event.entry.id) { event.entry }
                 }
             }.launchIn(scope)
         notificationCenter
             .subscribe(TimelineEntryDeletedEvent::class)
             .onEach { event ->
-                mutex.withLock {
-                    val idx = history.indexOfFirst { e -> e.id == event.id }
-                    if (idx >= 0) {
-                        history.removeAt(idx)
-                    }
+                withPaginationLock {
+                    removeHistoryItem(event.id)
                 }
             }.launchIn(scope)
     }
 
     override suspend fun reset(specification: TimelinePaginationSpecification) {
-        this.specification = specification
-        pageCursor = null
-        mutex.withLock {
+        super.reset(specification)
+        withPaginationLock {
             userRateLimits.clear()
             accountRepository.getActive()?.id?.also { accountId ->
                 userRateLimitRepository.getAll(accountId).forEach { limit ->
@@ -83,57 +72,57 @@ internal class DefaultTimelinePaginationManager(
                 }
                 stopWords = stopWordRepository.get(accountId)
             }
-            history.clear()
         }
-        canFetchMore = true
     }
 
     override suspend fun restoreHistory(values: List<TimelineEntryModel>) {
-        mutex.withLock {
-            history.clear()
-            history.addAll(values)
-            canFetchMore = true
+        withPaginationLock {
+            restorePaginationState(
+                specification = currentSpecification,
+                pageCursor = currentPageCursor,
+                history = values,
+            )
         }
     }
 
     override suspend fun loadNextPage(): List<TimelineEntryModel> {
-        val specification = this.specification ?: return emptyList()
+        val spec = currentSpecification ?: return emptyList()
 
-        val results =
-            when (specification) {
+        val results: ListWithPageCursor<TimelineEntryModel>? =
+            when (spec) {
                 is TimelinePaginationSpecification.Feed -> {
-                    when (specification.timelineType) {
+                    when (spec.timelineType) {
                         is TimelineType.All ->
                             timelineRepository.getPublic(
-                                pageCursor = pageCursor,
-                                refresh = specification.refresh,
+                                pageCursor = currentPageCursor,
+                                refresh = spec.refresh,
                             )
 
                         is TimelineType.Subscriptions ->
                             timelineRepository.getHome(
-                                pageCursor = pageCursor,
-                                refresh = specification.refresh,
+                                pageCursor = currentPageCursor,
+                                refresh = spec.refresh,
                             )
 
                         is TimelineType.Local ->
                             timelineRepository.getLocal(
-                                pageCursor = pageCursor,
-                                refresh = specification.refresh,
+                                pageCursor = currentPageCursor,
+                                refresh = spec.refresh,
                             )
 
                         is TimelineType.Circle ->
                             timelineRepository.getCircle(
                                 id =
-                                specification.timelineType.circle
+                                spec.timelineType.circle
                                     ?.id
                                     .orEmpty(),
-                                pageCursor = pageCursor,
+                                pageCursor = currentPageCursor,
                             )
 
                         is TimelineType.Foreign ->
                             timelineRepository.getLocal(
-                                pageCursor = pageCursor,
-                                otherInstance = specification.timelineType.otherInstance,
+                                pageCursor = currentPageCursor,
+                                otherInstance = spec.timelineType.otherInstance,
                             )
                     }?.toListWithPageCursor()
                 }
@@ -141,137 +130,128 @@ internal class DefaultTimelinePaginationManager(
                 is TimelinePaginationSpecification.Hashtag -> {
                     timelineRepository
                         .getHashtag(
-                            hashtag = specification.hashtag,
-                            pageCursor = pageCursor,
-                            otherInstance = specification.otherInstance,
+                            hashtag = spec.hashtag,
+                            pageCursor = currentPageCursor,
+                            otherInstance = spec.otherInstance,
                         )
                 }
 
                 is TimelinePaginationSpecification.User ->
                     timelineEntryRepository
                         .getByUser(
-                            userId = specification.userId,
-                            pageCursor = pageCursor,
-                            excludeReplies = specification.excludeReplies,
-                            excludeReblogs = specification.excludeReblogs,
-                            onlyMedia = specification.onlyMedia,
-                            pinned = specification.pinned,
-                            enableCache = specification.enableCache,
-                            refresh = specification.refresh,
-                            otherInstance = specification.otherInstance,
+                            userId = spec.userId,
+                            pageCursor = currentPageCursor,
+                            excludeReplies = spec.excludeReplies,
+                            excludeReblogs = spec.excludeReblogs,
+                            onlyMedia = spec.onlyMedia,
+                            pinned = spec.pinned,
+                            enableCache = spec.enableCache,
+                            refresh = spec.refresh,
+                            otherInstance = spec.otherInstance,
                         )?.toListWithPageCursor()
 
                 is TimelinePaginationSpecification.Forum ->
                     timelineEntryRepository
                         .getByUser(
-                            userId = specification.userId,
-                            pageCursor = pageCursor,
+                            userId = spec.userId,
+                            pageCursor = currentPageCursor,
                             excludeReplies = true,
-                            otherInstance = specification.otherInstance,
+                            otherInstance = spec.otherInstance,
                         )?.toListWithPageCursor()
 
                 is TimelinePaginationSpecification.Bookmarks ->
                     timelineEntryRepository
-                        .getBookmarks(pageCursor = pageCursor)
+                        .getBookmarks(pageCursor = currentPageCursor)
                         ?.toListWithPageCursor()
 
                 is TimelinePaginationSpecification.Favorites ->
                     timelineEntryRepository
-                        .getFavorites(pageCursor = pageCursor)
+                        .getFavorites(pageCursor = currentPageCursor)
                         ?.toListWithPageCursor()
 
                 is TimelinePaginationSpecification.Quotes ->
                     timelineEntryRepository
                         .getQuotes(
-                            id = specification.id,
-                            pageCursor = pageCursor,
-                            otherInstance = specification.otherInstance,
+                            id = spec.id,
+                            pageCursor = currentPageCursor,
+                            otherInstance = spec.otherInstance,
                         )
             }
-        return mutex.withLock {
-            when (specification) {
-                is TimelinePaginationSpecification.Feed ->
-                    results
-                        ?.deduplicate()
-                        ?.updatePaginationData()
-                        ?.filterReplies(included = !specification.excludeReplies)
-                        ?.filterNsfw(specification.includeNsfw)
-                        ?.filterWithRateLimits()
-                        ?.filterByStopWords()
-                        ?.fixupCreatorEmojis()
-                        ?.fixupInReplyTo()
-                        ?.fixupFollowedHashtags()
 
-                is TimelinePaginationSpecification.Hashtag ->
-                    results
-                        ?.deduplicate()
-                        ?.updatePaginationData()
-                        ?.filterNsfw(specification.includeNsfw)
-                        ?.filterWithRateLimits()
-                        ?.filterByStopWords()
-                        ?.fixupCreatorEmojis()
-                        ?.fixupInReplyTo()
+        return updateHistory(
+            results = results,
+            distinctBy = { it.safeKey },
+            transform = { newItems ->
+                when (spec) {
+                    is TimelinePaginationSpecification.Feed ->
+                        newItems
+                            .filterReplies(included = !spec.excludeReplies)
+                            .filterNsfw(spec.includeNsfw)
+                            .filterWithRateLimits()
+                            .filterByStopWords()
+                            .fixupCreatorEmojis()
+                            .fixupInReplyTo()
+                            .fixupFollowedHashtags()
 
-                is TimelinePaginationSpecification.User ->
-                    results
-                        ?.deduplicate()
-                        ?.updatePaginationData()
-                        ?.filterNsfw(specification.includeNsfw)
-                        ?.filterByStopWords()
-                        ?.fixupCreatorEmojis()
-                        ?.fixupInReplyTo()
+                    is TimelinePaginationSpecification.Hashtag ->
+                        newItems
+                            .filterNsfw(spec.includeNsfw)
+                            .filterWithRateLimits()
+                            .filterByStopWords()
+                            .fixupCreatorEmojis()
+                            .fixupInReplyTo()
 
-                is TimelinePaginationSpecification.Forum ->
-                    results
-                        ?.deduplicate()
-                        ?.updatePaginationData()
-                        ?.filterNsfw(specification.includeNsfw)
-                        ?.filter { it.reblog != null && it.reblog?.inReplyTo == null }
-                        ?.filterByStopWords()
-                        ?.fixupCreatorEmojis()
+                    is TimelinePaginationSpecification.User ->
+                        newItems
+                            .filterNsfw(spec.includeNsfw)
+                            .filterByStopWords()
+                            .fixupCreatorEmojis()
+                            .fixupInReplyTo()
 
-                is TimelinePaginationSpecification.Bookmarks ->
-                    results
-                        ?.deduplicate()
-                        ?.updatePaginationData()
-                        ?.filterNsfw(specification.includeNsfw)
-                        ?.filterByStopWords()
-                        ?.fixupCreatorEmojis()
-                        ?.fixupInReplyTo()
+                    is TimelinePaginationSpecification.Forum ->
+                        newItems
+                            .filterNsfw(spec.includeNsfw)
+                            .filter { it.reblog != null && it.reblog?.inReplyTo == null }
+                            .filterByStopWords()
+                            .fixupCreatorEmojis()
 
-                is TimelinePaginationSpecification.Favorites ->
-                    results
-                        ?.deduplicate()
-                        ?.updatePaginationData()
-                        ?.filterNsfw(specification.includeNsfw)
-                        ?.filterByStopWords()
-                        ?.fixupCreatorEmojis()
-                        ?.fixupInReplyTo()
+                    is TimelinePaginationSpecification.Bookmarks ->
+                        newItems
+                            .filterNsfw(spec.includeNsfw)
+                            .filterByStopWords()
+                            .fixupCreatorEmojis()
+                            .fixupInReplyTo()
 
-                is TimelinePaginationSpecification.Quotes ->
-                    results
-                        ?.deduplicate()
-                        ?.updatePaginationData()
-            }?.also { history.addAll(it) }
-            // return a copy
-            history.map { it }
-        }
+                    is TimelinePaginationSpecification.Favorites ->
+                        newItems
+                            .filterNsfw(spec.includeNsfw)
+                            .filterByStopWords()
+                            .fixupCreatorEmojis()
+                            .fixupInReplyTo()
+
+                    is TimelinePaginationSpecification.Quotes ->
+                        newItems
+                }
+            },
+        )
     }
 
     override fun extractState(): TimelinePaginationManagerState = DefaultTimelinePaginationManagerState(
-        specification = specification,
-        pageCursor = pageCursor,
-        history = history,
-        userRateLimits = userRateLimits,
+        specification = currentSpecification,
+        pageCursor = currentPageCursor,
+        history = history.toList(),
+        userRateLimits = userRateLimits.toMap(),
         stopWords = stopWords,
     )
 
     override fun restoreState(state: TimelinePaginationManagerState) {
         (state as? DefaultTimelinePaginationManagerState)?.also {
-            specification = it.specification
-            pageCursor = it.pageCursor
-            history.clear()
-            history.addAll(it.history)
+            restorePaginationState(
+                specification = it.specification,
+                pageCursor = it.pageCursor,
+                history = it.history,
+            )
+            userRateLimits.clear()
             userRateLimits.putAll(it.userRateLimits)
             stopWords = it.stopWords
         }
@@ -281,16 +261,6 @@ internal class DefaultTimelinePaginationManager(
         val cursor = list.lastOrNull()?.id
         ListWithPageCursor(list = list, cursor = cursor)
     }
-
-    private fun ListWithPageCursor<TimelineEntryModel>.updatePaginationData(): List<TimelineEntryModel> = run {
-        pageCursor = cursor
-        canFetchMore = list.isNotEmpty()
-        list
-    }
-
-    private fun List<TimelineEntryModel>.deduplicate(): List<TimelineEntryModel> = filter { e1 ->
-        history.none { e2 -> e1.id == e2.id }
-    }.distinctBy { it.safeKey }
 
     private fun List<TimelineEntryModel>.filterWithRateLimits(): List<TimelineEntryModel> =
         filterIndexed { index, timelineEntryModel ->
@@ -305,14 +275,6 @@ internal class DefaultTimelinePaginationManager(
                 (entriesByThisUserInHistory + entriesByThisUserSoFar + 1).toDouble() / (total + 1)
             rate <= rateLimit
         }
-
-    private fun ListWithPageCursor<TimelineEntryModel>.deduplicate(): ListWithPageCursor<TimelineEntryModel> = run {
-        val newList = list.deduplicate()
-        ListWithPageCursor(
-            list = newList,
-            cursor = newList.lastOrNull()?.id,
-        )
-    }
 
     private fun List<TimelineEntryModel>.filterReplies(included: Boolean): List<TimelineEntryModel> = filter {
         included || it.inReplyTo == null

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUnpublishedPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUnpublishedPaginationManager.kt
@@ -13,8 +13,6 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import org.koin.core.annotation.Factory
 
 @Factory
@@ -23,81 +21,57 @@ internal class DefaultUnpublishedPaginationManager(
     private val draftRepository: DraftRepository,
     notificationCenter: NotificationCenter,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
-) : UnpublishedPaginationManager {
-    private var specification: UnpublishedPaginationSpecification? = null
-    private var pageCursor: String? = null
+) : BasePaginationManager<TimelineEntryModel, UnpublishedPaginationSpecification>(
+    idSelector = { it.id },
+),
+    UnpublishedPaginationManager {
     private var page: Int = 0
-    override var canFetchMore: Boolean = true
-    override val history = mutableListOf<TimelineEntryModel>()
-    private val mutex = Mutex()
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
 
     init {
         notificationCenter
             .subscribe(TimelineEntryDeletedEvent::class)
             .onEach { event ->
-                mutex.withLock {
-                    val idx = history.indexOfFirst { e -> e.id == event.id }
-                    if (idx >= 0) {
-                        history.removeAt(idx)
-                    }
+                withPaginationLock {
+                    removeHistoryItem(event.id)
                 }
             }.launchIn(scope)
         notificationCenter
             .subscribe(TimelineEntryUpdatedEvent::class)
             .onEach { event ->
-                mutex.withLock {
-                    val idx = history.indexOfFirst { e -> e.id == event.entry.id }
-                    if (idx >= 0) {
-                        history[idx] = event.entry
-                    }
+                withPaginationLock {
+                    updateHistoryItem(event.entry.id) { event.entry }
                 }
             }.launchIn(scope)
     }
 
     override suspend fun reset(specification: UnpublishedPaginationSpecification) {
-        this.specification = specification
-        pageCursor = null
-        page = 0
-        mutex.withLock {
-            history.clear()
+        super.reset(specification)
+        withPaginationLock {
+            page = 0
         }
-        canFetchMore = true
     }
 
     override suspend fun loadNextPage(): List<TimelineEntryModel> {
-        val specification = this.specification ?: return emptyList()
+        val spec = currentSpecification ?: return emptyList()
 
         val results =
-            when (specification) {
+            when (spec) {
                 UnpublishedPaginationSpecification.Scheduled ->
-                    scheduledEntryRepository.getAll(pageCursor)
+                    scheduledEntryRepository.getAll(currentPageCursor)
 
                 UnpublishedPaginationSpecification.Drafts ->
                     draftRepository.getAll(page = page)
-            }.orEmpty()
+            }
 
-        return mutex.withLock {
-            results
-                .deduplicate()
-                .updatePaginationData()
-                .also { history.addAll(it) }
-            // return a copy
-            history.map { it }
-        }
+        return updateHistory(
+            items = results,
+            transform = { newItems ->
+                if (newItems.isNotEmpty()) {
+                    page++
+                }
+                newItems
+            },
+        )
     }
-
-    private fun List<TimelineEntryModel>.updatePaginationData(): List<TimelineEntryModel> = apply {
-        lastOrNull()?.also {
-            pageCursor = it.id
-        }
-        if (isNotEmpty()) {
-            page++
-        }
-        canFetchMore = isNotEmpty()
-    }
-
-    private fun List<TimelineEntryModel>.deduplicate(): List<TimelineEntryModel> = filter { e1 ->
-        history.none { e2 -> e1.id == e2.id }
-    }.distinctBy { it.id }
 }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUserPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUserPaginationManager.kt
@@ -10,6 +10,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Emoji
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRateLimitRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.ListWithPageCursor
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -18,8 +19,6 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import org.koin.core.annotation.Factory
 
 @Factory
@@ -32,107 +31,86 @@ internal class DefaultUserPaginationManager(
     private val emojiHelper: EmojiHelper,
     notificationCenter: NotificationCenter,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
-) : UserPaginationManager {
-    private var specification: UserPaginationSpecification? = null
-    private var pageCursor: String? = null
-    override var canFetchMore: Boolean = true
-    private val history = mutableListOf<UserModel>()
-    private val mutex = Mutex()
+) : BasePaginationManager<UserModel, UserPaginationSpecification>(
+    idSelector = { it.id },
+),
+    UserPaginationManager {
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
 
     init {
         notificationCenter
             .subscribe(UserUpdatedEvent::class)
             .onEach { event ->
-                mutex.withLock {
-                    val idx = history.indexOfFirst { u -> u.id == event.user.id }
-                    if (idx >= 0) {
-                        history[idx] = event.user
-                    }
+                withPaginationLock {
+                    updateHistoryItem(event.user.id) { event.user }
                 }
             }.launchIn(scope)
     }
 
-    override suspend fun reset(specification: UserPaginationSpecification) {
-        this.specification = specification
-        pageCursor = null
-        mutex.withLock {
-            history.clear()
-        }
-        canFetchMore = true
-    }
-
     override suspend fun loadNextPage(): List<UserModel> {
-        val specification = this.specification ?: return emptyList()
+        val spec = currentSpecification ?: return emptyList()
 
-        val results =
-            when (specification) {
+        val results: ListWithPageCursor<UserModel>? =
+            when (spec) {
                 is UserPaginationSpecification.Follower ->
                     userRepository
                         .getFollowers(
-                            id = specification.userId,
-                            pageCursor = pageCursor,
-                        )
+                            id = spec.userId,
+                            pageCursor = currentPageCursor,
+                        )?.toListWithPageCursor()
 
                 is UserPaginationSpecification.Following ->
                     userRepository
                         .getFollowing(
-                            id = specification.userId,
-                            pageCursor = pageCursor,
-                        )
+                            id = spec.userId,
+                            pageCursor = currentPageCursor,
+                        )?.toListWithPageCursor()
 
                 is UserPaginationSpecification.EntryUsersFavorite ->
                     timelineEntryRepository
                         .getUsersWhoFavorited(
-                            id = specification.entryId,
-                            pageCursor = pageCursor,
-                        )
+                            id = spec.entryId,
+                            pageCursor = currentPageCursor,
+                        )?.toListWithPageCursor()
 
                 is UserPaginationSpecification.EntryUsersReblog ->
                     timelineEntryRepository
                         .getUsersWhoReblogged(
-                            id = specification.entryId,
-                            pageCursor = pageCursor,
-                        )
+                            id = spec.entryId,
+                            pageCursor = currentPageCursor,
+                        )?.toListWithPageCursor()
 
                 is UserPaginationSpecification.Search ->
                     userRepository
                         .search(
-                            query = specification.query,
-                            offset =
-                            history
-                                .indexOfLast { it.id == pageCursor }
-                                .takeIf { it >= 0 }
-                                ?.let {
-                                    // offset is count, not index
-                                    it + 1
-                                } ?: 0,
-                        )
+                            query = spec.query,
+                            offset = history.size,
+                        )?.toListWithPageCursor()
 
                 UserPaginationSpecification.Blocked ->
-                    userRepository.getBlocked(pageCursor = pageCursor)
+                    userRepository.getBlocked(pageCursor = currentPageCursor)?.toListWithPageCursor()
 
                 UserPaginationSpecification.Muted ->
-                    userRepository.getMuted(pageCursor = pageCursor)
+                    userRepository.getMuted(pageCursor = currentPageCursor)?.toListWithPageCursor()
 
                 is UserPaginationSpecification.CircleMembers ->
                     circlesRepository
                         .getMembers(
-                            id = specification.id,
-                            pageCursor = pageCursor,
-                        )
+                            id = spec.id,
+                            pageCursor = currentPageCursor,
+                        )?.toListWithPageCursor()
 
                 is UserPaginationSpecification.SearchFollowing ->
                     userRepository
                         .searchMyFollowing(
-                            query = specification.query,
-                            pageCursor = pageCursor,
-                        )
+                            query = spec.query,
+                            pageCursor = currentPageCursor,
+                        )?.toListWithPageCursor()
 
                 UserPaginationSpecification.Limited -> {
                     val accountId = accountRepository.getActive()?.id ?: 0
                     val rates = userRateLimitRepository.getAll(accountId)
-                    rates.map {
+                    val list = rates.map {
                         UserModel(
                             id = it.handle,
                             handle = it.handle,
@@ -140,109 +118,65 @@ internal class DefaultUserPaginationManager(
                             username = "${it.rate}",
                         )
                     }
+                    ListWithPageCursor(list = list, cursor = null)
                 }
             }
 
-        return mutex.withLock {
-            // result post-processing
-            when (specification) {
-                is UserPaginationSpecification.Follower -> {
-                    results
-                        ?.deduplicate()
-                        ?.determineRelationshipStatus()
-                        ?.updatePaginationData()
-                        ?.fixupCreatorEmojis()
-                }
+        return updateHistory(
+            results = results,
+            transform = { newItems ->
+                when (spec) {
+                    is UserPaginationSpecification.Follower,
+                    is UserPaginationSpecification.Following,
+                    is UserPaginationSpecification.EntryUsersFavorite,
+                    is UserPaginationSpecification.EntryUsersReblog,
+                    UserPaginationSpecification.Blocked,
+                    UserPaginationSpecification.Muted,
+                    -> {
+                        newItems
+                            .determineRelationshipStatus()
+                            .fixupCreatorEmojis()
+                    }
 
-                is UserPaginationSpecification.Following -> {
-                    results
-                        ?.deduplicate()
-                        ?.determineRelationshipStatus()
-                        ?.updatePaginationData()
-                        ?.fixupCreatorEmojis()
-                }
-
-                is UserPaginationSpecification.EntryUsersFavorite -> {
-                    results
-                        ?.determineRelationshipStatus()
-                        ?.deduplicate()
-                        ?.updatePaginationData()
-                        ?.fixupCreatorEmojis()
-                }
-
-                is UserPaginationSpecification.EntryUsersReblog -> {
-                    results
-                        ?.deduplicate()
-                        ?.determineRelationshipStatus()
-                        ?.updatePaginationData()
-                        ?.fixupCreatorEmojis()
-                }
-
-                is UserPaginationSpecification.Search -> {
-                    results
-                        ?.deduplicate()
-                        ?.let {
-                            if (specification.withRelationship) {
+                    is UserPaginationSpecification.Search -> {
+                        newItems.let {
+                            if (spec.withRelationship) {
                                 it.determineRelationshipStatus()
                             } else {
                                 it
                             }
-                        }?.updatePaginationData()
-                        ?.fixupCreatorEmojis()
-                }
+                        }.fixupCreatorEmojis()
+                    }
 
-                UserPaginationSpecification.Blocked -> {
-                    results
-                        ?.deduplicate()
-                        ?.updatePaginationData()
-                        ?.fixupCreatorEmojis()
-                }
+                    is UserPaginationSpecification.CircleMembers -> {
+                        newItems
+                            .filter(spec.query)
+                            .fixupCreatorEmojis()
+                    }
 
-                UserPaginationSpecification.Muted -> {
-                    results
-                        ?.deduplicate()
-                        ?.updatePaginationData()
-                        ?.fixupCreatorEmojis()
-                }
-
-                is UserPaginationSpecification.CircleMembers -> {
-                    results
-                        ?.deduplicate()
-                        ?.updatePaginationData()
-                        ?.filter(specification.query)
-                        ?.fixupCreatorEmojis()
-                }
-
-                is UserPaginationSpecification.SearchFollowing -> {
-                    results
-                        ?.deduplicate()
-                        ?.let {
-                            if (specification.withRelationship) {
+                    is UserPaginationSpecification.SearchFollowing -> {
+                        newItems.let {
+                            if (spec.withRelationship) {
                                 it.determineRelationshipStatus()
                             } else {
                                 it
                             }
-                        }?.updatePaginationData()
-                        ?.filter {
-                            it.id !in specification.excludeIds
-                        }?.fixupCreatorEmojis()
-                }
+                        }.filter {
+                            it.id !in spec.excludeIds
+                        }.fixupCreatorEmojis()
+                    }
 
-                UserPaginationSpecification.Limited -> {
-                    canFetchMore = false
-                    results
+                    UserPaginationSpecification.Limited -> {
+                        newItems
+                    }
                 }
-            }.orEmpty().also { history.addAll(it) }
-            // return a copy
-            history.map { it }
-        }
+            },
+        )
     }
 
-    private fun List<UserModel>.updatePaginationData(): List<UserModel> = apply {
-        lastOrNull()?.also {
-            pageCursor = it.id
-        }
-        canFetchMore = isNotEmpty()
+    private fun List<UserModel>.toListWithPageCursor(): ListWithPageCursor<UserModel> = let { list ->
+        val cursor = list.lastOrNull()?.id
+        ListWithPageCursor(list = list, cursor = cursor)
     }
 
     private suspend fun List<UserModel>.determineRelationshipStatus(): List<UserModel> = run {
@@ -256,10 +190,6 @@ internal class DefaultUserPaginationManager(
             )
         }
     }
-
-    private fun List<UserModel>.deduplicate(): List<UserModel> = filter { e1 ->
-        history.none { e2 -> e1.id == e2.id }
-    }.distinctBy { it.id }
 
     private fun List<UserModel>.filter(query: String): List<UserModel> = filter {
         query.isEmpty() ||


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes a bug in pagination due to which paginated lists were occasionally truncated because deduplication was performed before extracting pagination data.

This led to two issues:

- **Cursor Misalignment:** since the last item id was used as a pagination token, taking the last of the deduplicated list could lead to an unwanted backward leap; 
- **Premature Termination:** since an empty list is interpreted as a termination signal, if all items were filtered out due to deduplication, the sequence is considered exhausted even if there were potentially more items.

Considering there was a lot of common logic between all pagination helpers, this PR also introduces a common superclass `BasePaginationManager` to hold the history (with thread-safe accessors) pagination cursor and specification.