### PR TITLE
refactor: migrate pull notification worker to leverage Koin-WorkManager integration

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -84,6 +84,7 @@ dependencies {
     implementation(libs.androidx.splashscreen)
     implementation(project.dependencies.platform(libs.koin.bom))
     implementation(libs.koin.android)
+    implementation(libs.koin.androidx.workmanager)
 
     implementation(projects.shared)
     implementation(projects.core.appearance)

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -121,6 +121,18 @@
                 <action android:name="org.unifiedpush.android.connector.PUSH_EVENT" />
             </intent-filter>
         </service>
+
+        <!-- Disable default WorkManagerInitializer (in favor of koin-androidx-workmanager) -->
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
     </application>
 
 </manifest>

--- a/androidApp/src/main/kotlin/com/livefast/eattrash/raccoonforfriendica/MainApplication.kt
+++ b/androidApp/src/main/kotlin/com/livefast/eattrash/raccoonforfriendica/MainApplication.kt
@@ -3,6 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica
 import android.app.Application
 import com.livefast.eattrash.raccoonforfriendica.di.setupDi
 import org.koin.android.ext.koin.androidContext
+import org.koin.androidx.workmanager.koin.workManagerFactory
 
 class MainApplication : Application() {
 
@@ -10,6 +11,7 @@ class MainApplication : Application() {
         super.onCreate()
         setupDi {
             androidContext(applicationContext)
+            workManagerFactory()
         }
     }
 }

--- a/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/ProvideStrings.kt
+++ b/core/l10n/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/l10n/ProvideStrings.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.platform.LocalLayoutDirection
 import org.koin.compose.koinInject
-import org.koin.core.parameter.parametersOf
 
 val LocalStrings: ProvidableCompositionLocal<Strings> =
     staticCompositionLocalOf {
@@ -15,7 +14,7 @@ val LocalStrings: ProvidableCompositionLocal<Strings> =
 
 @Composable
 fun ProvideStrings(lang: String, content: @Composable () -> Unit) {
-    val strings: Strings = koinInject(parameters = { parametersOf(lang) })
+    val strings: Strings = koinInject()
     CompositionLocalProvider(
         LocalStrings provides strings,
         LocalLayoutDirection provides lang.toLanguageDirection(),

--- a/domain/pullnotifications/build.gradle.kts
+++ b/domain/pullnotifications/build.gradle.kts
@@ -9,6 +9,7 @@ kotlin {
         androidMain {
             dependencies {
                 implementation(libs.androidx.work.runtime)
+                implementation(libs.koin.androidx.workmanager)
             }
         }
         commonMain {

--- a/domain/pullnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pullnotifications/CheckNotificationWorker.kt
+++ b/domain/pullnotifications/src/androidMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/pullnotifications/CheckNotificationWorker.kt
@@ -10,21 +10,18 @@ import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import com.livefast.eattrash.raccoonforfriendica.core.l10n.Strings
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.InboxManager
-import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.SettingsRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.koin.core.parameter.parametersOf
-import org.koin.java.KoinJavaComponent.inject
+import org.koin.android.annotation.KoinWorker
 import java.util.Collections.max
 
-internal class CheckNotificationWorker(private val context: Context, parameters: WorkerParameters) :
-    CoroutineWorker(context, parameters) {
-    private val inboxManager: InboxManager by inject(InboxManager::class.java)
-    private val settingsRepository: SettingsRepository by inject(SettingsRepository::class.java)
-    private val strings: Strings by inject(
-        clazz = Strings::class.java,
-        parameters = { parametersOf(settingsRepository.current.value?.lang ?: "en") },
-    )
+@KoinWorker
+internal class CheckNotificationWorker(
+    private val context: Context,
+    parameters: WorkerParameters,
+    private val inboxManager: InboxManager,
+    private val strings: Strings,
+) : CoroutineWorker(context, parameters) {
 
     private val notificationManager: NotificationManager
         get() = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -107,6 +107,7 @@ koin-core = { module = "io.insert-koin:koin-core" }
 koin-annotations = { module = "io.insert-koin:koin-annotations" }
 koin-compose = { module = "io.insert-koin:koin-compose" }
 koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel" }
+koin-androidx-workmanager = {module="io.insert-koin:koin-androidx-workmanager"}
 koin-gradlePlugin = { module = "io.insert-koin:koin-compiler-gradle-plugin", version.ref="koin-plugin" }
 koin-test = { module = "io.insert-koin:koin-test" }
 


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR refactors `CheckNotificationWorker` in order to take advantage of [Koin-WorkManager integration](https://insert-koin.io/docs/reference/koin-android/workmanager/) on Android. 

This makes it possible to validate at compile-time the dependencies of the worker[^1] and make it more testable because collaborators are passed through its constructor, instead of being lazily and dynamically resolved at runtime.

Moreover, this was the occasion to cleanup the unused `"lang"` parameter passed while resolving a `Strings` implementor. It was a residue from the Old Times when Compose Multiplatform did not have resource support and I was using third-party libraries (e.g. Lyricist).

[^1]: I checked that dependencies retrieved using `by KoinJavaComponent.inject(...)` are still in the "blind spot" of the KCP.