### PR TITLE
fix: ensure pagination end for follow suggestions

### DIFF
--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultExplorePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultExplorePaginationManager.kt
@@ -125,18 +125,15 @@ internal class DefaultExplorePaginationManager(
                         }?.determineUserRelationshipStatus()
             }
 
+        // for follow suggestions there is no pagination, just the first page
+        val stopPagination = spec == ExplorePaginationSpecification.Suggestions && !currentPageCursor.isNullOrEmpty()
+
         return updateHistory(
-            items = results,
+            items = if (stopPagination) emptyList() else results,
             transform = { newItems ->
                 newItems
                     .filterByStopWords()
-                    .let { list ->
-                        if (spec is ExplorePaginationSpecification.Posts) {
-                            list.filterNsfw(spec.includeNsfw)
-                        } else {
-                            list
-                        }
-                    }
+                    .filterNsfw(included = if (spec is ExplorePaginationSpecification.Posts) spec.includeNsfw else true)
                     .fixupCreatorEmojis()
                     .fixupInReplyTo()
             },
@@ -144,8 +141,7 @@ internal class DefaultExplorePaginationManager(
     }
 
     private fun List<ExploreItemModel>.filterNsfw(included: Boolean): List<ExploreItemModel> = filter {
-        included ||
-            !it.isNsfw
+        included || !it.isNsfw
     }
 
     private suspend fun List<ExploreItemModel>.determineUserRelationshipStatus(): List<ExploreItemModel> = run {


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
The [suggestions endpoint](https://docs.joinmastodon.org/methods/suggestions/#v2) does not allow pagination. This PR makes sure the list ends after the first set of result is fetched.

**Note:** minor cosmetic refactoring of `DefaultExplorePaginationManager` are included.