### PR TITLE
chore: add new fields to instance configuration

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Instance.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Instance.kt
@@ -13,21 +13,9 @@ data class Instance(
     @SerialName("languages") val languages: List<String> = emptyList(),
     @SerialName("rules") val rules: List<InstanceRule> = emptyList(),
     @SerialName("source_url") val sourceUrl: String? = null,
-    @SerialName("thumbnail") val thumbnail: InstanceTumbnail? = null,
+    @SerialName("thumbnail") val thumbnail: InstanceThumbnail? = null,
     @SerialName("title") val title: String? = null,
     @SerialName("uri") val uri: String? = null,
     @SerialName("usage") val usage: InstanceUsage? = null,
     @SerialName("version") val version: String? = null,
-)
-
-@Serializable
-data class InstanceContact(
-    @SerialName("email") val email: String? = null,
-    @SerialName("account") val account: Account? = null,
-)
-
-@Serializable
-data class InstanceTumbnail(
-    @SerialName("url") val url: String? = null,
-    @SerialName("blurhash") val blurhash: String? = null,
 )

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/InstanceConfiguration.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/InstanceConfiguration.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class InstanceConfiguration(
+    @SerialName("accounts") val accounts: InstanceConfigurationAccounts? = null,
     @SerialName("statuses") val statuses: InstanceConfigurationStatuses? = null,
     @SerialName("vapid") val vapid: VapidKey? = null,
 )

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/InstanceConfigurationAccounts.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/InstanceConfigurationAccounts.kt
@@ -1,0 +1,15 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class InstanceConfigurationAccounts(
+    @SerialName("max_featured_tags") val maxFeaturedTags: Int? = null,
+    @SerialName("max_pinned_statuses") val maxPinnedStatuses: Int? = null,
+    @SerialName("max_note_length") val maxBioLength: Int? = null,
+    @SerialName("max_display_name_length") val maxDisplayNameLength: Int? = null,
+    @SerialName("max_profile_fields") val maxProfileFields: Int? = null,
+    @SerialName("profile_field_name_limit") val profileFieldNameLimit: Int? = null,
+    @SerialName("profile_field_value_limit") val profileFieldValueLimit: Int? = null,
+)

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/InstanceConfigurationStatuses.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/InstanceConfigurationStatuses.kt
@@ -7,4 +7,5 @@ import kotlinx.serialization.Serializable
 data class InstanceConfigurationStatuses(
     @SerialName("max_characters") val maxCharacters: Int? = null,
     @SerialName("max_media_attachments") val maxMediaAttachments: Int? = null,
+    @SerialName("characters_reserved_per_url") val charactersReservedPerUrl: Int? = null,
 )

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/InstanceContact.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/InstanceContact.kt
@@ -1,0 +1,10 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class InstanceContact(
+    @SerialName("email") val email: String? = null,
+    @SerialName("account") val account: Account? = null,
+)

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/InstanceIcon.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/InstanceIcon.kt
@@ -4,4 +4,4 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class InstanceIcon(@SerialName("size") val size: String? = null, @SerialName("url") val url: String? = null)
+data class InstanceIcon(@SerialName("size") val size: String? = null, @SerialName("src") val url: String? = null)

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/InstanceThumbnail.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/InstanceThumbnail.kt
@@ -1,0 +1,11 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class InstanceThumbnail(
+    @SerialName("url") val url: String? = null,
+    @SerialName("blurhash") val blurhash: String? = null,
+    @SerialName("description") val description: String? = null,
+)


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR  adds the new properties added in the response of the GET [v2/instance](https://docs.joinmastodon.org/methods/instance/#v2) endpoint, as detailed [here](https://blog.joinmastodon.org/2026/06/mastodon-4-6-for-devs/#instance-api-additions).

This is a first tiny step towards #1331.
