### PR TITLE
fix: search result pagination

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultSearchService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultSearchService.kt
@@ -16,16 +16,14 @@ internal class DefaultSearchService(@InjectedParam args: ServiceCreationArgs) : 
     override suspend fun search(
         query: String,
         type: String,
-        maxId: String?,
-        minId: String?,
+        offset: Int?,
         following: Boolean,
         limit: Int,
         resolve: Boolean,
     ): Search = client.get("$baseUrl/v2/search") {
         parameter("q", query)
         parameter("type", type)
-        parameter("max_id", maxId)
-        parameter("min_id", minId)
+        parameter("offset", offset)
         parameter("following", following)
         parameter("limit", limit)
         parameter("resolve", resolve)

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/SearchService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/SearchService.kt
@@ -6,8 +6,7 @@ interface SearchService {
     suspend fun search(
         query: String = "",
         type: String,
-        maxId: String? = null,
-        minId: String? = null,
+        offset: Int? = null,
         following: Boolean = false,
         limit: Int = 20,
         resolve: Boolean = false,

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/BasePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/BasePaginationManager.kt
@@ -52,8 +52,6 @@ internal abstract class BasePaginationManager<T, S>(private val idSelector: (T) 
         historyIds.clear()
         _history.addAll(history)
         history.forEach { historyIds.add(idSelector(it)) }
-        // We assume that if we are restoring history, we should enable fetching more
-        // if the cursor is present, or just default to true if unsure.
         _canFetchMore = true
     }
 

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultSearchPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultSearchPaginationManager.kt
@@ -13,6 +13,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Emoji
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.ReplyHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.SearchRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.ListWithPageCursor
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.StopWordRepository
 import kotlinx.coroutines.CoroutineDispatcher
@@ -120,8 +121,14 @@ internal class DefaultSearchPaginationManager(
                     )
             }
 
+        // use the calculated offset as cursor
+        val cursor = if (results.isNullOrEmpty()) null else (history.size + results.size).toString()
+
         return updateHistory(
-            items = results,
+            results = ListWithPageCursor(
+                list = results.orEmpty(),
+                cursor = cursor,
+            ),
             transform = { newItems ->
                 newItems
                     .filterByStopWords()

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSearchRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSearchRepository.kt
@@ -21,7 +21,7 @@ internal class DefaultSearchRepository(private val provider: ServiceProvider) : 
             provider.search
                 .search(
                     query = query,
-                    maxId = pageCursor,
+                    offset = pageCursor?.toIntOrNull(),
                     limit = DEFAULT_PAGE_SIZE,
                     type = type.toDto(),
                     resolve = resolve,

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepository.kt
@@ -139,7 +139,7 @@ internal class DefaultUserRepository(
         provider.search
             .search(
                 query = query,
-                maxId = pageCursor,
+                offset = pageCursor?.toIntOrNull(),
                 type = SearchResultType.Users.toDto(),
                 following = true,
                 limit = DEFAULT_PAGE_SIZE,

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSearchRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultSearchRepositoryTest.kt
@@ -35,7 +35,7 @@ class DefaultSearchRepositoryTest {
         everySuspend {
             searchService.search(
                 query = any(),
-                maxId = any(),
+                offset = any(),
                 limit = any(),
                 type = any(),
                 resolve = any(),
@@ -52,7 +52,7 @@ class DefaultSearchRepositoryTest {
         everySuspend {
             searchService.search(
                 query = any(),
-                maxId = any(),
+                offset = any(),
                 limit = any(),
                 type = any(),
                 resolve = any(),
@@ -70,7 +70,7 @@ class DefaultSearchRepositoryTest {
         verifySuspend {
             searchService.search(
                 query = "query",
-                maxId = null,
+                offset = null,
                 limit = 20,
                 type = "statuses",
                 resolve = false,
@@ -83,7 +83,7 @@ class DefaultSearchRepositoryTest {
         everySuspend {
             searchService.search(
                 query = any(),
-                maxId = any(),
+                offset = any(),
                 limit = any(),
                 type = any(),
                 resolve = any(),
@@ -101,7 +101,7 @@ class DefaultSearchRepositoryTest {
         verifySuspend {
             searchService.search(
                 query = "query",
-                maxId = null,
+                offset = null,
                 limit = 20,
                 type = "hashtags",
                 resolve = false,
@@ -114,7 +114,7 @@ class DefaultSearchRepositoryTest {
         everySuspend {
             searchService.search(
                 query = any(),
-                maxId = any(),
+                offset = any(),
                 limit = any(),
                 type = any(),
                 resolve = any(),
@@ -132,7 +132,7 @@ class DefaultSearchRepositoryTest {
         verifySuspend {
             searchService.search(
                 query = "query",
-                maxId = null,
+                offset = null,
                 limit = 20,
                 type = "accounts",
                 resolve = false,

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepositoryTest.kt
@@ -126,7 +126,7 @@ class DefaultUserRepositoryTest {
             searchService.search(
                 query = any(),
                 type = any(),
-                maxId = any(),
+                offset = any(),
                 following = any(),
                 limit = any(),
             )


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes a bug in the search feature, for result types different than posts. When searching users, hashtags or groups, the safest way to perform pagination is to pass an offset parameter (see [doc](https://docs.joinmastodon.org/methods/search/#v2)).

This reviews the pagination mechanism to combine offset + limit while searching for contents.