### PR TITLE
fix: follower, following, muted and blocked pagination

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultUserService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultUserService.kt
@@ -9,6 +9,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.dto.UserList
 import com.livefast.eattrash.raccoonforfriendica.core.api.form.FollowUserForm
 import com.livefast.eattrash.raccoonforfriendica.core.api.form.MuteUserForm
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceCreationArgs
+import com.livefast.eattrash.raccoonforfriendica.core.api.utils.extractCursorFromLinkHeaderValue
 import io.ktor.client.call.body
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.client.request.forms.MultiPartFormDataContent
@@ -71,21 +72,39 @@ internal class DefaultUserService(@InjectedParam args: ServiceCreationArgs) : Us
         parameter("limit", limit)
     }.body()
 
-    override suspend fun getFollowers(id: String, maxId: String?, minId: String?, limit: Int): List<Account> =
-        client.get("$baseUrl/v1/accounts/$id/followers") {
+    override suspend fun getFollowers(
+        id: String,
+        maxId: String?,
+        minId: String?,
+        limit: Int,
+    ): Pair<List<Account>, String?> {
+        val response = client.get("$baseUrl/v1/accounts/$id/followers") {
             parameter("id", id)
             parameter("max_id", maxId)
             parameter("min_id", minId)
             parameter("limit", limit)
-        }.body()
+        }
+        val cursor = response.headers["link"]?.extractCursorFromLinkHeaderValue()
+        val data: List<Account> = response.body()
+        return data to cursor
+    }
 
-    override suspend fun getFollowing(id: String, maxId: String?, minId: String?, limit: Int): List<Account> =
-        client.get("$baseUrl/v1/accounts/$id/following") {
+    override suspend fun getFollowing(
+        id: String,
+        maxId: String?,
+        minId: String?,
+        limit: Int,
+    ): Pair<List<Account>, String?> {
+        val response = client.get("$baseUrl/v1/accounts/$id/following") {
             parameter("id", id)
             parameter("max_id", maxId)
             parameter("min_id", minId)
             parameter("limit", limit)
-        }.body()
+        }
+        val cursor = response.headers["link"]?.extractCursorFromLinkHeaderValue()
+        val data: List<Account> = response.body()
+        return data to cursor
+    }
 
     override suspend fun follow(id: String, data: FollowUserForm): Relationship =
         client.post("$baseUrl/v1/accounts/$id/follow") {
@@ -124,15 +143,25 @@ internal class DefaultUserService(@InjectedParam args: ServiceCreationArgs) : Us
 
     override suspend fun unblock(id: String): Relationship = client.post("$baseUrl/v1/accounts/$id/unblock").body()
 
-    override suspend fun getMuted(maxId: String?, limit: Int): List<Account> = client.get("$baseUrl/v1/mutes") {
-        parameter("max_id", maxId)
-        parameter("limit", limit)
-    }.body()
+    override suspend fun getMuted(maxId: String?, limit: Int): Pair<List<Account>, String?> {
+        val response = client.get("$baseUrl/v1/mutes") {
+            parameter("max_id", maxId)
+            parameter("limit", limit)
+        }
+        val cursor = response.headers["link"]?.extractCursorFromLinkHeaderValue()
+        val data: List<Account> = response.body()
+        return data to cursor
+    }
 
-    override suspend fun getBlocked(maxId: String?, limit: Int): List<Account> = client.get("$baseUrl/v1/blocks") {
-        parameter("max_id", maxId)
-        parameter("limit", limit)
-    }.body()
+    override suspend fun getBlocked(maxId: String?, limit: Int): Pair<List<Account>, String?> {
+        val response = client.get("$baseUrl/v1/blocks") {
+            parameter("max_id", maxId)
+            parameter("limit", limit)
+        }
+        val cursor = response.headers["link"]?.extractCursorFromLinkHeaderValue()
+        val data: List<Account> = response.body()
+        return data to cursor
+    }
 
     override suspend fun updateProfile(content: FormDataContent): Account =
         client.patch("$baseUrl/v1/accounts/update_credentials") {

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/UserService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/UserService.kt
@@ -38,9 +38,19 @@ interface UserService {
 
     suspend fun getSuggestions(limit: Int): List<Suggestion>
 
-    suspend fun getFollowers(id: String, maxId: String? = null, minId: String? = null, limit: Int = 20): List<Account>
+    suspend fun getFollowers(
+        id: String,
+        maxId: String? = null,
+        minId: String? = null,
+        limit: Int = 20,
+    ): Pair<List<Account>, String?>
 
-    suspend fun getFollowing(id: String, maxId: String? = null, minId: String? = null, limit: Int = 20): List<Account>
+    suspend fun getFollowing(
+        id: String,
+        maxId: String? = null,
+        minId: String? = null,
+        limit: Int = 20,
+    ): Pair<List<Account>, String?>
 
     suspend fun follow(id: String, data: FollowUserForm): Relationship
 
@@ -60,9 +70,9 @@ interface UserService {
 
     suspend fun unblock(id: String): Relationship
 
-    suspend fun getMuted(maxId: String? = null, limit: Int = 20): List<Account>
+    suspend fun getMuted(maxId: String? = null, limit: Int = 20): Pair<List<Account>, String?>
 
-    suspend fun getBlocked(maxId: String? = null, limit: Int = 20): List<Account>
+    suspend fun getBlocked(maxId: String? = null, limit: Int = 20): Pair<List<Account>, String?>
 
     suspend fun updateProfile(content: FormDataContent): Account
 

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/utils/Extensions.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/utils/Extensions.kt
@@ -1,6 +1,6 @@
 package com.livefast.eattrash.raccoonforfriendica.core.api.utils
 
 internal fun String.extractCursorFromLinkHeaderValue(): String? {
-    val match = Regex("max_id=(?<maxId>\\d+)>").find(this)
-    return match?.groups?.get("maxId")?.value
+    val match = Regex("max_id=([^&>]+)").find(this)
+    return match?.groupValues?.get(1)
 }

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUserPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUserPaginationManager.kt
@@ -57,14 +57,14 @@ internal class DefaultUserPaginationManager(
                         .getFollowers(
                             id = spec.userId,
                             pageCursor = currentPageCursor,
-                        )?.toListWithPageCursor()
+                        )
 
                 is UserPaginationSpecification.Following ->
                     userRepository
                         .getFollowing(
                             id = spec.userId,
                             pageCursor = currentPageCursor,
-                        )?.toListWithPageCursor()
+                        )
 
                 is UserPaginationSpecification.EntryUsersFavorite ->
                     timelineEntryRepository
@@ -85,13 +85,13 @@ internal class DefaultUserPaginationManager(
                         .search(
                             query = spec.query,
                             offset = history.size,
-                        )?.toListWithPageCursor()
+                        )?.toListWithPageCursor(useOffset = true)
 
                 UserPaginationSpecification.Blocked ->
-                    userRepository.getBlocked(pageCursor = currentPageCursor)?.toListWithPageCursor()
+                    userRepository.getBlocked(pageCursor = currentPageCursor)
 
                 UserPaginationSpecification.Muted ->
-                    userRepository.getMuted(pageCursor = currentPageCursor)?.toListWithPageCursor()
+                    userRepository.getMuted(pageCursor = currentPageCursor)
 
                 is UserPaginationSpecification.CircleMembers ->
                     circlesRepository
@@ -105,7 +105,7 @@ internal class DefaultUserPaginationManager(
                         .searchMyFollowing(
                             query = spec.query,
                             pageCursor = currentPageCursor,
-                        )?.toListWithPageCursor()
+                        )?.toListWithPageCursor(useOffset = true)
 
                 UserPaginationSpecification.Limited -> {
                     val accountId = accountRepository.getActive()?.id ?: 0
@@ -174,10 +174,15 @@ internal class DefaultUserPaginationManager(
         )
     }
 
-    private fun List<UserModel>.toListWithPageCursor(): ListWithPageCursor<UserModel> = let { list ->
-        val cursor = list.lastOrNull()?.id
-        ListWithPageCursor(list = list, cursor = cursor)
-    }
+    private fun List<UserModel>.toListWithPageCursor(useOffset: Boolean = false): ListWithPageCursor<UserModel> =
+        let { list ->
+            val cursor = if (useOffset) {
+                if (list.isEmpty()) null else (history.size + list.size).toString()
+            } else {
+                list.lastOrNull()?.id
+            }
+            ListWithPageCursor(list = list, cursor = cursor)
+        }
 
     private suspend fun List<UserModel>.determineRelationshipStatus(): List<UserModel> = run {
         val userIds = map { user -> user.id }

--- a/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUserPaginationManagerTest.kt
+++ b/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUserPaginationManagerTest.kt
@@ -10,6 +10,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Emoji
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRateLimitRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.ListWithPageCursor
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.data.AccountModel
 import com.livefast.eattrash.raccoonforfriendica.domain.identity.repository.AccountRepository
 import dev.mokkery.answering.returns
@@ -72,7 +73,7 @@ class DefaultUserPaginationManagerTest {
                 id = any(),
                 pageCursor = any(),
             )
-        } returns emptyList()
+        } returns ListWithPageCursor(emptyList(), null)
 
         sut.reset(UserPaginationSpecification.Follower(userId = "1"))
         val res = sut.loadNextPage()
@@ -92,7 +93,7 @@ class DefaultUserPaginationManagerTest {
                 id = any(),
                 pageCursor = any(),
             )
-        } returns list
+        } returns ListWithPageCursor(list, "2")
 
         sut.reset(UserPaginationSpecification.Follower(userId = "1"))
         val res = sut.loadNextPage()
@@ -115,8 +116,8 @@ class DefaultUserPaginationManagerTest {
                 )
             } sequentiallyReturns
                 listOf(
-                    list,
-                    emptyList(),
+                    ListWithPageCursor(list, "2"),
+                    ListWithPageCursor(emptyList(), null),
                 )
 
             sut.reset(UserPaginationSpecification.Follower(userId = "1"))
@@ -140,7 +141,7 @@ class DefaultUserPaginationManagerTest {
                 id = any(),
                 pageCursor = any(),
             )
-        } returns emptyList()
+        } returns ListWithPageCursor(emptyList(), null)
 
         sut.reset(UserPaginationSpecification.Following(userId = "1"))
         val res = sut.loadNextPage()
@@ -160,7 +161,7 @@ class DefaultUserPaginationManagerTest {
                 id = any(),
                 pageCursor = any(),
             )
-        } returns list
+        } returns ListWithPageCursor(list, "2")
 
         sut.reset(UserPaginationSpecification.Following(userId = "1"))
         val res = sut.loadNextPage()
@@ -183,8 +184,8 @@ class DefaultUserPaginationManagerTest {
                 )
             } sequentiallyReturns
                 listOf(
-                    list,
-                    emptyList(),
+                    ListWithPageCursor(list, "2"),
+                    ListWithPageCursor(emptyList(), null),
                 )
 
             sut.reset(UserPaginationSpecification.Following(userId = "1"))
@@ -520,7 +521,7 @@ class DefaultUserPaginationManagerTest {
                 )
                 userRepository.searchMyFollowing(
                     query = "query",
-                    pageCursor = "2",
+                    pageCursor = "1",
                 )
             }
         }
@@ -529,7 +530,7 @@ class DefaultUserPaginationManagerTest {
     // region Muted
     @Test
     fun `given no results when loadNextPage with Muted then result is as expected`() = runTest {
-        everySuspend { userRepository.getMuted(pageCursor = any()) } returns emptyList()
+        everySuspend { userRepository.getMuted(pageCursor = any()) } returns ListWithPageCursor(emptyList(), null)
 
         sut.reset(UserPaginationSpecification.Muted)
         val res = sut.loadNextPage()
@@ -544,7 +545,7 @@ class DefaultUserPaginationManagerTest {
     @Test
     fun `given results when loadNextPage with Muted then result is as expected`() = runTest {
         val list = listOf(UserModel(id = "2"))
-        everySuspend { userRepository.getMuted(pageCursor = any()) } returns list
+        everySuspend { userRepository.getMuted(pageCursor = any()) } returns ListWithPageCursor(list, "2")
 
         sut.reset(UserPaginationSpecification.Muted)
         val res = sut.loadNextPage()
@@ -561,8 +562,8 @@ class DefaultUserPaginationManagerTest {
         val list = listOf(UserModel(id = "2"))
         everySuspend { userRepository.getMuted(pageCursor = any()) } sequentiallyReturns
             listOf(
-                list,
-                emptyList(),
+                ListWithPageCursor(list, "2"),
+                ListWithPageCursor(emptyList(), null),
             )
 
         sut.reset(UserPaginationSpecification.Muted)
@@ -581,7 +582,7 @@ class DefaultUserPaginationManagerTest {
     // region Blocked
     @Test
     fun `given no results when loadNextPage with Blocked then result is as expected`() = runTest {
-        everySuspend { userRepository.getBlocked(pageCursor = any()) } returns emptyList()
+        everySuspend { userRepository.getBlocked(pageCursor = any()) } returns ListWithPageCursor(emptyList(), null)
 
         sut.reset(UserPaginationSpecification.Blocked)
         val res = sut.loadNextPage()
@@ -596,7 +597,7 @@ class DefaultUserPaginationManagerTest {
     @Test
     fun `given results when loadNextPage with Blocked then result is as expected`() = runTest {
         val list = listOf(UserModel(id = "2"))
-        everySuspend { userRepository.getBlocked(pageCursor = any()) } returns list
+        everySuspend { userRepository.getBlocked(pageCursor = any()) } returns ListWithPageCursor(list, "2")
 
         sut.reset(UserPaginationSpecification.Blocked)
         val res = sut.loadNextPage()
@@ -613,8 +614,8 @@ class DefaultUserPaginationManagerTest {
         val list = listOf(UserModel(id = "2"))
         everySuspend { userRepository.getBlocked(pageCursor = any()) } sequentiallyReturns
             listOf(
-                list,
-                emptyList(),
+                ListWithPageCursor(list, "2"),
+                ListWithPageCursor(emptyList(), null),
             )
 
         sut.reset(UserPaginationSpecification.Blocked)

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepository.kt
@@ -100,28 +100,38 @@ internal class DefaultUserRepository(
         null
     }
 
-    override suspend fun getFollowers(id: String, pageCursor: String?, otherInstance: String?): List<UserModel>? = try {
+    override suspend fun getFollowers(
+        id: String,
+        pageCursor: String?,
+        otherInstance: String?,
+    ): ListWithPageCursor<UserModel>? = try {
         withProvider(otherInstance) { provider ->
-            provider.user
+            val (list, cursor) = provider.user
                 .getFollowers(
                     id = id,
                     maxId = pageCursor,
                     limit = DEFAULT_PAGE_SIZE,
-                ).map { it.toModel() }
+                )
+            ListWithPageCursor(list = list.map { it.toModel() }, cursor = cursor)
         }
     } catch (e: Exception) {
         if (e is CancellationException) throw e
         null
     }
 
-    override suspend fun getFollowing(id: String, pageCursor: String?, otherInstance: String?): List<UserModel>? = try {
+    override suspend fun getFollowing(
+        id: String,
+        pageCursor: String?,
+        otherInstance: String?,
+    ): ListWithPageCursor<UserModel>? = try {
         withProvider(otherInstance) { provider ->
-            provider.user
+            val (list, cursor) = provider.user
                 .getFollowing(
                     id = id,
                     maxId = pageCursor,
                     limit = DEFAULT_PAGE_SIZE,
-                ).map { it.toModel() }
+                )
+            ListWithPageCursor(list = list.map { it.toModel() }, cursor = cursor)
         }
     } catch (e: Exception) {
         if (e is CancellationException) throw e
@@ -238,23 +248,27 @@ internal class DefaultUserRepository(
         null
     }
 
-    override suspend fun getMuted(pageCursor: String?): List<UserModel>? = try {
-        provider.user
-            .getMuted(
-                maxId = pageCursor,
-                limit = DEFAULT_PAGE_SIZE,
-            ).map { it.toModel() }
+    override suspend fun getMuted(pageCursor: String?): ListWithPageCursor<UserModel>? = try {
+        val (list, cursor) =
+            provider.user
+                .getMuted(
+                    maxId = pageCursor,
+                    limit = DEFAULT_PAGE_SIZE,
+                )
+        ListWithPageCursor(list = list.map { it.toModel() }, cursor = cursor)
     } catch (e: Exception) {
         if (e is CancellationException) throw e
         null
     }
 
-    override suspend fun getBlocked(pageCursor: String?): List<UserModel>? = try {
-        provider.user
-            .getBlocked(
-                maxId = pageCursor,
-                limit = DEFAULT_PAGE_SIZE,
-            ).map { it.toModel() }
+    override suspend fun getBlocked(pageCursor: String?): ListWithPageCursor<UserModel>? = try {
+        val (list, cursor) =
+            provider.user
+                .getBlocked(
+                    maxId = pageCursor,
+                    limit = DEFAULT_PAGE_SIZE,
+                )
+        ListWithPageCursor(list = list.map { it.toModel() }, cursor = cursor)
     } catch (e: Exception) {
         if (e is CancellationException) throw e
         null

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/UserRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/UserRepository.kt
@@ -19,9 +19,17 @@ interface UserRepository {
 
     suspend fun getSuggestions(): List<UserModel>?
 
-    suspend fun getFollowers(id: String, pageCursor: String? = null, otherInstance: String? = null): List<UserModel>?
+    suspend fun getFollowers(
+        id: String,
+        pageCursor: String? = null,
+        otherInstance: String? = null,
+    ): ListWithPageCursor<UserModel>?
 
-    suspend fun getFollowing(id: String, pageCursor: String? = null, otherInstance: String? = null): List<UserModel>?
+    suspend fun getFollowing(
+        id: String,
+        pageCursor: String? = null,
+        otherInstance: String? = null,
+    ): ListWithPageCursor<UserModel>?
 
     suspend fun getListsContaining(id: String): List<CircleModel>?
 
@@ -45,9 +53,9 @@ interface UserRepository {
 
     suspend fun unblock(id: String): RelationshipModel?
 
-    suspend fun getMuted(pageCursor: String? = null): List<UserModel>?
+    suspend fun getMuted(pageCursor: String? = null): ListWithPageCursor<UserModel>?
 
-    suspend fun getBlocked(pageCursor: String? = null): List<UserModel>?
+    suspend fun getBlocked(pageCursor: String? = null): ListWithPageCursor<UserModel>?
 
     suspend fun updateProfile(
         note: String? = null,

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultUserRepositoryTest.kt
@@ -164,13 +164,13 @@ class DefaultUserRepositoryTest {
                 maxId = any(),
                 limit = any(),
             )
-        } returns listOf(Account(id = "2", username = "following", acct = "following@node"))
+        } returns (listOf(Account(id = "2", username = "following", acct = "following@node")) to null)
 
         val res = sut.getFollowing(id = "1", pageCursor = null, otherInstance = otherInstance)
 
         assertNotNull(res)
-        assertEquals(1, res.size)
-        assertEquals("2", res.first().id)
+        assertEquals(1, res.list.size)
+        assertEquals("2", res.list.first().id)
         verifySuspend {
             userService.getFollowing(
                 id = "1",
@@ -193,13 +193,13 @@ class DefaultUserRepositoryTest {
                 maxId = any(),
                 limit = any(),
             )
-        } returns listOf(Account(id = "2", username = "follower", acct = "follower@node"))
+        } returns (listOf(Account(id = "2", username = "follower", acct = "follower@node")) to null)
 
         val res = sut.getFollowers(id = "1", pageCursor = null, otherInstance = otherInstance)
 
         assertNotNull(res)
-        assertEquals(1, res.size)
-        assertEquals("2", res.first().id)
+        assertEquals(1, res.list.size)
+        assertEquals("2", res.list.first().id)
         verifySuspend {
             userService.getFollowers(
                 id = "1",
@@ -294,19 +294,19 @@ class DefaultUserRepositoryTest {
     @Test
     fun `given results when getMuted then result is expected`() = runTest {
         everySuspend { userService.getMuted(any(), any()) } returns
-            listOf(Account(id = "1", username = "u", acct = "a"))
+            (listOf(Account(id = "1", username = "u", acct = "a")) to null)
         val res = sut.getMuted(null)
         assertNotNull(res)
-        assertEquals(1, res.size)
+        assertEquals(1, res?.list?.size)
     }
 
     @Test
     fun `given results when getBlocked then result is expected`() = runTest {
         everySuspend { userService.getBlocked(any(), any()) } returns
-            listOf(Account(id = "1", username = "u", acct = "a"))
+            (listOf(Account(id = "1", username = "u", acct = "a")) to null)
         val res = sut.getBlocked(null)
         assertNotNull(res)
-        assertEquals(1, res.size)
+        assertEquals(1, res.list.size)
     }
     // endregion
 

--- a/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/DefaultExportUserListUseCase.kt
+++ b/domain/content/usecase/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/DefaultExportUserListUseCase.kt
@@ -18,7 +18,7 @@ internal class DefaultExportUserListUseCase(private val userRepository: UserRepo
         var canFetchMore = true
         val result = mutableListOf<UserModel>()
         while (canFetchMore) {
-            val list =
+            val response =
                 when (specification) {
                     is ExportUserSpecification.Follower ->
                         userRepository.getFollowers(
@@ -31,9 +31,10 @@ internal class DefaultExportUserListUseCase(private val userRepository: UserRepo
                             id = specification.userId,
                             pageCursor = cursor,
                         )
-                }.orEmpty()
-            canFetchMore = list.isNotEmpty()
-            cursor = list.lastOrNull()?.id
+                }
+            val list = response?.list.orEmpty()
+            canFetchMore = response?.cursor != null && list.isNotEmpty()
+            cursor = response?.cursor
             result += list
         }
         return result

--- a/domain/content/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/DefaultExportUserListUseCaseTest.kt
+++ b/domain/content/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/usecase/DefaultExportUserListUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.usecase
 
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.ListWithPageCursor
 import dev.mokkery.answering.sequentiallyReturns
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
@@ -36,7 +37,11 @@ class DefaultExportUserListUseCaseTest {
                 id = any(),
                 pageCursor = any(),
             )
-        } sequentiallyReturns listOf(chunk1, chunk2, emptyList())
+        } sequentiallyReturns listOf(
+            ListWithPageCursor(chunk1, "2"),
+            ListWithPageCursor(chunk2, "4"),
+            ListWithPageCursor(emptyList(), null),
+        )
 
         val expected =
             buildList {
@@ -81,7 +86,11 @@ class DefaultExportUserListUseCaseTest {
                 id = any(),
                 pageCursor = any(),
             )
-        } sequentiallyReturns listOf(chunk1, chunk2, emptyList())
+        } sequentiallyReturns listOf(
+            ListWithPageCursor(chunk1, "2"),
+            ListWithPageCursor(chunk2, "4"),
+            ListWithPageCursor(emptyList(), null),
+        )
 
         val expected =
             buildList {


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR solves pagination issues in GET `/accounts/:id/followers`, `/accounts/:id/following`, `/mutes` and `/blocks` introducing the retrieval of the next page cursor from the `link` response header.
