### PR TITLE
fix: pagination issues in notifications, circle members, post favorites, post reblogs, favorites, bookmarks

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultListService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultListService.kt
@@ -6,6 +6,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.dto.EditListMembersFor
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaCircle
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.UserList
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceCreationArgs
+import com.livefast.eattrash.raccoonforfriendica.core.api.utils.extractCursorFromLinkHeaderValue
 import io.ktor.client.call.body
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
@@ -30,11 +31,15 @@ internal class DefaultListService(@InjectedParam args: ServiceCreationArgs) : Li
 
     override suspend fun getBy(id: String): UserList = client.get("$baseUrl/v1/lists/$id").body()
 
-    override suspend fun getMembers(id: String, maxId: String?, limit: Int): List<Account> =
-        client.get("$baseUrl/v1/lists/$id/accounts") {
+    override suspend fun getMembers(id: String, maxId: String?, limit: Int): Pair<List<Account>, String?> {
+        val response = client.get("$baseUrl/v1/lists/$id/accounts") {
             parameter("max_id", maxId)
             parameter("limit", limit)
-        }.body()
+        }
+        val data: List<Account> = response.body()
+        val cursor = response.headers["link"]?.extractCursorFromLinkHeaderValue()
+        return data to cursor
+    }
 
     override suspend fun create(data: EditListForm): UserList = client.post("$baseUrl/v1/lists") {
         contentType(ContentType.Application.Json)

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultNotificationService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultNotificationService.kt
@@ -3,6 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica.core.api.service
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Notification
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.NotificationType
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceCreationArgs
+import com.livefast.eattrash.raccoonforfriendica.core.api.utils.extractCursorFromLinkHeaderValue
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
@@ -22,18 +23,23 @@ internal class DefaultNotificationService(@InjectedParam args: ServiceCreationAr
         minId: String?,
         includeAll: Boolean,
         limit: Int,
-    ): List<Notification> = client.get("$baseUrl/v1/notifications") {
-        types.forEach { value ->
-            parameter("types[]", value)
+    ): Pair<List<Notification>, String?> {
+        val response = client.get("$baseUrl/v1/notifications") {
+            types.forEach { value ->
+                parameter("types[]", value)
+            }
+            excludeTypes?.forEach { value ->
+                parameter("exclude_types[]", value)
+            }
+            parameter("max_id", maxId)
+            parameter("minId", minId)
+            parameter("include_all", includeAll)
+            parameter("limit", limit)
         }
-        excludeTypes?.forEach { value ->
-            parameter("exclude_types[]", value)
-        }
-        parameter("max_id", maxId)
-        parameter("minId", minId)
-        parameter("include_all", includeAll)
-        parameter("limit", limit)
-    }.body()
+        val data: List<Notification> = response.body()
+        val cursor = response.headers["link"]?.extractCursorFromLinkHeaderValue()
+        return data to cursor
+    }
 
     override suspend fun dismiss(id: String): Boolean =
         client.post("$baseUrl/v1/notifications/$id/dismiss").status.isSuccess()

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultStatusService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultStatusService.kt
@@ -55,17 +55,25 @@ internal class DefaultStatusService(@InjectedParam args: ServiceCreationArgs) : 
 
     override suspend fun unfavorite(id: String): Status = client.post("$baseUrl/v1/statuses/$id/unfavourite").body()
 
-    override suspend fun getFavoritedBy(id: String, maxId: String?, limit: Int): List<Account> =
-        client.get("$baseUrl/v1/statuses/$id/favourited_by") {
+    override suspend fun getFavoritedBy(id: String, maxId: String?, limit: Int): Pair<List<Account>, String?> {
+        val response = client.get("$baseUrl/v1/statuses/$id/favourited_by") {
             parameter("max_id", maxId)
             parameter("limit", limit)
-        }.body()
+        }
+        val data: List<Account> = response.body()
+        val cursor = response.headers["link"]?.extractCursorFromLinkHeaderValue()
+        return data to cursor
+    }
 
-    override suspend fun getRebloggedBy(id: String, maxId: String?, limit: Int): List<Account> =
-        client.get("$baseUrl/v1/statuses/$id/reblogged_by") {
+    override suspend fun getRebloggedBy(id: String, maxId: String?, limit: Int): Pair<List<Account>, String?> {
+        val response = client.get("$baseUrl/v1/statuses/$id/reblogged_by") {
             parameter("max_id", maxId)
             parameter("limit", limit)
-        }.body()
+        }
+        val data: List<Account> = response.body()
+        val cursor = response.headers["link"]?.extractCursorFromLinkHeaderValue()
+        return data to cursor
+    }
 
     override suspend fun create(key: String, data: CreateStatusForm): Status = client.post("$baseUrl/v1/statuses") {
         header("Idempotency-Key", key)

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultUserService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultUserService.kt
@@ -114,19 +114,27 @@ internal class DefaultUserService(@InjectedParam args: ServiceCreationArgs) : Us
 
     override suspend fun unfollow(id: String): Relationship = client.post("$baseUrl/v1/accounts/$id/unfollow").body()
 
-    override suspend fun getFavorites(maxId: String?, minId: String?, limit: Int): List<Status> =
-        client.get("$baseUrl/v1/favourites") {
+    override suspend fun getFavorites(maxId: String?, minId: String?, limit: Int): Pair<List<Status>, String?> {
+        val response = client.get("$baseUrl/v1/favourites") {
             parameter("max_id", maxId)
             parameter("min_id", minId)
             parameter("limit", limit)
-        }.body()
+        }
+        val cursor = response.headers["link"]?.extractCursorFromLinkHeaderValue()
+        val data: List<Status> = response.body()
+        return data to cursor
+    }
 
-    override suspend fun getBookmarks(maxId: String?, minId: String?, limit: Int): List<Status> =
-        client.get("$baseUrl/v1/bookmarks") {
+    override suspend fun getBookmarks(maxId: String?, minId: String?, limit: Int): Pair<List<Status>, String?> {
+        val response = client.get("$baseUrl/v1/bookmarks") {
             parameter("max_id", maxId)
             parameter("min_id", minId)
             parameter("limit", limit)
-        }.body()
+        }
+        val cursor = response.headers["link"]?.extractCursorFromLinkHeaderValue()
+        val data: List<Status> = response.body()
+        return data to cursor
+    }
 
     override suspend fun getListsContaining(id: String): List<UserList> =
         client.get("$baseUrl/v1/accounts/$id/lists").body()

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/ListService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/ListService.kt
@@ -13,7 +13,7 @@ interface ListService {
 
     suspend fun getBy(id: String): UserList
 
-    suspend fun getMembers(id: String, maxId: String? = null, limit: Int = 20): List<Account>
+    suspend fun getMembers(id: String, maxId: String? = null, limit: Int = 20): Pair<List<Account>, String?>
 
     suspend fun create(data: EditListForm): UserList
 

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/NotificationService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/NotificationService.kt
@@ -11,7 +11,7 @@ interface NotificationService {
         minId: String? = null,
         includeAll: Boolean = false,
         limit: Int = 20,
-    ): List<Notification>
+    ): Pair<List<Notification>, String?>
 
     suspend fun dismiss(id: String): Boolean
 

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/StatusService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/StatusService.kt
@@ -32,9 +32,9 @@ interface StatusService {
 
     suspend fun unfavorite(id: String): Status
 
-    suspend fun getFavoritedBy(id: String, maxId: String? = null, limit: Int = 20): List<Account>
+    suspend fun getFavoritedBy(id: String, maxId: String? = null, limit: Int = 20): Pair<List<Account>, String?>
 
-    suspend fun getRebloggedBy(id: String, maxId: String? = null, limit: Int = 20): List<Account>
+    suspend fun getRebloggedBy(id: String, maxId: String? = null, limit: Int = 20): Pair<List<Account>, String?>
 
     suspend fun create(key: String, data: CreateStatusForm): Status
 

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/UserService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/UserService.kt
@@ -56,9 +56,9 @@ interface UserService {
 
     suspend fun unfollow(id: String): Relationship
 
-    suspend fun getFavorites(maxId: String? = null, minId: String? = null, limit: Int = 20): List<Status>
+    suspend fun getFavorites(maxId: String? = null, minId: String? = null, limit: Int = 20): Pair<List<Status>, String?>
 
-    suspend fun getBookmarks(maxId: String? = null, minId: String? = null, limit: Int = 20): List<Status>
+    suspend fun getBookmarks(maxId: String? = null, minId: String? = null, limit: Int = 20): Pair<List<Status>, String?>
 
     suspend fun getListsContaining(id: String): List<UserList>
 

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultNotificationsPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultNotificationsPaginationManager.kt
@@ -36,7 +36,7 @@ internal class DefaultNotificationsPaginationManager(
             }
 
         return updateHistory(
-            items = results,
+            results = results,
             transform = { newItems ->
                 newItems
                     .determineRelationshipStatus()

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManager.kt
@@ -162,12 +162,10 @@ internal class DefaultTimelinePaginationManager(
                 is TimelinePaginationSpecification.Bookmarks ->
                     timelineEntryRepository
                         .getBookmarks(pageCursor = currentPageCursor)
-                        ?.toListWithPageCursor()
 
                 is TimelinePaginationSpecification.Favorites ->
                     timelineEntryRepository
                         .getFavorites(pageCursor = currentPageCursor)
-                        ?.toListWithPageCursor()
 
                 is TimelinePaginationSpecification.Quotes ->
                     timelineEntryRepository

--- a/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUserPaginationManager.kt
+++ b/domain/content/pagination/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUserPaginationManager.kt
@@ -71,14 +71,14 @@ internal class DefaultUserPaginationManager(
                         .getUsersWhoFavorited(
                             id = spec.entryId,
                             pageCursor = currentPageCursor,
-                        )?.toListWithPageCursor()
+                        )
 
                 is UserPaginationSpecification.EntryUsersReblog ->
                     timelineEntryRepository
                         .getUsersWhoReblogged(
                             id = spec.entryId,
                             pageCursor = currentPageCursor,
-                        )?.toListWithPageCursor()
+                        )
 
                 is UserPaginationSpecification.Search ->
                     userRepository
@@ -98,7 +98,7 @@ internal class DefaultUserPaginationManager(
                         .getMembers(
                             id = spec.id,
                             pageCursor = currentPageCursor,
-                        )?.toListWithPageCursor()
+                        )
 
                 is UserPaginationSpecification.SearchFollowing ->
                     userRepository

--- a/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultNotificationsPaginationManagerTest.kt
+++ b/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultNotificationsPaginationManagerTest.kt
@@ -8,6 +8,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.Emoji
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.NotificationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.ReplyHelper
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.UserRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.ListWithPageCursor
 import dev.mokkery.answering.returns
 import dev.mokkery.answering.returnsArgAt
 import dev.mokkery.answering.sequentiallyReturns
@@ -52,7 +53,7 @@ class DefaultNotificationsPaginationManagerTest {
                 pageCursor = any(),
                 refresh = any(),
             )
-        } returns emptyList()
+        } returns ListWithPageCursor(emptyList(), null)
 
         sut.reset(
             NotificationsPaginationSpecification.Default(
@@ -82,7 +83,7 @@ class DefaultNotificationsPaginationManagerTest {
                 pageCursor = any(),
                 refresh = any(),
             )
-        } returns elements
+        } returns ListWithPageCursor(elements, "1")
 
         sut.reset(
             NotificationsPaginationSpecification.Default(
@@ -112,7 +113,7 @@ class DefaultNotificationsPaginationManagerTest {
                 pageCursor = any(),
                 refresh = any(),
             )
-        } returns elements
+        } returns ListWithPageCursor(elements, "1")
 
         sut.reset(
             NotificationsPaginationSpecification.Default(
@@ -150,7 +151,7 @@ class DefaultNotificationsPaginationManagerTest {
                 pageCursor = any(),
                 refresh = any(),
             )
-        } returns elements
+        } returns ListWithPageCursor(elements, "2")
 
         sut.reset(
             NotificationsPaginationSpecification.Default(
@@ -188,7 +189,7 @@ class DefaultNotificationsPaginationManagerTest {
                 pageCursor = any(),
                 refresh = any(),
             )
-        } returns elements
+        } returns ListWithPageCursor(elements, "2")
 
         sut.reset(
             NotificationsPaginationSpecification.Default(
@@ -221,8 +222,8 @@ class DefaultNotificationsPaginationManagerTest {
             )
         } sequentiallyReturns
             listOf(
-                elements,
-                emptyList(),
+                ListWithPageCursor(elements, "1"),
+                ListWithPageCursor(emptyList(), null),
             )
 
         sut.reset(

--- a/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManagerTest.kt
+++ b/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultTimelinePaginationManagerTest.kt
@@ -1110,7 +1110,7 @@ class DefaultTimelinePaginationManagerTest {
     fun `given no results when loadNextPage with Bookmarks specification then result is as expected`() = runTest {
         everySuspend {
             timelineEntryRepository.getBookmarks(pageCursor = any())
-        } returns emptyList()
+        } returns ListWithPageCursor()
 
         sut.reset(TimelinePaginationSpecification.Bookmarks(includeNsfw = false))
         val res = sut.loadNextPage()
@@ -1130,7 +1130,7 @@ class DefaultTimelinePaginationManagerTest {
             )
         everySuspend {
             timelineEntryRepository.getBookmarks(pageCursor = any())
-        } returns list
+        } returns ListWithPageCursor(list = list, cursor = "1")
 
         sut.reset(TimelinePaginationSpecification.Bookmarks(includeNsfw = false))
         val res = sut.loadNextPage()
@@ -1157,7 +1157,7 @@ class DefaultTimelinePaginationManagerTest {
                 )
             everySuspend {
                 timelineEntryRepository.getBookmarks(pageCursor = any())
-            } returns list
+            } returns ListWithPageCursor(list = list, cursor = "3")
 
             sut.reset(TimelinePaginationSpecification.Bookmarks(includeNsfw = false))
             val res = sut.loadNextPage()
@@ -1184,7 +1184,7 @@ class DefaultTimelinePaginationManagerTest {
                 )
             everySuspend {
                 timelineEntryRepository.getBookmarks(pageCursor = any())
-            } returns list
+            } returns ListWithPageCursor(list = list, cursor = "3")
 
             sut.reset(TimelinePaginationSpecification.Bookmarks(includeNsfw = true))
             val res = sut.loadNextPage()
@@ -1205,7 +1205,11 @@ class DefaultTimelinePaginationManagerTest {
                 )
             everySuspend {
                 timelineEntryRepository.getBookmarks(pageCursor = any())
-            } sequentiallyReturns listOf(list, emptyList())
+            } sequentiallyReturns
+                listOf(
+                    ListWithPageCursor(list = list, cursor = "1"),
+                    ListWithPageCursor(),
+                )
 
             sut.reset(TimelinePaginationSpecification.Bookmarks(includeNsfw = false))
             sut.loadNextPage()
@@ -1225,7 +1229,7 @@ class DefaultTimelinePaginationManagerTest {
     fun `given no results when loadNextPage with Favorites specification then result is as expected`() = runTest {
         everySuspend {
             timelineEntryRepository.getFavorites(pageCursor = any())
-        } returns emptyList()
+        } returns ListWithPageCursor()
 
         sut.reset(TimelinePaginationSpecification.Favorites(includeNsfw = false))
         val res = sut.loadNextPage()
@@ -1245,7 +1249,7 @@ class DefaultTimelinePaginationManagerTest {
             )
         everySuspend {
             timelineEntryRepository.getFavorites(pageCursor = any())
-        } returns list
+        } returns ListWithPageCursor(list = list, cursor = "1")
 
         sut.reset(TimelinePaginationSpecification.Favorites(includeNsfw = false))
         val res = sut.loadNextPage()
@@ -1266,7 +1270,11 @@ class DefaultTimelinePaginationManagerTest {
                 )
             everySuspend {
                 timelineEntryRepository.getFavorites(pageCursor = any())
-            } sequentiallyReturns listOf(list, emptyList())
+            } sequentiallyReturns
+                listOf(
+                    ListWithPageCursor(list = list, cursor = "1"),
+                    ListWithPageCursor(),
+                )
 
             sut.reset(TimelinePaginationSpecification.Favorites(includeNsfw = false))
             sut.loadNextPage()

--- a/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUserPaginationManagerTest.kt
+++ b/domain/content/pagination/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/pagination/DefaultUserPaginationManagerTest.kt
@@ -209,7 +209,7 @@ class DefaultUserPaginationManagerTest {
                 id = any(),
                 pageCursor = any(),
             )
-        } returns emptyList()
+        } returns ListWithPageCursor(emptyList(), null)
 
         sut.reset(UserPaginationSpecification.EntryUsersReblog(entryId = "1"))
         val res = sut.loadNextPage()
@@ -232,7 +232,7 @@ class DefaultUserPaginationManagerTest {
                 id = any(),
                 pageCursor = any(),
             )
-        } returns list
+        } returns ListWithPageCursor(list, "2")
 
         sut.reset(UserPaginationSpecification.EntryUsersReblog(entryId = "1"))
         val res = sut.loadNextPage()
@@ -258,8 +258,8 @@ class DefaultUserPaginationManagerTest {
                 )
             } sequentiallyReturns
                 listOf(
-                    list,
-                    emptyList(),
+                    ListWithPageCursor(list, "2"),
+                    ListWithPageCursor(emptyList(), null),
                 )
 
             sut.reset(UserPaginationSpecification.EntryUsersReblog(entryId = "1"))
@@ -289,7 +289,7 @@ class DefaultUserPaginationManagerTest {
                 id = any(),
                 pageCursor = any(),
             )
-        } returns emptyList()
+        } returns ListWithPageCursor(emptyList(), null)
 
         sut.reset(UserPaginationSpecification.EntryUsersFavorite(entryId = "1"))
         val res = sut.loadNextPage()
@@ -312,7 +312,7 @@ class DefaultUserPaginationManagerTest {
                 id = any(),
                 pageCursor = any(),
             )
-        } returns list
+        } returns ListWithPageCursor(list, "2")
 
         sut.reset(UserPaginationSpecification.EntryUsersFavorite(entryId = "1"))
         val res = sut.loadNextPage()
@@ -338,8 +338,8 @@ class DefaultUserPaginationManagerTest {
                 )
             } sequentiallyReturns
                 listOf(
-                    list,
-                    emptyList(),
+                    ListWithPageCursor(list, "2"),
+                    ListWithPageCursor(emptyList(), null),
                 )
 
             sut.reset(UserPaginationSpecification.EntryUsersFavorite(entryId = "1"))
@@ -636,7 +636,7 @@ class DefaultUserPaginationManagerTest {
     fun `given no results when loadNextPage with CircleMembers then result is as expected`() = runTest {
         everySuspend {
             circlesRepository.getMembers(id = any(), pageCursor = any())
-        } returns emptyList()
+        } returns ListWithPageCursor(emptyList(), null)
 
         sut.reset(UserPaginationSpecification.CircleMembers(id = "1", query = "query"))
         val res = sut.loadNextPage()
@@ -656,7 +656,7 @@ class DefaultUserPaginationManagerTest {
         val list = listOf(UserModel(id = "2", displayName = "query"))
         everySuspend {
             circlesRepository.getMembers(id = any(), pageCursor = any())
-        } returns list
+        } returns ListWithPageCursor(list, "2")
 
         sut.reset(UserPaginationSpecification.CircleMembers(id = "1", query = "query"))
         val res = sut.loadNextPage()
@@ -679,8 +679,8 @@ class DefaultUserPaginationManagerTest {
                 circlesRepository.getMembers(id = any(), pageCursor = any())
             } sequentiallyReturns
                 listOf(
-                    list,
-                    emptyList(),
+                    ListWithPageCursor(list, "2"),
+                    ListWithPageCursor(emptyList(), null),
                 )
 
             sut.reset(UserPaginationSpecification.CircleMembers(id = "1", query = "query"))

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/CirclesRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/CirclesRepository.kt
@@ -3,13 +3,14 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.CircleModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.CircleReplyPolicy
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.ListWithPageCursor
 
 interface CirclesRepository {
     suspend fun getAll(): List<CircleModel>?
 
     suspend fun get(id: String): CircleModel?
 
-    suspend fun getMembers(id: String, pageCursor: String? = null): List<UserModel>?
+    suspend fun getMembers(id: String, pageCursor: String? = null): ListWithPageCursor<UserModel>?
 
     suspend fun create(
         title: String,

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultCirclesRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultCirclesRepository.kt
@@ -6,6 +6,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvid
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.CircleModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.CircleReplyPolicy
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.UserModel
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.ListWithPageCursor
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toDto
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
 import io.ktor.utils.io.CancellationException
@@ -27,8 +28,9 @@ internal class DefaultCirclesRepository(private val provider: ServiceProvider) :
         null
     }
 
-    override suspend fun getMembers(id: String, pageCursor: String?): List<UserModel>? = try {
-        provider.list.getMembers(id = id, maxId = pageCursor).map { it.toModel() }
+    override suspend fun getMembers(id: String, pageCursor: String?): ListWithPageCursor<UserModel>? = try {
+        val (list, cursor) = provider.list.getMembers(id = id, maxId = pageCursor)
+        ListWithPageCursor(list = list.map { it.toModel() }, cursor = cursor)
     } catch (e: Exception) {
         if (e is CancellationException) throw e
         null

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultInboxManager.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultInboxManager.kt
@@ -20,9 +20,9 @@ internal class DefaultInboxManager(
 
     override suspend fun refreshUnreadCount() {
         val lastReadId = markerRepository.get(MarkerType.Notifications)?.lastReadId
-        val notifications = notificationRepository.getAll(refresh = true)
+        val response = notificationRepository.getAll(refresh = true)
         unreadCount.update {
-            notifications?.count { it.hasLaterIdThan(lastReadId) } ?: 0
+            response?.list?.count { it.hasLaterIdThan(lastReadId) } ?: 0
         }
     }
 

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNotificationRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNotificationRepository.kt
@@ -3,6 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationType
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.ListWithPageCursor
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toDto
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
 import io.ktor.utils.io.CancellationException
@@ -19,31 +20,29 @@ internal class DefaultNotificationRepository(private val provider: ServiceProvid
         types: List<NotificationType>,
         pageCursor: String?,
         refresh: Boolean,
-    ): List<NotificationModel>? {
+    ): ListWithPageCursor<NotificationModel>? {
         if (refresh) {
             mutex.withLock {
                 cachedValues.clear()
             }
         }
         if (pageCursor == null && cachedValues.isNotEmpty()) {
-            return cachedValues
+            return ListWithPageCursor(list = cachedValues, cursor = null) // Simplified for cache
         }
         return try {
-            val response =
+            val (list, cursor) =
                 provider.notification.get(
                     types = types.mapNotNull { it.toDto() },
                     maxId = pageCursor,
                     limit = DEFAULT_PAGE_SIZE,
                 )
-            response
-                .map { it.toModel() }
-                .also {
-                    if (pageCursor == null) {
-                        mutex.withLock {
-                            cachedValues.addAll(it)
-                        }
-                    }
+            val models = list.map { it.toModel() }
+            if (pageCursor == null) {
+                mutex.withLock {
+                    cachedValues.addAll(models)
                 }
+            }
+            ListWithPageCursor(list = models, cursor = cursor)
         } catch (e: Exception) {
             if (e is CancellationException) throw e
             null

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTimelineEntryRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTimelineEntryRepository.kt
@@ -175,23 +175,25 @@ internal class DefaultTimelineEntryRepository(
         null
     }
 
-    override suspend fun getFavorites(pageCursor: String?): List<TimelineEntryModel>? = try {
-        provider.user
+    override suspend fun getFavorites(pageCursor: String?): ListWithPageCursor<TimelineEntryModel>? = try {
+        val (list, cursor) = provider.user
             .getFavorites(
                 maxId = pageCursor,
                 limit = DEFAULT_PAGE_SIZE,
-            ).map { it.toModelWithReply() }
+            )
+        return ListWithPageCursor(list.map { it.toModelWithReply() }, cursor)
     } catch (e: Exception) {
         if (e is CancellationException) throw e
         null
     }
 
-    override suspend fun getBookmarks(pageCursor: String?): List<TimelineEntryModel>? = try {
-        provider.user
+    override suspend fun getBookmarks(pageCursor: String?): ListWithPageCursor<TimelineEntryModel>? = try {
+        val (list, cursor) = provider.user
             .getBookmarks(
                 maxId = pageCursor,
                 limit = DEFAULT_PAGE_SIZE,
-            ).map { it.toModelWithReply() }
+            )
+        return ListWithPageCursor(list.map { it.toModelWithReply() }, cursor)
     } catch (e: Exception) {
         if (e is CancellationException) throw e
         null
@@ -201,14 +203,15 @@ internal class DefaultTimelineEntryRepository(
         id: String,
         pageCursor: String?,
         otherInstance: String?,
-    ): List<UserModel>? = try {
+    ): ListWithPageCursor<UserModel>? = try {
         withProvider(otherInstance) { provider ->
-            provider.status
+            val (list, cursor) = provider.status
                 .getFavoritedBy(
                     id = id,
                     maxId = pageCursor,
                     limit = DEFAULT_PAGE_SIZE,
-                ).map { it.toModel() }
+                )
+            ListWithPageCursor(list = list.map { it.toModel() }, cursor = cursor)
         }
     } catch (e: Exception) {
         if (e is CancellationException) throw e
@@ -219,14 +222,15 @@ internal class DefaultTimelineEntryRepository(
         id: String,
         pageCursor: String?,
         otherInstance: String?,
-    ): List<UserModel>? = try {
+    ): ListWithPageCursor<UserModel>? = try {
         withProvider(otherInstance) { provider ->
-            provider.status
+            val (list, cursor) = provider.status
                 .getRebloggedBy(
                     id = id,
                     maxId = pageCursor,
                     limit = DEFAULT_PAGE_SIZE,
-                ).map { it.toModel() }
+                )
+            ListWithPageCursor(list = list.map { it.toModel() }, cursor = cursor)
         }
     } catch (e: Exception) {
         if (e is CancellationException) throw e

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/NotificationRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/NotificationRepository.kt
@@ -2,13 +2,14 @@ package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationType
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.ListWithPageCursor
 
 interface NotificationRepository {
     suspend fun getAll(
         types: List<NotificationType> = NotificationType.ALL,
         pageCursor: String? = null,
         refresh: Boolean = false,
-    ): List<NotificationModel>?
+    ): ListWithPageCursor<NotificationModel>?
 
     suspend fun dismiss(id: String): Boolean
 

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/TimelineEntryRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/TimelineEntryRepository.kt
@@ -45,21 +45,21 @@ interface TimelineEntryRepository {
 
     suspend fun unbookmark(id: String): TimelineEntryModel?
 
-    suspend fun getFavorites(pageCursor: String? = null): List<TimelineEntryModel>?
+    suspend fun getFavorites(pageCursor: String? = null): ListWithPageCursor<TimelineEntryModel>?
 
-    suspend fun getBookmarks(pageCursor: String? = null): List<TimelineEntryModel>?
+    suspend fun getBookmarks(pageCursor: String? = null): ListWithPageCursor<TimelineEntryModel>?
 
     suspend fun getUsersWhoFavorited(
         id: String,
         pageCursor: String? = null,
         otherInstance: String? = null,
-    ): List<UserModel>?
+    ): ListWithPageCursor<UserModel>?
 
     suspend fun getUsersWhoReblogged(
         id: String,
         pageCursor: String? = null,
         otherInstance: String? = null,
-    ): List<UserModel>?
+    ): ListWithPageCursor<UserModel>?
 
     suspend fun create(
         localId: String,

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultCirclesRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultCirclesRepositoryTest.kt
@@ -7,6 +7,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.dto.UserList
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.ListService
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.CircleReplyPolicy
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.ListWithPageCursor
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
 import dev.mokkery.answering.returns
 import dev.mokkery.every
@@ -57,11 +58,11 @@ class DefaultCirclesRepositoryTest {
     @Test
     fun `when getMembers then result is as expected`() = runTest {
         val list = listOf(Account(acct = "", id = "", username = ""))
-        everySuspend { listService.getMembers(id = any(), maxId = any()) } returns list
+        everySuspend { listService.getMembers(id = any(), maxId = any()) } returns Pair(list, null)
 
         val res = sut.getMembers("1")
 
-        assertEquals(list.map { it.toModel() }, res)
+        assertEquals(ListWithPageCursor(list.map { it.toModel() }), res)
         verifySuspend {
             listService.getMembers(id = "1", maxId = null)
         }

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultInboxManagerTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultInboxManagerTest.kt
@@ -4,6 +4,7 @@ import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MarkerModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.MarkerType
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationType
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.ListWithPageCursor
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
@@ -30,7 +31,7 @@ class DefaultInboxManagerTest {
     @Test
     fun `given no results when refreshUnreadCount then count is as expected`() = runTest {
         val list = emptyList<NotificationModel>()
-        everySuspend { notificationRepository.getAll(any(), any(), any()) } returns list
+        everySuspend { notificationRepository.getAll(any(), any(), any()) } returns ListWithPageCursor(list)
 
         sut.refreshUnreadCount()
         val res = sut.unreadCount.value
@@ -52,7 +53,7 @@ class DefaultInboxManagerTest {
                 NotificationModel(id = "1", entry = null),
                 NotificationModel(id = "2", entry = null),
             )
-        everySuspend { notificationRepository.getAll(any(), any(), any()) } returns list
+        everySuspend { notificationRepository.getAll(any(), any(), any()) } returns ListWithPageCursor(list)
 
         sut.refreshUnreadCount()
         val res = sut.unreadCount.value
@@ -74,7 +75,7 @@ class DefaultInboxManagerTest {
                 NotificationModel(id = "1", entry = null),
                 NotificationModel(id = "2", entry = null),
             )
-        everySuspend { notificationRepository.getAll(any(), any(), any()) } returns list
+        everySuspend { notificationRepository.getAll(any(), any(), any()) } returns ListWithPageCursor(list)
         sut.refreshUnreadCount()
         val resBefore = sut.unreadCount.value
         assertEquals(2, resBefore)
@@ -91,7 +92,7 @@ class DefaultInboxManagerTest {
                 NotificationModel(id = "1", entry = null),
                 NotificationModel(id = "2", entry = null),
             )
-        everySuspend { notificationRepository.getAll(any(), any(), any()) } returns list
+        everySuspend { notificationRepository.getAll(any(), any(), any()) } returns ListWithPageCursor(list)
         sut.refreshUnreadCount()
         val resBefore = sut.unreadCount.value
         assertEquals(2, resBefore)

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNotificationRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultNotificationRepositoryTest.kt
@@ -4,6 +4,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Notification
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.NotificationService
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.NotificationType
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.ListWithPageCursor
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.toModel
 import dev.mokkery.answering.returns
 import dev.mokkery.every
@@ -37,11 +38,11 @@ class DefaultNotificationRepositoryTest {
                 includeAll = any(),
                 limit = any(),
             )
-        } returns emptyList()
+        } returns Pair(emptyList(), null)
 
         val res = sut.getAll(types = NotificationType.ALL)
 
-        assertEquals(emptyList(), res)
+        assertEquals(ListWithPageCursor(), res)
         verifySuspend {
             notificationService.get(
                 types = matches { it.contains(NotificationTypeDto.MENTION) },
@@ -66,11 +67,11 @@ class DefaultNotificationRepositoryTest {
                 includeAll = any(),
                 limit = any(),
             )
-        } returns list
+        } returns Pair(list, null)
 
         val res = sut.getAll(types = NotificationType.ALL)
 
-        assertEquals(list.map { it.toModel() }, res)
+        assertEquals(ListWithPageCursor(list.map { it.toModel() }), res)
         verifySuspend {
             notificationService.get(
                 types = matches { it.contains(NotificationTypeDto.MENTION) },
@@ -95,11 +96,11 @@ class DefaultNotificationRepositoryTest {
                 includeAll = any(),
                 limit = any(),
             )
-        } returns list
+        } returns Pair(list, null)
 
         val res = sut.getAll(types = NotificationType.ALL, pageCursor = "0")
 
-        assertEquals(list.map { it.toModel() }, res)
+        assertEquals(ListWithPageCursor(list.map { it.toModel() }), res)
         verifySuspend {
             notificationService.get(
                 types = matches { it.contains(NotificationTypeDto.MENTION) },
@@ -124,12 +125,12 @@ class DefaultNotificationRepositoryTest {
                 includeAll = any(),
                 limit = any(),
             )
-        } returns list
+        } returns Pair(list, null)
 
         sut.getAll(types = NotificationType.ALL)
         val res = sut.getAll(types = NotificationType.ALL)
 
-        assertEquals(list.map { it.toModel() }, res)
+        assertEquals(ListWithPageCursor(list.map { it.toModel() }), res)
         verifySuspend(VerifyMode.exactly(1)) {
             notificationService.get(
                 types = matches { it.contains(NotificationTypeDto.MENTION) },
@@ -154,12 +155,12 @@ class DefaultNotificationRepositoryTest {
                 includeAll = any(),
                 limit = any(),
             )
-        } returns list
+        } returns Pair(list, null)
 
         sut.getAll(types = NotificationType.ALL)
         val res = sut.getAll(types = NotificationType.ALL, refresh = true)
 
-        assertEquals(list.map { it.toModel() }, res)
+        assertEquals(ListWithPageCursor(list.map { it.toModel() }), res)
         verifySuspend(VerifyMode.exactly(2)) {
             notificationService.get(
                 types = matches { it.contains(NotificationTypeDto.MENTION) },

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTimelineEntryRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultTimelineEntryRepositoryTest.kt
@@ -532,20 +532,22 @@ class DefaultTimelineEntryRepositoryTest {
     // region Favorites and Bookmarks
     @Test
     fun `given results when getFavorites then result is expected`() = runTest {
-        everySuspend { userService.getFavorites(maxId = any(), limit = any()) } returns listOf(Status(id = "1"))
+        everySuspend { userService.getFavorites(maxId = any(), limit = any()) } returns
+            (listOf(Status(id = "1")) to null)
         val res = sut.getFavorites(null)
         assertNotNull(res)
-        assertEquals(1, res.size)
-        assertEquals("1", res[0].id)
+        assertEquals(1, res.list.size)
+        assertEquals("1", res.list[0].id)
     }
 
     @Test
     fun `given results when getBookmarks then result is expected`() = runTest {
-        everySuspend { userService.getBookmarks(maxId = any(), limit = any()) } returns listOf(Status(id = "1"))
+        everySuspend { userService.getBookmarks(maxId = any(), limit = any()) } returns
+            (listOf(Status(id = "1")) to null)
         val res = sut.getBookmarks(null)
         assertNotNull(res)
-        assertEquals(1, res.size)
-        assertEquals("1", res[0].id)
+        assertEquals(1, res.list.size)
+        assertEquals("1", res.list[0].id)
     }
     // endregion
 
@@ -558,11 +560,11 @@ class DefaultTimelineEntryRepositoryTest {
                 maxId = any(),
                 limit = any(),
             )
-        } returns listOf(Account(id = "1", acct = "user", username = "user"))
+        } returns (listOf(Account(id = "1", acct = "user", username = "user")) to null)
         val res = sut.getUsersWhoFavorited("1", null)
         assertNotNull(res)
-        assertEquals(1, res.size)
-        assertEquals("1", res[0].id)
+        assertEquals(1, res.list.size)
+        assertEquals("1", res.list[0].id)
     }
 
     @Test
@@ -573,11 +575,11 @@ class DefaultTimelineEntryRepositoryTest {
                 maxId = any(),
                 limit = any(),
             )
-        } returns listOf(Account(id = "1", acct = "user", username = "user"))
+        } returns (listOf(Account(id = "1", acct = "user", username = "user")) to null)
         val res = sut.getUsersWhoReblogged("1", null)
         assertNotNull(res)
-        assertEquals(1, res.size)
-        assertEquals("1", res[0].id)
+        assertEquals(1, res.list.size)
+        assertEquals("1", res.list[0].id)
     }
     // endregion
 

--- a/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultContentPreloadManagerTest.kt
+++ b/domain/identity/usecase/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/identity/usecase/DefaultContentPreloadManagerTest.kt
@@ -3,6 +3,7 @@ package com.livefast.eattrash.raccoonforfriendica.domain.identity.usecase
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.NotificationRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TimelineEntryRepository
 import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.TrendingRepository
+import com.livefast.eattrash.raccoonforfriendica.domain.content.repository.utils.ListWithPageCursor
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
@@ -47,7 +48,7 @@ class DefaultContentPreloadManagerTest {
                     pageCursor = any(),
                     refresh = any(),
                 )
-            } returns listOf()
+            } returns ListWithPageCursor()
         }
     private val sut =
         DefaultContentPreloadManager(


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR fixes the same issue of #1338 for a bunch of other endpoints:

- GET `/notifications`
- GET `/lists/:id/accounts`
- GET `/statuses/:id/favourited_by`
- GET `/statuses/:id/reblogged_by`
- GET `/favourites`
- GET `/bookmarks`
