### PR TITLE
fix: truncated post content if both images and hashtags are present

### DIFF
--- a/core/commonui/content/build.gradle.kts
+++ b/core/commonui/content/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.livefast.eattrash.kotlinMultiplatform")
     id("com.livefast.eattrash.composeMultiplatform")
     id("com.livefast.eattrash.di")
+    id("com.livefast.eattrash.test")
     id("com.livefast.eattrash.spotless")
 }
 

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentBody.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentBody.kt
@@ -114,28 +114,41 @@ fun ContentBody(
     }
 }
 
-private fun String.splitTextAndImages(): List<String> = buildList {
+internal fun String.splitTextAndImages(): List<String> = buildList {
     val original = this@splitTextAndImages
     val matches = IMAGE_REGEX.findAll(original).toList()
     var index = 0
+    val currentText = StringBuilder()
+
     for (match in matches) {
         val range = match.range
-        val chunkBefore =
-            original
-                .substring(index, range.first)
-                .trim()
-                // remove empty paragraph at the end
-                .replace(Regex("<p( /)?>\$"), "")
-        add(chunkBefore)
+        val before = original.substring(index, range.first)
+        currentText.append(before)
+
         val htmlImage = original.substring(range)
         val data = extractImageData(htmlImage)
         if (data != null && data.description?.looksLikeAnEmoji != true) {
+            // it's a real image, flush current text and add image chunk
+            val text =
+                currentText
+                    .toString()
+                    .trim()
+                    // remove empty paragraph at the end
+                    .replace(Regex("<p( /)?>$"), "")
+            if (text.isNotEmpty()) add(text)
+            currentText.clear()
             add(htmlImage.trim())
+        } else {
+            // it's an emoji or something else, keep it in the text
+            currentText.append(htmlImage)
         }
         index = range.last + 1
     }
     if (index < original.length) {
-        val chunkAfter = original.substring(index, original.length).trim()
-        add(chunkAfter)
+        currentText.append(original.substring(index))
+    }
+    val finalRow = currentText.toString().trim()
+    if (finalRow.isNotEmpty()) {
+        add(finalRow)
     }
 }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentBody.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentBody.kt
@@ -22,7 +22,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.htmlparse.parseHtml
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EmojiModel
 
 // lazy wildcard matcher after element name, optional closing "/"
-internal val IMAGE_REGEX = Regex("(<img.*?/?>)|(<a href=\".*?\"><img.*?/?></a>)")
+internal val IMAGE_REGEX = Regex("(?s)(<img.*?/?>)|(<a href=\".*?\"><img.*?/?></a>)")
 
 @Composable
 fun ContentBody(

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ImageData.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ImageData.kt
@@ -18,8 +18,11 @@ internal fun extractImageData(html: String): ImageData? {
             .onOpenTag { name, attributes, _ ->
                 when (name) {
                     "img" -> {
-                        url = attributes["src"]
-                        description = attributes["alt"]
+                        // only take the first one if multiple are somehow matched
+                        if (url == null) {
+                            url = attributes["src"]
+                            description = attributes["alt"]
+                        }
                     }
 
                     else -> Unit

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TextWithCustomEmojis.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TextWithCustomEmojis.kt
@@ -51,14 +51,12 @@ fun TextWithCustomEmojis(
                 EMOJI_REGEX.substituteAllOccurrences(this) { occurrence ->
                     val emojiCode = occurrence.groups[1]?.value.orEmpty()
                     val foundEmoji = emojis.firstOrNull { it.code == emojiCode }
-                    if (foundEmoji != null) {
-                        if (autoloadImages) {
-                            appendInlineContent(
-                                id = emojiCode,
-                                alternateText = occurrence.value,
-                            )
-                            foundEmojis += foundEmoji
-                        }
+                    if (foundEmoji != null && autoloadImages) {
+                        appendInlineContent(
+                            id = emojiCode,
+                            alternateText = occurrence.value,
+                        )
+                        foundEmojis += foundEmoji
                     } else {
                         append(occurrence.value)
                     }
@@ -76,15 +74,17 @@ fun TextWithCustomEmojis(
                     if (looksLikeAnEmoji) {
                         val emojiCode = alternateText.replace(":", "")
                         val foundEmoji = emojis.firstOrNull { it.code == emojiCode }
-                        if (foundEmoji != null) {
-                            if (autoloadImages) {
-                                appendInlineContent(
-                                    id = emojiCode,
-                                    alternateText = occurrence.value,
-                                )
-                                foundEmojis += foundEmoji
-                            }
+                        if (foundEmoji != null && autoloadImages) {
+                            appendInlineContent(
+                                id = emojiCode,
+                                alternateText = occurrence.value,
+                            )
+                            foundEmojis += foundEmoji
+                        } else {
+                            append(occurrence.value)
                         }
+                    } else {
+                        append(occurrence.value)
                     }
                 }
             }

--- a/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TextWithCustomEmojis.kt
+++ b/core/commonui/content/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/TextWithCustomEmojis.kt
@@ -25,7 +25,7 @@ import com.livefast.eattrash.raccoonforfriendica.core.commonui.components.Custom
 import com.livefast.eattrash.raccoonforfriendica.core.utils.substituteAllOccurrences
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.EmojiModel
 
-private val EMOJI_REGEX = Regex(":(\\w+):")
+private val EMOJI_REGEX = Regex(":([\\w-]+):")
 private val EMOJI_SIZE = 1.15.em
 
 internal val String.looksLikeAnEmoji: Boolean get() = EMOJI_REGEX.matches(this)

--- a/core/commonui/content/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentBodyTest.kt
+++ b/core/commonui/content/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/core/commonui/content/ContentBodyTest.kt
@@ -1,0 +1,52 @@
+package com.livefast.eattrash.raccoonforfriendica.core.commonui.content
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ContentBodyTest {
+
+    @Test
+    fun `given an inline emoji, when splitting text and images, then the emoji stays in the text chunk`() {
+        val html = "Text before <img src=\"emoji.png\" alt=\":emoji:\" /> text after"
+
+        val chunks = html.splitTextAndImages()
+
+        assertEquals(1, chunks.size)
+        assertEquals("Text before <img src=\"emoji.png\" alt=\":emoji:\" /> text after", chunks[0])
+    }
+
+    @Test
+    fun `given a real image, when splitting text and images, then the image is in its own chunk`() {
+        val html = "Text before <img src=\"image.png\" alt=\"An image\" /> text after"
+
+        val chunks = html.splitTextAndImages()
+
+        assertEquals(3, chunks.size)
+        assertEquals("Text before", chunks[0].trim())
+        assertEquals("<img src=\"image.png\" alt=\"An image\" />", chunks[1])
+        assertEquals("text after", chunks[2].trim())
+    }
+
+    @Test
+    fun `given hashtag and image, when splitting text and images, then it returns both chunks without truncation`() {
+        val html = "<p>Check this #hashtag</p><img src=\"image.png\" alt=\"image\" />"
+
+        val chunks = html.splitTextAndImages()
+
+        assertEquals(2, chunks.size)
+        assertEquals("<p>Check this #hashtag</p>", chunks[0])
+        assertEquals("<img src=\"image.png\" alt=\"image\" />", chunks[1])
+    }
+
+    @Test
+    fun `given a multiline image tag, when splitting text and images, then it correctly identifies the image chunk`() {
+        val html = "Text before <img\n src=\"image.png\"\n alt=\"image\" /> text after"
+
+        val chunks = html.splitTextAndImages()
+
+        assertEquals(3, chunks.size)
+        assertEquals("Text before", chunks[0].trim())
+        assertEquals("<img\n src=\"image.png\"\n alt=\"image\" />", chunks[1])
+        assertEquals("text after", chunks[2].trim())
+    }
+}


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
A user reported that posts containing both hashtags and images are truncated after the first hash character.

This PR makes inline images and custom emojis parsing more robust to consider edge cases (e.g. markup spanning multiple lines, emojis containing hyphens, etc.) and avoids accidental test loss.

CC: @informapirata