### PR TITLE
refactor(ci): replace assemble tasks with compile ones in CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,12 +48,12 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
         run: ./gradlew test
 
-      - name: Build
+      - name: Compile app targets
         env:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEYSTORE_ALIAS: ${{ secrets.KEYSTORE_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
-        run: ./gradlew :androidApp:assembleDebug :desktopApp:assemble
+        run: ./gradlew :androidApp:compileDebugSources :desktopApp:compileKotlinJvm
 
       - name: Generate code coverage
         run: ./gradlew koverXmlReport


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR replaces calling `:androidApp:assembleDebug`  and `:desktopApp:assemble` in the CI verification flow, in favor of `:androidApp:compileDebugSources` and `:desktopApp:compileKotlinJvm` to skip extra work which is not needed in this verification stage (resource merging, APK packaging or desktop bundle creation).