### PR TITLE
feat(api): add support for Mastodon collections

### DIFF
--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Collection.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/Collection.kt
@@ -1,0 +1,25 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Collection(
+    @SerialName("account_id") val accountId: String,
+    @SerialName("created_at") val createdAt: String? = null,
+    @SerialName("description") val description: String,
+    @SerialName("discoverable") val discoverable: Boolean = true,
+    @SerialName("id") val id: String,
+    @SerialName("item_count") val itemCount: Int = 0,
+    @SerialName("items") val items: List<CollectionItem> = emptyList(),
+    @SerialName("language") val language: String,
+    @SerialName("local") val local: Boolean = true,
+    @SerialName("name") val name: String,
+    @SerialName("sensitive") val sensitive: Boolean = false,
+    @SerialName("tag") val tag: Tag? = null,
+    @SerialName("updated_at") val updatedAt: String? = null,
+    @SerialName("uri") val uri: String,
+    @SerialName("url") val url: String,
+)
+
+data class Collections(@SerialName("collections") val collections: List<Collection> = emptyList())

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/CollectionItem.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/dto/CollectionItem.kt
@@ -1,0 +1,26 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CollectionItem(
+    @SerialName("account_id") val accountId: String,
+    @SerialName("created_at") val createdAt: String? = null,
+    @SerialName("id") val id: String,
+    @SerialName("state") val state: CollectionItemState = CollectionItemState.Accepted,
+)
+
+enum class CollectionItemState {
+    @SerialName("pending")
+    Pending,
+
+    @SerialName("accepted")
+    Accepted,
+
+    @SerialName("rejected")
+    Rejected,
+
+    @SerialName("revoked")
+    Revoked,
+}

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/form/AddCollectionItemForm.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/form/AddCollectionItemForm.kt
@@ -1,0 +1,7 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.form
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AddCollectionItemForm(@SerialName("account_id") val accountId: String)

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/form/CreateCollectionForm.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/form/CreateCollectionForm.kt
@@ -1,0 +1,15 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.form
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CreateCollectionForm(
+    @SerialName("account_ids") val accountIds: List<String>? = null,
+    @SerialName("description") val description: String? = null,
+    @SerialName("discoverable") val discoverable: Boolean = true,
+    @SerialName("language") val language: String? = null,
+    @SerialName("name") val name: String = "",
+    @SerialName("sensitive") val sensitive: Boolean = false,
+    @SerialName("tag_name") val tagName: String? = null,
+)

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/form/EditListForm.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/form/EditListForm.kt
@@ -1,4 +1,4 @@
-package com.livefast.eattrash.raccoonforfriendica.core.api.dto
+package com.livefast.eattrash.raccoonforfriendica.core.api.form
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/form/EditListMembersForm.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/form/EditListMembersForm.kt
@@ -1,4 +1,4 @@
-package com.livefast.eattrash.raccoonforfriendica.core.api.dto
+package com.livefast.eattrash.raccoonforfriendica.core.api.form
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/DefaultServiceFactory.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/DefaultServiceFactory.kt
@@ -4,6 +4,8 @@ import com.livefast.eattrash.raccoonforfriendica.core.api.service.AnnouncementSe
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.AnnouncementServiceFactory
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.AppService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.AppServiceFactory
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.CollectionService
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.CollectionServiceFactory
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.DirectMessageService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.DirectMessageServiceFactory
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.EventService
@@ -46,12 +48,14 @@ import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
 import kotlin.reflect.KClass
+import kotlin.reflect.cast
 
 @ContributesBinding(AppScope::class)
 @Inject
 class DefaultServiceFactory(
     private val announcementServiceFactory: AnnouncementServiceFactory,
     private val appServiceFactory: AppServiceFactory,
+    private val collectionServiceFactory: CollectionServiceFactory,
     private val directMessageServiceFactory: DirectMessageServiceFactory,
     private val eventServiceFactory: EventServiceFactory,
     private val followRequestServiceFactory: FollowRequestServiceFactory,
@@ -77,6 +81,7 @@ class DefaultServiceFactory(
         val service = when (clazz) {
             AnnouncementService::class -> announcementServiceFactory.create(args)
             AppService::class -> appServiceFactory.create(args)
+            CollectionService::class -> collectionServiceFactory.create(args)
             DirectMessageService::class -> directMessageServiceFactory.create(args)
             EventService::class -> eventServiceFactory.create(args)
             FollowRequestService::class -> followRequestServiceFactory.create(args)
@@ -98,7 +103,6 @@ class DefaultServiceFactory(
             UserService::class -> userServiceFactory.create(args)
             else -> throw IllegalArgumentException("Unknown service class: ${clazz.simpleName}")
         }
-        @Suppress("UNCHECKED_CAST")
-        return service as T
+        return clazz.cast(service)
     }
 }

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/DefaultServiceProvider.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/DefaultServiceProvider.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.core.api.provider
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.AnnouncementService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.AppService
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.CollectionService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.DirectMessageService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.EventService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.FollowRequestService
@@ -68,6 +69,7 @@ class DefaultServiceProvider(
 
     override lateinit var announcement: AnnouncementService
     override lateinit var app: AppService
+    override lateinit var collection: CollectionService
     override lateinit var directMessage: DirectMessageService
     override lateinit var event: EventService
     override lateinit var followRequest: FollowRequestService
@@ -201,6 +203,7 @@ class DefaultServiceProvider(
         val creationArgs = ServiceCreationArgs(baseUrl = baseUrl, client = currentClient)
         announcement = factory.create(clazz = AnnouncementService::class, args = creationArgs)
         app = factory.create(clazz = AppService::class, args = creationArgs)
+        collection = factory.create(clazz = CollectionService::class, args = creationArgs)
         directMessage = factory.create(clazz = DirectMessageService::class, args = creationArgs)
         event = factory.create(clazz = EventService::class, args = creationArgs)
         followRequest = factory.create(clazz = FollowRequestService::class, args = creationArgs)

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/ServiceProvider.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/provider/ServiceProvider.kt
@@ -2,6 +2,7 @@ package com.livefast.eattrash.raccoonforfriendica.core.api.provider
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.AnnouncementService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.AppService
+import com.livefast.eattrash.raccoonforfriendica.core.api.service.CollectionService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.DirectMessageService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.EventService
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.FollowRequestService
@@ -31,6 +32,7 @@ interface ServiceProvider {
     val currentNode: String
     val announcement: AnnouncementService
     val app: AppService
+    val collection: CollectionService
     val directMessage: DirectMessageService
     val event: EventService
     val followRequest: FollowRequestService

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/CollectionService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/CollectionService.kt
@@ -1,0 +1,16 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.service
+
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Collection
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.CollectionItem
+import com.livefast.eattrash.raccoonforfriendica.core.api.form.AddCollectionItemForm
+import com.livefast.eattrash.raccoonforfriendica.core.api.form.CreateCollectionForm
+
+interface CollectionService {
+    suspend fun create(data: CreateCollectionForm): Collection
+    suspend fun get(id: String): Collection
+    suspend fun delete(id: String): Boolean
+    suspend fun update(id: String, data: CreateCollectionForm): Collection
+    suspend fun addItem(id: String, data: AddCollectionItemForm): CollectionItem
+    suspend fun deleteItem(id: String, itemId: String): Boolean
+    suspend fun revokeInclusion(id: String, itemId: String): Boolean
+}

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultCollectionService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultCollectionService.kt
@@ -1,0 +1,57 @@
+package com.livefast.eattrash.raccoonforfriendica.core.api.service
+
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Collection
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.CollectionItem
+import com.livefast.eattrash.raccoonforfriendica.core.api.form.AddCollectionItemForm
+import com.livefast.eattrash.raccoonforfriendica.core.api.form.CreateCollectionForm
+import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceCreationArgs
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.AssistedInject
+import io.ktor.client.call.body
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.patch
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+
+@AssistedInject
+class DefaultCollectionService(@Assisted args: ServiceCreationArgs) : CollectionService {
+    private val baseUrl = args.baseUrl
+    private val client = args.client
+
+    override suspend fun create(data: CreateCollectionForm): Collection = client.post("$baseUrl/v1/collections") {
+        contentType(ContentType.Application.Json)
+        setBody(data)
+    }.body()
+
+    override suspend fun get(id: String): Collection = client.get("$baseUrl/v1/collections/$id").body()
+
+    override suspend fun delete(id: String): Boolean = client.delete("$baseUrl/v1/collections/$id").status.isSuccess()
+
+    override suspend fun update(id: String, data: CreateCollectionForm): Collection =
+        client.patch("$baseUrl/v1/collections") {
+            contentType(ContentType.Application.Json)
+            setBody(data)
+        }.body()
+
+    override suspend fun addItem(id: String, data: AddCollectionItemForm): CollectionItem =
+        client.post("$baseUrl/v1/collections") {
+            contentType(ContentType.Application.Json)
+            setBody(data)
+        }.body()
+
+    override suspend fun deleteItem(id: String, itemId: String): Boolean =
+        client.delete("$baseUrl/v1/collections/$id/items/$itemId").status.isSuccess()
+
+    override suspend fun revokeInclusion(id: String, itemId: String): Boolean =
+        client.delete("$baseUrl/v1/collections/$id/items/$itemId/revoke").status.isSuccess()
+}
+
+@AssistedFactory
+fun interface CollectionServiceFactory {
+    fun create(@Assisted args: ServiceCreationArgs): DefaultCollectionService
+}

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultListService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultListService.kt
@@ -1,10 +1,10 @@
 package com.livefast.eattrash.raccoonforfriendica.core.api.service
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Account
-import com.livefast.eattrash.raccoonforfriendica.core.api.dto.EditListForm
-import com.livefast.eattrash.raccoonforfriendica.core.api.dto.EditListMembersForm
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaCircle
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.UserList
+import com.livefast.eattrash.raccoonforfriendica.core.api.form.EditListForm
+import com.livefast.eattrash.raccoonforfriendica.core.api.form.EditListMembersForm
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceCreationArgs
 import com.livefast.eattrash.raccoonforfriendica.core.api.utils.extractCursorFromLinkHeaderValue
 import dev.zacsweers.metro.Assisted

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultUserService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/DefaultUserService.kt
@@ -1,6 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.core.api.service
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Account
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Collections
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.CredentialAccount
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Relationship
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Status
@@ -189,6 +190,22 @@ class DefaultUserService(@Assisted args: ServiceCreationArgs) : UserService {
             contentType(ContentType.Application.Json)
             setBody(data)
         }.body()
+
+    override suspend fun getCollections(id: String, offset: Int, limit: Int): Collections {
+        val response = client.get("$baseUrl/v1/accounts/$id/collections") {
+            parameter("offset", offset)
+            parameter("limit", limit)
+        }
+        return response.body<Collections>()
+    }
+
+    override suspend fun getCollectionsContaining(id: String, offset: Int, limit: Int): Collections {
+        val response = client.get("$baseUrl/v1/accounts/$id/in_collections") {
+            parameter("offset", offset)
+            parameter("limit", limit)
+        }
+        return response.body<Collections>()
+    }
 }
 
 @AssistedFactory

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/ListService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/ListService.kt
@@ -1,10 +1,10 @@
 package com.livefast.eattrash.raccoonforfriendica.core.api.service
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Account
-import com.livefast.eattrash.raccoonforfriendica.core.api.dto.EditListForm
-import com.livefast.eattrash.raccoonforfriendica.core.api.dto.EditListMembersForm
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.FriendicaCircle
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.UserList
+import com.livefast.eattrash.raccoonforfriendica.core.api.form.EditListForm
+import com.livefast.eattrash.raccoonforfriendica.core.api.form.EditListMembersForm
 
 interface ListService {
     suspend fun getAll(): List<UserList>

--- a/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/UserService.kt
+++ b/core/api/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/core/api/service/UserService.kt
@@ -1,6 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.core.api.service
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Account
+import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Collections
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.CredentialAccount
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Relationship
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Status
@@ -79,4 +80,8 @@ interface UserService {
     suspend fun updateProfileImage(content: MultiPartFormDataContent): Account
 
     suspend fun updatePersonalNote(id: String, data: FormDataContent): Relationship
+
+    suspend fun getCollections(id: String, offset: Int = 0, limit: Int = 20): Collections
+
+    suspend fun getCollectionsContaining(id: String, offset: Int = 0, limit: Int = 20): Collections
 }

--- a/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultCirclesRepository.kt
+++ b/domain/content/repository/src/commonMain/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultCirclesRepository.kt
@@ -1,7 +1,7 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 
-import com.livefast.eattrash.raccoonforfriendica.core.api.dto.EditListForm
-import com.livefast.eattrash.raccoonforfriendica.core.api.dto.EditListMembersForm
+import com.livefast.eattrash.raccoonforfriendica.core.api.form.EditListForm
+import com.livefast.eattrash.raccoonforfriendica.core.api.form.EditListMembersForm
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.CircleModel
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.CircleReplyPolicy

--- a/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultCirclesRepositoryTest.kt
+++ b/domain/content/repository/src/commonTest/kotlin/com/livefast/eattrash/raccoonforfriendica/domain/content/repository/DefaultCirclesRepositoryTest.kt
@@ -1,9 +1,9 @@
 package com.livefast.eattrash.raccoonforfriendica.domain.content.repository
 
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.Account
-import com.livefast.eattrash.raccoonforfriendica.core.api.dto.EditListForm
-import com.livefast.eattrash.raccoonforfriendica.core.api.dto.EditListMembersForm
 import com.livefast.eattrash.raccoonforfriendica.core.api.dto.UserList
+import com.livefast.eattrash.raccoonforfriendica.core.api.form.EditListForm
+import com.livefast.eattrash.raccoonforfriendica.core.api.form.EditListMembersForm
 import com.livefast.eattrash.raccoonforfriendica.core.api.provider.ServiceProvider
 import com.livefast.eattrash.raccoonforfriendica.core.api.service.ListService
 import com.livefast.eattrash.raccoonforfriendica.domain.content.data.CircleReplyPolicy


### PR DESCRIPTION
## Technical details
<!-- Describe the motivation and scope of your changes -->
This PR adds support for collections (introduced in Mastodon 4.6) to `:core:api` in an effort to provide a UX to Mastodon users comparable to other client apps (see #1331).

These endpoints are not (yet) available on Friendica, therefore guards will be added to make sure the corresponding operations are not exposed when connecting to a Friendica instance.